### PR TITLE
feature: clear bad token cookies in http requests

### DIFF
--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -910,14 +910,14 @@ module.exports = function(app, config) {
               debug('unknown user: ' + (decoded.id || decoded.device))
             }
           } else {
-            debug('bad token: ' + req.path)
+            debug(`bad token: ${err.message} ${req.path}`)
+            res.clearCookie('JAUTHENTICATION')
           }
 
           if (configuration.allow_readonly) {
             req.skIsAuthenticated = false
             next()
           } else {
-            res.clearCookie('JAUTHENTICATION')
             res.status(401).send('bad auth token')
           }
         })


### PR DESCRIPTION
Previously bad tokens (whose verification fails for one reason or another)
were not cleared in http requests if read only access was on. After
 #1401 ws requests are closed with 401 status code if the token can not
be verified. This resultedin a state where the admin UI loaded but
websocket did not connect. This is not very useful, because read only
access over ws does not work and admin ui shows an annoying "Not
connected to the server" error message.

There is no use for bad tokens from cookies, so we can outright delete
the cookie whenever token verification fails. This handles for example
token expiration, falling back to read only access if it is available.

In browser use there are always http requests prior to opening the ws,
so bad token cookies are cleared before opening ws.