### PR TITLE
feature: show average cpu load on dashboard

### DIFF
--- a/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
+++ b/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
@@ -9,7 +9,10 @@ const Dashboard = props => {
     numberOfAvailablePaths,
     wsClients,
     providerStatistics,
-    uptime
+    uptime,
+    loadAvg1m,
+    loadAvg5m,
+    loadAvg15m
   } = props.serverStatistics || {
     deltaRate: 0,
     numberOfAvailablePaths: 0,
@@ -62,6 +65,13 @@ const Dashboard = props => {
                     </small>
                     <br />
                     <strong className='h5'>{uptimeD} days, {uptimeH} hours, {uptimeM} minutes</strong>
+                  </div>
+                  <div className='callout callout-primary'>
+                    <small className='text-muted'>
+                      Average CPU Load (1/5/15min)
+                    </small>
+                    <br />
+                    <strong className='h5'>{loadAvg1m} {loadAvg5m} {loadAvg15m}</strong>
                   </div>
                 </Col>
                 <Col xs='12' md='6'>

--- a/src/deltastats.js
+++ b/src/deltastats.js
@@ -15,6 +15,7 @@
 */
 
 const { isUndefined, values } = require('lodash')
+const os = require('os')
 
 module.exports = {
   startDeltaStatistics: function(app) {
@@ -32,7 +33,10 @@ module.exports = {
           numberOfAvailablePaths: app.streambundle.getAvailablePaths().length,
           wsClients: app.interfaces.ws ? app.interfaces.ws.numClients() : 0,
           providerStatistics: app.providerStatistics,
-          uptime: process.uptime()
+          uptime: process.uptime(),
+          loadAvg1m: os.loadavg()[0].toFixed(2),
+          loadAvg5m: os.loadavg()[1].toFixed(2),
+          loadAvg15m: os.loadavg()[2].toFixed(2)
         }
       })
       app.lastIntervalDeltaCount = app.deltaCount


### PR DESCRIPTION
Load statistics of CPU on Dashboard in 1/5/15min resolution. User can easily see how hardware is performing.  