### PR TITLE
fix: concurrent delta ACL filtering

### DIFF
--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -608,10 +608,11 @@ module.exports = function(app, config) {
   strategy.filterReadDelta = (principal, delta) => {
     const configuration = getConfiguration()
     if (delta.updates && configuration.acls && configuration.acls.length) {
+      const filtered = { ...delta }
       const context =
         delta.context === app.selfContext ? 'vessels.self' : delta.context
 
-      delta.updates = delta.updates
+      filtered.updates = delta.updates
         .map(update => {
           let res = (update.values || update.meta)
             .map(valuePath => {
@@ -635,7 +636,7 @@ module.exports = function(app, config) {
           }
         })
         .filter(update => update != null)
-      return delta.updates.length > 0 ? delta : null
+      return filtered.updates.length > 0 ? filtered : null
     } else if (!principal) {
       return null
     } else {


### PR DESCRIPTION
ACL filtering was modifying a shared delta's updates. In a case
where the first handled ws connection would not have access to
a path a second ws connection would get served the same delta where
the limited access path was no longer there.