### PR TITLE
fix: log offending input in n2kAnalyzer

### DIFF
--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -50,6 +50,7 @@ function N2KAnalyzer (options) {
       that.push(parsed)
       options.app.emit('N2KAnalyzerOut', parsed)
     } catch (ex) {
+      console.error(data)
       console.error(ex.stack)
     }
   })


### PR DESCRIPTION
If analyzer output parsing fails we can log the offending
input to help troubleshooting.