### PR TITLE
feature: remove old webapps

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,10 +121,8 @@
   "optionalDependencies": {
     "@signalk/freeboard-sk": "^1.0.0",
     "@signalk/instrumentpanel": "0.x",
-    "@signalk/sailgauge": "^1.1.0",
     "@signalk/set-system-time": "^1.2.0",
     "@signalk/signalk-to-nmea0183": "^1.0.0",
-    "@signalk/simplegauges": "^1.0.1",
     "@signalk/vesselpositions": "^1.0.0",
     "@signalk/zones": "^1.0.0",
     "mdns": "^2.5.1",

--- a/src/modules.test.js
+++ b/src/modules.test.js
@@ -8,7 +8,6 @@ const {
   getLatestServerVersion
 } = require('./modules')
 
-
 describe('modulesWithKeyword', () => {
   it('returns a list of modules with one "installed" update in config dir', () => {
     const expectedModules = [
@@ -16,7 +15,9 @@ describe('modulesWithKeyword', () => {
       '@signalk/instrumentpanel'
     ]
     const updateInstalledModule = '@signalk/instrumentpanel'
-    const indexOfInstalledModule = expectedModules.indexOf(updateInstalledModule)
+    const indexOfInstalledModule = expectedModules.indexOf(
+      updateInstalledModule
+    )
 
     const testTempDir = path.join(
       require('os').tmpdir(),
@@ -53,7 +54,9 @@ describe('modulesWithKeyword', () => {
     const moduleList = modulesWithKeyword(app, 'signalk-webapp')
     chai.expect(_.map(moduleList, 'module')).to.eql(expectedModules)
     chai.expect(moduleList[0].location).to.not.eql(tempNodeModules)
-    chai.expect(moduleList[indexOfInstalledModule].location).to.eql(tempNodeModules)
+    chai
+      .expect(moduleList[indexOfInstalledModule].location)
+      .to.eql(tempNodeModules)
   })
 })
 

--- a/src/modules.test.js
+++ b/src/modules.test.js
@@ -13,9 +13,7 @@ describe('modulesWithKeyword', () => {
   it('returns a list of modules with one "installed" update in config dir', () => {
     const expectedModules = [
       '@signalk/freeboard-sk',
-      '@signalk/instrumentpanel',
-      '@signalk/sailgauge',
-      '@signalk/simplegauges'
+      '@signalk/instrumentpanel'
     ]
     const updateInstalledModule = '@signalk/instrumentpanel'
     const indexOfInstalledModule = expectedModules.indexOf(updateInstalledModule)


### PR DESCRIPTION
Do not install sailgauge and simplegauges by default, as they
are getting a little dated. Furthermore one can not get rid of
any of the default webapps, as they are going to be reinstalled
with next server update.