### PR TITLE
chore: serialport@9

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "node": "10"
   },
   "dependencies": {
-    "@serialport/bindings": "^8.0.6",
     "@signalk/server-admin-ui": "1.30.x",
     "@signalk/signalk-schema": "1.5.0",
     "@signalk/streams": "1.14.x",
@@ -111,6 +110,7 @@
     "pem": "^1.14.3",
     "primus": "^7.0.0",
     "semver": "^7.1.1",
+    "serialport": "^9.0.1",
     "spdy": "^4.0.0",
     "split": "^1.0.0",
     "stat-mode": "^1.0.0",

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -37,6 +37,6 @@
     "stream-throttle": "^0.1.3"
   },
   "optionalDependencies": {
-    "serialport": "^7.1.5"
+    "serialport": "^9.0.1"
   }
 }


### PR DESCRIPTION
Update to latest version of serialport that support Node 14,
that people seem to bump against.

Add the real serialport dependency at root, so that it gets
installed there, and make it optional in streams, so that even
without it the other streams' install succeeds.