### PR TITLE
Add missing units from DataBrowser

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -26,6 +26,7 @@
     "font-awesome": "^4.7.0",
     "html-webpack-plugin": "^5.0.0-alpha.6",
     "jsonlint-mod": "^1.7.6",
+    "jsonpath-plus": "^5.0.7",
     "lodash.get": "^4.4.2",
     "lodash.remove": "^4.7.0",
     "lodash.set": "^4.3.2",

--- a/packages/server-admin-ui/src/views/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import get from 'lodash.get'
+import {JSONPath} from 'jsonpath-plus'
 import JSONTree from 'react-json-tree'
 import {
   Badge,
@@ -27,6 +28,7 @@ const metaStorageKey = 'admin.v1.dataBrowser.meta'
 const pauseStorageKey = 'admin.v1.dataBrowser.v1.pause'
 const contextStorageKey = 'admin.v1.dataBrowser.context'
 const searchStorageKey = 'admin.v1.dataBrowser.search'
+const editStorageKey = 'admin.v1.dataBrowser.edit'
 
 function fetchSources () {
   fetch(`/signalk/v1/api/sources`, {
@@ -49,18 +51,48 @@ function fetchSources () {
     })
 }
 
+function fetchBaseDeltas() {
+  fetch(`/skServer/baseDeltas`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    credentials: 'include'
+  })
+    .then(response => response.json())
+    .then(response => {
+    this.setState({ ...this.state, baseDeltas: response })
+    this.fetchUnit(response)
+  })
+
+}
+
+function fetchUnitList() {
+  fetch(`/skServer/listUnits`, {
+    credentials: 'include'
+  })
+  .then(response => response.json())
+  .then(response => {
+    this.setState({...this.state, unitList: response})
+  })
+}
+
 
 class DataBrowser extends Component {
   constructor (props) {
     super(props)
     this.state = {
+      edit: localStorage.getItem(editStorageKey) === 'true',
       hasData: false,
       webSocket: null,
       didSubscribe: false,
       pause: localStorage.getItem(pauseStorageKey) === 'true',
       includeMeta: localStorage.getItem(metaStorageKey) === 'true',
       data: {},
+      unit: [],
       meta: {},
+      baseDeltas: {},
+      unitList: {},
       context: localStorage.getItem(contextStorageKey) || 'self',
       search: localStorage.getItem(searchStorageKey) || ''
     }
@@ -71,6 +103,12 @@ class DataBrowser extends Component {
     this.handleContextChange = this.handleContextChange.bind(this)
     this.handleSearch = this.handleSearch.bind(this)
     this.handleMeta = this.handleMeta.bind(this)
+    this.handleUnitChange = this.handleUnitChange.bind(this)
+    this.handleEdit = this.handleEdit.bind(this)
+    this.handleSave = this.handleSave.bind(this)
+    this.fetchUnit = this.fetchUnit.bind(this)
+    this.fetchBaseDeltas = fetchBaseDeltas.bind(this)
+    this.fetchUnitList = fetchUnitList.bind(this)
   }
 
   handleMessage(msg) {
@@ -78,7 +116,7 @@ class DataBrowser extends Component {
     if ( this.state.pause ) {
       return
     }
-    
+
     if ( msg.context && msg.updates ) {
       const key = msg.context === this.state.webSocket.skSelf ? 'self' : msg.context
 
@@ -95,7 +133,7 @@ class DataBrowser extends Component {
 
       let context = this.state.data[key]
       let contextMeta = this.state.meta[key]
-      
+
       msg.updates.forEach(update => {
         if ( update.values ) {
           let pgn = update.source && update.source.pgn && `(${update.source.pgn})`
@@ -130,7 +168,7 @@ class DataBrowser extends Component {
           })
         }
       })
-      
+
       if ( isNew || (this.state.context && this.state.context === key) ) {
         this.setState({...this.state, hasData:true, data: this.state.data, meta: this.state.meta  })
       }
@@ -147,7 +185,7 @@ class DataBrowser extends Component {
           period: 2000
         }]
       }
-      
+
       this.props.webSocket.send(JSON.stringify(sub))
       this.state.webSocket = this.props.webSocket
       this.state.didSubscribe = true
@@ -168,33 +206,148 @@ class DataBrowser extends Component {
       this.props.webSocket.messageHandler = null
     }
   }
-  
+
   componentDidMount() {
     this.fetchSources()
     this.subscribeToDataIfNeeded()
+    this.fetchBaseDeltas()
+    this.fetchUnitList()
   }
 
   componentDidUpdate() {
     this.subscribeToDataIfNeeded()
   }
-  
+
   componentWillUnmount () {
     this.unsubscribeToData()
   }
 
   handleContextChange(event) {
     this.setState({...this.state, context: event.target.value})
-    localStorage.setItem(contextStorageKey, event.target.value)  
+    localStorage.setItem(contextStorageKey, event.target.value)
   }
 
   handleSearch(event) {
     this.setState({...this.state, search: event.target.value})
-    localStorage.setItem(searchStorageKey, event.target.value)  
+    localStorage.setItem(searchStorageKey, event.target.value)
   }
 
   handleMeta(event) {
     this.setState({...this.state, includeMeta: event.target.checked})
     localStorage.setItem(metaStorageKey, event.target.checked)
+  }
+
+  handleEdit(event) {
+    this.setState({...this.state, edit: event.target.checked})
+    localStorage.setItem(editStorageKey, event.target.checked)
+  }
+
+  fetchUnit(basedeltas){
+    basedeltas.map((resArray) => { //context also?
+      resArray.updates.map((update) => {
+        if (update.meta){
+          update.meta.map((metas, index) => {
+            if (metas.path && metas.value.units) {
+              let units = this.state.unit
+              units[metas.path] = metas.value.units
+              this.setState({...this.state, unit: units})
+            }
+          })
+        }
+      })
+    })
+  }
+
+  handleUnitChange(event, key) {
+    let stateUnitTemp = this.state.unit
+
+    stateUnitTemp[key.split('$')[0]] = event.target.value
+    this.setState({
+      ...this.state, unit: stateUnitTemp
+    })
+
+
+    const changedObject = {
+      "context": 'vessels.' + this.state.context, //@TODO shouldn't this.state.context be vessels.*?
+      "updates": [
+        {
+          "meta": [
+            {
+              "path": key.split('$')[0],
+              "value": {
+                "units": event.target.value
+              }
+            }
+          ]
+        }
+      ]
+    }
+
+    let baseDeltaTemp = this.state.baseDeltas
+
+    const path = JSONPath({json:baseDeltaTemp, path:'$[*].updates[*].meta[*].path',resultType:"all"});
+    if(Array.isArray(path) && path.length){
+      for ( const pth in path){
+        const nPath = path[pth].pointer.split('/')
+        nPath.shift()
+        if (nPath.length == 6){
+          if (baseDeltaTemp[nPath[0]].context == 'vessels.self'){
+            if (path[pth].value == key.split('$')[0]){
+              baseDeltaTemp[nPath[0]][nPath[1]][nPath[2]][nPath[3]][nPath[4]].value.units = event.target.value
+              this.setState({
+                ...this.state, baseDeltas : baseDeltaTemp
+              })
+              this.handleSave()
+              break
+            } else if (pth == path.length - 1){
+              baseDeltaTemp[nPath[0]][nPath[1]][nPath[2]][nPath[3]].push(changedObject.updates[0].meta[0])
+              this.setState({
+                ...this.state, baseDeltas : baseDeltaTemp
+              })
+              this.handleSave()
+            }
+          }
+        }
+      }
+    } else {
+      const sPath = JSONPath({json:baseDeltaTemp, path:'$[*].updates[*]', resultType:"all"});
+      if(Array.isArray(sPath) && sPath.length){
+        for ( const pth in sPath){
+          const nPath = sPath[pth].pointer.split('/')
+          nPath.shift()
+          if (nPath.length == 4){
+            if (baseDeltaTemp[nPath[0]].context == 'vessels.self'){
+              baseDeltaTemp[nPath[0]][nPath[1]].push(changedObject.updates[0]);
+              this.setState({
+                ...this.state, baseDeltas : baseDeltaTemp
+              })
+              this.handleSave()
+              break
+            }
+          } else {
+            baseDeltaTemp.push(changedObject)
+            this.setState({
+              ...this.state, baseDeltas : baseDeltaTemp
+            })
+            this.handleSave()
+          }
+        }
+      }
+    }
+  }
+
+  handleSave () {
+
+    var payload = {
+    }
+    fetch(`${window.serverRoutesPrefix}/baseDeltas`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(this.state.baseDeltas),
+      credentials: 'include'
+    })
   }
 
   handlePause (event) {
@@ -274,6 +427,24 @@ class DataBrowser extends Component {
                               <span className='switch-handle' />
           </Label>{' '}Pause
           </Col>
+          <Col xs='8' md='2'>
+          <Label className='switch switch-text switch-primary'>
+                              <Input
+                                type='checkbox'
+                                id="Edit"
+                                name='edit'
+                                className='switch-input'
+                                onChange={this.handleEdit}
+                                checked={this.state.edit}
+                              />
+                              <span
+                                className='switch-label'
+                                data-on='Yes'
+                                data-off='No'
+                              />
+                              <span className='switch-handle' />
+          </Label>{' '}Edit units
+          </Col>
           </FormGroup>
           { this.state.context && this.state.context !== 'none' &&  (
           <FormGroup row>
@@ -318,7 +489,25 @@ class DataBrowser extends Component {
                   null,
                   typeof data.value === 'object' && Object.keys(data.value || {}).length > 1 ? 2 : 0)
                 const meta = this.state.meta[this.state.context][data.path]
-                const units = meta && meta.units ? meta.units : ''
+                const valueIsNumber = typeof data.value === 'number' ? true : false //do not show or edit units for objects
+                var unitFromUser = this.state.unit[key.split('$')[0]]?true:false
+                const userUnit = typeof this.state.unit[key.split('$')[0]] == 'string' ? this.state.unit[key.split('$')[0]] : ''
+                  const units = meta && meta.units && !unitFromUser  ? meta.units : !valueIsNumber || !this.state.edit? userUnit : <Input
+                  type='select'
+                      name='unit'
+                      value={this.state.unit[key.split('$')[0]]}
+                      onChange={(e) => {this.handleUnitChange(e, key);}}
+                      >
+                      <option value=''>no unit</option>
+
+                      {Object.keys(this.state.unitList.properties || {}).sort().map(key => {
+                        if (key != 'deg'){
+                        return (
+                            <option key={key} value={key}>{key}: { this.state.unitList.properties[key].quantity }</option>
+                        )}
+                    })}
+                      </Input>
+
                 const path = key.substring(0, key.lastIndexOf('.'))
 
                 return (
@@ -332,12 +521,11 @@ class DataBrowser extends Component {
                 )
               })
           }
-       
           </tbody>
           </Table>
 
         )}
-        
+
         {this.state.includeMeta && this.state.context && this.state.context !== 'none' && (
           <Table responsive bordered striped size='sm'>
             <thead>
@@ -361,7 +549,7 @@ class DataBrowser extends Component {
           </tbody>
             </Table>
           )}
-         
+
              </Form>
             </CardBody>
           </Card>
@@ -377,8 +565,9 @@ class DataBrowser extends Component {
             </Card>
         )}
         </div>
+
       )
-    
+
   }
 }
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -279,16 +279,20 @@ function sendBaseDeltas(app) {
   })
 }
 
