### PR TITLE
fix: data fiddler null value handling & UI crash remedy

### DIFF
--- a/packages/server-admin-ui/src/containers/Full/Full.js
+++ b/packages/server-admin-ui/src/containers/Full/Full.js
@@ -142,9 +142,20 @@ export default connect()(Full)
 
 const loginOrOriginal = (BaseComponent, componentSupportsReadOnly) => {
   class Restricted extends Component {
+    constructor(props) {
+      super(props)
+      this.state = { hasError: false }
+    }
+
+    static getDerivedStateFromError(error) {
+      return { hasError: true }
+    }
+
     render() {
       if (loginRequired(this.props.loginStatus, componentSupportsReadOnly)) {
         return <Login />
+      } else if (this.state.hasError) {
+        return <span>Something went wrong.</span>
       } else {
         return <BaseComponent {...this.props} />
       }

--- a/packages/server-admin-ui/src/views/Playground.js
+++ b/packages/server-admin-ui/src/views/Playground.js
@@ -409,6 +409,7 @@ class Playground extends Component {
                                   data.value,
                                   null,
                                   typeof data.value === 'object' &&
+                                  data.value !== null &&
                                     Object.keys(data.value).length > 1
                                     ? 2
                                     : 0

--- a/packages/server-admin-ui/src/views/Playground.js
+++ b/packages/server-admin-ui/src/views/Playground.js
@@ -409,7 +409,7 @@ class Playground extends Component {
                                   data.value,
                                   null,
                                   typeof data.value === 'object' &&
-                                  data.value !== null &&
+                                    data.value !== null &&
                                     Object.keys(data.value).length > 1
                                     ? 2
                                     : 0


### PR DESCRIPTION
Data Fiddler was crashing if the delta had any values
as null. This showed up as a blank page after entering input data that created such a delta and you would need to clear the bad data from localStorage to get Data Fiddle working again.

This PR also adds a per page error handler that should keep the rest of the UI working even if a single subpage is crashing.
