### PR TITLE
feature: NODE_ENV=production

### DIFF
--- a/bin/signalk-server-setup
+++ b/bin/signalk-server-setup
@@ -277,6 +277,7 @@ StandardError=syslog
 WorkingDirectory=${configDirectory}
 User=${process.env.SUDO_USER}
 Environment=EXTERNALPORT=${primaryPort}
+Environment=NODE_ENV=production
 Environment=RUN_FROM_SYSTEMD=true
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Make signalk-server-setup add NODE_ENV=production environment variable.