### PR TITLE
fix: unauthenticated subscriptions allowed when allow read only is off

### DIFF
--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -518,7 +518,7 @@ function processSubscribe(app, unsubscribes, spark, assertBufferSize, msg) {
       spark.write.bind(spark),
       message => {
         const filtered = app.securityStrategy.filterReadDelta(
-          spark.request,
+          spark.request.skPrincipal,
           message
         )
         if (filtered) {


### PR DESCRIPTION
The unauthenticated connection gets severed by the server after 60 seconds.