### PR TITLE
feature: add client$source

### DIFF
--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -488,7 +488,7 @@ function processUpdates(app, pathSources, spark, msg) {
     )
     return
   }
-  app.handleMessage(spark.request.source || 'ws', msg)
+  app.handleMessage(clientSourceId(spark), msg)
 
   msg.updates.forEach(update => {
     if (update.values) {
@@ -653,10 +653,15 @@ function wrapWithverifyWS(securityStrategy, spark, theFunction) {
   }
 }
 
+function clientSourceId(spark) {
+  return `ws:${spark.id}`
+}
+
 function sendHello(app, helloProps, spark) {
   spark.write({
     ...app.getHello(),
-    ...helloProps
+    ...helloProps,
+    client$source: clientSourceId(spark)
   })
 }
 


### PR DESCRIPTION
This adds client$source property to WebSocket hello message and uses that
same value as $source value for all updates in deltas received from that
WebSocket that do not have source object or $source property already
when received from the client.

The purpose is to create a mechanism for a ws client to tell which of
the messages were originally sent by itself.