### PR TITLE
fix: baseDeltas.json is missing in restore process

### DIFF
--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -787,7 +787,8 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
     'settings.json',
     'defaults.json',
     'security.json',
-    'package.json'
+    'package.json',
+    'baseDeltas.json'
   ]
   function listSafeRestoreFiles(restorePath) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
After a backup/restore of the server the Name, MMSI, ... parameters are not restored.
The `baseDeltas.json` file is present in the backup but it is not restored
issue: #1421 