### PR TITLE
expose Suppress0183Checkbox in all NMEA1083 connection configurations

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -793,14 +793,12 @@ const NMEA0183 = props => {
            />
         </div>
       )}
-      {props.value.options.type === 'tcpserver' && (
-        <div>
-          <Suppress0183Checkbox
-            value={props.value.options}
-            onChange={props.onChange}
-          />
-        </div>
-      )}
+      <div>
+        <Suppress0183Checkbox
+          value={props.value.options}
+          onChange={props.onChange}
+        />
+      </div>
       {props.value.options.type === 'udp' && (
         <PortInput value={props.value.options} onChange={props.onChange} />
       )}


### PR DESCRIPTION
Setting to True suppresses data in 10110 output so it's not duplicated when using SignalK to NMEA0183 plugin. 

This PR just exposes this setting in the server config page for all NMEA data providers.

Fixes #1319 