### PR TITLE
fix: empty path subscription period handling

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -163,7 +163,11 @@ function handleSubscribeRow(
           )
         }
         debug('minPeriod:' + subscribeRow.minPeriod)
-        filteredBus = filteredBus.debounceImmediate(subscribeRow.minPeriod)
+        if (key !== '') {
+          // we can not apply minPeriod for empty path subscriptions
+          debug('debouncing')
+          filteredBus = filteredBus.debounceImmediate(subscribeRow.minPeriod)
+        }
       } else if (
         subscribeRow.period ||
         (subscribeRow.policy && subscribeRow.policy === 'fixed')
@@ -172,7 +176,8 @@ function handleSubscribeRow(
           errorCallback(
             `period assumes policy 'fixed', ignoring policy ${subscribeRow.policy}`
           )
-        } else {
+        } else if (key !== '') {
+          // we can not apply period for empty path subscriptions
           const interval = subscribeRow.period || 1000
           filteredBus = filteredBus
             .bufferWithTime(interval)


### PR DESCRIPTION
Period and minPeriod do not quite make sense with
empty path subscriptions: for different values the
path is the same, so how do you send data only every
x milliseconds, as it means dropping some of the
values and not sending them at all.

This changes subscription handling so that period
and minPeriod are silently ignored for subscriptions
with an empty path.

Fixes https://github.com/SignalK/freeboard-sk/issues/108