### PR TITLE
Gpsd client package to node-gpsd-client, add reconnect

### DIFF
--- a/packages/streams/gpsd.js
+++ b/packages/streams/gpsd.js
@@ -31,7 +31,7 @@
  */
 
 const Transform = require('stream').Transform
-const gpsd = require('node-gpsd')
+const GpsdClient = require('node-gpsd-client')
 
 function Gpsd(options) {
   Transform.call(this, {
@@ -40,6 +40,8 @@ function Gpsd(options) {
 
   const port = options.port || 2947
   const hostname = options.hostname || options.host || 'localhost'
+  const noDataReceivedTimeout = options.noDataReceivedTimeout || 0
+
 
   function setProviderStatus(msg) {
     options.app.setProviderStatus(options.providerId, msg)
@@ -47,9 +49,9 @@ function Gpsd(options) {
 
   const createDebug = options.createDebug || require('debug')
 
-  this.listener = new gpsd.Listener({
-    port,
-    hostname,
+  this.listener = new GpsdClient({
+    port: port,
+    hostname: hostname,
     logger: {
       info: createDebug('signalk:streams:gpsd'),
       warn: console.warn,
@@ -61,12 +63,19 @@ function Gpsd(options) {
       },
     },
     parse: false,
+    reconnectThreshold: noDataReceivedTimeout,
+    reconnectInterval: noDataReceivedTimeout / 2
   })
 
   setProviderStatus(`Connecting to ${hostname}:${port}`)
 
-  this.listener.connect(function () {
+  this.listener.on('connected', () =>  {
     setProviderStatus(`Connected to ${hostname}:${port}`)
+    this.listener.watch({
+      class : "WATCH",
+      nmea: true,
+      json: false
+    })
   })
 
   const self = this
@@ -74,10 +83,7 @@ function Gpsd(options) {
     self.push(data)
   })
 
-  this.listener.watch({
-    class: 'WATCH',
-    nmea: true,
-  })
+  this.listener.connect();
 }
 
 require('util').inherits(Gpsd, Transform)

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -32,7 +32,7 @@
     "file-timestamp-stream": "^2.1.2",
     "lodash": "^4.17.4",
     "moment": "^2.24.0",
-    "node-gpsd": "^0.3.0",
+    "node-gpsd-client": "^1.4.1",
     "reconnect-core": "^1.3.0",
     "stream-throttle": "^0.1.3"
   },


### PR DESCRIPTION
from node-gpsd - this is done to make signalk able to reconnect to gpsd socket when no data has been received for a configurable time.

Tested on my laptop with an ssh port forward to gpsd on my boat -- reconnects fine.

Fixes #1363