### PR TITLE
fix: subscribe for path '' should not match all

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -210,9 +210,6 @@ function handleSubscribeRow(
 }
 
 function pathMatcher(path: string) {
-  if (path === '') {
-    return () => true
-  }
   const pattern = path.replace('.', '\\.').replace('*', '.*')
   const matcher = new RegExp('^' + pattern + '$')
   return (aPath: string) => matcher.test(aPath)


### PR DESCRIPTION
Changed in #1356. Subscribing for path: '' should not
match everything, just pathvalues with an empty path.