### PR TITLE
[WIP] function to update plugin configuration before starting it

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -98,15 +98,15 @@ module.exports = function (app) {
   // plugin.updateConfiguration: It's an optional function,
   // it allows you to update the configuration of the plugin saved on the server
   // when you want to modify the schema from one version to another and thus avoid incompatibilities that will block the start of the plugin
-  plugin.updateConfiguration = function (startupOptions, compareVersions) {
+  plugin.updateConfiguration = function (startupOptions, pluginVersion, compareVersions) {
     // Here you receive:
     // - startupOptions: An object that contains the entire plugin configuration
     // - startupOptions.version: contains the current version of the configuration file or '0.0.0.0' if your plugin has never managed a configuration version.
+    // - pluginVersion: contains the current version of your plugin (extract from package.json)
     // - compareVersions: A function to compare versions https://www.npmjs.com/package/compare-versions
 
-    // In return you must respond with the new configuration
-    // If the new version is different from the current version,
-    // it will automatically be saved on the server instead of the old one.
+    // In return you must respond with the new startupOptions
+    // startupOptions.version must be set with pluginVersion value to validate the saving of the new configuration and to be able to launch the plugin.
     return startupOptions
   }
 

--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -95,6 +95,21 @@ module.exports = function (app) {
     app.debug('Plugin stopped');
   };
 
+  // plugin.updateConfiguration: It's an optional function,
+  // it allows you to update the configuration of the plugin saved on the server
+  // when you want to modify the schema from one version to another and thus avoid incompatibilities that will block the start of the plugin
+  plugin.updateConfiguration = function (startupOptions, compareVersions) {
+    // Here you receive:
+    // - startupOptions: An object that contains the entire plugin configuration
+    // - startupOptions.version: contains the current version of the configuration file or '0.0.0.0' if your plugin has never managed a configuration version.
+    // - compareVersions: A function to compare versions https://www.npmjs.com/package/compare-versions
+
+    // In return you must respond with the new configuration
+    // If the new version is different from the current version,
+    // it will automatically be saved on the server instead of the old one.
+    return startupOptions
+  }
+
   plugin.schema = {
     // The plugin schema
   };


### PR DESCRIPTION
Recently, I wanted to update the GUI schema and configuration of the `signalk-to-nmea0183` plugin.
I realized that the access to the configuration of a plugin is only accessible inside the `start` function.
And so it must be active to be able to update it.
If it is not active and the user tries to save the configuration, he receives an error because the current configuration is too different from the new schema.
The purpose of this PR is to call a function `plugin.updateConfiguration` if it exists in the plugin when the plugin is discovered.
The plugin can update its configuration and add a version number.
If the version number is different, `signalk-server-node` automatically saves the new version before launching the plugin.
I don't know if it's better to use a specific version number for configuration or to reuse the version number of the plugin ?

Before updating `SERVERPLUGINS.md` to describe this function, I would like to know if this seems sufficient.
I'm not sure this option will be used much so it may not be necessary to make it more complex.

And an additional question about naming:
`options` or `configuration` ?
Since there are already savePluginOptions and readPluginOptions, it may be embarrassing to talk about configuration.

Comments are welcome.