### PR TITLE
feature: clean up interfaces settings

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -166,7 +166,7 @@ class ServerSettings extends Component {
                       {Object.keys(this.state.options).map(name => {
                         return (
                           <div key={name}>
-                            <Label className='switch switch-text switch-primary'>
+                            <Label style={{marginRight: '15px'}} className='switch switch-text switch-primary'>
                               <Input
                                 type='checkbox'
                                 id={name}
@@ -181,8 +181,8 @@ class ServerSettings extends Component {
                                 data-off='Off'
                               />
                               <span className='switch-handle' />
-                            </Label>{' '}
-                            {name}
+                            </Label>
+                            <span style={{lineHeight: '23px'}}>{name}</span>
                           </div>
                         )
                       })}
@@ -196,10 +196,10 @@ class ServerSettings extends Component {
                   </Col>
                   <Col md={fieldColWidthMd}>
                     <FormGroup check>
-                      {Object.keys(this.state.interfaces).map(name => {
+                      {Object.keys(SettableInterfaces).map(name => {
                         return (
                           <div key={name}>
-                            <Label className='switch switch-text switch-primary'>
+                            <Label style={{marginRight: '15px'}} className='switch switch-text switch-primary'>
                               <Input
                                 type='checkbox'
                                 id={name}
@@ -214,8 +214,8 @@ class ServerSettings extends Component {
                                 data-off='Off'
                               />
                               <span className='switch-handle' />
-                            </Label>{' '}
-                            {name}
+                            </Label>
+                            <span style={{lineHeight: '24px'}}>{SettableInterfaces[name]}</span>
                           </div>
                         )
                       })}
@@ -278,6 +278,13 @@ class ServerSettings extends Component {
       )
     )
   }
+}
+
+const SettableInterfaces = {
+  'applicationData': 'Application Data Storage',
+  'logfiles': 'Data log files access',
+  'nmea-tcp': 'NMEA 0183 over TCP (10110)',
+  'tcp': 'Signal K over TCP (8375)'
 }
 
 const ReduxedSettings = connect()(ServerSettings)


### PR DESCRIPTION
Allow disabling only the interfaces that a normal user
might want to disable, and not all the interfaces. The
interfaces list structure is a relic with not much
relevance. You can still disable all the interfaces
by manually editing the settings file, but this makes
it so that you can not accidentally lock yourself
out of the admin UI.

Includes minor styling changes to get the switch labels
aligned a little more nicely.