### PR TITLE
fix: nmea0183-signalk logging

### DIFF
--- a/packages/streams/nmea0183-signalk.js
+++ b/packages/streams/nmea0183-signalk.js
@@ -39,6 +39,8 @@ function Nmea0183ToSignalK(options) {
   Transform.call(this, {
     objectMode: true,
   })
+  this.debug = (options.createDebug || require('debug'))('signalk:streams:nmea0183-signalk')
+  
 
   this.parser = new Parser(options)
   this.n2kParser = new FromPgn(options)
@@ -107,7 +109,7 @@ Nmea0183ToSignalK.prototype._transform = function (chunk, encoding, done) {
       }
     }
   } catch (e) {
-    console.error(e)
+    this.debug(e)
   }
 
   done()


### PR DESCRIPTION
Use debug instead of console.error changed in 55fe8aa553684f83bf429da37992461793a5f5f2
otherwise people get too verbose logging under normal conditions with some
unrecognised sentences.