### PR TITLE
Deprecate plugin set provider xx

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -680,7 +680,7 @@ app.registerDeltaInputHandler((delta, next) => {
 })
 ```
 
-### `app.setProviderStatus(msg)`
+### `app.setPluginStatus(msg)`
 
 Set the current status of the plugin. The `msg` should be a short message describing the current status of the plugin and will be displayed in the plugin configuration UI and the Dashboard.
 
@@ -690,13 +690,17 @@ app.setProviderStatus('Initializing');
 app.setProviderStatus('Done initializing');
 ```
 
-### `app.setProviderError(msg)`
+Use this instead of deprecated `setProviderStatus`
+
+### `app.setPluginError(msg)`
 
 Set the current error status of the plugin. The `msg` should be a short message describing the current status of the plugin and will be displayed in the plugin configuration UI and the Dashboard.
 
 ```javascript
-app.setProviderError('Error connecting to database');
+app.setPluginError('Error connecting to database');
 ```
+
+Use this instead of deprecated `setProviderError`
 
 ### `app.getSerialPorts() => Promise<Ports>`
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -449,6 +449,13 @@ module.exports = (theApp: any) => {
     location: string
   ) {
     let plugin: PluginInfo
+    let setProviderUseLogged = false
+    const logSetProviderUsage = () => {
+      if (!setProviderUseLogged) {
+        console.log(`Note: ${plugin.name} is using deprecated setProviderStatus/Error https://github.com/SignalK/signalk-server/blob/master/SERVERPLUGINS.md#appsetproviderstatusmsg`)
+        setProviderUseLogged = true
+      }
+    }
     const appCopy: ServerAPI = _.assign({}, app, {
       getSelfPath,
       getPath,
@@ -462,9 +469,17 @@ module.exports = (theApp: any) => {
         onStopHandlers[plugin.id].push(app.registerDeltaInputHandler(handler))
       },
       setProviderStatus: (msg: string) => {
+        logSetProviderUsage()
         app.setPluginStatus(plugin.id, msg)
       },
       setProviderError: (msg: string) => {
+        logSetProviderUsage()
+        app.setPluginError(plugin.id, msg)
+      },
+      setPluginStatus: (msg: string) => {
+        app.setPluginStatus(plugin.id, msg)
+      },
+      setPluginError: (msg: string) => {
         app.setPluginError(plugin.id, msg)
       },
       getSerialPorts


### PR DESCRIPTION
feature: add setPluginStatus/Error and deprecate setProvider versions 

Start actively deprecating 'Provider' concept, starting with plugins, that
never were providers in the first place.

Logs usage of either of the old versions once with a url that points to the
documentation. I tried to craft the message to be neutral enough so that
we don't get support requests from end users about this.

No idea if we can ever really deprecate these without having all plugins that
have not been updated for ages also deprecated, but it's a start."