### PR TITLE
chore: optimise Docker master build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,16 +3,55 @@ name: Build Docker development container
 on:
   push:
     branches:
-    - master
-    - "build-docker"
+      - master
+      - 'build-docker'
     tags:
-    - '*'
-    - '!v*'
+      - '*'
+      - '!v*'
   workflow_dispatch:
 
 jobs:
+  signalk-server_npm_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Node setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - name: Build npm files locally and upload artifacts
+        run: |
+          npm cache clean -f
+          npm install npm@latest -g
+          npm install --package-lock-only
+          npm ci && npm cache clean --force
+          npm run build --workspaces --if-present
+          cd packages/server-admin-ui
+          npm pack && mv *.tgz ../../
+          cd ../server-api
+          npm pack && mv *.tgz ../../
+          cd ../streams
+          npm pack && mv *.tgz ../../
+          cd ../..
+          jq '.workspaces=[]' package.json > _package.json && mv _package.json package.json
+          npm i --save *.tgz
+          npm run build
+          npm pack
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 1
+          name: packed-modules
+          path: |
+            *.tgz
+
   build_docker_images:
     runs-on: ubuntu-latest
+    needs: [signalk-server_npm_files]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,9 +70,14 @@ jobs:
         with:
           username: signalkci
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: packed-modules
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,36 @@
-FROM signalk/signalk-server-base:latest
+FROM signalk/signalk-server-base:latest AS base
 
 USER node
 RUN mkdir -p /home/node/.signalk/ \
   && mkdir -p /home/node/signalk/
 
 WORKDIR /home/node/signalk
-COPY --chown=node . .
-COPY --chown=node docker/startup.sh startup.sh
-RUN chmod +x startup.sh
 
 RUN npm config rm proxy \
   && npm config rm https-proxy
 
-RUN npm install --package-lock-only \
-  && npm ci && npm cache clean --force \
-  && npm run build:all
+FROM base AS tarballs_installed
+WORKDIR /home/node/signalk
+COPY *.tgz .
+USER root
+RUN npm i -g signalk-server-*.tgz
+# move server-admin-ui that gets installed as sibling of signalk-server
+RUN mv /usr/lib/node_modules/@signalk/* /usr/lib/node_modules/signalk-server/node_modules/@signalk/
+
+FROM base
+
+USER root
+# add signalk-server on path like in production build
+RUN ln -s /usr/lib/node_modules/signalk-server/bin/signalk-server /usr/bin/signalk-server
+# all -g installed modules
+COPY --from=tarballs_installed /usr/lib/node_modules /usr/lib/node_modules
+
+USER node
+COPY --chown=node docker/startup.sh startup.sh
+RUN chmod +x startup.sh
 
 EXPOSE 3000
 ENV IS_IN_DOCKER true
+ENV SKIP_ADMINUI_VERSION_CHECK true
 WORKDIR /home/node/.signalk
 ENTRYPOINT /home/node/signalk/startup.sh

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -2,4 +2,4 @@
 service dbus restart
 /usr/sbin/avahi-daemon -k
 /usr/sbin/avahi-daemon --no-drop-root &
-/home/node/signalk/bin/signalk-server --securityenabled
+/usr/lib/node_modules/signalk-server/bin/signalk-server --securityenabled

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -97,7 +97,12 @@ export function load(app: ConfigApp) {
     config.version = pkg.version
     config.description = pkg.description
 
-    checkPackageVersion('@signalk/server-admin-ui', pkg, app.config.appPath)
+    //if dependencies are installed from tarballs like in
+    //master docker build the version will be like
+    //file:signalk-server-admin-ui-1.44.1.tgz
+    if (!process.env.SKIP_ADMINUI_VERSION_CHECK) {
+      checkPackageVersion('@signalk/server-admin-ui', pkg, app.config.appPath)
+    }
   } catch (err) {
     console.error('error parsing package.json', err)
     process.exit(1)


### PR DESCRIPTION
Build all the server related js code only once and store them as
artifacts. Modify the server's dependencies by removing workspaces
configuration and using npm i from each tarball to update the versions
to point to the tarballs.

Then in reach platform specific Docker build use the prebuilt server
and the modules from artifacts.

This PR also changes the master build to be more in line with the
release build so that the server is installed globally with -g.

Inspired by #1499 