### PR TITLE
feat: use baseDeltas by default

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -67,7 +67,7 @@ function load(app) {
       let defaults = getFullDefaults(app)
       if (defaults) {
         convertOldDefaultsToDeltas(app.config.baseDeltaEditor, defaults)
-        if (app.config.settings.useBaseDeltas) {
+        if (typeof app.config.settings.useBaseDeltas == 'undefined' || app.config.settings.useBaseDeltas) {
           writeBaseDeltasFileSync(app)
         } else {
           app.config.hasOldDefaults = true


### PR DESCRIPTION
It is better to maintain one single file for metadata and static values.