### PR TITLE
Resources api schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@signalk/signalk-schema": "1.5.1",
     "@signalk/streams": "2.x",
     "@types/debug": "^4.1.5",
+    "api-schema-builder": "^2.0.11",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "figlet": "^1.2.0",
     "file-timestamp-stream": "^2.1.2",
     "flatmap": "0.0.3",
-    "geojson-validation": "^1.0.2",
     "geolib": "3.2.2",
     "get-installed-path": "^4.0.8",
     "inquirer": "^7.0.0",

--- a/packages/server-api/src/resourcetypes.ts
+++ b/packages/server-api/src/resourcetypes.ts
@@ -18,12 +18,13 @@ export interface Route {
 }
 
 export interface Waypoint {
-  position?: Position
+  name?: string,
+  description?: string,
   feature: {
     type: 'Feature'
     geometry: {
       type: 'Point'
-      coords: GeoJsonPoint
+      coordinates: GeoJsonPoint
     }
     properties?: object
     id?: string

--- a/src/@types/api-schema-builder.d.ts
+++ b/src/@types/api-schema-builder.d.ts
@@ -1,0 +1,1 @@
+declare module 'api-schema-builder'

--- a/src/@types/geojson-validation.d.ts
+++ b/src/@types/geojson-validation.d.ts
@@ -1,1 +1,0 @@
-declare module 'geojson-validation'

--- a/src/api/course/openApi.json
+++ b/src/api/course/openApi.json
@@ -374,6 +374,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "oneOf": [
+                    { "required":
+                      [ "position" ] },
+                    { "required":
+                      [ "href" ] }
+                  ],
                   "properties": {
                     "oneOf": {
                       "properties": {

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -14,7 +14,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { WithSecurityStrategy } from '../../security'
 
 import { Responses } from '../'
-import { buildResource } from './resources'
+import { buildResource, fromPostData } from './resources'
 import { validate } from './validate'
 
 const SIGNALK_API_PATH = `/signalk/v1/api`
@@ -242,9 +242,10 @@ export class ResourcesApi {
         }
 
         try {
-          const retVal = await this.resProvider[
-            req.params.resourceType
-          ]?.setResource(id, req.body)
+          await this.resProvider[req.params.resourceType]?.setResource(
+            id,
+            fromPostData(req.params.resourceType, req.body)
+          )
 
           server.handleMessage(
             this.resProvider[req.params.resourceType]?.pluginId as string,

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -229,7 +229,7 @@ export class ResourcesApi {
               req.body
             )
           } catch (e) {
-            res.status(400).send(e.message)
+            res.status(400).json(e.message)
             return
           }
         }
@@ -312,7 +312,7 @@ export class ResourcesApi {
               req.body
             )
           } catch (e) {
-            res.status(400).send(e.message)
+            res.status(400).json(e.message)
           }
         }
 

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -114,9 +114,7 @@ export class ResourcesApi {
           new Error(`Invalid resource id provided (${resId})`)
         )
       }
-      if (!validate.resource(resType, data)) {
-        return Promise.reject(new Error(`Invalid resource data!`))
-      }
+      validate.resource(resType as SignalKResourceType, 'PUT', data)
     }
 
     return this.resProvider[resType]?.setResource(resId, data)
@@ -224,8 +222,14 @@ export class ResourcesApi {
           return
         }
         if (isSignalKResourceType(req.params.resourceType)) {
-          if (!validate.resource(req.params.resourceType, req.body)) {
-            res.status(400).json(Responses.invalid)
+          try {
+            validate.resource(
+              req.params.resourceType as SignalKResourceType,
+              req.method,
+              req.body
+            )
+          } catch (e) {
+            res.status(400).send(e.message)
             return
           }
         }
@@ -300,9 +304,14 @@ export class ResourcesApi {
 
           debug('req.body')
           debug(req.body)
-          if (!validate.resource(req.params.resourceType, req.body)) {
-            res.status(400).json(Responses.invalid)
-            return
+          try {
+            validate.resource(
+              req.params.resourceType as SignalKResourceType,
+              req.method,
+              req.body
+            )
+          } catch (e) {
+            res.status(400).send(e.message)
           }
         }
 

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -61,10 +61,10 @@
           "externalDocs": {
             "url": "http://geojson.org/geojson-spec.html#id2"
           },
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
-              "required": true,
               "enum": [
                 "Point"
               ]
@@ -80,10 +80,10 @@
           "externalDocs": {
             "url": "http://geojson.org/geojson-spec.html#id3"
           },
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
-              "required": true,
               "enum": [
                 "LineString"
               ]
@@ -102,10 +102,10 @@
           "externalDocs": {
             "url": "http://geojson.org/geojson-spec.html#id4"
           },
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
-              "required": true,
               "enum": [
                 "Polygon"
               ]
@@ -124,10 +124,10 @@
           "externalDocs": {
             "url": "http://geojson.org/geojson-spec.html#id6"
           },
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
-              "required": true,
               "enum": [
                 "MultiPolygon"
               ]

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -403,11 +403,11 @@
           "properties": {
             "name": {
               "type": "string",
-              "description": "Title of waypoint"
+              "description": "Name of waypoint"
             },
             "description": {
               "type": "string",
-              "description": "Text describing waypoint"
+              "description": "Waypoint description"
             },
             "position": {
               "allOf": [

--- a/src/api/resources/resources.ts
+++ b/src/api/resources/resources.ts
@@ -1,4 +1,4 @@
-import { Position, SignalKResourceType } from '@signalk/server-api'
+import { Position, SignalKResourceType, Waypoint } from '@signalk/server-api'
 import { getDistance, isValidCoordinate } from 'geolib'
 
 export const buildResource = (resType: SignalKResourceType, data: any): any => {
@@ -332,3 +332,28 @@ const transformCoords = (coords: Position[]) => {
     return [p.longitude, p.latitude]
   })
 }
+
+const FROM_POST_MAPPERS: {
+  [key: string]: (data: any) => any
+} = {
+  waypoints: (data: any) => {
+    const { name, description, position, properties } = data
+    const result: Waypoint = {
+      feature: {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [position.longitude, position.latitude]
+        }
+      }
+    }
+    name && (result.name = name)
+    description && (result.description = description)
+    properties && (result.feature.properties = properties)
+    return result
+  }
+}
+export const fromPostData = (type: string, data: any) =>
+  FROM_POST_MAPPERS[type as string]
+    ? FROM_POST_MAPPERS[type as string](data)
+    : data

--- a/test/course.ts
+++ b/test/course.ts
@@ -123,14 +123,7 @@ describe('Course Api', () => {
       longitude: 24.9384
     }
     const { id } = await post('/resources/waypoints', {
-      feature: {
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [destination.longitude, destination.latitude]
-        },
-        properties: {}
-      }
+      position: destination
     }).then(response => {
       response.status.should.equal(200)
       return response.json()


### PR DESCRIPTION
Use the schemas in openapi definition to validate resources api payloads. The main idea is that `validate` just throws if the data is not valid and the errors are propagated to the client as payload of the 400 response, 
