### PR TITLE
fix: CORS: security routes and origin handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@types/busboy": "^1.5.0",
     "@types/chai": "^4.2.15",
     "@types/command-exists": "^1.2.0",
+    "@types/cors": "^2.8.12",
     "@types/express": "^4.17.1",
     "@types/lodash": "^4.14.139",
     "@types/mocha": "^8.2.0",

--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -108,7 +108,7 @@ class Settings extends Component {
                   className="form-horizontal"
                 >
                   <FormGroup row>
-                    <Col xs="0" md="2">
+                    <Col xs="0" md="3">
                       <Label>Allow Readonly Access</Label>
                     </Col>
                     <Col md="9">
@@ -186,10 +186,10 @@ class Settings extends Component {
                     </Col>
                   </FormGroup>
                   <FormGroup row>
-                    <Col md="2">
+                    <Col md="3">
                       <Label htmlFor="text-input">Login Session Timeout</Label>
                     </Col>
-                    <Col xs="12" md="9">
+                    <Col xs="12" md="2">
                       <Input
                         type="text"
                         name="expiration"
@@ -202,7 +202,7 @@ class Settings extends Component {
                     </Col>
                   </FormGroup>
                   <FormGroup row>
-                    <Col md="2">
+                    <Col md="3">
                       <Label htmlFor="text-input">Allowed CORS origins</Label>
                     </Col>
                     <Col xs="12" md="9">

--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -6,16 +6,12 @@ import {
   CardHeader,
   CardBody,
   CardFooter,
-  InputGroup,
-  InputGroupAddon,
   Input,
   Form,
   Col,
   Label,
   FormGroup,
   FormText,
-  Table,
-  Row,
 } from 'reactstrap'
 import EnableSecurity from './EnableSecurity'
 

--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -25,6 +25,8 @@ export function fetchSecurityConfig() {
     })
 }
 
+const adminUIOrigin = `${window.location.protocol}//${window.location.host}`
+
 class Settings extends Component {
   constructor(props) {
     super(props)
@@ -67,6 +69,7 @@ class Settings extends Component {
       allowNewUserRegistration: this.state.allowNewUserRegistration,
       allowDeviceAccessRequests: this.state.allowDeviceAccessRequests,
       allowedCorsOrigins: this.state.allowedCorsOrigins,
+      adminUIOrigin,
     }
     fetch(`${window.serverRoutesPrefix}/security/config`, {
       method: 'PUT',
@@ -197,6 +200,18 @@ class Settings extends Component {
                       </FormText>
                     </Col>
                   </FormGroup>
+                  <FormGroup row>
+                    <Col md="12">
+                      <Label>
+                        Simple CORS requests are allowed from all hosts by
+                        default. You can restrict CORS requests to named hosts
+                        by configuring allowed CORS origins below. The host
+                        where this page is loaded from is automatically included
+                        in the allowed CORS origins so that the Admin UI
+                        continues to work.
+                      </Label>
+                    </Col>
+                  </FormGroup>{' '}
                   <FormGroup row>
                     <Col md="3">
                       <Label htmlFor="text-input">Allowed CORS origins</Label>

--- a/public/examples/loginform.html
+++ b/public/examples/loginform.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Login form</title>
+</head>
+
+<body>
+  <form id="loginForm">
+    <input type="text" id="username" /><br />
+    <input type="password" id="password" /><br />
+    <button type="submit">Submit</button>
+    <p id="result"></p>
+  </form>
+</body>
+<script>
+  window.onload = function () {
+    document.getElementById('loginForm').onsubmit = function () {
+      document.getElementById('result').innerHTML = ''
+      const username = document.getElementById('username').value
+      const password = document.getElementById('password').value
+      const body = JSON.stringify({ username, password })
+      fetch('http://localhost:3000/signalk/v1/auth/login', {
+        method: 'POST',
+        withCredentials: true,
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body
+      })
+        .then(r => r.json())
+        .then(r => { 
+          document.getElementById('result').innerHTML = JSON.stringify(r)
+        })
+      return false;
+    }
+  }
+</script>
+
+</html>

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,60 @@
+import { IRouter } from 'express'
+import { createDebug } from './debug'
+import { SecurityConfig } from './security'
+import cors, { CorsOptions } from 'cors'
+
+type OriginCallback = (err: Error | null, origin?: string) => void
+
+export function setupCors(
+  app: IRouter,
+  { allowedCorsOrigins }: SecurityConfig
+) {
+  const corsDebug = createDebug('signalk-server:cors')
+
+  const corsOrigins = allowedCorsOrigins
+    ? allowedCorsOrigins
+        .split(',')
+        .map((s: string) => s.trim().replace(/\/*$/, ''))
+    : []
+  corsDebug(`corsOrigins:${corsOrigins.toString()}`)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const corsOptions: CorsOptions = {
+    credentials: true
+  }
+  if (corsOrigins.length) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    corsOptions.origin = (origin: string | undefined, cb: OriginCallback) => {
+      if (origin === undefined || corsOrigins.indexOf(origin) >= 0) {
+        corsDebug(`${origin} OK`)
+        cb(null, origin)
+      } else {
+        const errorMsg = `${origin} not allowed`
+        corsDebug(errorMsg)
+        cb(new Error(errorMsg))
+      }
+    }
+  }
+  app.use(cors(corsOptions))
+}
+
+export const handleAdminUICORSOrigin = (
+  securityConfig: SecurityConfig & { adminUIOrigin: string }
+) => {
+  let allowedCorsOrigins: string[] = []
+  if (
+    securityConfig.adminUIOrigin &&
+    securityConfig.allowedCorsOrigins &&
+    securityConfig.allowedCorsOrigins.length > 0
+  ) {
+    allowedCorsOrigins = securityConfig.allowedCorsOrigins?.split(',')
+    if (allowedCorsOrigins.indexOf(securityConfig.adminUIOrigin) === -1) {
+      allowedCorsOrigins.push(securityConfig.adminUIOrigin)
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { adminUIOrigin, ...configWithoutAdminUIOrigin } = securityConfig
+  return {
+    ...configWithoutAdminUIOrigin,
+    allowedCorsOrigins: allowedCorsOrigins.join(',')
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -564,7 +564,11 @@ function startInterfaces(app: ServerApp & WithConfig) {
 function setupCors(app: any, { allowedCorsOrigins }: any) {
   const corsDebug = createDebug('signalk-server:cors')
 
-  const corsOrigins = allowedCorsOrigins ? allowedCorsOrigins.split(',') : []
+  const corsOrigins = allowedCorsOrigins
+    ? allowedCorsOrigins
+        .split(',')
+        .map((s: string) => s.trim().replace(/\/*$/, ''))
+    : []
   corsDebug(`corsOrigins:${corsOrigins.toString()}`)
   const corsOptions: any = {
     credentials: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,13 +571,13 @@ function setupCors(app: any, { allowedCorsOrigins }: any) {
   }
   if (corsOrigins.length) {
     corsOptions.origin = (origin: any, cb: any) => {
-      if (corsOrigins.indexOf(origin)) {
+      if (origin === undefined || corsOrigins.indexOf(origin) >= 0) {
         corsDebug(`Found CORS origin ${origin}`)
         cb(undefined, origin)
       } else {
         const errorMsg = `CORS origin not allowed ${origin}`
         corsDebug(errorMsg)
-        cb(new Error(errorMsg))
+        cb(errorMsg)
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -576,10 +576,10 @@ function setupCors(app: any, { allowedCorsOrigins }: any) {
   if (corsOrigins.length) {
     corsOptions.origin = (origin: any, cb: any) => {
       if (origin === undefined || corsOrigins.indexOf(origin) >= 0) {
-        corsDebug(`Found CORS origin ${origin}`)
+        corsDebug(`${origin} OK`)
         cb(undefined, origin)
       } else {
-        const errorMsg = `CORS origin not allowed ${origin}`
+        const errorMsg = `${origin} not allowed`
         corsDebug(errorMsg)
         cb(errorMsg)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   saveSecurityConfig,
   startSecurity
 } from './security.js'
+import { setupCors } from './cors'
 import SubscriptionManager from './subscriptionmanager'
 import { Delta } from './types'
 const debug = createDebug('signalk-server')
@@ -559,31 +560,4 @@ function startInterfaces(app: ServerApp & WithConfig) {
       debug(`Not loading interface '${name}' because of configuration`)
     }
   })
-}
-
-function setupCors(app: any, { allowedCorsOrigins }: any) {
-  const corsDebug = createDebug('signalk-server:cors')
-
-  const corsOrigins = allowedCorsOrigins
-    ? allowedCorsOrigins
-        .split(',')
-        .map((s: string) => s.trim().replace(/\/*$/, ''))
-    : []
-  corsDebug(`corsOrigins:${corsOrigins.toString()}`)
-  const corsOptions: any = {
-    credentials: true
-  }
-  if (corsOrigins.length) {
-    corsOptions.origin = (origin: any, cb: any) => {
-      if (origin === undefined || corsOrigins.indexOf(origin) >= 0) {
-        corsDebug(`${origin} OK`)
-        cb(undefined, origin)
-      } else {
-        const errorMsg = `${origin} not allowed`
-        corsDebug(errorMsg)
-        cb(errorMsg)
-      }
-    }
-  }
-  app.use(require('cors')(corsOptions))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ class Server {
     app.logging = require('./logging')(app)
     app.version = '0.0.1'
 
-    startSecurity(app, opts ? opts.securityConfig : null)
     setupCors(app, getSecurityConfig(app))
+    startSecurity(app, opts ? opts.securityConfig : null)
 
     require('./serverroutes')(app, saveSecurityConfig, getSecurityConfig)
     require('./put').start(app)

--- a/src/security.ts
+++ b/src/security.ts
@@ -98,6 +98,7 @@ export interface SecurityConfig {
   allow_readonly: boolean
   allowNewUserRegistration: boolean
   allowDeviceAccessRequests: boolean
+  allowedCorsOrigins?: string
   expiration: string
   devices: Device[]
   secretKey: string

--- a/src/security.ts
+++ b/src/security.ts
@@ -229,7 +229,7 @@ export function getSecurityConfig(
   app: WithConfig & WithSecurityStrategy,
   forceRead = false
 ) {
-  if (!forceRead && app.securityStrategy.configFromArguments) {
+  if (!forceRead && app.securityStrategy?.configFromArguments) {
     return app.securityStrategy.securityConfig
   } else {
     try {

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -36,6 +36,7 @@ import {
   writeSettingsFile
 } from './config/config'
 import { SERVERROUTESPREFIX } from './constants'
+import { handleAdminUICORSOrigin } from './cors'
 import { createDebug, listKnownDebugs } from './debug'
 import { getAuthor, Package, restoreModules } from './modules'
 import { getHttpPort, getSslPort } from './ports'
@@ -205,7 +206,8 @@ module.exports = function (
         }
 
         let config = getSecurityConfig(app)
-        config = app.securityStrategy.setConfig(config, req.body)
+        const configToSave = handleAdminUICORSOrigin(req.body)
+        config = app.securityStrategy.setConfig(config, configToSave)
         saveSecurityConfig(app, config, (err) => {
           if (err) {
             console.log(err)


### PR DESCRIPTION
CORS was previously not enabled for any of the security related routes, specifically `/signalk/v1/auth/login. This PR changes the order in server setup so that CORS middleware is activated before security routes. Fixes #1479.

Without any origins configured the server allows CORS requests from any host.

However when configured the origin list was not working correctly:
- the first configured origin was not accepted
- all others were
- except `undefined` that is _same host_
This PR fixes the origin checking logic so that it actually works.

In addition this PR adds special handling for the Admin UI origin: the origin that the security configuration form that is used to set CORS origin field to non empty value is automatically added to the list of allowed CORS origins. Otherwise Admin UI itself will stop working, blocked by CORS.

Now the security configuration form also includes a short description of how CORS works.