### PR TITLE
Embeddable webapps as webapps

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Apps/AppsList.js
+++ b/packages/server-admin-ui/src/views/appstore/Apps/AppsList.js
@@ -70,6 +70,7 @@ function mainIcon (app) {
   return (
     <span>
       {app.isWebapp && <i className='icon-grid bg-primary' title="webapp" />}
+      {app.isEmbeddableWebapp && <i className='icon-puzzle bg-primary' title="embeddable webapp" />}
       {app.isPlugin && <i className='icon-settings bg-success' title="plugin" />}
     </span>
   )

--- a/packages/vesselpositions/package.json
+++ b/packages/vesselpositions/package.json
@@ -10,8 +10,6 @@
     "clean": "rimraf ./public"
   },
   "keywords": [
-    "signalk-node-server-addon",
-    "signalk-webapp",
     "signalk-embeddable-webapp"
   ],
   "author": "teppo.kurki@iki.fi",

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -153,8 +153,12 @@ module.exports = function(app) {
   function findPluginsAndWebapps() {
     return Promise.all([
       findModulesWithKeyword('signalk-node-server-plugin'),
+      findModulesWithKeyword('signalk-embeddable-webapp'),
       findModulesWithKeyword('signalk-webapp')
-    ])
+    ]).then(([plugins, embeddableWebapps, webapps]) => {
+      const allWebapps = [].concat(embeddableWebapps).concat(webapps)
+      return [plugins, _.uniqBy(allWebapps, 'name')]
+    })
   }
 
   function getPlugin(id) {
@@ -240,7 +244,8 @@ module.exports = function(app) {
         isPlugin: plugin.package.keywords.some(
           v => v === 'signalk-node-server-plugin'
         ),
-        isWebapp: plugin.package.keywords.some(v => v === 'signalk-webapp')
+        isWebapp: plugin.package.keywords.some(v => v === 'signalk-webapp'),
+        isEmbeddableWebapp: plugin.package.keywords.some(v => v === 'signalk-embeddable-webapp')
       }
 
       const installedModule = existing(name)

--- a/src/interfaces/webapps.js
+++ b/src/interfaces/webapps.js
@@ -20,6 +20,7 @@ const path = require('path')
 const express = require('express')
 const modulesWithKeyword = require('../modules').modulesWithKeyword
 import { SERVERROUTESPREFIX } from '../constants'
+import { uniqBy} from 'lodash'
 
 module.exports = function(app) {
   return {
@@ -61,7 +62,8 @@ function mountWebModules(app, keyword) {
 
 function mountApis(app) {
   app.get(`${SERVERROUTESPREFIX}/webapps`, function(req, res) {
-    res.json(app.webapps)
+    const allWebapps = [].concat(app.webapps).concat(app.embeddablewebapps)
+    res.json(uniqBy(allWebapps, 'name'))
   })
   app.get(`${SERVERROUTESPREFIX}/addons`, function(req, res) {
     res.json(app.addons)


### PR DESCRIPTION
Load embeddable webapps explicitly, not relying on `signalk-webapp` keyword.

Make vesselpositions just an embeddable webapp, not a plain webapp.
