### PR TITLE
Fix: clean up Server Update in Admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,0 @@
-
-## Please see [Releases](https://github.com/SignalK/signalk-server-node/releases) for the release notes.

--- a/README.md
+++ b/README.md
@@ -248,12 +248,6 @@ There is no timeout for the highest priority source, it is handled always.
 
 Timeout for data from unlisted sources is 10 seconds.
 
-Changelog
----------
-
-See [CHANGELOG.md](CHANGELOG.md).
-
-
 [FAQ](https://github.com/SignalK/signalk-server-node/wiki/FAQ:-Frequently-Asked-Questions)
 -------------
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,10 +38,10 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-1. In GitHub, send a pull request to `signalk-server-node:master`.
-* Use the same guidelines as commit messages to write the PR title and description. The server changelog is automatically generated from PR titles, so think about how you can make the changelog informative and easy to understand. The description should tell how the change affects the server's behavior and motivation for doing the change.
-* If we suggest changes then:
-  * Make the required updates.
+1. In GitHub, send a pull request to `signalk-server:master`.
+* Use the same guidelines as commit messages to write the PR title and description. The server's release notes are automatically generated from PR titles, so think about how you can make them informative and easy to understand. The description should tell how the change affects the server's behavior and motivation for doing the change.
+* If we suggest changes to your PR we expect you to:
+  * Once agreed implement the changes.
   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -41,7 +41,6 @@
     "react-html-parser": "^2.0.2",
     "react-json-tree": "^0.11.2",
     "react-jsonschema-form-bs4": "^1.0.6",
-    "react-markdown": "^4.0.3",
     "react-redux": "^5.0.6",
     "react-router-dom": "4.2.2",
     "react-select": "^3.1.0",

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run clean && npm run build",
-    "dev": "webpack -d --progress --watch --profile --json > compilation-stats.json --env.dev",
+    "dev": "webpack -d --progress --watch --env.dev",
     "build": "webpack -p --progress --env.prod",
     "clean": "rimraf ./build"
   },

--- a/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
 import { Alert, Button, Card, CardHeader, CardBody } from 'reactstrap'
 import { connect } from 'react-redux'
-import {withRouter} from "react-router-dom";
-import ReactMarkdown from 'react-markdown'
+import {withRouter} from "react-router-dom"
 
 class ServerUpdate extends Component {
   constructor (props) {
@@ -68,13 +67,14 @@ class ServerUpdate extends Component {
         )}
       {this.props.appStore.canUpdateServer && this.props.appStore.serverUpdate && !isInstalling && !isInstalled  && (
         <Card>
-            <CardHeader>Version {this.props.appStore.serverUpdate} is available <Button className="btn btn-danger float-right" size='sm' color='primary' onClick={this.handleUpdate}>Update</Button></CardHeader>
+          <CardHeader>Server version {this.props.appStore.serverUpdate} is available</CardHeader>
           <CardBody>
-     
-          <ReactMarkdown source={this.state.changelog} />
-            </CardBody>
-            </Card>
-        
+            <a href="https://github.com/SignalK/signalk-server/releases/">Release Notes for latest releases.</a>
+            <br/><br/>
+            <Button className="btn btn-danger" size='sm' color='primary' onClick={this.handleUpdate}>Update</Button>
+          </CardBody>
+        </Card>
+
       )}
       {isInstalling && (
         <Card>

--- a/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
@@ -37,6 +37,15 @@ class ServerUpdate extends Component {
   }
 
   render () {
+    if (!this.props.appStore.storeAvailable) {
+      return (
+        <div className='animated fadeIn'>
+          <Card>
+            <CardHeader>Waiting for App store data to load...</CardHeader>
+          </Card>
+        </div>
+      )
+    }
     let isInstalling = false
     let isInstalled = false
     let info = this.props.appStore.installing.find(p => p.name == 'signalk-server')

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -189,8 +189,7 @@ module.exports = function(app) {
           version: serverVersion,
           description: app.config.description,
           author: getAuthor(app.config),
-          npmUrl:
-            'https://github.com/SignalK/signalk-server-node/blob/master/CHANGELOG.md',
+          npmUrl: null,
           isPlugin: false,
           isWebapp: false
         }


### PR DESCRIPTION
- remove CHANGELOG:md and references to it in .md files
- replace dummy changelog with a link to Github releases in the admin ui
- improve admin ui by adding a loading text when app store is not yet available

![image](https://user-images.githubusercontent.com/1049678/95663939-11dc4380-0b4c-11eb-94a8-ff4ffee39293.png)


Includes a little fix to admin ui dev mode.