### PR TITLE
fix: subscription handling for empty path

### DIFF
--- a/src/streambundle.js
+++ b/src/streambundle.js
@@ -37,31 +37,14 @@ StreamBundle.prototype.pushDelta = function(delta) {
   function processIems(update, items, isMeta) {
     if (items) {
       items.forEach(pathValue => {
-        let outgoingPath = pathValue.path
-        /*
-        if (isMeta) {
-          outgoingPath = outgoingPath + '.meta'
-        }*/
-        var paths =
-          pathValue.path === ''
-            ? getPathsFromObjectValue(pathValue.value)
-            : [outgoingPath]
-        /*
-          For values with empty path and object value we enumerate all the paths in the object
-          and push the original delta's value to all those buses, so that subscriptionmanager
-          can track hits also for paths of naked values (no path, just object value) and when
-          regenerating the outgoing delta will use the unmodified, original delta pathvalue.
-        */
-        paths.forEach(path => {
-          that.push(path, {
-            path: outgoingPath,
-            value: pathValue.value,
-            context: delta.context,
-            source: update.source,
-            $source: update.$source,
-            timestamp: update.timestamp,
-            isMeta: isMeta
-          })
+        that.push(pathValue.path, {
+          path: pathValue.path,
+          value: pathValue.value,
+          context: delta.context,
+          source: update.source,
+          $source: update.$source,
+          timestamp: update.timestamp,
+          isMeta: isMeta
         })
       }, that)
     }

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -120,7 +120,7 @@ function handleSubscribeRows(
   user?: string
 ) {
   rows.reduce((acc, subscribeRow) => {
-    if (subscribeRow.path) {
+    if (subscribeRow.path !== undefined) {
       handleSubscribeRow(
         app,
         subscribeRow,
@@ -210,6 +210,9 @@ function handleSubscribeRow(
 }
 
 function pathMatcher(path: string) {
+  if (path === '') {
+    return () => true
+  }
   const pattern = path.replace('.', '\\.').replace('*', '.*')
   const matcher = new RegExp('^' + pattern + '$')
   return (aPath: string) => matcher.test(aPath)

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -322,7 +322,7 @@ describe('Subscriptions', _ => {
           context: 'vessels.*',
           subscribe: [
             {
-              path: 'name'
+              path: ''
             }
           ]
         })


### PR DESCRIPTION
When handling delta pathvalues with an empty path:

Previously StreamBundle claimed to be pushing the value to
all the paths generated from the object value's structure.
However the code was buggy and pushed the value only to
path streams generated from top level properties with
primitive values, ignoring all nested properties.

If this were fixed by fixing the bug, generating all the paths
for nested values we get into two kinds of trouble:
- what is a value? where do we stop descending into the object's
properties? the problem that the empty path mechanism was originally
created to solve
- what about * subscriptions? SubscriptionManager subscribes to
all the paths' streams individually, and if the pathvalue is pushed
to multiple streams the subscription will match multiple paths and
the client will get the same pathvalue delta multiple times

This fixes the problem by removing the buggy logic and removing
the extra logic related to paths with empty path. Now you can subscribe
to empty paths explicitly and wildcard subscriptions produce
pathvalue deltas with empty paths, like one would reasonably
expect.

Fixes #1349.