### PR TITLE
fix: add guard against bad pathvalues in deltacache

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -208,11 +208,13 @@ function pathToProcessForFull(pathArray: any[]) {
 }
 
 function pickDeltasFromBranch(acc: any[], obj: any) {
-  if (isUndefined(obj.path) || isUndefined(obj.value)) {
-    // not a delta, so process possible children
-    _.values(obj).reduce(pickDeltasFromBranch, acc)
-  } else {
-    acc.push(obj)
+  if (typeof obj === 'object') {
+    if (isUndefined(obj.path) || isUndefined(obj.value)) {
+      // not a delta, so process possible children
+      _.values(obj).reduce(pickDeltasFromBranch, acc)
+    } else {
+      acc.push(obj)
+    }
   }
   return acc
 }


### PR DESCRIPTION
Sending pathvalues without either path or value in
delta would cause delta retrieval from deltacache to
fail with infinite recursion. So after such a 'poison'
value in any delta cache retrieval would start failing
until a new value would be written for that path in the
cache.