### PR TITLE
chore: increase npm fetch timeout

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,11 @@ COPY --chown=node . .
 COPY --chown=node docker/startup.sh startup.sh
 RUN chmod +x startup.sh
 
+RUN npm config set fetch-retries 5 \
+&& npm config set fetch-retry-mintimeout 600000 \
+&& npm config set fetch-retry-maxtimeout 1200000 \
+&& npm config set fetch-timeout 1800000
+
 RUN npm install --package-lock-only \
   && npm ci && npm cache clean --force \
   && npm run build:all


### PR DESCRIPTION
GH Action builds are failing with

npm ERR! code ERR_SOCKET_TIMEOUT

let's see if this improves things.