### PR TITLE
feat: add optional setting for log files to keep and downloading all log files as a zip file

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Logging.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Logging.js
@@ -70,8 +70,11 @@ class Settings extends Component {
               </CardBody>
               <CardFooter>
                 <small className='text-muted'>
-                  Click button to download each logfile
+                  Click button to download each logfile or
                 </small>
+                <a href={`${window.serverRoutesPrefix}/ziplogs`}>
+                  <Button className='m-2'>Get all logs in one ZIP file</Button>
+                </a>
               </CardFooter>
             </Card>
           </Col>

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -258,7 +258,43 @@ class ServerSettings extends Component {
                       files in Multiplexed format in this directory
                     </FormText>
                   </Col>
-              </FormGroup>
+                </FormGroup>
+                <FormGroup row>
+                  <Col md='2'>
+                    <Label>Keep only most recent logs</Label>
+                  </Col>
+                  <Col>
+                    <FormGroup check>
+                      <Label className='switch switch-text switch-primary'>
+                        <Input
+                          type='checkbox'
+                          name='keepMostRecentLogsOnly'
+                          id='keepMostRecentLogsOnly'
+                          className='switch-input'
+                          onChange={this.handleChange}
+                          checked={this.state.keepMostRecentLogsOnly}
+                        />
+                        <span
+                          className='switch-label'
+                          data-on='On'
+                          data-off='Off'
+                        />
+                        <span className='switch-handle' />
+                      </Label>
+                    </FormGroup>
+                  </Col>
+                  <Col>
+                    <Input
+                      type='text'
+                      name='logCountToKeep'
+                      onChange={this.handleChange}
+                      value={this.state.logCountToKeep}
+                    />
+                    <FormText color='muted'>
+                      How many hourly files to keep
+                    </FormText>
+                  </Col>
+                </FormGroup>
               </Form>
             </CardBody>
             <CardFooter>

--- a/packages/streams/README.md
+++ b/packages/streams/README.md
@@ -1,0 +1,14 @@
+# @signalk/streams
+
+Used within the [Signal K](http://signalk.org) [Node Server](https://github.com/SignalK/signalk-server-node) for streaming and converting input data in different formats.
+
+The code is not compiled and is not more effective, but allows using the streams and their conversions independently outside the server.
+
+## Development
+
+* Install dev packages with `npm i`.
+* Edit files with `/src`.
+* `npm link`
+* `cd ../../`
+* `npm link @signalk/streams`
+* Restart signalk `npm start`

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -381,6 +381,8 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
       },
       loggingDirectory: app.config.settings.loggingDirectory,
       pruneContextsMinutes: app.config.settings.pruneContextsMinutes || 60,
+      keepMostRecentLogsOnly: app.config.settings.keepMostRecentLogsOnly || false,
+      logCountToKeep: app.config.settings.logCountToKeep || 24,
       runFromSystemd: process.env.RUN_FROM_SYSTEMD === 'true'
     }
 
@@ -498,6 +500,16 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     if (!_.isUndefined(settings.pruneContextsMinutes)) {
       app.config.settings.pruneContextsMinutes = Number(
         settings.pruneContextsMinutes
+      )
+    }
+
+    if (!_.isUndefined(settings.keepMostRecentLogsOnly)) {
+      app.config.settings.keepMostRecentLogsOnly = settings.keepMostRecentLogsOnly
+    }
+
+    if (!_.isUndefined(settings.logCountToKeep)) {
+      app.config.settings.logCountToKeep = Number(
+        settings.logCountToKeep
       )
     }
 


### PR DESCRIPTION
On a memory limited device like Raspberry PI unlimited growth of the log files is undesirable.

This changes adds two controls to the Server Settings panel:
- Switch "Keep only most recent logs" to enable/disable this feature
- Input "How many hourly files to keep" allows user to specify how many most recent hourly logs the server will keep

Since it's difficult for the mobile user to download text files one by one the button [Get all logs in one ZIP] is added.