### PR TITLE
[WIP] feature: bind PUT handler after interfaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,6 @@ function Server (opts) {
   startSecurity(app, opts ? opts.securityConfig : null)
 
   require('./serverroutes')(app, saveSecurityConfig, getSecurityConfig)
-  require('./put').start(app)
 
   app.signalk = new FullSignalK(app.selfId, app.selfType, app.config.defaults)
 
@@ -262,6 +261,7 @@ Server.prototype.start = function () {
       debug('ID: ' + app.selfId)
 
       startInterfaces(app)
+      require('./put').start(app)
       startMdns(app)
       app.providers = require('./pipedproviders')(app).start()
 


### PR DESCRIPTION
PUT handler is currently bound before interfaces, including plugins. As PUT handler never calls `next()` control never ends up in plugin, making handling PUT requests impossible.

This is an experimental PR to see if just changing the order would make sense.

Fixes #738. 

See also #758.