### PR TITLE
fix: nmea2000 output with canboat

### DIFF
--- a/packages/streams/execute.js
+++ b/packages/streams/execute.js
@@ -37,6 +37,7 @@
  */
 
 const Transform = require('stream').Transform
+const { pgnToActisenseSerialFormat } = require('@canboat/canboatjs')
 
 function Execute (options) {
   Transform.call(this, {})
@@ -116,8 +117,8 @@ Execute.prototype.pipe = function (pipeTo) {
   })
 
   if (stdOutEvent === 'nmea2000out') {
-    that.options.app.on('nmea2000outJson', pgn => {
-      that.serial.write(pgnToActisenseSerialFormat(pgn) + '\r\n')
+    that.options.app.on('nmea2000JsonOut', pgn => {
+      that.childProcess.stdin.write(pgnToActisenseSerialFormat(pgn) + '\r\n')
     })
     that.options.app.emit('nmea2000OutAvailable')
   }


### PR DESCRIPTION
nmea2000out configured as stdout event by [streams/simple](https://github.com/SignalK/signalk-server/blob/f02bbb5807e0d238b202445f1cd25ab09d4682cd/packages/streams/simple.js#L251-L256) tried to
also subscribe to nmea2000JsonOut events with conversion in place,
but because the event name was not correct this has never worked.

This commit fixes the event name, writes to child process's stdin
and adds require for the conversion function.

