### PR TITLE
feature: checkable list of debug keys in Server Log view

### DIFF
--- a/packages/server-admin-ui/src/index.js
+++ b/packages/server-admin-ui/src/index.js
@@ -55,7 +55,7 @@ const state = {
   discoveredProviders: [],
   log: {
     entries,
-    debugEnabled: [],
+    debugEnabled: '',
     rememberDebug: false
   },
   restoreStatus: {}

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -625,6 +625,10 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
+  app.get(`${serverRoutesPrefix}/debugKeys`, (req, res) => {
+    res.json(_.uniq(require('debug').instances.map(i => i.namespace)))
+  })
+
   app.post(`${serverRoutesPrefix}/rememberDebug`, (req, res) => {
     app.logging.rememberDebug(req.body.value)
     res.status(200).send()


### PR DESCRIPTION
Add a list of checkboxes for all debug keys known in server's
Debug. Keep the text field also, so that you can enter wildcards, but
keep both checkboxes and text field working.

Reorganise the Server Log view a little: associate the Pause button
with the actual server log and gather all Debug related stuff at
the top.

Reindent all the jsx code.

![image](https://user-images.githubusercontent.com/1049678/93000080-8e203e80-f52e-11ea-8ed4-d53a21e9b80a.png)
