### PR TITLE
feature: Event Statistics

### DIFF
--- a/packages/server-admin-ui/src/bootstrap.js
+++ b/packages/server-admin-ui/src/bootstrap.js
@@ -52,6 +52,9 @@ const state = {
     installing: []
   },
   loginStatus: {},
+  eventStatistics: {
+    stats: {}
+  },
   serverSpecification: {},
   websocketStatus: 'initial',
   webSocket: null,
@@ -115,6 +118,12 @@ let store = createStore(
       return {
         ...state,
         serverStatistics: action.data
+      }
+    }
+    if (action.type === 'EVENTSTATISTICS') {
+      return {
+        ...state,
+        eventStatistics: action.data
       }
     }
     if (action.type === 'PROVIDERSTATUS') {

--- a/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
+++ b/packages/server-admin-ui/src/views/Dashboard/Dashboard.js
@@ -34,7 +34,7 @@ const Dashboard = props => {
             <CardHeader>Stats</CardHeader>
             <CardBody>
               <Row>
-                <Col xs='12' md='6'>
+                <Col xs='12' md='4'>
                   <div className='callout callout-primary'>
                     <small className='text-muted'>
                       Total server Signal K throughput (deltas/second)
@@ -64,7 +64,7 @@ const Dashboard = props => {
                     <strong className='h5'>{uptimeD} days, {uptimeH} hours, {uptimeM} minutes</strong>
                   </div>
                 </Col>
-                <Col xs='12' md='6'>
+                <Col xs='12' md='4'>
                   <div className='text-muted'>
                     Connection activity (deltas/second)
                   </div>
@@ -101,6 +101,14 @@ const Dashboard = props => {
                         </li>
                       )
                     })}
+                  </ul>
+                </Col>
+                <Col xs='12' md='4'>
+                <div className='text-muted'>
+                    Event activity (events/second)
+                  </div>
+                  <ul className='horizontal-bars type-2'>
+                    {eventStats(props.eventStatistics)}
                   </ul>
                 </Col>
               </Row>
@@ -163,6 +171,19 @@ const Dashboard = props => {
   )
 }
 
+function eventStats(eventStatistics) {
+  return Object.entries(eventStatistics.stats)
+    .filter(([key, value]) => value > 0)
+    .map(([key, value]) => {
+    return (
+      <li key={key}>
+        <span className='title'>{key}</span>
+        <span className='value'>{(value / eventStatistics.periodMillis * 1000).toFixed(1) }</span>
+      </li>
+    )
+  })
+}
+
 function pluginNameLink (id) {
   return (<a href={'#/serverConfiguration/plugins/' + id}>{id}</a>)
 }
@@ -171,8 +192,9 @@ function providerIdLink (id) {
   return (<a href={'#/serverConfiguration/connections/' + id}>{id}</a>)
 }
 
-export default connect(({ serverStatistics, websocketStatus, providerStatus }) => ({
+export default connect(({ serverStatistics, websocketStatus, providerStatus, eventStatistics }) => ({
   serverStatistics,
+  eventStatistics,
   websocketStatus,
   providerStatus
 }))(Dashboard)

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,63 @@
+import Debug, { Debugger } from 'debug'
+
+interface App {
+  emit: (...args: any[]) => void
+}
+
+interface EventData {
+  count: number
+  debug: Debugger
+}
+
+export function startEventStats(app: App) {
+  const eventDataHolder: {
+    [eventName: string]: EventData
+  } = {}
+
+  const origEmit = app.emit
+  app.emit = (...args: any[]) => {
+    const [eventName] = args
+    if (eventName !== 'serverlog') {
+      let eventDebugStat = eventDataHolder[eventName]
+      if (!eventDebugStat) {
+        const debug = Debug(`signalk-server:events:${eventName}`)
+        eventDataHolder[eventName] = eventDebugStat = {
+          debug,
+          count: 0
+        }
+      }
+      if (eventDebugStat.debug.enabled) {
+        eventDebugStat.debug(args.slice(1))
+      }
+      eventDebugStat.count++
+    }
+    origEmit.apply(app, [...args])
+  }
+
+  let lastStats: { [eventName: string]: number } = {}
+  let lastRun = Date.now()
+
+  return setInterval(() => {
+    const now = Date.now()
+    const statsNow: { [eventName: string]: number } = Object.entries(
+      eventDataHolder
+    ).reduce((acc, [eventName, stats]) => {
+      acc[eventName] = stats.count
+      return acc
+    }, {} as any)
+    app.emit('serverevent', {
+      type: 'EVENTSTATISTICS',
+      from: 'signalk-server',
+      data: {
+        periodMillis: now - lastRun,
+        periodEndMillis: now,
+        stats: Object.entries(statsNow).reduce((acc, [eventName, count]) => {
+          acc[eventName] = count - (lastStats[eventName] || 0)
+          return acc
+        }, {} as any)
+      }
+    })
+    lastRun = now
+    lastStats = statsNow
+  }, 5 * 1000)
+}


### PR DESCRIPTION
We refer to _events_ in for example output configuration, but they are a pretty well hidden concept. This PR attempts to make events more approachable by showing event statistics in Dashboard.

There's been the option to see events in the system log if you know which debug keys to turn on. The dashboard events could be used as links to Server Log that turn on that particular event.

The code stores now also the total number of each event - maybe that would be useful to show? If you are tracking some event generation just showing the stats for last 5 seconds is not very useful. Or a sparkline graph?

Then again I am not dead set on having this up front in Dashboard, as just adding more and more stuff to the dashboard makes it messy.

![image](https://user-images.githubusercontent.com/1049678/103138495-f52bc280-46db-11eb-9a6d-bc15392bb2b9.png)
