### PR TITLE
feature: allow configuring CORS origins explicitly

### DIFF
--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -70,6 +70,7 @@ class Settings extends Component {
       expiration: this.state.expiration,
       allowNewUserRegistration: this.state.allowNewUserRegistration,
       allowDeviceAccessRequests: this.state.allowDeviceAccessRequests,
+      allowedCorsOrigins: this.state.allowedCorsOrigins
     }
     fetch(`${window.serverRoutesPrefix}/security/config`, {
       method: 'PUT',
@@ -196,7 +197,23 @@ class Settings extends Component {
                         value={this.state.expiration}
                       />
                       <FormText color="muted">
-                        Exmaples: 60s, 1m, 1h, 1d
+                        Examples: 60s, 1m, 1h, 1d
+                      </FormText>
+                    </Col>
+                  </FormGroup>
+                  <FormGroup row>
+                    <Col md="2">
+                      <Label htmlFor="text-input">Allowed CORS origins</Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <Input
+                        type="text"
+                        name="allowedCorsOrigins"
+                        onChange={this.handleChange}
+                        value={this.state.allowedCorsOrigins}
+                      />
+                      <FormText color="muted">
+                       Use comma delimited list, example: http://host1.name.com:3000,http://host2.name.com:3000
                       </FormText>
                     </Col>
                   </FormGroup>


### PR DESCRIPTION
If you want to use any of the http APIs from
another origin with credentials you can not use just
a wildcard origin, CORS rules don't allow that.

This adds a setting under security that allows configuration
of one or several allowed CORS origins.

A practical use case for this is when you use the (wip)
history API from Grafana Signal K datasource. Grafana
typically runs on another port, making the requests from
Grafana UI cross domain.