### PR TITLE
feature: add Swagger and first OpenApi descriptions for discover and security/authentication APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Environment variables
 - `SIGNALK_NODE_CONFIG_DIR` override the path to find server configuration files.
 - `PORT` override the port for http/ws service (default is 3000).
 - `SSLPORT` override the port for https/wss service. If defined activates ssl as forced, default protocol (default is 3443).
+- `PROTOCOL` override http/https where the server is accessed via https but the server sees http (for example when Heroku handles https termination)
 - `EXTERNALPORT` the port used in /signalk response and Bonjour advertisement. Has precedence over configuration file.
 - `EXTERNALHOST` the host used in /signalk response and Bonjour advertisement. Has precedence over configuration file.
 - `FILEUPLOADSIZELIMIT` override the file upload size limit (default is '10mb').

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "semver": "^7.1.1",
     "split": "^1.0.0",
     "stat-mode": "^1.0.0",
+    "swagger-ui-express": "^4.5.0",
     "unzipper": "^0.10.10",
     "uuid": "^8.1.0",
     "ws": "^7.0.0"
@@ -153,6 +154,7 @@
     "@types/semver": "^7.1.0",
     "@types/serialport": "^8.0.1",
     "@types/split": "^1.0.0",
+    "@types/swagger-ui-express": "^4.1.3",
     "@types/unzipper": "^0.10.5",
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -268,6 +268,10 @@ const mapStateToProps = (state) => {
             url: '/serverConfiguration/datafiddler',
           },
           {
+            name: 'OpenApi',
+            url: `${window.location.protocol}//${window.location.host}/admin/openapi`,
+          },
+          {
             name: 'Backup/Restore',
             url: '/serverConfiguration/backuprestore',
           },

--- a/src/api/apps/openApi.json
+++ b/src/api/apps/openApi.json
@@ -30,11 +30,12 @@
     ],
     "components": {
       "schemas": {
-        "AppEntry": {
+        "WebAppInformation": {
           "type": "object",
           "required": [
             "name",
-            "version"
+            "version",
+            "location"
           ],
           "properties": {
             "name": {
@@ -95,39 +96,6 @@
             }
           }
         },
-        "ErrorResponse": {
-          "description": "Failed operation",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "description": "Request error response",
-                "properties": {
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "FAILED"
-                    ]
-                  },
-                  "statusCode": {
-                    "type": "number",
-                    "enum": [
-                      404
-                    ]
-                  },
-                  "message": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "state",
-                  "statusCode",
-                  "message"
-                ]
-              }
-            }
-          }
-        },
         "AppsListResponse": {
           "description": "Application list response.",
           "content": {
@@ -136,7 +104,7 @@
                 "description": "Application list.",
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/AppEntry"
+                  "$ref": "#/components/schemas/WebAppInformation"
                 }
               }
             }
@@ -202,9 +170,6 @@
           "responses": {
             "200": {
               "$ref": "#/components/responses/AppsListResponse"
-            },
-            "default": {
-              "$ref": "#/components/responses/ErrorResponse"
             }
           }
         }
@@ -229,9 +194,6 @@
           "responses": {
             "200": {
               "$ref": "#/components/responses/PluginDetailResponse"
-            },
-            "default": {
-              "$ref": "#/components/responses/ErrorResponse"
             }
           }
         }

--- a/src/api/apps/openApi.json
+++ b/src/api/apps/openApi.json
@@ -1,202 +1,327 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-      "version": "1.0.0",
-      "title": "Signal K Apps API",
-      "termsOfService": "http://signalk.org/terms/",
-      "license": {
-        "name": "Apache 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-      }
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Signal K Apps API",
+    "termsOfService": "http://signalk.org/terms/",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://signalk.org/specification/",
+    "description": "Signal K specification."
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "apps",
+      "description": "WebApps Information"
     },
