### PR TITLE
Update pigpio-seatalk.js

### DIFF
--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -56,7 +56,12 @@ if __name__ == "__main__":
                                 x=0
                                 while x < out0:
                                         if out_data[x+1] ==0:
-                                                string1=str(hex(out_data[x]))
+                                                if out_data[x] > 15:
+                                                  string1=str(hex(out_data[x]))
+                                                elif out_data[x] ==0:
+                                                  string1="0x00"
+                                                else:
+                                                  string1="0x0"+str(hex(out_data[x]).lstrip("0x"))
                                                 data= data+string1[2:]+ ","
                                         else:
                                                 data=data[0:-1]


### PR DESCRIPTION
I’ve found that the 9c seatalk1 datagram gets translated to signalk but not the 84 that reports autopilot state.

This is one example taken from my device (ST2000+):

$STALK,84,56,e,0,0,0,0,0,8*0F

I tried pasting it into the Data Fiddler but it didn’t translate into any delta. I also tried the command line nmea signalk parser and got the same result so i did a step trace debug of the code and found that when it parses for the values of:

[U, VW, V, XY, Z, M, RR, SS, TT]

I get this results:

[ 5, 14, 14, 0, NaN, NaN, 0, 0, 8 ]

And the function returns a null after finding the NaNs

Those values are parsed like this:

  var Z = parseInt(parts[4].charAt(1), 16)
  var M = parseInt(parts[5].charAt(1), 16)

It's clear that the charAt(1) fails for single digit values

After this finding i tried the following modified datagram adding some zeros and it translated correctly:

$STALK,84,56,0e,00,00,00,00,00,08*3F

This proposed modification always returns the completed hexadecimal pair of digits even in the cases of a left zero or a pair o zeros.