### PR TITLE
fix: safe plugin configuration object

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -440,7 +440,12 @@ module.exports = (theApp: any) => {
         app.logging.removeDebug(plugin.packageName)
       }
 
-      plugin.start(configuration, restart)
+      let safeConfiguration = configuration
+      if (!safeConfiguration) {
+        console.error(`${plugin.id}:no configuration data`)
+        safeConfiguration = {}
+      }
+      plugin.start(safeConfiguration, restart)
       debug('Started plugin ' + plugin.name)
       setPluginStartedMessage(plugin)
     } catch (e) {


### PR DESCRIPTION
Now that plugin enable is outside the plugin configuration form and
not part of it the user may enable the plugin without touching the
configuration. Without this check the plugin gets passed undefined
as configuration, that most plugins probably won't expect and will
fail. The failures should not affect the server's base functions,
but the log messages can be cryptic.