### PR TITLE
feature: move debug log settings under .signalk

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,4 +12,4 @@ Share the resulting file, preferably via Dropbox, Google Drive, Github Gist or s
 
 If the console is available, go to Server -> Server Log and enter the the names of the compononets you want to debug.
 
-Otherwise, you can edit the file `~/.signalk_debug' and add them there. For example: `@signalk/aisreporter,signalk-server:udp-provider`
+Otherwise, you can edit the file `~/.signalk/debug' and add them there. For example: `@signalk/aisreporter,signalk-server:udp-provider`

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ function Server(opts) {
   app.started = false
   _.merge(app, opts)
 
-  app.logging = require('./logging')(app)
   config.load(app)
+  app.logging = require('./logging')(app)
   app.version = '0.0.1'
 
   startSecurity(app, opts ? opts.securityConfig : null)

--- a/src/logging.js
+++ b/src/logging.js
@@ -14,15 +14,13 @@ module.exports = function(app) {
     debugEnabled = process.env.DEBUG
   }
 
-  if (process.env.HOME) {
-    debugPath = path.join(process.env.HOME, '.signalk_debug')
-    if (fs.existsSync(debugPath)) {
-      const enabled = fs.readFileSync(debugPath, 'utf8')
-      if (enabled.length > 0) {
-        debugCore.enable(enabled)
-        debugEnabled = enabled
-        rememberDebug = true
-      }
+  debugPath = path.join(app.config.configPath, 'debug')
+  if (fs.existsSync(debugPath)) {
+    const enabled = fs.readFileSync(debugPath, 'utf8')
+    if (enabled.length > 0) {
+      debugCore.enable(enabled)
+      debugEnabled = enabled
+      rememberDebug = true
     }
   }
 


### PR DESCRIPTION
This changes the ordering in startup so that config is loaded first, then
logging that uses config to find the settings directory. So if you need
to debug log settings you need to use an env variable.