### PR TITLE
feature: allow ssl to be terminated on a load balancer

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -138,7 +138,7 @@ module.exports = function(app) {
 
         let httpProtocol = 'http://'
         let wsProtocol = 'ws://'
-        if (app.config.settings.ssl) {
+        if (app.config.settings.ssl || (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] === "https")) {
           httpProtocol = 'https://'
           wsProtocol = 'wss://'
         }


### PR DESCRIPTION
If the SSL connection is terminated on a load balancer then SK is not
aware that clients should use https. This change allows SK to look for
the x-forwarded-proto header so that it knows the connection should use
https.

For this to work the load balancer must provide the x-forwarded-proto
header.
