### PR TITLE
fix: display of webapps in appstore with tag signalk-webapp only

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -157,7 +157,12 @@ module.exports = function(app) {
       findModulesWithKeyword('signalk-webapp')
     ]).then(([plugins, embeddableWebapps, webapps]) => {
       const allWebapps = [].concat(embeddableWebapps).concat(webapps)
-      return [plugins, _.uniqBy(allWebapps, 'name')]
+      return [
+        plugins,
+        _.uniqBy(allWebapps, plugin => {
+          return plugin.package.name
+        })
+      ]
     })
   }
 


### PR DESCRIPTION
fix: #1203  plugins with tag signalk-webapp only are not displayed in the appstore.