### PR TITLE
chore: automate Github Release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  release:
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
   docker_image:
     runs-on: ubuntu-latest
     needs: signalk-server

--- a/.github/workflows/require_pr_label.yml
+++ b/.github/workflows/require_pr_label.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "fix, feature, doc, chore, test, ignore, other, dependencies"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "lint": "tslint --config tslint.js --project tsconfig.json --fix",
     "ci-lint": "tslint --config tslint.js --project tsconfig.json",
     "prepublishOnly": "npm run lint && npm run build:all && npm run build-declaration",
-    "create-release": "github-create-release --owner signalk --repository signalk-server --npm-base-url https://www.npmjs.com/package/signalk-server",
-    "release": "npm run prepublishOnly && git tag -d latest && git push --delete origin latest && git tag latest && git push --tags && git push && npm run create-release",
     "update-latest-release": "git checkout master && git branch -D latest-release || git checkout -b latest-release && git push -f origin/latest-release",
     "start": "node bin/signalk-server",
     "test-only": "mocha --require ts-node/register --extensions ts,tsx,js --timeout 10000 --exit 'test/**/*.[jt]s' 'lib/**/*.test.js'",
@@ -140,7 +138,6 @@
     "serialport": "^9.0.1"
   },
   "devDependencies": {
-    "@signalk/github-create-release": "^1.0.0",
     "@types/chai": "^4.2.15",
     "@types/express": "^4.17.1",
     "@types/lodash": "^4.14.139",


### PR DESCRIPTION
Use actions to create release notes off labeled PRs and release
itself, triggered by tags.