-    "externalDocs": {
-      "url": "http://signalk.org/specification/",
-      "description": "Signal K specification."
-    },
-    "servers":[
-      {
-        "url": "/"
-      }
-    ],
-    "tags": [
-      {
-        "name": "apps",
-        "description": "WebApps Information"
+    {
+      "name": "plugins",
+      "description": "Plugin Management"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "WebAppInformation": {
+        "type": "object",
+        "required": ["name", "version", "location"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "@signalk/instrumentpanel"
+          },
+          "version": {
+            "type": "string",
+            "example": "1.3.1"
+          },
+          "description": {
+            "type": "string",
+            "example": "Signal K Instrument Panel"
+          },
+          "location": {
+            "type": "string",
+            "description": "Path where WebApp is mounted",
+            "example": "/@signalk/instrumentpanel"
+          },
+          "license": {
+            "type": "string",
+            "example": "Apache-2.0"
+          },
+          "author": {
+            "type": "string",
+            "description": "WebApp author(s)",
+            "example": "author1@hotmail.com, author2@hotmail.com"
+          }
+        }
       },
-      {
-        "name": "plugins",
-        "description": "Plugin Management"
+      "PluginInformation": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "packageName",
+          "keywords",
+          "version",
+          "description",
+          "schema",
+          "data"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "packageName": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "object",
+            "properties": {}
+          },
+          "statusMessage": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "configuration",
+              "enabled",
+              "enableDebug",
+              "enableLogging"
+            ],
+            "properties": {
+              "configuration": {
+                "type": "object",
+                "properties": {}
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "enableLogging": {
+                "type": "boolean"
+              },
+              "enableDebug": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
       }
-    ],
-    "components": {
-      "schemas": {
-        "WebAppInformation": {
-          "type": "object",
-          "required": [
-            "name",
-            "version",
-            "location"
-          ],
-          "properties": {
-            "name": {
-              "type": "string",
-              "example": "@signalk/instrumentpanel"
-            },
-            "version": {
-              "type": "string",
-              "example": "1.3.1"
-            },
-            "description": {
-              "type": "string",
-              "example": "Signal K Instrument Panel"
-            },
-            "location": {
-              "type": "string",
-              "description": "Path where WebApp is mounted",
-              "example": "/@signalk/instrumentpanel"
-            },
-            "license": {
-              "type": "string",
-              "example": "Apache-2.0"
-            },
-            "author": {
-              "type": "string",
-              "description": "WebApp author(s)",
-              "example": "author1@hotmail.com, author2@hotmail.com"
+    },
+    "responses": {
+      "200Ok": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["COMPLETED"]
+                },
+                "statusCode": {
+                  "type": "number",
+                  "enum": [200]
+                }
+              },
+              "required": ["state", "statusCode"]
             }
           }
         }
       },
-      "responses": {
-        "200Ok": {
-          "description": "OK",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "state": {
-                    "type": "string",
-                    "enum": [
-                      "COMPLETED"
-                    ]
-                  },
-                  "statusCode": {
-                    "type": "number",
-                    "enum": [
-                      200
-                    ]
-                  }
-                },
-                "required": [
-                  "state",
-                  "statusCode"
-                ]
+      "AppsListResponse": {
+        "description": "Application list response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Application list.",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/WebAppInformation"
               }
             }
           }
-        },
-        "AppsListResponse": {
-          "description": "Application list response.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Application list.",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/WebAppInformation"
+        }
+      },
+      "PluginDetailResponse": {
+        "description": "Plugin detail response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Plugin detail.",
+              "type": "object",
+              "required": [
+                "enabled",
+                "enabledByDefault",
+                "id",
+                "name",
+                "version"
+              ],
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "enabledByDefault": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "string",
+                  "example": "sksim"
+                },
+                "name": {
+                  "type": "string",
+                  "example": "Data stream generator"
+                },
+                "version": {
+                  "type": "string",
+                  "example": "1.5.4"
                 }
               }
             }
           }
-        },
-        "PluginDetailResponse": {
-          "description": "Plugin detail response.",
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "JAUTHENTICATION"
+      }
+    }
+  },
+
+  "paths": {
+    "/signalk/v1/apps/list": {
+      "get": {
+        "tags": ["apps"],
+        "summary": "List of installed Webapps",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/AppsListResponse"
+          }
+        }
+      }
+    },
+    "/plugins": {
+      "get": {
+        "tags": ["plugins"],
+        "summary": "List of installed plugins with detailed data",
+        "description": "This provides comprehensive data about all installed plugin, including their versions, configuration schemas and configuration data as well as enabled statuses.",
+        "responses": {
+          "200": {
+            "description": "Array of detailed data for installed plugins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PluginInformation"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plugins/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "Plugin identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": ["plugins"],
+        "summary": "Status information for a plugin",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PluginDetailResponse"
+          }
+        }
+      }
+    },
+    "/plugins/{id}/config": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "Plugin identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "tags": ["plugins"],
+        "summary": "Save configuration for a plugin",
+        "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "description": "Plugin detail.",
                 "type": "object",
