### PR TITLE
Server-api improvements, support plugin development in TypeScript

### DIFF
--- a/packages/server-api/src/deltas.ts
+++ b/packages/server-api/src/deltas.ts
@@ -1,8 +1,30 @@
+import { Brand } from '.'
+
+export interface WithContext {
+  context: Context
+}
+
+export interface NormalizedDelta extends WithContext {
+  $source: SourceRef
+  source: Source
+  path: Path
+  value: Value
+  isMeta: boolean
+}
+
+export type SourceRef = Brand<string, 'sourceRef'>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Source = any
+export type Path = Brand<string, 'path'>
+export type Timestamp = Brand<string, 'timestamp'>
+export type Context = Brand<string, 'context'>
+export type Value = object | number | string | null | Notification
+
 // Delta subscription
 export interface DeltaSubscription {
-  context: string
+  context: Context
   subscribe: Array<{
-    path: string
+    path: Path
     period: number
     format: 'delta' | 'full'
     policy: 'instant' | 'ideal' | 'fixed'
@@ -10,16 +32,30 @@ export interface DeltaSubscription {
   }>
 }
 
+// "Classic" Delta with values
+export interface ValuesDelta {
+  context?: Context
+  updates: Update[]
+}
+
+export interface MetaDelta {
+  metas: Array<{ values: Meta[] }>
+}
+
 // Delta Message
-export interface DeltaMessage {
-  updates?: Array<{ values: Update[] }>
-  metas?: Array<{ values: Meta[] }>
+export type Delta = ValuesDelta | MetaDelta
+
+export interface Update {
+  timestamp?: Timestamp
+  source?: Source
+  $source?: SourceRef
+  values: PathValue[]
 }
 
 // Update delta
-export interface Update {
-  path: string
-  value: object | number | string | null | Notification
+export interface PathValue {
+  path: Path
+  value: Value
 }
 
 // Notification payload

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -19,6 +19,8 @@ export enum SKVersion {
   v2 = 'v2'
 }
 
+export type Brand<K, T> = K & { __brand: T }
+
 export * from './deltas'
 export * from './resourcetypes'
 export * from './resourcesapi'

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -89,3 +89,75 @@ export interface Plugin {
   signalKApiRoutes?: (router: IRouter) => IRouter
   enabledByDefault?: boolean
 }
+
+export type DeltaInputHandler = (
+  delta: object,
+  next: (delta: object) => void
+) => void
+
+export interface Ports {
+  byId: string[]
+  byPath: string[]
+  byOpenPlotter: string[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serialports: any
+}
+
+export interface ServerAPI extends PluginServerApp {
+  getSelfPath: (path: string) => void
+  getPath: (path: string) => void
+  getMetadata: (path: string) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  putSelfPath: (aPath: string, value: any, updateCb: () => void) => Promise<any>
+  putPath: (
+    aPath: string,
+    value: number | string | object | boolean,
+    updateCb: (err?: Error) => void,
+    source: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<any>
+  //TSTODO convert queryRequest to ts
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  queryRequest: (requestId: string) => Promise<any>
+  error: (msg: string) => void
+  debug: (msg: string) => void
+  registerDeltaInputHandler: (handler: DeltaInputHandler) => void
+  setPluginStatus: (msg: string) => void
+  setPluginError: (msg: string) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handleMessage: (id: string, msg: any, skVersion?: SKVersion) => void
+  savePluginOptions: (
+    configuration: object,
+    cb: (err: NodeJS.ErrnoException | null) => void
+  ) => void
+  readPluginOptions: () => object
+  getDataDirPath: () => string
+  registerPutHandler: (
+    context: string,
+    path: string,
+    callback: () => void,
+    source: string
+  ) => void
+  registerActionHandler: (
+    context: string,
+    path: string,
+    callback: () => void,
+    source: string
+  ) => void
+  registerHistoryProvider: (provider: {
+    hasAnydata: (options: object, cb: (hasResults: boolean) => void) => void
+    getHistory: (
+      date: Date,
+      path: string,
+      cb: (deltas: object[]) => void
+    ) => void
+    streamHistory: (
+      // TSTODO propert type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spark: any,
+      options: object,
+      onDelta: (delta: object) => void
+    ) => void
+  }) => void
+  getSerialPorts: () => Promise<Ports>
+}

--- a/src/@types/signalk_signalk-schema.d.ts
+++ b/src/@types/signalk_signalk-schema.d.ts
@@ -2,7 +2,9 @@
 declare module '@signalk/signalk-schema' {
   import { EventEmitter } from 'events'
 
-  export function getSourceId(source: any): import('../types').SourceRef
+  export function getSourceId(
+    source: any
+  ): import('@signalk/server-api').SourceRef
   export class FullSignalK extends EventEmitter {
     constructor(selfId: string, selfType: string, defaults?: any)
     addDelta: (_: any) => void

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -9,10 +9,13 @@ import { SignalKMessageHub, WithConfig } from '../../app'
 import { WithSecurityStrategy } from '../../security'
 
 import {
+  Delta,
   GeoJsonPoint,
+  PathValue,
   Position,
   Route,
-  SignalKResourceType
+  SignalKResourceType,
+  SKVersion
 } from '@signalk/server-api'
 import { isValidCoordinate } from 'geolib'
 import { Responses } from '../'
@@ -21,7 +24,6 @@ import { Store } from '../../serverstate/store'
 import { buildSchemaSync } from 'api-schema-builder'
 import courseOpenApi from './openApi.json'
 import { ResourcesApi } from '../resources'
-import { Delta, SKVersion } from '../../types'
 
 const COURSE_API_SCHEMA = buildSchemaSync(courseOpenApi)
 
@@ -859,7 +861,7 @@ export class CourseApi {
     return {
       updates: [
         {
-          values
+          values: values as PathValue[]
         }
       ]
     }

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -3,10 +3,13 @@ import { createDebug } from '../../debug'
 const debug = createDebug('signalk-server:api:resources')
 
 import {
+  Delta,
   isSignalKResourceType,
+  Path,
   ResourceProvider,
   ResourceProviderMethods,
-  SignalKResourceType
+  SignalKResourceType,
+  SKVersion
 } from '@signalk/server-api'
 
 import { IRouter, NextFunction, Request, Response } from 'express'
@@ -16,7 +19,6 @@ import { WithSecurityStrategy } from '../../security'
 import { Responses } from '../'
 import { validate } from './validate'
 import { SignalKMessageHub } from '../../app'
-import { Delta, SKVersion } from '../../types'
 
 export const RESOURCES_API_PATH = `/signalk/v2/api/resources`
 
@@ -722,7 +724,7 @@ export class ResourcesApi {
         {
           values: [
             {
-              path: `resources.${resType}.${resid}`,
+              path: `resources.${resType}.${resid}` as Path,
               value: resValue
             }
           ]

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { SKVersion } from '@signalk/server-api'
 import { FullSignalK } from '@signalk/signalk-schema'
 import { Config } from './config/config'
 import DeltaCache from './deltacache'
-import { SKVersion } from './types'
 
 export interface ServerApp {
   started: boolean

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Context, Path, SourceRef } from '@signalk/server-api'
 import { createDebug } from './debug'
-import { Context, Path, SourceRef } from './types'
 const debug = createDebug('signalk-server:sourcepriorities')
 
 interface SourcePriority {

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -20,15 +20,8 @@ const debug = createDebug('signalk-server:deltacache')
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
 import _, { isUndefined } from 'lodash'
 import { toDelta } from './streambundle'
-import {
-  Context,
-  ContextMatcher,
-  Delta,
-  NormalizedDelta,
-  SignalKServer,
-  SourceRef,
-  StreamBundle
-} from './types'
+import { ContextMatcher, SignalKServer, StreamBundle } from './types'
+import { Context, NormalizedDelta, SourceRef } from '@signalk/server-api'
 
 interface StringKeyed {
   [key: string]: any
@@ -77,7 +70,7 @@ export default class DeltaCache {
     this.lastModifieds[msg.context] = Date.now()
   }
 
-  setSourceDelta(key: string, delta: Delta) {
+  setSourceDelta(key: string, delta: any) {
     this.sourceDeltas[key] = delta
     this.app.signalk.addDelta(delta)
   }
@@ -132,7 +125,7 @@ export default class DeltaCache {
 
   buildFullFromDeltas(
     user: string,
-    deltas: Delta[] | undefined,
+    deltas: any[] | undefined,
     includeSources: boolean
   ) {
     const signalk = new FullSignalK(this.app.selfId, this.app.selfType)
@@ -185,7 +178,7 @@ export default class DeltaCache {
       return acc
     }, [])
 
-    deltas.sort((left: Delta, right: Delta) => {
+    deltas.sort((left: any, right: any) => {
       return (
         new Date(left.timestamp).getTime() - new Date(right.timestamp).getTime()
       )
@@ -193,7 +186,7 @@ export default class DeltaCache {
 
     deltas = deltas.map(toDelta)
 
-    deltas = deltas.filter((delta: Delta) => {
+    deltas = deltas.filter((delta: any) => {
       return this.app.securityStrategy.filterReadDelta(user, delta)
     })
 

--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export type DeltaInputHandler = (
-  delta: object,
-  next: (delta: object) => void
-) => void
+
+import { DeltaInputHandler } from '@signalk/server-api'
 
 export default class DeltaChain {
   chain: any

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ if (typeof [].includes !== 'function') {
 
 import {
   Delta,
+  DeltaInputHandler,
   PropertyValues,
   SKVersion,
   SourceRef,
@@ -42,7 +43,7 @@ import { SelfIdentity, ServerApp, SignalKMessageHub, WithConfig } from './app'
 import { ConfigApp, load, sendBaseDeltas } from './config/config'
 import { createDebug } from './debug'
 import DeltaCache from './deltacache'
-import DeltaChain, { DeltaInputHandler } from './deltachain'
+import DeltaChain from './deltachain'
 import { getToPreferredDelta, ToPreferredDelta } from './deltaPriority'
 import { incDeltaStatistics, startDeltaStatistics } from './deltastats'
 import { checkForNewServerVersion } from './modules'

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,14 @@ if (typeof [].includes !== 'function') {
   process.exit(-1)
 }
 
-import { PropertyValues } from '@signalk/server-api'
+import {
+  Delta,
+  PropertyValues,
+  SKVersion,
+  SourceRef,
+  Timestamp,
+  Update
+} from '@signalk/server-api'
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
 import { Debugger } from 'debug'
 import express, { IRouter, Request, Response } from 'express'
@@ -49,7 +56,6 @@ import {
 } from './security.js'
 import { setupCors } from './cors'
 import SubscriptionManager from './subscriptionmanager'
-import { Delta, SKVersion } from './types'
 const debug = createDebug('signalk-server')
 
 const { StreamBundle } = require('./streambundle')
@@ -227,7 +233,7 @@ class Server {
           data.context = 'vessels.' + app.selfId
         }
         const now = new Date()
-        data.updates.forEach((update: Delta) => {
+        data.updates.forEach((update: Update) => {
           if (typeof update.source !== 'undefined') {
             update.source.label = providerId
             if (!update.$source) {
@@ -235,11 +241,11 @@ class Server {
             }
           } else {
             if (typeof update.$source === 'undefined') {
-              update.$source = providerId
+              update.$source = providerId as SourceRef
             }
           }
           if (!update.timestamp || app.config.overrideTimestampWithNow) {
-            update.timestamp = now.toISOString()
+            update.timestamp = now.toISOString() as Timestamp
           }
         })
         try {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -19,7 +19,8 @@ import {
   PluginServerApp,
   PropertyValues,
   PropertyValuesCallback,
-  ResourceProvider
+  ResourceProvider,
+  SKVersion
 } from '@signalk/server-api'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -36,7 +37,6 @@ import { listAllSerialPorts, Ports } from '../serialports'
 const debug = createDebug('signalk-server:interfaces:plugins')
 
 import { modulesWithKeyword } from '../modules'
-import { SKVersion } from '../types'
 
 const put = require('../put')
 const _putPath = put.putPath

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -16,11 +16,10 @@
  * limitations under the License.
 */
 import {
-  PluginServerApp,
   PropertyValues,
   PropertyValuesCallback,
   ResourceProvider,
-  SKVersion
+  ServerAPI
 } from '@signalk/server-api'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -32,8 +31,7 @@ import path from 'path'
 import { ResourcesApi } from '../api/resources'
 import { SERVERROUTESPREFIX } from '../constants'
 import { createDebug } from '../debug'
-import { DeltaInputHandler } from '../deltachain'
-import { listAllSerialPorts, Ports } from '../serialports'
+import { listAllSerialPorts } from '../serialports'
 const debug = createDebug('signalk-server:interfaces:plugins')
 
 import { modulesWithKeyword } from '../modules'
@@ -75,58 +73,6 @@ interface PluginInfo extends Plugin {
   state: string
   enabledByDefault: boolean
   statusMessage: () => string | void
-}
-
-export interface ServerAPI extends PluginServerApp {
-  getSelfPath: (path: string) => void
-  getPath: (path: string) => void
-  getMetadata: (path: string) => void
-  putSelfPath: (aPath: string, value: any, updateCb: () => void) => Promise<any>
-  putPath: (
-    aPath: string,
-    value: number | string | object | boolean,
-    updateCb: (err?: Error) => void,
-    source: string
-  ) => Promise<any>
-  queryRequest: (requestId: string) => Promise<any>
-  error: (msg: string) => void
-  debug: (msg: string) => void
-  registerDeltaInputHandler: (handler: DeltaInputHandler) => void
-  setProviderStatus: (msg: string) => void
-  handleMessage: (id: string, msg: any, skVersion?: SKVersion) => void
-  setProviderError: (msg: string) => void
-  savePluginOptions: (
-    configuration: object,
-    cb: (err: NodeJS.ErrnoException | null) => void
-  ) => void
-  readPluginOptions: () => object
-  getDataDirPath: () => string
-  registerPutHandler: (
-    context: string,
-    path: string,
-    callback: () => void,
-    source: string
-  ) => void
-  registerActionHandler: (
-    context: string,
-    path: string,
-    callback: () => void,
-    source: string
-  ) => void
-  registerHistoryProvider: (provider: {
-    hasAnydata: (options: object, cb: (hasResults: boolean) => void) => void
-    getHistory: (
-      date: Date,
-      path: string,
-      cb: (deltas: object[]) => void
-    ) => void
-    streamHistory: (
-      spark: any,
-      options: object,
-      onDelta: (delta: object) => void
-    ) => void
-  }) => void
-  getSerialPorts: () => Promise<Ports>
 }
 
 interface ModuleMetadata {

--- a/src/serialports.ts
+++ b/src/serialports.ts
@@ -15,14 +15,8 @@
  * limitations under the License.
 */
 
+import { Ports } from '@signalk/server-api'
 import fs from 'fs'
-
-export interface Ports {
-  byId: string[]
-  byPath: string[]
-  byOpenPlotter: string[]
-  serialports: any
-}
 
 export const listAllSerialPorts = (): Promise<Ports> => {
   return new Promise((resolve, reject) => {

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-import { Position } from '@signalk/server-api'
+import { Position, WithContext } from '@signalk/server-api'
 import Bacon from 'baconjs'
 import { isPointWithinRadius } from 'geolib'
 import _, { forOwn, get, isString } from 'lodash'
 import { createDebug } from './debug'
 import DeltaCache from './deltacache'
 import { toDelta } from './streambundle'
-import { ContextMatcher, Unsubscribes, WithContext } from './types'
+import { ContextMatcher, Unsubscribes } from './types'
 const debug = createDebug('signalk-server:subscriptionmanager')
 
 interface BusesMap {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { WithContext } from '@signalk/server-api'
 import { FullSignalK } from '@signalk/signalk-schema'
 import { SecurityStrategy } from './security'
 import SubscriptionManager from './subscriptionmanager'
@@ -57,30 +58,4 @@ export interface MdnsAdvertisement {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Unsubscribes extends Array<() => void> {}
 
-export interface WithContext {
-  context: Context
-}
-
 export type ContextMatcher = (_: WithContext) => boolean
-
-export interface NormalizedDelta extends WithContext {
-  $source: SourceRef
-  source: Source
-  path: Path
-  value: Value
-  isMeta: boolean
-}
-
-export type Brand<K, T> = K & { __brand: T }
-
-export type SourceRef = Brand<string, 'sourceRef'>
-export type Source = Brand<string, 'source'>
-export type Delta = any
-export type Path = Brand<string, 'path'>
-export type Context = Brand<string, 'context'>
-export type Value = object | number | string | null
-
-export enum SKVersion {
-  v1 = 'v1',
-  v2 = 'v2'
-}


### PR DESCRIPTION
- Move base Signal K types to server-api so that both server and ts plugins can use them
- Move ServerAPI to server-api module (fixes #1516)