### PR TITLE
feature: make OpenApi link always available in the menu

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -84,7 +84,7 @@ class Sidebar extends Component {
       return (
         <NavItem key={key} className={classes.item}>
           {isExternal(url) ? (
-            <RsNavLink href={url} className={classes.link} active>
+            <RsNavLink href={url} className={classes.link}>
               <i className={classes.icon} />
               {item.name}
               {badge(item.badge)}

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -268,10 +268,6 @@ const mapStateToProps = (state) => {
             url: '/serverConfiguration/datafiddler',
           },
           {
-            name: 'OpenApi',
-            url: `${window.location.protocol}//${window.location.host}/admin/openapi`,
-          },
-          {
             name: 'Backup/Restore',
             url: '/serverConfiguration/backuprestore',
           },
@@ -318,6 +314,18 @@ const mapStateToProps = (state) => {
     }
     result.items.push(security)
   }
+
+  result.items.push({
+    name: 'Documentation',
+    url: '/doc',
+    icon: 'icon-settings',
+    children: [
+      {
+        name: 'OpenApi',
+        url: `${window.location.protocol}//${window.location.host}/doc/openapi`,
+      },
+    ],
+  })
 
   return result
 }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -105,7 +105,7 @@ module.exports = function (
   }
 
   // mount before the main /admin
-  mountSwaggerUi(app, '/admin/openapi')
+  mountSwaggerUi(app, '/doc/openapi')
 
   app.get('/admin/', (req: Request, res: Response) => {
     fs.readFile(


### PR DESCRIPTION
Since the OpenApi ui is not authenticated and we'd like
    it to be available for perusal at demo.signalk.org move
    it under a top level menu Documentation that is always
    available. We can also add other documentation here in
    the future.

OpenApi link need not look different from other many items, make external links look the same as internal.

<img width="194" alt="image" src="https://user-images.githubusercontent.com/1049678/226993981-96b27993-6155-4a7b-aefb-7e9dfe27a131.png">
