### PR TITLE
Fix: Align implementations of getExternalPort().

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -25,6 +25,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { SelfIdentity, SignalKMessageHub, WithConfig } from '../app'
 import { createDebug } from '../debug'
 import DeltaEditor from '../deltaeditor'
+import { getExternalPort  as getExtPort} from '../ports'
 const debug = createDebug('signalk-server:config')
 
 let disableWriteSettings = false
@@ -90,7 +91,7 @@ export function load(app: ConfigApp) {
   const env = (app.env = process.env)
 
   config.getExternalHostname = getExternalHostname.bind(config, config)
-  config.getExternalPort = getExternalPort.bind(config, config)
+  config.getExternalPort = getExternalPort.bind(config, config, app)
 
   config.appPath = config.appPath || path.normalize(__dirname + '/../../')
   debug('appPath:' + config.appPath)
@@ -448,16 +449,13 @@ function getExternalHostname(config: Config) {
   }
 }
 
-function getExternalPort(config: Config): any {
-  if (process.env.EXTERNALPORT) {
-    return process.env.EXTERNALPORT
-  }
+function getExternalPort(config: Config, app: ConfigApp): any {
   if (config.settings.proxy_port) {
     return config.settings.proxy_port
   } else if (config.port) {
     return config.port
   }
-  return ''
+  return getExtPort(app)
 }
 
 function scanDefaults(deltaEditor: DeltaEditor, vpath: string, item: any) {


### PR DESCRIPTION
Have the `getExternalPort()` function in `ports.ts` be the target of the `getExternalPort()` function defined in `config.ts`.

_**NOTE: The preferencing of `process.env.EXTERNALPORT` has changed as a result, `config.proxy_port` and `config.port` will prevail if they are present!**_
