### PR TITLE
fix: ws JWT verification

### DIFF
--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -27,6 +27,7 @@ const {
 const { putPath } = require('../put')
 const skConfig = require('../config/config')
 import { createDebug } from '../debug'
+import { JsonWebTokenError } from 'jsonwebtoken'
 const debug = createDebug('signalk-server:interfaces:ws')
 const debugConnection = createDebug('signalk-server:interfaces:ws:connections')
 const Primus = require('primus')
@@ -465,7 +466,10 @@ function createPrimusAuthorize(authorizeWS) {
       // To be able to login or request access via WS with security in place
       // only clearly invalid tokens result in 401 response, so that we can inform
       // the client that the credentials do not work.
-      if (error instanceof InvalidTokenError) {
+      if (
+        error instanceof InvalidTokenError ||
+        error instanceof JsonWebTokenError
+      ) {
         authorized(error)
       } else {
         authorized()

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -728,7 +728,7 @@ module.exports = function(app, config) {
     // `jwt-simple` throws errors if something goes wrong when decoding the JWT.
     //
     if (token) {
-      payload = jwt.decode(token, configuration.secretKey)
+      payload = jwt.verify(token, configuration.secretKey)
 
       if (!payload) {
         error = new InvalidTokenError('Invalid access token')

--- a/test/security.js
+++ b/test/security.js
@@ -237,6 +237,22 @@ describe('Security', () => {
     return result
   })
 
+  it('websocket with mangled token returns 401', async () => {
+    console.log(readToken)
+    return fetch(`${url}/signalk/v1/stream`, {
+      headers: {
+        Authorization: `JWT ${readToken.substring(0, readToken.length - 1)}`
+      }
+    }).then(response => response.status.should.equal(401))
+  })
+
+  it('websocket with invalid token returns 401', async () =>
+    fetch(`${url}/signalk/v1/stream`, {
+      headers: {
+        Authorization: `JWT ${readToken[0] + 1}${readToken.substring(1)}`
+      }
+    }).then(response => response.status.should.equal(401)))
+
   it('websockets acls work', async function () {
     const readPromiser = new WsPromiser(
       `ws://0.0.0.0:${port}/signalk/v1/stream?subsribe=all&metaDeltas=none&token=${readToken}`


### PR DESCRIPTION
When authorizing WebSocket connection the JWT was just
decoded, not verified.

This changes decode to verify and now JWTs with an
invalid signature are rejected and the caller sees a
401 response.