### PR TITLE
feature: remove --unsafe-perm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prerequisites
 
 ## Use: Install from npm
 
-    $ sudo npm install -g --unsafe-perm signalk-server
+    $ sudo npm install -g signalk-server
 
 Now you can start the server with sample data:
 * NMEA0183 sample data: `signalk-server --sample-nmea0183-data`

--- a/raspberry_pi_installation.md
+++ b/raspberry_pi_installation.md
@@ -41,7 +41,7 @@ A Signal K Server is the central hub of a Signal K system; reading and convertin
 
 Install the Node Server using npm
 
-    $ sudo npm install -g --unsafe-perm signalk-server
+    $ sudo npm install -g signalk-server
     
 ### Step 2.1 OPTIONAL test the server with sample data
 
@@ -286,7 +286,7 @@ Click on update and the installation will start
 
 If below version 1.8.0 use this command instead
 
-    $ sudo npm install --unsafe-perm -g signalk-server
+    $ sudo npm install -g signalk-server
 
 ![server_during_update](https://user-images.githubusercontent.com/16189982/51401178-71a9e400-1b4a-11e9-86b9-1148442ba59c.png)
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -180,17 +180,9 @@ function runNpm(
 
   if (isTheServerModule(name, config)) {
     if (process.platform === 'win32') {
-      npm = spawn(
-        'cmd',
-        ['/c', `npm ${command} -g --unsafe-perm ${packageString} `],
-        opts
-      )
+      npm = spawn('cmd', ['/c', `npm ${command} -g ${packageString} `], opts)
     } else {
-      npm = spawn(
-        'sudo',
-        ['npm', command, '-g', '--unsafe-perm', packageString],
-        opts
-      )
+      npm = spawn('sudo', ['npm', command, '-g', packageString], opts)
     }
   } else {
     opts.cwd = config.configPath


### PR DESCRIPTION
It seems that the transitive dependency that originally caused the
need for --unsafe-perm is no longer there/no longer requires
the extra permissions. SK server's functioning never needed
the extra permmission level, so let's remove that.