### PR TITLE
fix: use plugin.id when setting error

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -474,7 +474,7 @@ module.exports = (theApp: any) => {
     } catch (e: any) {
       console.error('error starting plugin: ' + e)
       console.error(e.stack)
-      app.setProviderError(plugin.name, `Failed to start: ${e.message}`)
+      app.setProviderError(plugin.id, `Failed to start: ${e.message}`)
     }
   }
 


### PR DESCRIPTION
Status is managed by id, not by name. This was resulting in multiple lines on the Dashboard, with errors that were already cleared.