### PR TITLE
feature: use wrapper to keep track of created debuggers

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -567,6 +567,8 @@ Log debug messages. This is the debug method from the [debug module](https://www
 
 `app.debug()` can take any type and will serialize it before outputting.
 
+*Do not use `debug` directly*. Using the debug function provided by the server makes sure that the plugin taps into the server's debug logging system, including the helper switches in Admin UI's Server Log page.
+
 ### `app.savePluginOptions(options, callback)`
 
 Save changes to the plugin's options.

--- a/packages/streams/canboatjs.js
+++ b/packages/streams/canboatjs.js
@@ -16,7 +16,6 @@
 
 const Transform = require('stream').Transform
 const FromPgn = require('@canboat/canboatjs').FromPgn
-const debug = require('debug')('signalk:streams:canboatjs')
 const _ = require('lodash')
 
 function CanboatJs (options) {
@@ -25,6 +24,9 @@ function CanboatJs (options) {
   })
 
   this.fromPgn = new FromPgn(options)
+  const createDebug = options.createDebug || require('debug')
+  const debug = createDebug('signalk:streams:nmea0183-signalk')
+
 
   this.fromPgn.on('warning', (pgn, warning) => {
     debug(`[warning] ${pgn.pgn} ${warning}`)

--- a/packages/streams/execute.js
+++ b/packages/streams/execute.js
@@ -42,7 +42,8 @@ const { pgnToActisenseSerialFormat } = require('@canboat/canboatjs')
 function Execute (options) {
   Transform.call(this, {})
   this.options = options
-  this.debug = options.debug || require('debug')('signalk:streams:execute')
+  const createDebug = options.createDebug || require('debug')
+  this.debug = options.debug || createDebug('signalk:streams:execute')
 }
 
 require('util').inherits(Execute, Transform)

--- a/packages/streams/gpsd.js
+++ b/packages/streams/gpsd.js
@@ -32,7 +32,6 @@
 
 const Transform = require('stream').Transform
 const gpsd = require('node-gpsd')
-const debug = require('debug')('signalk:streams:gpsd')
 
 function Gpsd (options) {
   Transform.call(this, {
@@ -45,12 +44,14 @@ function Gpsd (options) {
   function setProviderStatus(msg) {
     options.app.setProviderStatus(options.providerId, msg)
   }
-  
+
+  const createDebug = options.createDebug || require('debug')
+
   this.listener = new gpsd.Listener({
     port,
     hostname,
     logger: {
-      info: debug,
+      info: createDebug('signalk:streams:gpsd'),
       warn: console.warn,
       error: (msg) => {
         options.app.setProviderError(options.providerId, `${hostname}:${port}: ` + msg)

--- a/packages/streams/keys-filter.js
+++ b/packages/streams/keys-filter.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk:streams:keys-filter')
 
 function ToSignalK (options) {
   Transform.call(this, {
     objectMode: true
   })
 
+  const createDebug = options.createDebug || require('debug')
+  this.debug = createDebug('signalk:streams:keys-filter')
   this.exclude = options.excludeMatchingPaths
 }
 
@@ -25,7 +26,7 @@ ToSignalK.prototype._transform = function (chunk, encoding, done) {
       delta = JSON.parse(chunk)
       string = true
     } catch (e) {
-      debug(`Error parsing chunk: ${e.message}`)
+      this.debug(`Error parsing chunk: ${e.message}`)
     }
   }
 

--- a/packages/streams/logging.js
+++ b/packages/streams/logging.js
@@ -16,7 +16,7 @@
 
 const { FileTimestampStream } = require('file-timestamp-stream')
 const path = require('path')
-const debug = require('debug')('signalk:streams:logging')
+let debug = require('debug')('signalk:streams:logging')
 const fs = require('fs')
 
 const filenamePattern = /skserver\-raw\_\d\d\d\d\-\d\d\-\d\dT\d\d\.log/
@@ -35,6 +35,7 @@ class FileTimestampStreamWithDelete extends FileTimestampStream {
     this.filesToKeep = filesToKeep
     this.fullLogDir = fullLogDir
     this.prevFilename = undefined
+    debug = (options.createDebug || require('debug'))('signalk:streams:logging')
   }
 
   // This method of base class is called when new file name is contemplated

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -15,7 +15,6 @@
  */
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk:streams:n2k-analyzer')
 
 function N2KAnalyzer (options) {
   Transform.call(this, {
@@ -68,7 +67,7 @@ N2KAnalyzer.prototype.pipe = function (pipeTo) {
 }
 
 N2KAnalyzer.prototype.end = function () {
-  debug('end, killing child analyzer process')
+  console.log('end, killing child analyzer process')
   this.analyzerProcess.kill()
   this.pipeTo.end()
 }

--- a/packages/streams/nmea0183-signalk.js
+++ b/packages/streams/nmea0183-signalk.js
@@ -32,7 +32,6 @@
 const Transform = require('stream').Transform
 const Parser = require('@signalk/nmea0183-signalk')
 const utils = require('@signalk/nmea0183-utilities')
-const debug = require('debug')('signalk:streams:nmea0183-signalk')
 const n2kToDelta = require('@signalk/n2k-signalk').toDelta
 const FromPgn = require('@canboat/canboatjs').FromPgn
 
@@ -108,7 +107,7 @@ Nmea0183ToSignalK.prototype._transform = function (chunk, encoding, done) {
       }
     }
   } catch (e) {
-    debug(`[error] ${e.message}`)
+    console.error(e)
   }
 
   done()

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -15,14 +15,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * 2020-06-24 Original Python code from @Thomas-GeDaD https://github.com/Thomas-GeDaD/Seatalk1-Raspi-reader
  * and finetuned by @MatsA
  *
  */
 
 const Execute = require('./execute')
-const debug = require('debug')('signalk:streams:pigpio-seatalk')
 
 const cmd = `
 import pigpio, time, signal, sys
@@ -79,13 +78,13 @@ if __name__ == "__main__":
                 print ("exit")
 `
 
-function PigpioSeatalk (options) {
-  Execute.call(this, {debug})
+function PigpioSeatalk(options) {
+  const createDebug = options.createDebug || require('debug')
+  Execute.call(this, { debug: createDebug('signalk:streams:pigpio-seatalk') })
   this.options = options
   this.options.command = `python -u -c '${cmd}' ${options.gpio} ${options.gpioInvert} `
 }
 
 require('util').inherits(PigpioSeatalk, Execute)
-
 
 module.exports = PigpioSeatalk

--- a/packages/streams/s3.js
+++ b/packages/streams/s3.js
@@ -23,8 +23,7 @@ var Transform = require('stream').Transform
   deprecation warnings.
   Known to work with ^2.413.0
 */
-const AWS = require('aws-sdk') 
-const debug = require('debug')('signalk:streams:s3-provider')
+const AWS = require('aws-sdk')
 
 function S3Provider ({ bucket, prefix }) {
   Transform.call(this, {

--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -1,7 +1,6 @@
 const Transform = require('stream').Transform
 const Writable = require('stream').Writable
 const _ = require('lodash')
-const debug = require('debug')('signalk:simple')
 const N2kAnalyzer = require('./n2kAnalyzer')
 const FromJson = require('./from_json')
 const MultiplexedLog = require('./multiplexedlog')
@@ -27,9 +26,14 @@ const pigpioSeatalk = require('./pigpio-seatalk')
 function Simple (options) {
   Transform.call(this, { objectMode: true })
 
-  const { emitPropertyValue, onPropertyValues } = options
+  const { emitPropertyValue, onPropertyValues, createDebug } = options
   options = { ...options }
-  options.subOptions = { ...options.subOptions, emitPropertyValue, onPropertyValues }
+  options.subOptions = {
+    ...options.subOptions,
+    emitPropertyValue,
+    onPropertyValues,
+    createDebug
+  }
 
   options.subOptions.providerId = options.providerId
   const dataType = options.subOptions.dataType || options.type

--- a/packages/streams/udp.js
+++ b/packages/streams/udp.js
@@ -34,13 +34,13 @@
  */
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk:streams:udp')
 
 function Udp (options) {
   Transform.call(this, {
     objectMode: false
   })
   this.options = options
+  this.debug = (options.createDebug || require('debug'))('signalk:streams:udp')
 }
 
 require('util').inherits(Udp, Transform)
@@ -52,7 +52,7 @@ Udp.prototype.pipe = function (pipeTo) {
   const socket = require('dgram').createSocket('udp4')
   const self = this
   socket.on('message', function (message, remote) {
-    debug(message.toString())
+    self.debug(message.toString())
     self.push(message)
   })
   socket.bind(this.options.port)

--- a/src/categories.ts
+++ b/src/categories.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
 */
 
-import Debug from 'debug'
-const debug = Debug('signalk:categories')
+import { createDebug } from './debug'
+const debug = createDebug('signalk:categories')
 // tslint:disable-next-line:no-var-requires
 const { getKeywords } = require('./modules')
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -15,15 +15,15 @@
 */
 'use strict'
 
-import Debug from 'debug'
-import path from 'path'
-import { SelfIdentity, SignalKMessageHub, WithConfig } from '../app'
-import DeltaEditor from '../deltaeditor'
-const debug = Debug('signalk-server:config')
 import fs from 'fs'
 import _ from 'lodash'
+import path from 'path'
 import semver from 'semver'
 import { v4 as uuidv4 } from 'uuid'
+import { SelfIdentity, SignalKMessageHub, WithConfig } from '../app'
+import { createDebug } from '../debug'
+import DeltaEditor from '../deltaeditor'
+const debug = createDebug('signalk-server:config')
 
 let disableWriteSettings = false
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,12 @@
+import coreDebug from 'debug'
+
+const knownDebugs = new Set<string>()
+
+export function createDebug(debugName: string) {
+  knownDebugs.add(debugName)
+  return coreDebug(debugName)
+}
+
+export function listKnownDebugs() {
+  return Array.from(knownDebugs)
+}

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -1,5 +1,5 @@
-import Debug from 'debug'
-const debug = Debug('signalk-server:sourcepriorities')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:sourcepriorities')
 
 type Brand<K, T> = K & { __brand: T }
 

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import Debug from 'debug'
-const debug = Debug('signalk-server:deltacache')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:deltacache')
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
 import _, { isUndefined } from 'lodash'
 import { toDelta } from './streambundle'

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('signalk-server:discovery')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:discovery')
 const canboatjs = require('@canboat/canboatjs')
 const dgram = require('dgram')
 const mdns = require('mdns-js')

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,6 @@ import SubscriptionManager from './subscriptionmanager'
 import { Delta } from './types'
 const debug = createDebug('signalk-server')
 
-
 // tslint:disable-next-line: no-var-requires
 const { StreamBundle } = require('./streambundle')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,27 +19,22 @@ if (typeof [].includes !== 'function') {
   process.exit(-1)
 }
 
-import Debug from 'debug'
-import express from 'express'
-import _ from 'lodash'
-const debug = Debug('signalk-server')
 import { PropertyValues } from '@signalk/server-api'
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
-import { Request, Response } from 'express'
+import { Debugger } from 'debug'
+import express, { Request, Response } from 'express'
 import http from 'http'
 import https from 'https'
+import _ from 'lodash'
 import path from 'path'
 import { SelfIdentity, ServerApp, SignalKMessageHub, WithConfig } from './app'
-import { Config, ConfigApp } from './config/config'
+import { ConfigApp, load, sendBaseDeltas } from './config/config'
+import { createDebug } from './debug'
 import DeltaCache from './deltacache'
 import DeltaChain, { DeltaInputHandler } from './deltachain'
 import { getToPreferredDelta, ToPreferredDelta } from './deltaPriority'
-import { checkForNewServerVersion } from './modules'
-import SubscriptionManager from './subscriptionmanager'
-import { Delta } from './types'
-
-import { load, sendBaseDeltas } from './config/config'
 import { incDeltaStatistics, startDeltaStatistics } from './deltastats'
+import { checkForNewServerVersion } from './modules'
 import { getExternalPort, getPrimaryPort, getSecondaryPort } from './ports'
 import {
   getCertificateOptions,
@@ -47,6 +42,10 @@ import {
   saveSecurityConfig,
   startSecurity
 } from './security.js'
+import SubscriptionManager from './subscriptionmanager'
+import { Delta } from './types'
+const debug = createDebug('signalk-server')
+
 
 // tslint:disable-next-line: no-var-requires
 const { StreamBundle } = require('./streambundle')
@@ -253,13 +252,13 @@ class Server {
     const self = this
     const app = this.app
 
-    const eventDebugs: { [key: string]: Debug.Debugger } = {}
+    const eventDebugs: { [key: string]: Debugger } = {}
     const expressAppEmit = app.emit.bind(app)
     app.emit = (eventName: string, ...args: any[]) => {
       if (eventName !== 'serverlog') {
         let eventDebug = eventDebugs[eventName]
         if (!eventDebug) {
-          eventDebugs[eventName] = eventDebug = Debug(
+          eventDebugs[eventName] = eventDebug = createDebug(
             `signalk-server:events:${eventName}`
           )
         }

--- a/src/interfaces/applicationData.js
+++ b/src/interfaces/applicationData.js
@@ -15,7 +15,8 @@
  */
 
 const _ = require('lodash')
-const debug = require('debug')('signalk-server:interfaces:applicationData')
+import { createDebug } from '../debug'
+const debug = createDebug('signalk-server:interfaces:applicationData')
 const fs = require('fs')
 const path = require('path')
 const jsonpatch = require('json-patch')

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -14,7 +14,8 @@
  * limitations under the License.
 */
 
-const debug = require('debug')('signalk:interfaces:appstore')
+import { createDebug } from '../debug'
+const debug = createDebug('signalk:interfaces:appstore')
 const _ = require('lodash')
 const compareVersions = require('compare-versions')
 const { installModule, removeModule } = require('../modules')

--- a/src/interfaces/logfiles.js
+++ b/src/interfaces/logfiles.js
@@ -14,7 +14,8 @@
  * limitations under the License.
 */
 
-const debug = require('debug')('signalk:interfaces:logfiles')
+import { createDebug } from '../debug'
+const debug = createDebug('signalk:interfaces:logfiles')
 const moment = require('moment')
 const fs = require('fs')
 const path = require('path')

--- a/src/interfaces/nmea-tcp.js
+++ b/src/interfaces/nmea-tcp.js
@@ -15,6 +15,9 @@
 
 const _ = require('lodash')
 
+import { createDebug } from '../debug'
+const debug = createDebug('signalk-server:interfaces:tcp:nmea0183')
+
 module.exports = function(app) {
   'use strict'
   const net = require('net')
@@ -24,7 +27,6 @@ module.exports = function(app) {
   const port = process.env.NMEA0183PORT || 10110
   const api = {}
 
-  const debug = require('debug')('signalk-server:interfaces:tcp:nmea0183')
   api.start = function() {
     debug('Starting tcp interface')
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-import Debug from 'debug'
-import { Request, Response } from 'express'
-const debug = Debug('signalk:interfaces:plugins')
 import {
   PluginServerApp,
   PropertyValues,
@@ -23,13 +20,15 @@ import {
 } from '@signalk/server-api'
 // @ts-ignore
 import { getLogger } from '@signalk/streams/logging'
-import express from 'express'
+import express, { Request, Response } from 'express'
 import fs from 'fs'
 import _ from 'lodash'
 import path from 'path'
 import { SERVERROUTESPREFIX } from '../constants'
+import { createDebug } from '../debug'
 import { DeltaInputHandler } from '../deltachain'
 import { listAllSerialPorts, Ports } from '../serialports'
+const debug = createDebug('signalk:interfaces:plugins')
 
 // tslint:disable-next-line:no-var-requires
 const modulesWithKeyword = require('../modules').modulesWithKeyword
@@ -511,7 +510,7 @@ module.exports = (theApp: any) => {
           console.error(msg.stack)
         }
       },
-      debug: require('debug')(packageName),
+      debug: createDebug(packageName),
       registerDeltaInputHandler: (handler: any) => {
         onStopHandlers[plugin.id].push(app.registerDeltaInputHandler(handler))
       },

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -14,7 +14,8 @@
  * limitations under the License.
 */
 
-const debug = require('debug')('signalk-server:interfaces:rest')
+const { createDebug } = require('../debug')
+const debug = createDebug('signalk-server:interfaces:rest')
 const express = require('express')
 const { getMetadata, getUnits } = require('@signalk/signalk-schema')
 const ports = require('../ports')

--- a/src/interfaces/tcp.ts
+++ b/src/interfaces/tcp.ts
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import Debug from 'debug'
-import { values } from 'lodash'
 import { createServer, Server, Socket } from 'net'
 import split from 'split'
-const debug = Debug('signalk-server:interfaces:tcp:signalk')
+import { createDebug } from '../debug'
 import { Interface, SignalKServer, Unsubscribes } from '../types'
+const debug = createDebug('signalk-server:interfaces:tcp:signalk')
 
 interface SocketWithId extends Socket {
   id?: number

--- a/src/interfaces/webapps.js
+++ b/src/interfaces/webapps.js
@@ -14,7 +14,8 @@
  * limitations under the License.
 */
 
-const debug = require('debug')('signalk:interfaces:webapps')
+import { createDebug } from '../debug'
+const debug = createDebug('signalk:interfaces:webapps')
 const fs = require('fs')
 const path = require('path')
 const express = require('express')

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -26,10 +26,9 @@ const {
 } = require('../requestResponse')
 const { putPath } = require('../put')
 const skConfig = require('../config/config')
-const debug = require('debug')('signalk-server:interfaces:ws')
-const debugConnection = require('debug')(
-  'signalk-server:interfaces:ws:connections'
-)
+import { createDebug } from '../debug'
+const debug = createDebug('signalk-server:interfaces:ws')
+const debugConnection = createDebug('signalk-server:interfaces:ws:connections')
 const Primus = require('primus')
 
 const supportedQuerySubscribeValues = ['self', 'all']

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -17,7 +17,8 @@
 'use strict'
 
 const _ = require('lodash')
-const debug = require('debug')('signalk-server:mdns')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:mdns')
 const dnssd = require('dnssd2')
 const ports = require('./ports')
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -15,16 +15,14 @@
 */
 
 import { spawn } from 'child_process'
-import Debug from 'debug'
 import fs from 'fs'
-import fetch from 'node-fetch'
-import { Response } from 'node-fetch'
-const debug = Debug('signalk:modules')
 import _ from 'lodash'
+import fetch, { Response } from 'node-fetch'
 import path from 'path'
 import semver, { SemVer } from 'semver'
-import { WithConfig } from './app'
 import { Config } from './config/config'
+import { createDebug } from './debug'
+const debug = createDebug('signalk:modules')
 
 interface ModuleData {
   module: string

--- a/src/pipedproviders.js
+++ b/src/pipedproviders.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { createDebug } from './debug'
 const deep = require('deep-get-set')
 const DevNull = require('dev-null-stream')
 const _ = require('lodash')
@@ -84,7 +85,10 @@ module.exports = function(app) {
     const efectiveElementType = elementConfig.type.startsWith('providers/')
       ? elementConfig.type.replace('providers/', '@signalk/streams/')
       : elementConfig.type
-    return new (require(efectiveElementType))(elementConfig.options)
+    return new (require(efectiveElementType))({
+      ...elementConfig.options,
+      createDebug
+    })
   }
 
   function startProviders() {

--- a/src/put.js
+++ b/src/put.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
-const debug = require('debug')('signalk-server:put')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:put')
 const { v4: uuidv4 } = require('uuid')
 const { createRequest, updateRequest } = require('./requestResponse')
 const skConfig = require('./config/config')

--- a/src/requestResponse.js
+++ b/src/requestResponse.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid')
-const debug = require('debug')('signalk-server:requestResponse')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:requestResponse')
 const _ = require('lodash')
 
 const requests = {}

--- a/src/security.ts
+++ b/src/security.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
 */
 
-import Debug from 'debug'
 import {
   chmodSync,
   existsSync,
@@ -29,8 +28,9 @@ import path from 'path'
 import pem from 'pem'
 import { Mode } from 'stat-mode'
 import { WithConfig } from './app'
+import { createDebug } from './debug'
 import dummysecurity from './dummysecurity'
-const debug = Debug('signalk-server:security')
+const debug = createDebug('signalk-server:security')
 
 export interface WithSecurityStrategy {
   securityStrategy: SecurityStrategy

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -18,7 +18,8 @@ const fs = require('fs')
 const os = require('os')
 const readdir = require('util').promisify(fs.readdir)
 const page = require('./page')
-const debug = require('debug')('signalk-server:serverroutes')
+import { createDebug, listKnownDebugs } from './debug'
+const debug = createDebug('signalk-server:serverroutes')
 const path = require('path')
 const _ = require('lodash')
 const skConfig = require('./config/config')
@@ -760,7 +761,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   })
 
   app.get(`${SERVERROUTESPREFIX}/debugKeys`, (req, res) => {
-    res.json(_.uniq(require('debug').instances.map(i => i.namespace)))
+    res.json(listKnownDebugs())
   })
 
   app.post(`${SERVERROUTESPREFIX}/rememberDebug`, (req, res) => {

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -15,13 +15,13 @@
  */
 
 import Bacon from 'baconjs'
-import Debug from 'debug'
 import { isPointWithinRadius } from 'geolib'
 import _, { forOwn, get, isString } from 'lodash'
-const debug = Debug('signalk-server:subscriptionmanager')
+import { createDebug } from './debug'
 import DeltaCache from './deltacache'
 import { toDelta } from './streambundle'
 import { ContextMatcher, Position, Unsubscribes, WithContext } from './types'
+const debug = createDebug('signalk-server:subscriptionmanager')
 
 interface BusesMap {
   [key: string]: any

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('signalk-server:tokensecurity')
+import { createDebug } from './debug'
+const debug = createDebug('signalk-server:tokensecurity')
 const util = require('util')
 const jwt = require('jsonwebtoken')
 const _ = require('lodash')


### PR DESCRIPTION
[Debug]() module's internal architecture changed in version 4.3.0 so that it no longer keeps internally track of created debuggers. This was used to populate the list of debuggers to enable in Admin UI's Server Log.

This PR adds `createDebug` wrapper to create `Debug` instances and keep a list of these for the UI. All server code is modified to use this. However all external code, that may use other versions of Debug and constructs the instances independently is not covered by this feature.

(decided not to expose `createDebug` to plugins, as they already have access to a default, plugin specific `debug` instance).