### PR TITLE
fix: do not suppress 0183 event by default

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -597,9 +597,6 @@ class RemoteSelfInput extends Component {
 class Suppress0183Checkbox extends Component {
   constructor(props) {
     super(props)
-    this.props.value.suppress0183event =
-      typeof this.props.value.suppress0183event === 'undefined' ||
-      this.props.value.suppress0183event
   }
   render() {
     return (
@@ -607,7 +604,7 @@ class Suppress0183Checkbox extends Component {
         <Col xs="3" md="3">
           <Label>Suppress nmea0183 event</Label>
         </Col>
-        <Col xs="2" md="3">
+        <Col xs="1" md="1">
           <Label className="switch switch-text switch-primary">
             <Input
               type="checkbox"
@@ -620,6 +617,12 @@ class Suppress0183Checkbox extends Component {
             <span className="switch-handle" />
           </Label>
         </Col>
+        <Col xs="12" md="6">
+          <label className="text-muted small">
+            Supress sending the default nmea0183 event for incoming sentences
+          </label>
+        </Col>
+
       </FormGroup>
     )
   }

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -393,7 +393,7 @@ class SentenceEventInput extends Component {
       <TextInput
         title="Input Event"
         name="options.sentenceEvent"
-        helpText="Event name for incoming sentences. Example: nmea1data"
+        helpText="Additional event name for incoming sentences. Example: nmea1data"
         value={this.props.value.sentenceEvent}
         onChange={this.props.onChange}
       />
@@ -622,7 +622,6 @@ class Suppress0183Checkbox extends Component {
             Supress sending the default nmea0183 event for incoming sentences
           </label>
         </Col>
-
       </FormGroup>
     )
   }


### PR DESCRIPTION
The default for suppressing 0183 event should be off, otherwise incoming 0183 data is not getting routed to tcp/10110 as it has been traditionally.

This was exposed to all 0183 connections in #1321 and having it on by default no longer makes sense for all new 0183 connections.