### PR TITLE
fix: scroll properly to connection form's top so that Data Type is shown

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -328,7 +328,7 @@ class ProvidersConfiguration extends Component {
         </Card>
 
         {this.state.selectedProvider && (
-          <div ref='selectedProvider'>
+          <div ref='selectedProvider' style={{ scrollMarginTop:'54px' }}>
             <Card>
               <CardBody>
                 {this.state.selectedProvider.editable ? (


### PR DESCRIPTION
Several people have missed the Data Type selection, because the connection
form is scrolled to the top of the window, not to the top of the visible area.

This hardcodes the header's height as scroll-margin-top so that the top of
the connection form is visible and we don't look like we have support only for
NMEA 2000.