-                "required": [
-                  "enabled", "enabledByDefault", "id",
-                  "name", "version"
-                ],
+                "required": ["enabled", "configuration"],
                 "properties": {
+                  "configuration": {
+                    "type": "object",
+                    "properties": {}
+                  },
                   "enabled": {
                     "type": "boolean"
                   },
-                  "enabledByDefault": {
+                  "enableLogging": {
                     "type": "boolean"
                   },
-                  "id": {
-                    "type": "string",
-                    "example": "sksim"
-                  },
-                  "name": {
-                    "type": "string",
-                    "example": "Data stream generator"
-                  },
-                  "version": {
-                    "type": "string",
-                    "example": "1.5.4"
+                  "enableDebug": {
+                    "type": "boolean"
                   }
                 }
               }
             }
           }
-        }
-      },
-      "securitySchemes": {
-        "bearerAuth": {
-          "type": "http",
-          "scheme": "bearer",
-          "bearerFormat": "JWT"
         },
-        "cookieAuth": {
-          "type": "apiKey",
-          "in": "cookie",
-          "name": "JAUTHENTICATION"
-        }
-      }
-    },
-
-    "paths": {
-      "/signalk/v1/apps/list": {
-        "get": {
-          "tags": [
-            "apps"
-          ],
-          "summary": "List of installed Webapps",
-          "responses": {
-            "200": {
-              "$ref": "#/components/responses/AppsListResponse"
-            }
-          }
-        }
-      },
-      "/plugins/{id}": {
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Plugin identifier",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "get": {
-          "tags": [
-            "plugins"
-          ],
-          "summary": "Status information for a plugin",
-          "responses": {
-            "200": {
-              "$ref": "#/components/responses/PluginDetailResponse"
-            }
+        "responses": {
+          "200": {
+            "description": "Plugin saved successfully"
           }
         }
       }
     }
   }
+}

