### PR TITLE
fix: admin ui in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,14 @@ WORKDIR /home/node/signalk
 
 COPY --chown=node:node . .
 
+RUN npm install
+
 WORKDIR /home/node/signalk/packages/server-api
-RUN npm install && npm run build
+RUN npm run build
+WORKDIR /home/node/signalk/packages/server-admin-ui
+RUN npm run build
 
 WORKDIR /home/node/signalk
-RUN npm install
 RUN npm run build
 RUN mkdir -p /home/node/.signalk
 


### PR DESCRIPTION
With npm workspaces @signalk/server-admin-ui is no longer
being installed from npm, so we need to build it explicitly.

Run npm install before any of the builds so that it runs
in all workspaces, no need to run it separately.