### PR TITLE
expose Suppress0183Checkbox to gpsd configuration

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -793,7 +793,7 @@ const NMEA0183 = props => {
            />
         </div>
       )}
-      {props.value.options.type === 'tcpserver' && (
+      {(props.value.options.type === 'tcpserver' || props.value.options.type === 'gpsd')&& (
         <div>
           <Suppress0183Checkbox
             value={props.value.options}


### PR DESCRIPTION
Setting to True suppresses gpsd data in 10110 output so it's not duplicated when using SignalK to NMEA0183 plugin.  This PR just exposes this setting in the server config page.