### PR TITLE
feature: add 'AccessLogging' as an option to the Server Settings

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -52,6 +52,7 @@ export interface Config {
     security?: any
     ssl?: boolean
     wsCompression?: boolean
+    accessLogging?: boolean
     landingPage?: string
     proxy_host?: string
     proxy_port?: number

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
  * Copyright 2014-2015 Fabian Tollenaar <fabian@starting-point.nl>
  *
@@ -13,20 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-module.exports = function(app) {
-  'use strict'
-
-  if (app.get('env') === 'development') {
-    app.config.environment = 'development'
-
-    app.use(
-      require('errorhandler')({
-        dumpExceptions: true,
-        showStack: true
-      })
-    )
-
-    app.use(require('morgan')('dev'))
-  }
-}
+module.exports = function (app) {
+    'use strict';
+    if (app.get('env') === 'development') {
+        app.config.environment = 'development';
+        app.use(require('errorhandler')({
+            dumpExceptions: true,
+            showStack: true
+        }));
+        app.use(require('morgan')('dev', {
+		// reflect the Server / Settings / Server Settings / AccessLogging setting
+		// i.e. skip logging lines from morgan if AccessLogging is disabled.
+		skip: function (req, res) { return !app.config.settings.accessLogging }
+	}));
+    }
+};

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
  * Copyright 2014-2015 Fabian Tollenaar <fabian@starting-point.nl>
  *
@@ -13,15 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-
-module.exports = function(app) {
-  'use strict'
-
-  if (app.get('env') === 'production') {
-    app.config.environment = 'production'
-    app.config.debug = false
-
-    app.use(require('morgan')('combined'))
-    app.use(require('errorhandler')())
-  }
-}
+module.exports = function (app) {
+    'use strict';
+    if (app.get('env') === 'production') {
+        app.config.environment = 'production';
+        app.config.debug = false;
+        app.use(require('morgan')('combined', {
+          // reflect the Server / Settings / Server Settings / AccessLogging setting
+          // i.e. skip logging lines from morgan if AccessLogging is disabled.
+          skip: function (req, res) { return !app.config.settings.accessLogging }
+	}));
+        app.use(require('errorhandler')());
+    }
+};

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -384,7 +384,11 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
         wsCompression: app.config.settings.wsCompression || false,
         enablePluginLogging:
           _.isUndefined(app.config.settings.enablePluginLogging) ||
-          app.config.settings.enablePluginLogging
+          app.config.settings.enablePluginLogging,
+	accessLogging: 
+	  _.isUndefined(app.config.settings.accessLogging) ||
+	  app.config.settings.accessLogging
+
       },
       loggingDirectory: app.config.settings.loggingDirectory,
       pruneContextsMinutes: app.config.settings.pruneContextsMinutes || 60,
@@ -486,6 +490,10 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
 
     if (!_.isUndefined(settings.options.wsCompression)) {
       app.config.settings.wsCompression = settings.options.wsCompression
+    }
+
+    if (!_.isUndefined(settings.options.accessLogging)) {
+      app.config.settings.accessLogging = settings.options.accessLogging
     }
 
     if (!_.isUndefined(settings.options.enablePluginLogging)) {


### PR DESCRIPTION
Adding 'AccessLogging' as an option to the server in order to control whether the Morgan web server should produce access log output.