### PR TITLE
fix: guard against plugin.schema() errors

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -192,7 +192,28 @@ module.exports = (theApp: any) => {
 
       Promise.all([
         Promise.resolve(
-          typeof plugin.schema === 'function' ? plugin.schema() : plugin.schema
+          typeof plugin.schema === 'function'
+            ? (() => {
+                try {
+                  return plugin.schema()
+                } catch (e) {
+                  console.error(e)
+                  // return a fake schema to inform the user
+                  // downside is that saving this may overwrite an existing configuration
+                  return {
+                    type: 'object',
+                    required: ['error'],
+                    properties: {
+                      error: {
+                        title:
+                          'Error loading plugin configuration schema, check server log',
+                        type: 'string'
+                      }
+                    }
+                  }
+                }
+              })()
+            : plugin.schema
         ),
         Promise.resolve(
           typeof plugin.uiSchema === 'function'


### PR DESCRIPTION
A single plugin that uses schema's function form whose schema() call
throws an error could prevent the server's plugin configuration ui
form page from loading.

This adds a guard against errors thrown in schema() call. The error
is logged and a fake schema containing a single field with a name
indicating that the schema could not be loaded. Problem with this
fake schema is that saving it may overwrite a perfectly good
plugin configuration, but it is a cheap way to show something is wrong.