### PR TITLE
feat: set current working directory in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN mkdir -p /home/node/.signalk
 
 EXPOSE 3000
 ENV IS_IN_DOCKER true
+WORKDIR /home/node/.signalk
 ENTRYPOINT /home/node/signalk/bin/signalk-server --securityenabled


### PR DESCRIPTION
Non-Docker default setup set current working directory as
/Users/tjk/.signalk. This is a pretty sane default, as for example
files created from non-SK stuff like node-RED end up in
the settings folder. In practise Docker users will manage
the settings directory themselves, so this works also
in that respect.