### PR TITLE
feature: Add Route Point Metadata definition to Resources OpenAPI

### DIFF
--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -374,14 +374,14 @@
                     "title": "Route point details",
                     "description": "Metadata for each point within the route. Array length MUST be the same as length of coordinates array!",
                     "items": {
-                        "oneOf": [
-                          {
-                            "$ref": "#/components/schemas/RoutePointMeta"
-                          },
-                          {
-                            "$ref": "#/components/schemas/HrefAttribute"
-                          }
-                        ]           
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/RoutePointMeta"
+                        },
+                        {
+                          "$ref": "#/components/schemas/HrefAttribute"
+                        }
+                      ]
                     },
                     "example": [
                       {

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -369,19 +369,26 @@
                 "type": "object",
                 "additionalProperties": true,
                 "properties": {
-                  "points": {
+                  "coordinatesMeta": {
                     "type": "array",
                     "title": "Route point details",
                     "description": "Metadata for each point within the route. Array length MUST be the same as length of coordinates array!",
                     "items": {
-                      "$ref": "#/components/schemas/RoutePointMeta"
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/RoutePointMeta"
+                          },
+                          {
+                            "$ref": "#/components/schemas/HrefAttribute"
+                          }
+                        ]           
                     },
                     "example": [
                       {
                         "name": "RtePt001"
                       },
                       {
-                        "name": "RtePt002"
+                        "href": "/resources/waypoints/ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a"
                       },
                       {
                         "name": "RtePt003"

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -992,7 +992,7 @@
         ],
         "responses": {
           "default": {
-            "description": "List of route resources identified by their UUID",
+            "description": "An object containing Route resources, keyed by their UUID.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1122,7 +1122,7 @@
         ],
         "responses": {
           "default": {
-            "description": "List of waypoint resources identified by their UUID",
+            "description": "An object containing Waypoint resources, keyed by their UUID.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1252,7 +1252,7 @@
         ],
         "responses": {
           "default": {
-            "description": "List of region resources identified by their UUID",
+            "description": "An object containing Region resources, keyed by their UUID.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1393,7 +1393,7 @@
         ],
         "responses": {
           "default": {
-            "description": "List of note resources identified by their UUID",
+            "description": "An object containing Note resources, keyed by their UUID.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1509,7 +1509,7 @@
         "summary": "Retrieve chart resources",
         "responses": {
           "default": {
-            "description": "List of chart resources identified by their UUID",
+            "description": "An object containing Chart resources, keyed by their UUID.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -374,14 +374,14 @@
                     "title": "Route point details",
                     "description": "Metadata for each point within the route. Array length MUST be the same as length of coordinates array!",
                     "items": {
-                      "$ref":"#/components/schemas/RoutePointMeta"
+                      "$ref": "#/components/schemas/RoutePointMeta"
                     },
                     "example": [
                       {
-                      "name": "RtePt001"
+                        "name": "RtePt001"
                       },
                       {
-                      "name": "RtePt002"
+                        "name": "RtePt002"
                       },
                       {
                         "name": "RtePt003"

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -367,9 +367,50 @@
               "properties": {
                 "description": "Additional feature properties",
                 "type": "object",
-                "additionalProperties": true
+                "additionalProperties": true,
+                "properties": {
+                  "points": {
+                    "type": "array",
+                    "title": "Route point details",
+                    "description": "Metadata for each point within the route. Array length MUST be the same as length of coordinates array!",
+                    "items": {
+                      "$ref":"#/components/schemas/RoutePointMeta"
+                    },
+                    "example": [
+                      {
+                      "name": "RtePt001"
+                      },
+                      {
+                      "name": "RtePt002"
+                      },
+                      {
+                        "name": "RtePt003"
+                      },
+                      {
+                        "name": "RtePt004"
+                      },
+                      {
+                        "name": "RtePt005"
+                      }
+                    ]
+                  }
+                }
               }
             }
+          }
+        }
+      },
+      "RoutePointMeta": {
+        "type": "object",
+        "title": "Route point metadata",
+        "description": "Attributes of a point within the route",
+        "required": ["name"],
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "description": "Point name / identifier",
+            "type": "string",
+            "example": "RtePt001"
           }
         }
       },

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -76,4 +76,49 @@ describe('Resources Api', () => {
         returnedIds[0].should.equal(resourceIds[1])
       })
   })
+
+  it('Create route with route point metadata', async function() {
+    const {
+      post,
+      stop
+    } = await startServer()
+
+
+    const route = {
+      feature: { 
+        type: "Feature", 
+        geometry: {
+          type: "LineString",
+          coordinates: [[3.3452,65.4567],[3.3352, 65.5567],[3.3261,65.5777]]
+        },
+        properties: {
+          coordinatesMeta: [
+            {
+              name: "Start point",
+              description: "Start of route."
+            },
+            {
+              name: "Mid-point marker",
+              description: "Turn here."
+            },
+            {
+              name: "Destination",
+              description: "End of route."
+            }
+          ]
+        }
+      }
+    }
+
+    const { id } = await post('/resources/routes', route)
+      .then(response => {
+        response.status.should.equal(201)
+        return response.json()
+      })
+    id.length.should.equal(
+      'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a'.length
+    )
+
+    stop()
+  })
 })


### PR DESCRIPTION
Add defintion for route point metadata within the feature `properties` to hold attributes for the points within the route.
This is useful when importing routes from GPX files, etc to hold information such as point name & description.
_Example:_
```
{
    "name": "my Route",
    ....
    "feature": {
      ....
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [24.897849923663273, 60.15202408867182], ... , [24.758341055158922, 59.44208867188729]
        ]
      },
      "properties": {
        "points": [
          {"name": "RtePt001"}, ... , {"name": "RtePt005"}
        ]
      }
    }
```