### PR TITLE
feat: implement YDWG RAW transmitting over UDP

### DIFF
--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -253,7 +253,12 @@ function nmea2000input(subOptions, logging) {
       new Liner(subOptions),
     ]
   } else if (subOptions.type === 'ydwg02-udp-canboatjs') {
-    return [new Udp(subOptions), new Liner(subOptions)]
+    return [
+      new Udp({
+        ...subOptions,
+        outEvent: 'ydwg02-out'}),
+        new Liner(subOptions)
+    ]
   } else if (subOptions.type === 'navlink2-tcp-canboatjs') {
     return [
       new Tcp({


### PR DESCRIPTION
These changes allow transmitting NMEA 2000 data over YDWG RAW UDP
broadcasts. This allows for wireless N2K connectivity via a suitable
gateway device.

At the moment, the server _does not_ do address claims or other
N2K protocol red tape over the YDWG RAW UDP interface.