### PR TITLE
fix: plugin configuration being occasionally empty

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -253,11 +253,12 @@ module.exports = (theApp: any) => {
     callback: (err: NodeJS.ErrnoException | null) => void
   ) {
     const config = JSON.parse(JSON.stringify(data))
-    fs.writeFile(
-      pathForPluginId(pluginId),
-      JSON.stringify(data, null, 2),
-      callback
-    )
+    try {
+      fs.writeFileSync(pathForPluginId(pluginId), JSON.stringify(data, null, 2))
+      callback(null)
+    } catch (err) {
+      callback(err)
+    }
   }
 
   function getPluginOptions(id: string) {


### PR DESCRIPTION
Sometimes users would see their plugin configurations looking empty, even if the configuration file is there with the content.

This fixes a race condition, where we were reading the configuration data to be sent to the plugin configuration UI while a plugin's configuration data was being written and the ui would see an empty configuration.