+function readBaseDeltas(app) {
+  return app.config.baseDeltaEditor.deltas
+}
+
 function writeDefaultsFile(app, defaults, cb) {
   fs.writeFile(getDefaultsPath(app), JSON.stringify(defaults, null, 2), cb)
 }
 
-function writeBaseDeltasFileSync(app) {
-  app.config.baseDeltaEditor.saveSync(getBaseDeltasPath(app))
-}
-
 function writeBaseDeltasFile(app) {
   return app.config.baseDeltaEditor.save(getBaseDeltasPath(app))
+}
+
+function writeBaseDeltasFileSync(app) {
+  app.config.baseDeltaEditor.saveSync(getBaseDeltasPath(app))
 }
 
 function setSelfSettings(app) {
@@ -435,9 +439,11 @@ const pluginsPackageJsonTemplate = {
 module.exports = {
   load,
   getConfigDirectory,
+  getBaseDeltasPath,
   writeSettingsFile,
   writeDefaultsFile,
   readDefaultsFile,
   sendBaseDeltas,
+  readBaseDeltas,
   writeBaseDeltasFile
 }

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -21,12 +21,14 @@ const page = require('./page')
 const debug = require('debug')('signalk-server:serverroutes')
 const path = require('path')
 const _ = require('lodash')
+const units = require('@signalk/signalk-schema').units
 const skConfig = require('./config/config')
 const { getHttpPort, getSslPort } = require('./ports')
 const express = require('express')
 const { getAISShipTypeName } = require('@signalk/signalk-schema')
 const { queryRequest } = require('./requestResponse')
 const { listAllSerialPorts } = require('./serialports')
+const config = require('./config/config')
 const commandExists = require('command-exists')
 const { getAuthor, restoreModules } = require('./modules')
 const zip = require('express-easy-zip')
@@ -407,6 +409,22 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     })
 
     res.json(settings)
+  })
+
+  app.get(`${SERVERROUTESPREFIX}/baseDeltas`, (req, res, next) => {
+    const filename = config.getBaseDeltasPath(app)
+    const basedeltas = JSON.parse(fs.readFileSync(filename))
+    res.json(basedeltas)
+  })
+
+  app.get(`${SERVERROUTESPREFIX}/listUnits`, (req, res, next) => {
+    res.json(units)
+  })
+
+  app.put(`${SERVERROUTESPREFIX}/baseDeltas`, (req, res) => {
+    const filename = config.getBaseDeltasPath(app)
+    const response = fs.writeFileSync(filename, JSON.stringify(req.body, null, 2))
+    res.json(response)
   })
 
   if (app.securityStrategy.getUsers().length === 0) {


### PR DESCRIPTION
A lot of paths in use are not in the specification, and thus do not have units or other metadata. This PR adds a way to select missing units directly from DataBrowser. 