### PR TITLE
feature: more strict connection id naming, disable edit

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -89,6 +89,7 @@ class BasicProvider extends Component {
               type='text'
               name='id'
               value={this.props.value.id}
+              disabled={!this.props.value.isNew}
               onChange={event => {
                 const dummyEvent = {
                   target: {

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -89,7 +89,16 @@ class BasicProvider extends Component {
               type='text'
               name='id'
               value={this.props.value.id}
-              onChange={event => this.props.onChange(event)}
+              onChange={event => {
+                const dummyEvent = {
+                  target: {
+                    name: event.target.name,
+                    type: event.target.type,
+                    value: (event.target.value || '').replace(/[^a-zA-Z\d-_]/g,'')
+                  }
+                }
+                this.props.onChange(dummyEvent)
+              }}
             />
           </Col>
         </FormGroup>


### PR DESCRIPTION
Fixes #1252 . Makes connection id alphanumeric with - and _ and disable editing the id for existing connections, as that does not work.