### PR TITLE
fix: hard code debug module to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "cookie": "^0.4.0",
     "cookie-parser": "^1.4.3",
     "cors": "^2.5.2",
-    "debug": "^4.1.1",
+    "debug": "4.2.0",
     "deep-get-set": "^1.1.0",
     "dev-null-stream": "0.0.1",
     "dnssd2": "1.0.0",


### PR DESCRIPTION
Version 4.3.0 removed `instances` which was causing issues with the ServerLog page