### PR TITLE
feature: support openApi in plugins

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -910,11 +910,15 @@ Code handling incoming PropertyValues should be fully reactive: even if all emit
 PropertyValues is not meant for data passing on a regular basis, as the total history makes it a potential memory leak. There is a safeguard against accidentally emitting regularly with an upper bound for values per property name. New values will be ignored if it is reached and emits logged as errors.
 
 
-### Exposing custom HTTP paths
+### Exposing custom HTTP paths & OpenApi
 
 If a plugin has a function called `registerWithRouter(router)` (like the plugin's `start` and `stop` functions) it will be called with an Express router as the parameter during plugin startup. The router will be mounted at `/plugins/<pluginId>` and you can use standard Express `.get` `.post` `.use` etc to add HTTP path handlers. Note that `GET /plugins/<pluginid>` and `POST /plugins/<pluginid>/configure` are reserved by server (see below).
 
 Express does not have a public API for deregistering subrouters, so `stop` does not do anything to the router.
+
+**Consider seriously providing an OpenApi description** for your plugin's API. This promotes further cooperation with other plugin/webapp authors. One way we can work together is by fleshing out new APIs within a plugin and then merge them in the Signal K specification for more cooperation.
+
+Implement `getOpenApi` in your plugin to expose your OpenApi to be included in the server's OpenApi UI tooling. See [testplugin](https://github.com/SignalK/signalk-server/tree/b82477e63ebdc14878164ce1ed3aedd80c5a8b0c/test/plugin-test-config/node_modules/testplugin) for an example.
 
 ## Plugin configuration HTTP API
 

--- a/src/api/apps/openApi.ts
+++ b/src/api/apps/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import appsApiDoc from './openApi.json'
 
 export const appsApiRecord = {
   name: 'apps',
   path: '/',
-  apiDoc: appsApiDoc
+  apiDoc: appsApiDoc as unknown as OpenApiDescription
 }

--- a/src/api/course/openApi.ts
+++ b/src/api/course/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import courseApiDoc from './openApi.json'
 
 export const courseApiRecord = {
   name: 'course',
   path: '/signalk/v2/api/vessels/self/navigation',
-  apiDoc: courseApiDoc
+  apiDoc: courseApiDoc as unknown as OpenApiDescription
 }

--- a/src/api/discovery/openApi.ts
+++ b/src/api/discovery/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import discoveryApiDoc from './openApi.json'
 
 export const discoveryApiRecord = {
   name: 'discovery',
   path: '',
-  apiDoc: discoveryApiDoc
+  apiDoc: discoveryApiDoc as unknown as OpenApiDescription
 }

--- a/src/api/notifications/openApi.ts
+++ b/src/api/notifications/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import notificationsApiDoc from './openApi.json'
 
 export const notificationsApiRecord = {
   name: 'notifications',
   path: '/signalk/v1/api/vessels/self/notifications',
-  apiDoc: notificationsApiDoc
+  apiDoc: notificationsApiDoc as unknown as OpenApiDescription
 }

--- a/src/api/resources/openApi.ts
+++ b/src/api/resources/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import resourcesApiDoc from './openApi.json'
 
 export const resourcesApiRecord = {
   name: 'resources',
   path: '/signalk/v2/api',
-  apiDoc: resourcesApiDoc
+  apiDoc: resourcesApiDoc as unknown as OpenApiDescription
 }

--- a/src/api/security/openApi.ts
+++ b/src/api/security/openApi.ts
@@ -1,7 +1,8 @@
+import { OpenApiDescription } from '../swagger'
 import securityApiDoc from './openApi.json'
 
 export const securityApiRecord = {
   name: 'security',
   path: '/signalk/v1',
-  apiDoc: securityApiDoc
+  apiDoc: securityApiDoc as unknown as OpenApiDescription
 }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -38,6 +38,7 @@ import {
 import { SERVERROUTESPREFIX } from './constants'
 import { handleAdminUICORSOrigin } from './cors'
 import { createDebug, listKnownDebugs } from './debug'
+import { PluginManager } from './interfaces/plugins'
 import { getAuthor, Package, restoreModules } from './modules'
 import { getHttpPort, getSslPort } from './ports'
 import { queryRequest } from './requestResponse'
@@ -67,7 +68,12 @@ interface ScriptsApp {
   embeddablewebapps: ModuleInfo[]
 }
 
-interface App extends ScriptsApp, WithSecurityStrategy, ConfigApp, IRouter {
+interface App
+  extends ScriptsApp,
+    WithSecurityStrategy,
+    ConfigApp,
+    IRouter,
+    PluginManager {
   webapps: Package[]
   logging: {
     rememberDebug: (r: boolean) => void

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -70,6 +70,10 @@ module.exports = function(app) {
     stop: function() {
       this.started = false
     },
+    registerWithRouter: (router) => {
+      router.get('/demopluginGet', (req, res) => res.json({message: 'test ok'}))
+    },
+    getOpenApi: () => require('./openApi'),
     app: app
   }
 }

--- a/test/plugin-test-config/node_modules/testplugin/openApi.json
+++ b/test/plugin-test-config/node_modules/testplugin/openApi.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "Signal K Demo/Test Plugin OpenApi",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/demopluginGet": {
+      "get": {
+        "tags": [],
+        "description": "Demo/Test Plugin Get Endpoint",
+        "responses": {
+          "200": {
+            "properties": {
+              "message": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allow plugins to expose OpenApi descriptions by implementing getOpenApi method. The description will be included in the server's OpenApi UI apis list.

- [x] update SERVERPLUGINS.md