### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The server can also automatically discover other Signal K devices and connect to
 
 HTTPS
 -----
-Https is enabled by default unless you disable it with `"ssl":true` in the [settings file](https://github.com/SignalK/signalk-server-node/blob/master/settings/aava-non-ssl-file-settings.json#L9). If no `ssl-key.pem` & `ssl-cert.pem` files are found under settings they will be created. If you need to configure a certificate chain add it in `ssl-chain.pem` under settings.
+Https is enabled by default unless you disable it with `"ssl":false` in the [settings file](https://github.com/SignalK/signalk-server-node/blob/master/settings/aava-non-ssl-file-settings.json#L9). If no `ssl-key.pem` & `ssl-cert.pem` files are found under settings they will be created. If you need to configure a certificate chain add it in `ssl-chain.pem` under settings.
 
 By default the server listens to both http and https in the same port.
 


### PR DESCRIPTION
Is Https enabled by default? If so you can disable it with `"ssl:false`. Otherwise, this sentence should be:

Https is disabled by default unless you enable it with `"ssl:true`

Right now, it's not clear what the default actually is.