### PR TITLE
Feature: Webapp icons

### DIFF
--- a/WEBAPPS.md
+++ b/WEBAPPS.md
@@ -36,6 +36,18 @@ This structure is all that is needed for a standalone webapp.
 
 There is no keyword for a module that provides only embedded components, use `signalk-webapp` instead.
 
+You can also including the following section in `package.json` to determine how your webapp appears in the `WebApps` list:
+```JSON
+  "signalk": {
+    "appIcon": "./assets/icons/icon-72x72.png",
+    "displayName": "Freeboard-SK"
+  },
+```
+
+where:
+- `appIcon` is the path (relative to the `public` directory) to an image within the package to display in the webapp list. The image should be at least 72x72 pixels in size.
+- `displayName` is the name to appear in the webapp list. By default the `name` in the package.json is used, when supplied this text will be used instead.
+
 The embedded components are implemented using [Webpack Federated Modules](https://webpack.js.org/concepts/module-federation/) and [React Code Splitting](https://reactjs.org/docs/code-splitting.html).
 
 You need to configured Webpack to create the necessary code for federation using *ModuleFederationPlugin* and expose the component with fixed names:

--- a/WEBAPPS.md
+++ b/WEBAPPS.md
@@ -34,9 +34,7 @@ The basic structure of a webapp is
 
 This structure is all that is needed for a standalone webapp.
 
-There is no keyword for a module that provides only embedded components, use `signalk-webapp` instead.
-
-You can also including the following section in `package.json` to determine how your webapp appears in the `WebApps` list:
+You can also include the following section in `package.json` to determine how your webapp appears in the _Webapps_ list:
 ```JSON
   "signalk": {
     "appIcon": "./assets/icons/icon-72x72.png",
@@ -49,6 +47,8 @@ where:
 - `displayName` is the name to appear in the webapp list. By default the `name` in the package.json is used, when supplied this text will be used instead.
 
 The embedded components are implemented using [Webpack Federated Modules](https://webpack.js.org/concepts/module-federation/) and [React Code Splitting](https://reactjs.org/docs/code-splitting.html).
+
+There is no keyword for a module that provides only embedded components, use `signalk-webapp` instead.
 
 You need to configured Webpack to create the necessary code for federation using *ModuleFederationPlugin* and expose the component with fixed names:
 - embeddable webapp: `./AppPanel`

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.js
@@ -15,6 +15,7 @@ const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   cssModule: PropTypes.object,
+  bgImage: PropTypes.string
 }
 
 const defaultProps = {
@@ -24,6 +25,7 @@ const defaultProps = {
   color: 'primary',
   variant: '0',
   link: '#',
+  bgImage: ''
 }
 
 class Widget02 extends Component {
@@ -40,6 +42,7 @@ class Widget02 extends Component {
       link,
       children,
       variant,
+      bgImage,
       ...attributes
     } = this.props
 
@@ -69,14 +72,18 @@ class Widget02 extends Component {
       'text-capitalize'
     )
 
-    const blockIcon = function (icon) {
+    const blockIcon = function (icon, bgImage = null) {
       const classes = classNames(
         icon,
         'bg-' + card.color,
         padding.icon,
         'font-2xl mr-3 float-left'
       )
-      return <i className={classes} />
+      const style = {
+        backgroundSize: 'cover',
+        backgroundImage: bgImage ? `url(${bgImage})` : 'unset'
+      }
+      return <i className={classes} style={style}/>
     }
 
     const cardFooter = function () {
@@ -99,7 +106,7 @@ class Widget02 extends Component {
       <a href={url}>
         <Card>
           <CardBody className={card.classes} {...attributes}>
-            {blockIcon(card.icon)}
+            {blockIcon(card.icon, `${this.props.url}/${this.props.bgImage}`)}
             <div className={lead.classes}>{header}</div>
             <div className="text-muted font-xs">{mainText}</div>
           </CardBody>

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.js
@@ -15,7 +15,7 @@ const propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   cssModule: PropTypes.object,
-  bgImage: PropTypes.string
+  bgImage: PropTypes.string,
 }
 
 const defaultProps = {
@@ -25,7 +25,7 @@ const defaultProps = {
   color: 'primary',
   variant: '0',
   link: '#',
-  bgImage: ''
+  bgImage: '',
 }
 
 class Widget02 extends Component {
@@ -81,9 +81,9 @@ class Widget02 extends Component {
       )
       const style = {
         backgroundSize: 'cover',
-        backgroundImage: bgImage ? `url(${bgImage})` : 'unset'
+        backgroundImage: bgImage ? `url(${bgImage})` : 'unset',
       }
-      return <i className={classes} style={style}/>
+      return <i className={classes} style={style} />
     }
 
     const cardFooter = function () {

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.js
@@ -56,11 +56,12 @@ class Webapps extends Component {
                     <Col xs="12" md="12" lg="6" xl="4" key={webappInfo.name}>
                       <Webapp
                         key={webappInfo.name}
-                        header={webappInfo.name}
+                        header={webappInfo.signalk && webappInfo.signalk.displayName ? webappInfo.signalk.displayName : webappInfo.name}
                         mainText={webappInfo.description}
                         url={url}
-                        icon="icon-grid fa fa-external-link"
+                        icon={`fa fa-external-link ${webappInfo.signalk && webappInfo.signalk.displayName ? '' : 'icon-grid'}`}
                         color="primary"
+                        bgImage={webappInfo.signalk && webappInfo.signalk.appIcon ? webappInfo.signalk.appIcon : ''}
                       />
                     </Col>
                   )

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.js
@@ -56,12 +56,24 @@ class Webapps extends Component {
                     <Col xs="12" md="12" lg="6" xl="4" key={webappInfo.name}>
                       <Webapp
                         key={webappInfo.name}
-                        header={webappInfo.signalk && webappInfo.signalk.displayName ? webappInfo.signalk.displayName : webappInfo.name}
+                        header={
+                          webappInfo.signalk && webappInfo.signalk.displayName
+                            ? webappInfo.signalk.displayName
+                            : webappInfo.name
+                        }
                         mainText={webappInfo.description}
                         url={url}
-                        icon={`fa fa-external-link ${webappInfo.signalk && webappInfo.signalk.displayName ? '' : 'icon-grid'}`}
+                        icon={`fa fa-external-link ${
+                          webappInfo.signalk && webappInfo.signalk.displayName
+                            ? ''
+                            : 'icon-grid'
+                        }`}
                         color="primary"
-                        bgImage={webappInfo.signalk && webappInfo.signalk.appIcon ? webappInfo.signalk.appIcon : ''}
+                        bgImage={
+                          webappInfo.signalk && webappInfo.signalk.appIcon
+                            ? webappInfo.signalk.appIcon
+                            : ''
+                        }
                       />
                     </Col>
                   )


### PR DESCRIPTION
Add support to determine how a webapp is displayed in the WebApps list including an icon by adding the following section in package.json:

```JSON
  "signalk": {
    "appIcon": "./assets/icons/icon-72x72.png",
    "displayName": "Freeboard-SK"
  }
```
where:

- `appIcon` is the path (relative to the public directory) to an image within the package to display in the webapp list. The image should be at least 72x72 pixels in size.
- `displayName` is the name to appear in the webapp list which will override the use of the `name` attribute in the package.json.

![image](https://user-images.githubusercontent.com/38519157/173266279-4cf319ad-97f7-48a9-8316-7066fab329a3.png)

(closes #629)