### PR TITLE
fix: UI: allow configuration of no-data timeout for all TCP N2K sources

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -781,6 +781,10 @@ const NMEA2000 = (props) => {
         <div>
           <HostInput value={props.value.options} onChange={props.onChange} />
           <PortInput value={props.value.options} onChange={props.onChange} />
+          <NoDataReceivedTimeoutInput
+            value={props.value.options}
+            onChange={props.onChange}
+          />
         </div>
       )}
       {(props.value.options.type === 'canbus' ||


### PR DESCRIPTION
# Include no data timeout setting for all TCP connections
---
Resolves: https://github.com/SignalK/signalk-server/issues/1425

This request to include this field for N2K was originally for Yacht Devices, and a fix was merged in here: https://github.com/SignalK/signalk-server/pull/1443 This resolved an overlapping issue: https://github.com/SignalK/signalk-server/issues/1442

NavLink2 is also TCP, and this PR adds the no data timeout setting for this, as well.  I'm not sure if there's a reason it wasn't added initially, so feel free to reject this if there's a reason it was left off.  Either way, I think this closes https://github.com/SignalK/signalk-server/issues/1425.