--- a/src/api/apps/openApi.json
+++ b/src/api/apps/openApi.json
@@ -1,0 +1,240 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+      "version": "1.0.0",
+      "title": "Signal K Apps API",
+      "termsOfService": "http://signalk.org/terms/",
+      "license": {
+        "name": "Apache 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+      }
+    },
+    "externalDocs": {
+      "url": "http://signalk.org/specification/",
+      "description": "Signal K specification."
+    },
+    "servers":[
+      {
+        "url": "/"
+      }
+    ],
+    "tags": [
+      {
+        "name": "apps",
+        "description": "WebApps Information"
+      },
+      {
+        "name": "plugins",
+        "description": "Plugin Management"
+      }
+    ],
+    "components": {
+      "schemas": {
+        "AppEntry": {
+          "type": "object",
+          "required": [
+            "name",
+            "version"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "example": "@signalk/instrumentpanel"
+            },
+            "version": {
+              "type": "string",
+              "example": "1.3.1"
+            },
+            "description": {
+              "type": "string",
+              "example": "Signal K Instrument Panel"
+            },
+            "location": {
+              "type": "string",
+              "description": "Path where WebApp is mounted",
+              "example": "/@signalk/instrumentpanel"
+            },
+            "license": {
+              "type": "string",
+              "example": "Apache-2.0"
+            },
+            "author": {
+              "type": "string",
+              "description": "WebApp author(s)",
+              "example": "author1@hotmail.com, author2@hotmail.com"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200Ok": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "COMPLETED"
+                    ]
+                  },
+                  "statusCode": {
+                    "type": "number",
+                    "enum": [
+                      200
+                    ]
+                  }
+                },
+                "required": [
+                  "state",
+                  "statusCode"
+                ]
+              }
+            }
+          }
+        },
+        "ErrorResponse": {
+          "description": "Failed operation",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request error response",
+                "properties": {
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "FAILED"
+                    ]
+                  },
+                  "statusCode": {
+                    "type": "number",
+                    "enum": [
+                      404
+                    ]
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "state",
+                  "statusCode",
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "AppsListResponse": {
+          "description": "Application list response.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Application list.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AppEntry"
+                }
+              }
+            }
+          }
+        },
+        "PluginDetailResponse": {
+          "description": "Plugin detail response.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Plugin detail.",
+                "type": "object",
+                "required": [
+                  "enabled", "enabledByDefault", "id",
+                  "name", "version"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "enabledByDefault": {
+                    "type": "boolean"
+                  },
+                  "id": {
+                    "type": "string",
+                    "example": "sksim"
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "Data stream generator"
+                  },
+                  "version": {
+                    "type": "string",
+                    "example": "1.5.4"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "securitySchemes": {
+        "bearerAuth": {
+          "type": "http",
+          "scheme": "bearer",
+          "bearerFormat": "JWT"
+        },
+        "cookieAuth": {
+          "type": "apiKey",
+          "in": "cookie",
+          "name": "JAUTHENTICATION"
+        }
+      }
+    },
+
+    "paths": {
+      "/signalk/v1/apps/list": {
+        "get": {
+          "tags": [
+            "apps"
+          ],
+          "summary": "List of installed Webapps",
+          "responses": {
+            "200": {
+              "$ref": "#/components/responses/AppsListResponse"
+            },
+            "default": {
+              "$ref": "#/components/responses/ErrorResponse"
+            }
+          }
+        }
+      },
+      "/plugins/{id}": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Plugin identifier",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "get": {
+          "tags": [
+            "plugins"
+          ],
+          "summary": "Status information for a plugin",
+          "responses": {
+            "200": {
+              "$ref": "#/components/responses/PluginDetailResponse"
+            },
+            "default": {
+              "$ref": "#/components/responses/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/src/api/apps/openApi.ts
+++ b/src/api/apps/openApi.ts
@@ -1,0 +1,7 @@
+import appsApiDoc from './openApi.json'
+
+export const appsApiRecord = {
+  name: 'apps',
+  path: '/',
+  apiDoc: appsApiDoc
+}

--- a/src/api/discovery/openApi.json
+++ b/src/api/discovery/openApi.json
@@ -1,0 +1,102 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Signal K discovery API",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://signalk.org/specification/",
+    "description": "Signal K specification."
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "tags": [],
+  "components": {
+    "schemas": {
+      "DiscoveryData": {
+        "type": "object",
+        "required": ["endpoints", "server"],
+        "properties": {
+          "endpoints": {
+            "type": "object",
+            "properties": {
+              "v1": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "string",
+                    "description": "Version of the Signal K API",
+                    "example": "1.1.0"
+                  },
+                  "signalk-http": {
+                    "type": "string",
+                    "description": "Address of the server's http API.",
+                    "example": "http://191.168.1.88:3000/signalk/v1/api/"
+                  },
+                  "signalk-ws": {
+                    "type": "string",
+                    "description": "Address of the server's WebSocket API.",
+                    "example": "http://191.168.1.88:3000/signalk/v1/stream"
+                  },
+                  "signalk-tcp": {
+                    "type": "string",
+                    "description": "Address of the server's Signal K over TCP API.",
+                    "example": "tcp://191.168.1.88:8375"
+                  }
+                }
+              }
+            }
+          },
+          "server": {
+            "type": "object",
+            "required": ["id", "version"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Id of the server implementation",
+                "example": "signalk-server-node"
+              },
+              "version": {
+                "type": "string",
+                "description": "Server software version"
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "DiscoveryResponse": {
+        "description": "Discovery response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DiscoveryData"
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "paths": {
+    "/signalk": {
+      "get": {
+        "tags": [],
+        "description": "Returns data about server's endpoints and versions.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DiscoveryResponse"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/api/discovery/openApi.ts
+++ b/src/api/discovery/openApi.ts
@@ -1,0 +1,7 @@
+import discoveryApiDoc from './openApi.json'
+
+export const discoveryApiRecord = {
+  name: 'discovery',
+  path: '',
+  apiDoc: discoveryApiDoc
+}

--- a/src/api/security/openApi.json
+++ b/src/api/security/openApi.json
@@ -1,0 +1,315 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Signal K Security API",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://signalk.org/specification/",
+    "description": "Signal K specification."
+  },
+  "servers": [
+    {
+      "url": "/signalk/v1"
+    }
+  ],
+  "tags": [
+    {
+      "name": "authentication",
+      "description": "User authentication"
+    },
+    {
+      "name": "access",
+      "description": "Device access"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "IsoTime": {
+        "type": "string",
+        "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2}(?:\\.\\d*)?)((-(\\d{2}):(\\d{2})|Z)?)$",
+        "example": "2022-04-22T05:02:56.484Z"
+      },
+      "RequestState": {
+        "type": "string",
+        "enum": ["PENDING", "FAILED", "COMPLETED"]
+      }
+    },
+    "responses": {
+      "200Ok": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["COMPLETED"]
+                },
+                "statusCode": {
+                  "type": "number",
+                  "enum": [200]
+                }
+              },
+              "required": ["state", "statusCode"]
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "description": "Failed operation",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Request error response",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["FAILED"]
+                },
+                "statusCode": {
+                  "type": "number",
+                  "enum": [404]
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": ["state", "statusCode", "message"]
+            }
+          }
+        }
+      },
+      "AccessRequestResponse": {
+        "description": "Request status",
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Request response",
+              "type": "object",
+              "required": ["state"],
+              "properties": {
+                "state": {
+                  "$ref": "#/components/schemas/RequestState",
+                  "default": "PENDING",
+                  "example": "PENDING",
+                  "description": "Status of request."
+                },
+                "href": {
+                  "type": "string",
+                  "example": "/signalk/v1/requests/358b5f32-76bf-4b33-8b23-10a330827185",
+                  "description": "Path where the status of the request can be checked."
+                }
+              }
+            }
+          }
+        }
+      },
+      "RequestStatusResponse": {
+        "description": "Request status",
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Request response",
+              "type": "object",
+              "required": ["state"],
+              "properties": {
+                "state": {
+                  "$ref": "#/components/schemas/RequestState",
+                  "example": "COMPLETED",
+                  "default": "COMPLETED",
+                  "description": "Status of request."
+                },
+                "statusCode": {
+                  "type": "number",
+                  "example": 200,
+                  "description": "Response status code."
+                },
+                "ip": {
+                  "type": "string",
+                  "example": "192.168.1.77",
+                  "description": "IP address of the original access request."
+                },
+                "accessRequest": {
+                  "type": "object",
+                  "required": ["permission", "token"],
+                  "description": "Access request result.",
+                  "properties": {
+                    "permission": {
+                      "enum": ["DENIED", "APPROVED"],
+                      "example": "APPROVED"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "Authentication token to be supplied with future requests."
+                    },
+                    "expirationTime": {
+                      "$ref": "#/components/schemas/IsoTime",
+                      "description": "Token expiration time."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "JAUTHENTICATION"
+      }
+    }
+  },
+
+  "paths": {
+    "/access/requests": {
+      "post": {
+        "tags": ["access"],
+        "summary": "Create a device access request.",
+        "description": "Endpoint to create (device) access requests. The response contains the href to poll for the status of the request.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["clientId", "description"],
+                "properties": {
+                  "clientId": {
+                    "type": "string",
+                    "description": "Client identifier.",
+                    "example": "1234-45653-343453"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Description of device.",
+                    "example": "humidity sensor"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/AccessRequestResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/requests/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "request id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": ["access"],
+        "summary": "Check device access status.",
+        "description": "Returns the status of the supplied request id.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RequestStatusResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "tags": ["authentication"],
+        "summary": "Authenticate user.",
+        "description": "Authenticate to server using username and password.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["username", "password"],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "User to authenticate"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password for supplied username."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Authentication response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Login success result",
+                  "type": "object",
+                  "required": ["token"],
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "Authentication token to be supplied with future requests."
+                    },
+                    "timeToLive": {
+                      "type": "number",
+                      "description": "Token validity time (seconds)."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "put": {
+        "tags": ["authentication"],
+        "summary": "Log out user.",
+        "description": "Log out the user with the token supplied in the request header.",
+        "security": ["cookieAuth", "bearerAuth"],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/api/security/openApi.ts
+++ b/src/api/security/openApi.ts
@@ -1,0 +1,7 @@
+import securityApiDoc from './openApi.json'
+
+export const securityApiRecord = {
+  name: 'security',
+  path: '/signalk/v1',
+  apiDoc: securityApiDoc
+}

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -1,0 +1,67 @@
+import { IRouter, Request, Response } from 'express'
+import swaggerUi from 'swagger-ui-express'
+import { SERVERROUTESPREFIX } from '../constants'
+import { securityApiRecord } from './security/openApi'
+import { discoveryApiRecord } from './discovery/openApi'
+
+interface WithServers {
+  servers: {
+    url: string
+  }[]
+}
+
+interface OpenApiRecord {
+  name: string
+  path: string
+  apiDoc: WithServers
+}
+
+interface ApiRecords {
+  [name: string]: OpenApiRecord
+}
+
+const apiDocs = [discoveryApiRecord, securityApiRecord].reduce<ApiRecords>(
+  (acc, apiRecord: OpenApiRecord) => {
+    acc[apiRecord.name] = apiRecord
+    return acc
+  },
+  {}
+)
+
+export function mountSwaggerUi(app: IRouter, path: string) {
+  app.use(
+    path,
+    swaggerUi.serve,
+    swaggerUi.setup(undefined, {
+      explorer: true,
+      swaggerOptions: {
+        urls: Object.keys(apiDocs).map((name) => ({
+          name,
+          url: `${SERVERROUTESPREFIX}/openapi/${name}`
+        }))
+      }
+    })
+  )
+  app.get(
+    `${SERVERROUTESPREFIX}/openapi/:api`,
+    (req: Request, res: Response) => {
+      if (apiDocs[req.params.api]) {
+        apiDocs[req.params.api].apiDoc.servers = [
+          {
+            url: `${process.env.PROTOCOL ? 'https' : req.protocol}://${req.get(
+              'Host'
+            )}${apiDocs[req.params.api].path}`
+          },
+          {
+            url: `https://demo.signalk.org${apiDocs[req.params.api].path}`
+          }
+
+        ]
+        res.json(apiDocs[req.params.api].apiDoc)
+      } else {
+        res.status(404)
+        res.send('Not found')
+      }
+    }
+  )
+}

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -3,6 +3,7 @@ import swaggerUi from 'swagger-ui-express'
 import { SERVERROUTESPREFIX } from '../constants'
 import { securityApiRecord } from './security/openApi'
 import { discoveryApiRecord } from './discovery/openApi'
+import { appsApiRecord } from './apps/openApi'
 
 interface WithServers {
   servers: {
@@ -20,13 +21,14 @@ interface ApiRecords {
   [name: string]: OpenApiRecord
 }
 
-const apiDocs = [discoveryApiRecord, securityApiRecord].reduce<ApiRecords>(
-  (acc, apiRecord: OpenApiRecord) => {
-    acc[apiRecord.name] = apiRecord
-    return acc
-  },
-  {}
-)
+const apiDocs = [
+  discoveryApiRecord,
+  appsApiRecord,
+  securityApiRecord
+].reduce<ApiRecords>((acc, apiRecord: OpenApiRecord) => {
+  acc[apiRecord.name] = apiRecord
+  return acc
+}, {})
 
 export function mountSwaggerUi(app: IRouter, path: string) {
   app.use(
@@ -55,7 +57,6 @@ export function mountSwaggerUi(app: IRouter, path: string) {
           {
             url: `https://demo.signalk.org${apiDocs[req.params.api].path}`
           }
-
         ]
         res.json(apiDocs[req.params.api].apiDoc)
       } else {

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -186,4 +186,5 @@ module.exports = function (app) {
   }
 }
 
+// @ts-ignore
 const getVersion = () => require('../../package.json').version

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -26,6 +26,7 @@ import os from 'os'
 import path from 'path'
 import unzipper from 'unzipper'
 import util from 'util'
+import { mountSwaggerUi } from './api/swagger'
 import {
   ConfigApp,
   readDefaultsFile,
@@ -95,6 +96,9 @@ module.exports = function (
       (req: Request, res: Response) => res.sendFile(logopath)
     )
   }
+
+  // mount before the main /admin
+  mountSwaggerUi(app, '/admin/openapi')
 
   app.get('/admin/', (req: Request, res: Response) => {
     fs.readFile(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "outDir": "./lib",
     "esModuleInterop": true,
     "strict": true,
-    "allowJs": true
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "rootDir": "./src"
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
This PR 
- adds the Swagger UI to the server, including a link to it from the Admin UI
- adds OpenAPI descriptions of the discovery api at /signalk and the security api

The goal is to introduce OpenApi to Signal K by creating descriptions of parts of the v1 API that are very OpenAPI compatible.

One idea here is to carve stuff off #1477 - stuff that can be published without getting into messy v1/v2 compatibility issues.

Based on #1490.