### PR TITLE
feature: improve detection of dead SignalK to SignalK connections

### DIFF
--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -66,6 +66,7 @@ function MdnsWs(options) {
       autoConnect: false,
       deltaStreamBehaviour,
       rejectUnauthorized: !(options.selfsignedcert === true),
+      wsKeepaliveInterval: 10
     })
     this.connect(this.signalkClient)
   } else {

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/SignalK/signalk-server-node#readme",
   "dependencies": {
     "@canboat/canboatjs": "^1.4.0",
-    "@signalk/client": "^2.1.0",
+    "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^2.0.0",
     "@signalk/nmea0183-signalk": "^3.0.0",
     "@signalk/nmea0183-utilities": "^0.8.0",


### PR DESCRIPTION
This addition makes ws client send periodic "keepalive" messages to the server. If the connection is no longer alive this will prompt the OS to eventually kill it, instead of keeping it lingering for ever.

This is still not perfect, as it is up to the OS settings to detect dead connections. We should implement keepalive / heartbeat messages from the server to make detection more deterministic, quicker and configurable.