### PR TITLE
fix: Remove unused Course OpenAPI schema definitions.

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -54,7 +54,6 @@ interface ActiveRoute extends DestinationBase {
   pointTotal: number
   reverse: boolean
   name: string
-  waypoints?: any[]
 }
 
 interface CourseInfo {

--- a/src/api/course/openApi.json
+++ b/src/api/course/openApi.json
@@ -101,13 +101,6 @@
             "description": "Name of route.",
             "example": "Here to eternity."
           },
-          "waypoints": {
-            "type": "array",
-            "description": "Array of points that make up the route.",
-            "items": {
-              "$ref": "#/components/schemas/Location"
-            }
-          },
           "pointIndex": {
             "type": "number",
             "minimum": 0,
@@ -153,21 +146,6 @@
                 "$ref": "#/components/schemas/SignalKPosition"
               }
             ]
-          }
-        }
-      },
-      "Location": {
-        "type": "object",
-        "description": "Position with metadata.",
-        "required": ["position"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Location name / identifier",
-            "example": "Wpt001"
-          },
-          "position": {
-            "$ref": "#/components/schemas/SignalKPosition"
           }
         }
       },

--- a/test/course.ts
+++ b/test/course.ts
@@ -330,7 +330,6 @@ describe('Course Api', () => {
       delete data.startTime
       delete data.targetArrivalTime
       delete data.activeRoute.name
-      delete data.activeRoute.waypoints
       data.should.deep.equal({
         arrivalCircle: 0,
         activeRoute: {


### PR DESCRIPTION
Removed references to `waypoints` in `ActiveRoute` as these references are not used.

Waypoint information is available in the referenced route resource.