### PR TITLE
chore: local npm build before docker build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,19 +22,20 @@ jobs:
           node-version: '16.x'
       - name: Build npm files locally and upload to artifacts
         run: |
+          mkdir patch
           npm cache clean -f
           npm install npm@latest -g
           npm install --package-lock-only
           npm ci && npm cache clean --force
           npm run build:all
-          npm pack && mv *.tgz ./../patch/
+          npm pack && mv *.tgz ./patch/
           cd packages/server-admin-ui
-          npm pack && mv *.tgz ./../../../patch/
+          npm pack && mv *.tgz ./../../patch/
           cd ./../server-api
-          npm pack && mv *.tgz ./../../../patch/
+          npm pack && mv *.tgz ./../../patch/
           cd ./../streams
-          npm pack && mv *.tgz ./../../../patch/
-          cd ./../../..
+          npm pack && mv *.tgz ./../../patch/
+          cd ./../..
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -70,6 +71,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/Dockerfile_npm
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,8 +11,40 @@ on:
   workflow_dispatch:
 
 jobs:
+  build_npm_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Node setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - name: Build npm files locally and upload to artifacts
+        run: |
+          npm cache clean -f
+          npm install npm@latest -g
+          npm install --package-lock-only
+          npm ci && npm cache clean --force
+          npm run build:all
+          npm pack && mv *.tgz ./../patch/
+          cd packages/server-admin-ui
+          npm pack && mv *.tgz ./../../../patch/
+          cd ./../server-api
+          npm pack && mv *.tgz ./../../../patch/
+          cd ./../streams
+          npm pack && mv *.tgz ./../../../patch/
+          cd ./../../..
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: signalk-npm-files
+          retention-days: 1
+          path: patch/*.tgz
+          
   build_docker_images:
     runs-on: ubuntu-latest
+    needs: build_npm_files
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,11 +62,15 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: signalkci
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}        
+      - uses: actions/download-artifact@v3
+        with:
+          name: signalk-npm-files
+          path: patch          
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          file: ./docker/Dockerfile
+          file: ./docker/Dockerfile_npm
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           images: signalk/signalk-server

--- a/docker/Dockerfile_npm
+++ b/docker/Dockerfile_npm
@@ -10,7 +10,7 @@ RUN npm i /patch/signalk-server-admin-ui-*.tgz --save \
   && npm i /patch/signalk-server-api-*.tgz --save \
   && npm i /patch/signalk-streams-*.tgz --save
 
-COPY startup.sh startup.sh
+COPY --chown=node docker/startup.sh startup.sh
 RUN chmod +x startup.sh
 
 USER node

--- a/docker/Dockerfile_npm
+++ b/docker/Dockerfile_npm
@@ -1,0 +1,22 @@
+FROM signalk/signalk-server-base:latest
+
+ADD patch patch
+
+RUN npm i -g /patch/signalk-server-*.tgz \
+  && ln -s /usr/lib/node_modules/signalk-server /home/node/signalk
+
+WORKDIR /home/node/signalk
+RUN npm i /patch/signalk-server-admin-ui-*.tgz --save \
+  && npm i /patch/signalk-server-api-*.tgz --save \
+  && npm i /patch/signalk-streams-*.tgz --save
+
+COPY startup.sh startup.sh
+RUN chmod +x startup.sh
+
+USER node
+RUN mkdir -p /home/node/.signalk
+
+EXPOSE 3000
+ENV IS_IN_DOCKER true
+WORKDIR /home/node/.signalk
+ENTRYPOINT /home/node/signalk/startup.sh


### PR DESCRIPTION
Content:
- npm packages are built separately before docker
- npm packages are temporarely upload to artifacts
- npm download from artifacts to docker build to avoid build process in each platforms separately