### PR TITLE
Log less in production mode; make unit file launch in production mode

### DIFF
--- a/bin/signalk-server-setup
+++ b/bin/signalk-server-setup
@@ -277,6 +277,7 @@ StandardError=syslog
 WorkingDirectory=${configDirectory}
 User=${process.env.SUDO_USER}
 Environment=EXTERNALPORT=${primaryPort}
+Environment=NODE_ENV=production
 Environment=RUN_FROM_SYSTEMD=true
 [Install]
 WantedBy=multi-user.target

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -21,7 +21,10 @@ module.exports = function(app) {
     app.config.environment = 'production'
     app.config.debug = false
 
-    app.use(require('morgan')('combined'))
+    // only log http traffic for status code 500 and above
+    app.use(require('morgan')('combined', {
+      skip: function (req, res) { return res.statusCode < 500 }
+    }))
     app.use(require('errorhandler')())
   }
 }


### PR DESCRIPTION
As per issue #1141.

- do not log http requests with status codes < 500
- make unit file launch Signal K server Node.js process in production mode