### PR TITLE
chore: convert Docker builds to Github Actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,25 +2,36 @@ name: ci
 
 on:
   push:
-    branches: ghcr
+    branches:
+    - master
+    - latest
+    tags:
+    - '*'
 
 jobs:
   build_docker_images:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: signalk/signalk-server
+          tag-sha: true # add git short SHA as Docker tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v1
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.repository_owner }}
-      #     password: ${{ secrets.CR_PAT }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64,linux/arm/v7
           push: true
-          tags: ghcr.io/signalk/signalk-server:ghcr-test
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+    branches: ghcr
+
+jobs:
+  build_docker_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v1
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.CR_PAT }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm/v7
+          push: true
+          tags: ghcr.io/signalk/signalk-server:ghcr-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG IMAGE_BASE=node
 FROM $IMAGE_BASE:10
 
 #COPY requires one valid argument, second can be nonexistent
-COPY empty_file tmp/qemu-arm-stati[c] /usr/bin/
+COPY empty_file tmp*/qemu-arm-stati[c] /usr/bin/
 
 RUN apt-get update && apt-get -y install libavahi-compat-libdnssd-dev
 


### PR DESCRIPTION
Docker build on Travis and push to Docker Hub is a bit clunky, especially the multiarch part.

This PR adds a Github Action to build x86 and arm multiarch image and push it / them to Docker Hub. The images are additionally tagged with short commit SHA:
The tags created per branch are like so:
```
#24 pushing manifest for docker.io/signalk/signalk-server:ghcr
#24 pushing manifest for docker.io/signalk/signalk-server:ghcr 1.0s done
#24 pushing layers 1.1s done
#24 pushing manifest for docker.io/signalk/signalk-server:sha-868318a
#24 pushing manifest for docker.io/signalk/signalk-server:sha-868318a 0.8s done
```