### PR TITLE
fix: beta update not showing as installing

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -290,7 +290,7 @@ module.exports = function(app) {
 
   function sendAppStoreChangedEvent() {
     findPluginsAndWebapps().then(([plugins, webapps]) => {
-      getLatestServerVersion().then(serverVersion => {
+      getLatestServerVersion(app.config.version).then(serverVersion => {
         const result = getAllModuleInfo(plugins, webapps, serverVersion)
         app.emit('serverevent', {
           type: 'APP_STORE_CHANGED',


### PR DESCRIPTION
getLatestServerVersion was being called without the currently
installed version and that shows the latest release as the
latest, so the APP_STORE_CHANGED event did not contain the
installing: true data.