### PR TITLE
feat: option in throttle-timestamp to bring recorded timestamps into current moment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,23 @@
 
 ## Please see [Releases](https://github.com/SignalK/signalk-server-node/releases) for the release notes.
+
+## Feature: option adjustTimestamp in timestamp-throttle piped provider element
+Piped provider element `timestamp-throttle` now has option `adjustTimestamp` to "adjust" the timestamp of messages as it plays them back.  When enabled, it calculates the difference between the recorded timestamp in the first message and system time at that moment and adds that difference to the timestamp in all messages.  This makes the playback appear to be happening in real time.
+
+To enable, in your `settings.json`:
+
+```json
+. . .
+"pipeElements": [
+. . .
+  {
+    "type": "providers/timestamp-throttle",
+    "options": {
+        "adjustTimestamp": true
+    }
+  },
+. . .
+]
+. . .
+```
+See `settings/n2k-from-file-settings-adjust-timestamp.json` for an example.

--- a/settings/n2k-from-file-settings-adjust-timestamp.json
+++ b/settings/n2k-from-file-settings-adjust-timestamp.json
@@ -1,0 +1,47 @@
+{
+  "vessel": {
+    "name": "Aava",
+    "brand": "Arcona",
+    "type": "Arcona 34",
+    "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d"
+  },
+  "pipedProviders": [
+    {
+      "id": "n2kFromFile",
+      "pipeElements": [
+        {
+          "type": "providers/filestream",
+          "options": {
+            "filename": "samples/aava-n2k.data",
+            "providerId": "n2kFromFile"
+          },
+          "optionMappings": [
+            {
+              "fromAppProperty": "argv.n2kfilename",
+              "toOption": "filename"
+            }
+          ]
+        },
+        {
+          "type": "providers/liner"
+        },
+        {
+          "type": "providers/canboatjs"
+        },
+        {
+          "type": "providers/timestamp-throttle",
+          "options": {
+              "adjustTimestamp": true
+          }
+        },
+        {
+          "type": "providers/n2k-signalk"
+        }
+      ]
+    }
+  ],
+  "interfaces": {},
+  "security": {
+    "strategy": "./tokensecurity"
+  }
+}


### PR DESCRIPTION
Added option `adjustTimestamp` in throttle-timestamp to "adjust" the timestamp of messages as it plays them back.  It calculates the difference between the recorded timestamp in the first message and system time at that moment and adds that difference to the timestamp in all messages.  This makes the playback appear to be happening in real time.

To enable, in your `settings.json`:

```json
. . .
"pipeElements": [
. . .
  {
    "type": "providers/timestamp-throttle",
    "options": {
        "adjustTimestamp": true
    }
  },
. . .
]
. . .
```
See `settings/n2k-from-file-settings-adjust-timestamp.json` for an example.
