### PR TITLE
revert: "fix: existing plugins with no configuration don't show properly in the ui"

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -276,9 +276,6 @@ module.exports = (theApp: any) => {
         debug('Plugins disabled by configuration')
         options.enabled = false
       }
-      if (!options.configuration) {
-        options.configuration = {}
-      }
       debug(optionsAsString)
       return options
     } catch (e) {


### PR DESCRIPTION
Reverts SignalK/signalk-server#1268

This change made so plugins could be enabled without configuring them

Now there's a little display issue, but this problem is much worse.