### PR TITLE
fix: source priorities with >1 periods

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.js
@@ -136,7 +136,7 @@ export const reduceSourcePriorities = (state, action) => {
 }
 
 function fetchSourceRefs(path, cb) {
-  fetch(`/signalk/v1/api/vessels/self/${path.replace('.', '/')}`, {
+  fetch(`/signalk/v1/api/vessels/self/${path.replace(/\./g, '/')}`, {
     credentials: 'include',
   })
     .then((response) => response.json())


### PR DESCRIPTION
Fixes #1343.

Source selection in Source Priorities setup was
not working for paths that had more than one
period in them.