### PR TITLE
Add subscription protocol

### DIFF
--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -23,7 +23,29 @@
       event = 'change:delta';
       onChange = function(data) {
         spark.write(data);
-      }
+      };
+    } else if (spark.query.stream === 'subscribe') {
+      debug('stream:subscribe');
+      spark.paths = [];
+      event = 'change:delta';
+      onChange = function (delta) {
+        var doSend = delta.updates.some(function (update) {
+          return update.values.some(function (value) {
+            return spark.paths.some(function (path) {
+              return path === value.path;
+            });
+          });
+        });
+        if (doSend) {
+          spark.write(delta);
+        }
+      };
+      spark.on('data', function (msg) {
+        debug("<" + JSON.stringify(msg));
+        if (msg.command === 'subscribe') {
+          spark.paths = spark.paths.concat(msg.paths);
+        }
+      });
     } else {
       event = 'change';
       onChange = function(data) {


### PR DESCRIPTION
I would like to merge this if it's ok with you @fabdrol  just to limit work in progress. We can revisit the subscription protocol when appropriate.

---

Add a way to subscribe to different SignalK messages by specifying stream=subscribe
in the query string and then by sending a JSON command message the consumer can
specify which SignalK paths it is interested. Current implementatin works only
with deltas and ignores context, just considers the paths in the update message.
See also https://github.com/SignalK/maptracker/blob/5cd3ba626188563640329253d6792aeee41a46fc/index.html#L158
