### PR TITLE
fix: security configuration validation

### DIFF
--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -333,7 +333,7 @@ module.exports = function(app, config) {
   strategy.validateConfiguration = newConfiguration => {
     const configuration = getConfiguration()
     const theExpiration = newConfiguration.expiration || '1h'
-    jwt.sign('dummyPayload', configuration.secretKey, {
+    jwt.sign({ dummy: 'payload' }, configuration.secretKey, {
       expiresIn: theExpiration
     })
   }


### PR DESCRIPTION
Security configuration validation introduced in #1267 had an
error in testing the login session timeout.

https://www.npmjs.com/package/jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback
'exp or any other claim is only set if the payload is an object literal.'