### PR TITLE
feature: shortcut resources handling in rest.js

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -31,6 +31,10 @@ module.exports = function(app) {
   const apiPathPrefix = pathPrefix + versionPrefix + '/api/'
   const streamPath = pathPrefix + versionPrefix + '/stream'
 
+  const KNOWN_OTHER_PATH_PREFIXES = [
+    'resources'
+  ]
+
   return {
     start: function() {
       app.use('/', express.static(__dirname + '/../../public'))
@@ -43,6 +47,11 @@ module.exports = function(app) {
         }
 
         path = path.length > 0 ? path.replace(/\/$/, '').split('/') : []
+
+        if (KNOWN_OTHER_PATH_PREFIXES.indexOf(path[0]) >= 0) {
+          next()
+          return
+        }
 
         if (path.length > 4 && path[path.length - 1] === 'meta') {
           let meta = getMetadata(path.slice(0, path.length - 1).join('.'))


### PR DESCRIPTION
Fixes #758.

The rest handler can shortcut known other path prefixes early
in the processing. The issue in #758 is way less pronounced
now, I think deltacache was in more use at the time of the
writing, but I think this shortcut makes still sense.