### PR TITLE
fix: connection status for serial ports

### DIFF
--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -113,7 +113,6 @@ SerialStream.prototype.start = function () {
         `Connected to ${this.options.device}`
       )
       this.isFirstError = true
-      this.options.app.setProviderError(this.options.providerId, '')
       const parser = new SerialPort.parsers.Readline()
       this.serial.pipe(parser).pipe(this)
     }.bind(this)


### PR DESCRIPTION
fix: connection status for serial ports ( issue #1144 )
Avoid sending an empty message that deletes the providerStatus