### PR TITLE
doc: update RPi instructions for Node.js 16 / 1.41

### DIFF
--- a/raspberry_pi_installation.md
+++ b/raspberry_pi_installation.md
@@ -1,12 +1,12 @@
 # Getting Started
 
-If you already have a Raspberry Pi up and running go direct to [Installing Signal K.](https://github.com/SignalK/signalk-server/blob/master/raspberry_pi_installation.md#installing-signal-k)
+If you are updating the Signal K server, especially moving from a version <= 1.40.0, [please check here.](https://github.com/SignalK/signalk-server/blob/master/raspberry_pi_installation.md#update-signal-k-node-server)
 
-Instructions to install the operating system, Raspberry Pi OS, [is found here.](https://www.raspberrypi.org/documentation/computers/getting-started.html#setting-up-your-raspberry-pi)
+Instructions to install the operating system, Raspberry Pi OS, [is found here.](https://www.raspberrypi.org/documentation/computers/getting-started.html#setting-up-your-raspberry-pi) Please use Buster OS! Bullseye, is not fully tested.
 
-If you are familiar with a "headless install", with Raspberry Pi OS Lite, it's also possible since the GUI for Signal K is browser based.
+If you are familiar with a "headless install" using Raspberry Pi OS Lite it's also possible since the GUI for Signal K is browser based.
 
-After everything has been configured you should be presented with the RPi Desktop up and running, just waiting for you to install Signal K.
+After everything has been configured, using the GUI install, you should be presented with the RPi Desktop up and running, just waiting for you to install Signal K.
 
 # Installing Signal K
 
@@ -24,12 +24,19 @@ Raspbian, the Linux distribution for RPi, is based on Debian, which has a powerf
 
 Now, install node and npm
 
-    $ sudo apt install nodejs npm
+    $ curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+    $ sudo apt-get install -y nodejs
 
 We want to make sure that we're using the latest version of npm:
 
     $ sudo npm install -g npm@latest
     
+Use the following command to check the install
+
+    node -v && npm -v
+
+which will report, something like, `v16.13.2, 8.3.1` which are the versions of "node" and "npm"
+
 Finally we need to install a Bonjour (mDNS) service for Linux called Avahi, which allows Apps and other network devices to Discover the Signal K server. To do this we will use "apt" again ...
 
      $ sudo apt install libnss-mdns avahi-utils libavahi-compat-libdnssd-dev
@@ -284,9 +291,10 @@ Click on that row and You will open next window
 
 Click on update and the installation will start
 
-If below version 1.8.0 use this command instead
+**Please note !**
 
-    $ sudo npm install -g signalk-server
+Starting with Signal K server version 1.41.0 the recommended Node.js version is 16. [16 is the active LTS](https://nodejs.org/en/about/releases/) (Long Term Support) version in Jan 2022, with End of Life set at 2024-04-30. Node 10 is past its end of life and won't receive any (security) updates.
+So if you are updating from a Signal K version <= V 1.40.0 [check out the Wiki](https://github.com/SignalK/signalk-server/wiki/Updating-to-Node.js-16) on how to. 
 
 ![server_during_update](https://user-images.githubusercontent.com/16189982/51401178-71a9e400-1b4a-11e9-86b9-1148442ba59c.png)
 


### PR DESCRIPTION
Added link to Wiki for how to upgrade to Node.js 16. 