### PR TITLE
feat: remove reconnect on idle in tcp provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "pem": "^1.11.0",
     "please-upgrade-node": "^3.0.1",
     "primus": "^7.0.0",
+    "reconnect-core": "^1.3.0",
     "serialport": "^6.0.0",
     "split": "^1.0.0",
     "stat-mode": "^0.2.2",


### PR DESCRIPTION
This PR reimplements tcp provider with reconnection logic
implemented with reconnect-core. This adds Fibonacci backoff with
maximum delay of 5 seconds and removes reconnection logic for
idle connections.

Previously tcp provider reconnected idle connections. This is not
needed, because as long as the tcp connection is alive we can assume
that the source is working. Repeated reconnections may be unwanted, as
when instruments are turned off and there is no data available.
OpenPlotter's misconfigured kplex left connections dangling in
CLOSE_WAIT and eventually caused kplex to run out of filedescriptors,
causing error logs to fill storage.
http://forum.openmarine.net/showthread.php?tid=1216