### PR TITLE
feature: move server management endpoints under /skServer

### DIFF
--- a/packages/server-admin-ui/src/actions.js
+++ b/packages/server-admin-ui/src/actions.js
@@ -1,3 +1,5 @@
+import {isUndefined} from 'lodash'
+
 const authFetch = (url, options) => {
   return fetch(url, {
     ...options,
@@ -82,7 +84,7 @@ export function enableSecurity (dispatch, userId, password, callback) {
     password: password,
     type: 'admin'
   }
-  fetch('/enableSecurity', {
+  fetch(`${window.serverRoutesPrefix}/enableSecurity`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -102,7 +104,7 @@ export function enableSecurity (dispatch, userId, password, callback) {
 export function restart () {
   return dispatch => {
     if (confirm('Are you sure you want to restart?')) {
-      fetch('/restart', {
+      fetch(`${window.serverRoutesPrefix}/restart`, {
         credentials: 'include',
         method: 'PUT'
       }).then(() => {
@@ -113,8 +115,8 @@ export function restart () {
 }
 
 // Build actions that perform a basic authFetch to the backend. Pull #514.
-export const buildFetchAction = (endpoint, type) => dispatch =>
-  authFetch(endpoint)
+export const buildFetchAction = (endpoint, type, prefix) => dispatch =>
+  authFetch(`${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`)
     .then(response => response.json())
     .then(data =>
       dispatch({
@@ -128,7 +130,7 @@ export const fetchPlugins = buildFetchAction('/plugins', 'RECEIVE_PLUGIN_LIST')
 export const fetchWebapps = buildFetchAction('/webapps', 'RECEIVE_WEBAPPS_LIST')
 export const fetchApps = buildFetchAction('/appstore/available', 'RECEIVE_APPSTORE_LIST')
 export const fetchAccessRequests = buildFetchAction('/security/access/requests', 'ACCESS_REQUEST')
-export const fetchServerSpecification = buildFetchAction('/signalk', 'RECEIVE_SERVER_SPEC')
+export const fetchServerSpecification = buildFetchAction('/signalk', 'RECEIVE_SERVER_SPEC', '')
 
 export function fetchAllData (dispatch) {
   fetchPlugins(dispatch)

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.js
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.js
@@ -19,7 +19,7 @@ class Dashboard extends Component {
   }
 
   componentDidMount() {
-    fetch(`/plugins`, {credentials: 'same-origin'}).then((response) => {
+    fetch(`${window.serverRoutesPrefix}/plugins`, {credentials: 'same-origin'}).then((response) => {
       if (response.status == 200) {
         return response.json()
       } else {
@@ -58,7 +58,7 @@ class Dashboard extends Component {
 }
 
 function saveData(id, data) {
-  fetch('/plugins/' + id + "/config", {
+  fetch(`${window.serverRoutesPrefix}/plugins/${id}/config`, {
     method: 'POST',
     body: JSON.stringify(data),
     headers: new Headers({'Content-Type': 'application/json'}),

--- a/packages/server-admin-ui/src/views/Playground.js
+++ b/packages/server-admin-ui/src/views/Playground.js
@@ -118,7 +118,7 @@ class Playground extends Component {
     if ( sendToServer ) {
       this.setState({...this.state, sending: true})
     }
-    fetch(`/skServer/inputTest`, {
+    fetch(`${window.serverRoutesPrefix}/inputTest`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/packages/server-admin-ui/src/views/ServerConfig/BackupRestore.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BackupRestore.js
@@ -51,13 +51,13 @@ class BackupRestore extends Component {
   }
 
   backup() {
-    const url = `/backup?includePlugins=${this.state.includePlugins}`
+    const url = `${window.serverRoutesPrefix}/backup?includePlugins=${this.state.includePlugins}`
     //const url = `/backup`
     window.location = url
   }
 
   restore() {
-    fetch(`/restore`, {
+    fetch(`${window.serverRoutesPrefix}/restore`, {
       credentials: 'include',
       method: 'POST',
       headers: {
@@ -100,7 +100,7 @@ class BackupRestore extends Component {
     data.append('file', this.state.restoreFile)
     
     this.setState({restoreState: RESTORE_VALIDATING})
-    fetch(`/validateBackup`, {
+    fetch(`${window.serverRoutesPrefix}/validateBackup`, {
       credentials: 'include',
       method: 'POST',
       headers: {

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -167,7 +167,7 @@ class DeviceInput extends Component {
   }
 
   componentDidMount() {
-    fetch(`/serialports`, {
+    fetch(`${window.serverRoutesPrefix}/serialports`, {
       credentials: 'include'
     })
       .then(response => response.json())

--- a/packages/server-admin-ui/src/views/ServerConfig/Logging.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Logging.js
@@ -13,7 +13,7 @@ import {
 } from 'reactstrap'
 
 function fetchLogfileList () {
-  const okResponse = fetch(`/logfiles/`, {
+  const okResponse = fetch(`${window.serverRoutesPrefix}/logfiles/`, {
     credentials: 'include'
   }).then(response => {
     if (!response.ok) {

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -29,7 +29,7 @@ import SourcePriorities from './SourcePriorities'
 import { set } from 'lodash'
 
 function fetchProviders () {
-  fetch(`/providers`, {
+  fetch(`${window.serverRoutesPrefix}/providers`, {
     credentials: 'include'
   })
     .then(response => response.json())
@@ -52,7 +52,7 @@ function fetchProviders () {
 }
 
 function runDiscovery () {
-  fetch(`/runDiscovery`, {
+  fetch(`${window.serverRoutesPrefix}/runDiscovery`, {
     method: 'PUT',
     credentials: 'include'
   })
@@ -139,7 +139,7 @@ class ProvidersConfiguration extends Component {
 
     var id = this.state.selectedProvider.originalId
 
-    fetch(`/providers/${id && !isNew ? id : ''}`, {
+    fetch(`${window.serverRoutesPrefix}/providers/${id && !isNew ? id : ''}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: {
         'Content-Type': 'application/json'
@@ -182,7 +182,7 @@ class ProvidersConfiguration extends Component {
   }
 
   handleDelete (event) {
-    fetch(`/providers/${this.state.selectedProvider.id}`, {
+    fetch(`${window.serverRoutesPrefix}/providers/${this.state.selectedProvider.id}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
@@ -27,7 +27,7 @@ class ServerUpdate extends Component {
     console.log('handleUpdate')
     if (confirm(`Are you sure you want to update the server?'`)) {
       this.props.history.push('/appstore/updates')
-      fetch(`/appstore/install/signalk-server/${this.props.appStore.serverUpdate}`, {
+      fetch(`${window.serverRoutesPrefix}/appstore/install/signalk-server/${this.props.appStore.serverUpdate}`, {
         method: 'POST',
         credentials: 'include'
       }).then(() => {

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -23,7 +23,7 @@ import VesselConfiguration from './VesselConfiguration'
 import LogFiles from './Logging'
 
 function fetchSettings () {
-  fetch(`/settings`, {
+  fetch(`${window.serverRoutesPrefix}/settings`, {
     credentials: 'include'
   })
     .then(response => response.json())
@@ -76,7 +76,7 @@ class ServerSettings extends Component {
   }
 
   handleSaveSettings () {
-    fetch(`/settings`, {
+    fetch(`${window.serverRoutesPrefix}/settings`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
@@ -295,7 +295,7 @@ const sourcePrioritySave = (sourcePriorities) => (dispatch) => {
 }
 
 function fetchAvailablePaths(cb) {
-  fetch(`/availablePaths`, {
+  fetch(`${window.serverRoutesPrefix}/availablePaths`, {
     credentials: 'include'
   })
     .then(response => response.json())

--- a/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
@@ -18,7 +18,7 @@ import {
 } from 'reactstrap'
 
 function fetchVessel () {
-  fetch(`/vessel`, {
+  fetch(`${window.serverRoutesPrefix}/vessel`, {
     credentials: 'include'
   })
     .then(response => response.json())
@@ -53,7 +53,7 @@ class VesselConfiguration extends Component {
   }
 
   handleSaveVessel () {
-    fetch(`/vessel`, {
+    fetch(`${window.serverRoutesPrefix}/vessel`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/server-admin-ui/src/views/ServerConfig/main.jsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import ConfigurationForm from "./ConfigurationForm.jsx"
 
 function saveData(id, data) {
-  fetch('/plugins/' + id + "/config", {
+  fetch(`${window.serverRoutesPrefix}/plugins/${id}/config`, {
     method: 'POST',
     body: JSON.stringify(data),
     headers: new Headers({'Content-Type': 'application/json'}),
@@ -15,7 +15,7 @@ function saveData(id, data) {
   })
 }
 
-fetch(`/plugins`, {credentials: 'same-origin'}).then((response) => {
+fetch(`${window.serverRoutesPrefix}/plugins`, {credentials: 'same-origin'}).then((response) => {
   if (response.status == 200) {
     response.json().then((plugins) => {
       ReactDOM.render(

--- a/packages/server-admin-ui/src/views/appstore/Apps/AppsList.js
+++ b/packages/server-admin-ui/src/views/appstore/Apps/AppsList.js
@@ -85,7 +85,7 @@ function updateInstalling(that, name, value)
 
 function installApp (name, version) {
   updateInstalling(this, name, true)
-  fetch(`/appstore/install/${name}/${version}`, {
+  fetch(`${window.serverRoutesPrefix}/appstore/install/${name}/${version}`, {
     method: 'POST',
     credentials: 'include'
   })
@@ -95,7 +95,7 @@ function installApp (name, version) {
 function removeApp (name) {
   if (confirm(`Are you sure you want to remove ${name}?`)) {
     updateInstalling(this, name, true)
-    fetch(`/appstore/remove/${name}`, {
+    fetch(`${window.serverRoutesPrefix}/appstore/remove/${name}`, {
       method: 'POST',
       credentials: 'include'
     })

--- a/packages/server-admin-ui/src/views/security/AccessRequests.js
+++ b/packages/server-admin-ui/src/views/security/AccessRequests.js
@@ -41,7 +41,7 @@ class AccessRequests extends Component {
       expiration: this.state.selectedRequest.expiration || '1y'
     }
     
-    fetch(`/security/access/requests/${identifier}/${approved ? 'approved' : 'denied'}`, {
+    fetch(`${window.serverRoutesPrefix}/security/access/requests/${identifier}/${approved ? 'approved' : 'denied'}`, {
       method: 'PUT',
       credentials: "include",
       headers: {

--- a/packages/server-admin-ui/src/views/security/Devices.js
+++ b/packages/server-admin-ui/src/views/security/Devices.js
@@ -20,7 +20,7 @@ import {
 import EnableSecurity from './EnableSecurity'
 
 export function fetchSecurityDevices () {
-  fetch(`/security/devices`, {
+  fetch(`${window.serverRoutesPrefix}/security/devices`, {
     credentials: 'include'
   })
     .then(response => response.json())
@@ -68,7 +68,7 @@ class Devices extends Component {
       description: this.state.selectedDevice.description
     }
 
-    fetch(`/security/devices/${this.state.selectedDevice.clientId}`, {
+    fetch(`${window.serverRoutesPrefix}/security/devices/${this.state.selectedDevice.clientId}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'
@@ -88,7 +88,7 @@ class Devices extends Component {
   }
 
   deleteDevice (event) {
-    fetch(`/security/devices/${this.state.selectedDevice.clientId}`, {
+    fetch(`${window.serverRoutesPrefix}/security/devices/${this.state.selectedDevice.clientId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -20,12 +20,11 @@ import {
 import EnableSecurity from './EnableSecurity'
 
 export function fetchSecurityConfig () {
-  fetch(`/security/config`, {
+  fetch(`${window.serverRoutesPrefix}/security/config`, {
     credentials: 'include'
   })
     .then(response => response.json())
     .then(data => {
-      console.log(JSON.stringify(data))
       this.setState(data)
     })
 }
@@ -66,7 +65,7 @@ class Settings extends Component {
       allowNewUserRegistration: this.state.allowNewUserRegistration,
       allowDeviceAccessRequests: this.state.allowDeviceAccessRequests
     }
-    fetch('/security/config', {
+    fetch(`${window.serverRoutesPrefix}/security/config`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/server-admin-ui/src/views/security/Users.js
+++ b/packages/server-admin-ui/src/views/security/Users.js
@@ -20,7 +20,7 @@ import {
 import EnableSecurity from './EnableSecurity'
 
 export function fetchSecurityUsers () {
-  fetch(`/security/users`, {
+  fetch(`${window.serverRoutesPrefix}/security/users`, {
     credentials: 'include'
   })
     .then(response => response.json())
@@ -105,7 +105,7 @@ class Users extends Component {
       type: this.state.selectedUser.type || 'readonly'
     }
 
-    fetch(`/security/users/${this.state.selectedUser.userId}`, {
+    fetch(`${window.serverRoutesPrefix}/security/users/${this.state.selectedUser.userId}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: {
         'Content-Type': 'application/json'
@@ -125,7 +125,7 @@ class Users extends Component {
   }
 
   deleteUser (event) {
-    fetch(`/security/users/${this.state.selectedUser.userId}`, {
+    fetch(`${window.serverRoutesPrefix}/security/users/${this.state.selectedUser.userId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SERVERROUTESPREFIX = '/skServer'

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -23,6 +23,7 @@ const {
   getLatestServerVersion,
   getAuthor
 } = require('../modules')
+const { SERVERROUTESPREFIX } = require('../constants')
 
 const npmServerInstallLocations = [
   '/usr/bin/signalk-server',
@@ -40,8 +41,8 @@ module.exports = function(app) {
     start: function() {
       app.post(
         [
-          '/appstore/install/:name/:version',
-          '/appstore/install/:org/:name/:version'
+          `${SERVERROUTESPREFIX}/appstore/install/:name/:version`,
+          `${SERVERROUTESPREFIX}/appstore/install/:org/:name/:version`
         ],
         (req, res) => {
           let name = req.params.name
@@ -80,7 +81,10 @@ module.exports = function(app) {
       )
 
       app.post(
-        ['/appstore/remove/:name', '/appstore/remove/:org/:name'],
+        [
+          `${SERVERROUTESPREFIX}/appstore/remove/:name`,
+          `${SERVERROUTESPREFIX}/appstore/remove/:org/:name`
+        ],
         (req, res) => {
           let name = req.params.name
 
@@ -115,7 +119,7 @@ module.exports = function(app) {
         }
       )
 
-      app.get('/appstore/available/', (req, res) => {
+      app.get(`${SERVERROUTESPREFIX}/appstore/available/`, (req, res) => {
         findPluginsAndWebapps()
           .then(([plugins, webapps]) => {
             getLatestServerVersion(app.config.version)

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -16,6 +16,7 @@
 const _ = require('lodash')
 const config = require('../config/config')
 const { runDiscovery } = require('../discovery')
+import { SERVERROUTESPREFIX } from '../constants'
 
 module.exports = function(app) {
   app.on('discovered', provider => {
@@ -27,11 +28,11 @@ module.exports = function(app) {
     })
   })
 
-  app.get('/providers', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/providers`, (req, res, next) => {
     res.json(getProviders(app.config.settings.pipedProviders))
   })
 
-  app.put('/runDiscovery', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/runDiscovery`, (req, res, next) => {
     app.discoveredProviders = []
     runDiscovery(app)
     res.send('Discovery started')
@@ -67,15 +68,15 @@ module.exports = function(app) {
     })
   }
 
-  app.put('/providers/:id', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/providers/:id`, (req, res, next) => {
     updateProvider(req.params.id, req.body, res)
   })
 
-  app.post('/providers', (req, res, next) => {
+  app.post(`${SERVERROUTESPREFIX}/providers`, (req, res, next) => {
     updateProvider(null, req.body, res)
   })
 
-  app.delete('/providers/:id', (req, res, next) => {
+  app.delete(`${SERVERROUTESPREFIX}/providers/:id`, (req, res, next) => {
     const idx = app.config.settings.pipedProviders.findIndex(
       p => p.id === req.params.id
     )

--- a/src/interfaces/webapps.js
+++ b/src/interfaces/webapps.js
@@ -19,12 +19,13 @@ const fs = require('fs')
 const path = require('path')
 const express = require('express')
 const modulesWithKeyword = require('../modules').modulesWithKeyword
+import { SERVERROUTESPREFIX } from '../constants'
 
 module.exports = function(app) {
   return {
     start: function() {
       mountWebapps(app)
-      mountApi(app)
+      mountApis(app)
     },
     // tslint:disable-next-line: no-empty
     stop: function() {}
@@ -44,8 +45,8 @@ function mountWebapps(app) {
   })
 }
 
-function mountApi(app) {
-  app.get('/webapps', function(req, res, next) {
+function mountApis(app) {
+  app.get(`${SERVERROUTESPREFIX}/webapps`, function(req, res) {
     res.json(app.webapps)
   })
 }

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -37,7 +37,7 @@ const ncp = require('ncp').ncp
 
 const defaultSecurityStrategy = './tokensecurity'
 const skPrefix = '/signalk/v1'
-const serverRoutesPrefix = '/skServer'
+import { SERVERROUTESPREFIX } from './constants'
 
 module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   let securityWasEnabled
@@ -66,7 +66,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     res.redirect('/admin')
   })
 
-  app.put('/restart', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/restart`, (req, res, next) => {
     if (app.securityStrategy.allowRestart(req)) {
       res.send('Restarting...')
       setTimeout(function() {
@@ -77,7 +77,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.get('/loginStatus', (req, res, next) => {
+  const getLoginStatus = (req, res) => {
     const result = app.securityStrategy.getLoginStatus(req)
     result.securityWasEnabled = !_.isUndefined(securityWasEnabled)
 
@@ -85,9 +85,18 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     res.header('Pragma', 'no-cache')
     res.header('Expires', 0)
     res.json(result)
+  }
+
+  app.get(`${SERVERROUTESPREFIX}/loginStatus`, getLoginStatus)
+  //TODO remove after a grace period
+  app.get(`/loginStatus`, (reg, res) => {
+    console.log(
+      `/loginStatus is deprecated, try updating webapps to the latest version`
+    )
+    getLoginStatus(req, res)
   })
 
-  app.get('/security/config', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/security/config`, (req, res, next) => {
     if (app.securityStrategy.allowConfigure(req)) {
       const config = getSecurityConfig(app)
       res.json(app.securityStrategy.getConfig(config))
@@ -96,7 +105,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.put('/security/config', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/security/config`, (req, res, next) => {
     if (app.securityStrategy.allowConfigure(req)) {
       let config = getSecurityConfig(app)
       config = app.securityStrategy.setConfig(config, req.body)
@@ -143,14 +152,14 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   }
 
-  app.get('/security/devices', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/security/devices`, (req, res, next) => {
     if (checkAllowConfigure(req, res)) {
       const config = getSecurityConfig(app)
       res.json(app.securityStrategy.getDevices(config))
     }
   })
 
-  app.put('/security/devices/:uuid', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/security/devices/:uuid`, (req, res, next) => {
     if (checkAllowConfigure(req, res)) {
       const config = getSecurityConfig(app)
       app.securityStrategy.updateDevice(
@@ -166,29 +175,32 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.delete('/security/devices/:uuid', (req, res, next) => {
-    if (checkAllowConfigure(req, res)) {
-      const config = getSecurityConfig(app)
-      app.securityStrategy.deleteDevice(
-        config,
-        req.params.uuid,
-        getConfigSavingCallback(
-          'Device deleted',
-          'Unable to delete device',
-          res
+  app.delete(
+    `${SERVERROUTESPREFIX}/security/devices/:uuid`,
+    (req, res, next) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        app.securityStrategy.deleteDevice(
+          config,
+          req.params.uuid,
+          getConfigSavingCallback(
+            'Device deleted',
+            'Unable to delete device',
+            res
+          )
         )
-      )
+      }
     }
-  })
+  )
 
-  app.get('/security/users', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/security/users`, (req, res, next) => {
     if (checkAllowConfigure(req, res)) {
       const config = getSecurityConfig(app)
       res.json(app.securityStrategy.getUsers(config))
     }
   })
 
-  app.put('/security/users/:id', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/security/users/:id`, (req, res, next) => {
     if (checkAllowConfigure(req, res)) {
       const config = getSecurityConfig(app)
       app.securityStrategy.updateUser(
@@ -200,7 +212,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.post('/security/users/:id', (req, res, next) => {
+  app.post(`${SERVERROUTESPREFIX}/security/users/:id`, (req, res, next) => {
     if (checkAllowConfigure(req, res)) {
       const config = getSecurityConfig(app)
       const user = req.body
@@ -213,57 +225,73 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.put('/security/user/:username/password', (req, res, next) => {
-    if (checkAllowConfigure(req, res)) {
-      const config = getSecurityConfig(app)
-      app.securityStrategy.setPassword(
-        config,
-        req.params.username,
-        req.body,
-        getConfigSavingCallback(
-          'Password changed',
-          'Unable to change password',
-          err
+  app.put(
+    `${SERVERROUTESPREFIX}/security/user/:username/password`,
+    (req, res, next) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        app.securityStrategy.setPassword(
+          config,
+          req.params.username,
+          req.body,
+          getConfigSavingCallback(
+            'Password changed',
+            'Unable to change password',
+            err
+          )
         )
+      }
+    }
+  )
+
+  app.delete(
+    `${SERVERROUTESPREFIX}/security/users/:username`,
+    (req, res, next) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        app.securityStrategy.deleteUser(
+          config,
+          req.params.username,
+          getConfigSavingCallback('User deleted', 'Unable to delete user', res)
+        )
+      }
+    }
+  )
+
+  app.get(
+    `${SERVERROUTESPREFIX}/security/token/:id/:expiration`,
+    (req, res, next) => {
+      app.securityStrategy.generateToken(
+        req,
+        res,
+        next,
+        req.params.id,
+        req.params.expiration
       )
     }
-  })
+  )
 
-  app.delete('/security/users/:username', (req, res, next) => {
-    if (checkAllowConfigure(req, res)) {
-      const config = getSecurityConfig(app)
-      app.securityStrategy.deleteUser(
-        config,
-        req.params.username,
-        getConfigSavingCallback('User deleted', 'Unable to delete user', res)
-      )
+  app.put(
+    `${SERVERROUTESPREFIX}/security/access/requests/:identifier/:status`,
+    (req, res) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        app.securityStrategy.setAccessRequestStatus(
+          config,
+          req.params.identifier,
+          req.params.status,
+          req.body,
+          getConfigSavingCallback(
+            'Request updated',
+            'Unable update request',
+            res
+          )
+        )
+      }
     }
-  })
+  )
 
-  app.get('/security/token/:id/:expiration', (req, res, next) => {
-    app.securityStrategy.generateToken(
-      req,
-      res,
-      next,
-      req.params.id,
-      req.params.expiration
-    )
-  })
-
-  app.put('/security/access/requests/:identifier/:status', (req, res) => {
-    if (checkAllowConfigure(req, res)) {
-      const config = getSecurityConfig(app)
-      app.securityStrategy.setAccessRequestStatus(
-        config,
-        req.params.identifier,
-        req.params.status,
-        req.body,
-        getConfigSavingCallback('Request updated', 'Unable update request', res)
-      )
-    }
-  })
-
-  app.get('/security/access/requests', (req, res) => {
+  app.get(`${SERVERROUTESPREFIX}/security/access/requests`, (req, res) => {
     if (checkAllowConfigure(req, res)) {
       res.json(app.securityStrategy.getAccessRequestsResponse())
     }
@@ -303,7 +331,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
       })
   })
 
-  app.get('/settings', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/settings`, (req, res, next) => {
     const settings = {
       interfaces: {},
       options: {
@@ -337,7 +365,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   })
 
   if (app.securityStrategy.getUsers().length === 0) {
-    app.post('/enableSecurity', (req, res, next) => {
+    app.post(`${SERVERROUTESPREFIX}/enableSecurity`, (req, res, next) => {
       if (app.securityStrategy.isDummy()) {
         app.config.settings.security = { strategy: defaultSecurityStrategy }
         const adminUser = req.body
@@ -393,7 +421,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
   }
 
-  app.put('/settings', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/settings`, (req, res, next) => {
     const settings = req.body
 
     _.forIn(settings.interfaces, (enabled, name) => {
@@ -444,7 +472,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
   })
 
-  app.get('/vessel', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/vessel`, (req, res, next) => {
     let defaults
 
     try {
@@ -485,7 +513,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     res.json(json)
   })
 
-  app.put('/vessel', (req, res, next) => {
+  app.put(`${SERVERROUTESPREFIX}/vessel`, (req, res, next) => {
     let data
 
     try {
@@ -567,27 +595,27 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
   })
 
-  app.get('/availablePaths', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/availablePaths`, (req, res, next) => {
     res.json(app.streambundle.getAvailablePaths())
   })
 
-  app.get('/serialports', (req, res, next) => {
+  app.get(`${SERVERROUTESPREFIX}/serialports`, (req, res, next) => {
     listAllSerialPorts()
       .then(ports => res.json(ports))
       .catch(next)
   })
 
-  app.get(`${serverRoutesPrefix}/hasAnalyzer`, (req, res) => {
+  app.get(`${SERVERROUTESPREFIX}/hasAnalyzer`, (req, res) => {
     commandExists('analyzer')
       .then(() => res.json(true))
       .catch(() => res.json(false))
   })
 
-  app.get(`${serverRoutesPrefix}/sourcePriorities`, (req, res) => {
+  app.get(`${SERVERROUTESPREFIX}/sourcePriorities`, (req, res) => {
     res.json(app.config.settings.sourcePriorities || {})
   })
 
-  app.put(`${serverRoutesPrefix}/sourcePriorities`, (req, res) => {
+  app.put(`${SERVERROUTESPREFIX}/sourcePriorities`, (req, res) => {
     app.config.settings.sourcePriorities = req.body
     app.activateSourcePriorities()
     skConfig.writeSettingsFile(app, app.config.settings, err => {
@@ -601,7 +629,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
   })
 
-  app.post(`${serverRoutesPrefix}/debug`, (req, res) => {
+  app.post(`${SERVERROUTESPREFIX}/debug`, (req, res) => {
     if (!app.logging.enableDebug(req.body.value)) {
       res.status(400).send('invalid debug value')
     } else {
@@ -609,11 +637,11 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     }
   })
 
-  app.get(`${serverRoutesPrefix}/debugKeys`, (req, res) => {
+  app.get(`${SERVERROUTESPREFIX}/debugKeys`, (req, res) => {
     res.json(_.uniq(require('debug').instances.map(i => i.namespace)))
   })
 
-  app.post(`${serverRoutesPrefix}/rememberDebug`, (req, res) => {
+  app.post(`${SERVERROUTESPREFIX}/rememberDebug`, (req, res) => {
     app.logging.rememberDebug(req.body.value)
     res.status(200).send()
   })
@@ -675,7 +703,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
   }
 
-  app.post('/restore', (req, res, next) => {
+  app.post(`${SERVERROUTESPREFIX}/restore`, (req, res, next) => {
     if (!restoreFilePath) {
       res.status(400).send('not exting restore file')
     } else if (!fs.existsSync(restoreFilePath)) {
@@ -736,7 +764,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
       })
   })
 
-  app.post('/validateBackup', (req, res, next) => {
+  app.post(`${SERVERROUTESPREFIX}/validateBackup`, (req, res, next) => {
     const busboy = new Busboy({ headers: req.headers })
     busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
       try {
@@ -800,7 +828,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
 
   app.use(zip())
 
-  app.get('/backup', (req, res) => {
+  app.get(`${SERVERROUTESPREFIX}/backup`, (req, res) => {
     readdir(app.config.configPath).then(filenames => {
       const files = filenames
         .filter(file => {

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -272,7 +272,10 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   )
 
   app.put(
-    `${SERVERROUTESPREFIX}/security/access/requests/:identifier/:status`,
+    [
+      `${SERVERROUTESPREFIX}/security/access/requests/:identifier/:status`,
+      '/security/access/requests/:identifier/:status' // for backwards compatibly with existing clients
+    ],
     (req, res) => {
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -41,6 +41,7 @@ const permissionDeniedMessage =
 const skPrefix = '/signalk/v1'
 const skAPIPrefix = `${skPrefix}/api`
 const skAuthPrefix = `${skPrefix}/auth`
+import { SERVERROUTESPREFIX } from './constants'
 
 const LOGIN_FAILED_MESSAGE = 'Invalid username/password'
 
@@ -224,18 +225,20 @@ module.exports = function(app, config) {
     // tslint:disable-next-line:variable-name
     const do_redir = http_authorize(false)
 
-    app.use('/', http_authorize(false, true))
-    app.use('/apps', http_authorize(false))
-    app.use('/appstore', http_authorize(false))
-    app.use('/plugins', http_authorize(false))
-    app.use('/restart', http_authorize(false))
-    app.use('/runDiscovery', http_authorize(false))
-    app.use('/security', http_authorize(false))
-    app.use('/vessel', http_authorize(false))
-    app.use('/providers', http_authorize(false))
-    app.use('/settings', http_authorize(false))
-    app.use('/webapps', http_authorize(false))
-    app.use('/skServer/inputTest', http_authorize(false))
+    app.use('/', http_authorize(false, true)) //semicolon required
+    ;[
+      '/apps',
+      '/appstore',
+      '/plugins',
+      '/restart',
+      '/runDiscovery',
+      '/security',
+      '/vessel',
+      '/providers',
+      '/settings',
+      '/webapps',
+      '/skServer/inputTest'
+    ].forEach(p => app.use(`${SERVERROUTESPREFIX}${p}`, http_authorize(false)))
 
     app.put(['/logout', `${skAuthPrefix}/logout`], function(req, res) {
       res.clearCookie('JAUTHENTICATION')
@@ -260,19 +263,25 @@ module.exports = function(app, config) {
         handlePermissionDenied(req, res, next)
       }
     }
+    // tslint:disable-next-line:semicolon
+    ;[
+      '/restart',
+      '/runDiscovery',
+      '/plugins',
+      '/appstore',
+      '/security',
+      '/settings',
+      '/backup',
+      '/restore',
+      '/providers',
+      '/vessel'
+    ].forEach(p =>
+      app.use(`${SERVERROUTESPREFIX}${p}`, adminAuthenticationMiddleware(false))
+    )
 
-    app.use('/restart', adminAuthenticationMiddleware(false))
-    app.use('/runDiscovery', adminAuthenticationMiddleware(false))
-    app.use('/plugins', adminAuthenticationMiddleware(false))
-    app.use('/appstore', adminAuthenticationMiddleware(false))
-    app.use('/security', adminAuthenticationMiddleware(false))
-    app.use('/settings', adminAuthenticationMiddleware(false))
-    app.use('/backup', adminAuthenticationMiddleware(false))
-    app.use('/restore', adminAuthenticationMiddleware(false))
-    app.use('/providers', adminAuthenticationMiddleware(false))
-    app.use('/vessel', adminAuthenticationMiddleware(false))
-
+    //TODO remove after grace period
     app.use('/loginStatus', http_authorize(false, true))
+    app.use(`${SERVERROUTESPREFIX}/loginStatus`, http_authorize(false, true))
 
     // tslint:disable-next-line:variable-name
     const no_redir = http_authorize(false)

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -27,7 +27,7 @@ describe('Demo plugin ', () => {
       config: { settings: { port } }
     })
     await server.start()
-    const plugins = await fetch(`http://0.0.0.0:${port}/plugins`).then(res =>
+    const plugins = await fetch(`http://0.0.0.0:${port}/skServer/plugins`).then(res =>
       res.json()
     )
     assert(plugins.find(plugin => plugin.id === 'testplugin'))
@@ -113,7 +113,7 @@ function writePluginConfig (config) {
 }
 
 async function postPluginConfig (port, config) {
-  await fetch(`http://0.0.0.0:${port}/plugins/testplugin/config`, {
+  await fetch(`http://0.0.0.0:${port}/skServer/plugins/testplugin/config`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'

--- a/test/providers.js
+++ b/test/providers.js
@@ -56,7 +56,7 @@ describe('Providers', _ => {
       enabled: true,
       type: 'simple'
     }
-    let result = await fetch(`${url}/providers`, {
+    let result = await fetch(`${url}/skServer/providers`, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(provider)
@@ -66,7 +66,7 @@ describe('Providers', _ => {
     text.should.equal(nullIdText)
 
     delete provider.id
-    result = await fetch(`${url}/providers`, {
+    result = await fetch(`${url}/skServer/providers`, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(provider)
@@ -77,7 +77,7 @@ describe('Providers', _ => {
   })
 
   it('New provider works', async function () {
-    const result = await fetch(`${url}/providers`, {
+    const result = await fetch(`${url}/skServer/providers`, {
       method: 'post',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -112,7 +112,7 @@ describe('Providers', _ => {
         type: 'NMEA0183'
       }
     }
-    let result = await fetch(`${url}/providers/testProvider`, {
+    let result = await fetch(`${url}/skServer/providers/testProvider`, {
       method: 'put',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(provider)
@@ -124,7 +124,7 @@ describe('Providers', _ => {
     pipedProviders[1].id.should.equal('testProvider')
 
     delete provider.id
-    result = await fetch(`${url}/providers/testProvider`, {
+    result = await fetch(`${url}/skServer/providers/testProvider`, {
       method: 'put',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(provider)
@@ -145,7 +145,7 @@ describe('Providers', _ => {
         device: '/dev/usb0'
       }
     }
-    const result = await fetch(`${url}/providers/testProvider`, {
+    const result = await fetch(`${url}/skServer/providers/testProvider`, {
       method: 'put',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(provider)

--- a/test/security.js
+++ b/test/security.js
@@ -184,7 +184,7 @@ describe('Security', () => {
   })
 
   it('admin request fails', async function () {
-    const result = await fetch(`${url}/plugins`)
+    const result = await fetch(`${url}/skServer/plugins`)
     result.status.should.equal(401)
   })
 
@@ -271,7 +271,7 @@ describe('Security', () => {
     json.should.have.property('requestId')
 
     result = await fetch(
-      `${url}/security/access/requests/1235-45653-343453/approved`,
+      `${url}/skServer/security/access/requests/1235-45653-343453/approved`,
       {
         method: 'PUT',
         headers: {
@@ -296,7 +296,7 @@ describe('Security', () => {
     json.accessRequest.permission.should.equal('APPROVED')
     json.accessRequest.should.have.property('token')
 
-    result = await fetch(`${url}/security/devices`, {
+    result = await fetch(`${url}/skServer/security/devices`, {
       headers: {
         Cookie: `JAUTHENTICATION=${adminToken}`
       }
@@ -334,7 +334,7 @@ describe('Security', () => {
     json.state.should.equal('PENDING')
 
     result = await fetch(
-      `${url}/security/access/requests/1235-45653-343455/denied`,
+      `${url}/skServer/security/access/requests/1235-45653-343455/denied`,
       {
         method: 'PUT',
         headers: {
@@ -357,7 +357,7 @@ describe('Security', () => {
     json.accessRequest.should.have.property('permission')
     json.accessRequest.permission.should.equal('DENIED')
 
-    result = await fetch(`${url}/security/devices`, {
+    result = await fetch(`${url}/skServer/security/devices`, {
       headers: {
         Cookie: `JAUTHENTICATION=${adminToken}`
       }


### PR DESCRIPTION
This PR moves all endpoints that are not part of the Signal K specification and mostly for managing the server and its function under common `/skServer` prefix.

The motivation for the change is to
- make it explicit which parts of the api are server-specific and not part of the standard
- leave root paths uncluttered

The PR leaves `/loginStatus` available both at the old and new path so that any webapps that depend on it can smoothly transition to using the new path. Or we can add it to the official `/signalk` api.