### PR TITLE
fix: Use servers array in plugin openApi.json.

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -918,7 +918,7 @@ Express does not have a public API for deregistering subrouters, so `stop` does 
 
 **Consider seriously providing an OpenApi description** for your plugin's API. This promotes further cooperation with other plugin/webapp authors. One way we can work together is by fleshing out new APIs within a plugin and then merge them in the Signal K specification for more cooperation.
 
-Implement `getOpenApi` in your plugin to expose your OpenApi to be included in the server's OpenApi UI tooling. See [testplugin](https://github.com/SignalK/signalk-server/tree/b82477e63ebdc14878164ce1ed3aedd80c5a8b0c/test/plugin-test-config/node_modules/testplugin) for an example.
+Implement `getOpenApi` in your plugin to expose your OpenApi to be included in the server's OpenApi UI tooling. The plugin's OpenApi description either not include `servers` property at all or specify only the path in the url. The server will provide servers if it is missing and relative, path only server urls work best in different environments. See [testplugin](https://github.com/SignalK/signalk-server/tree/b82477e63ebdc14878164ce1ed3aedd80c5a8b0c/test/plugin-test-config/node_modules/testplugin) for an example.
 
 ## Plugin configuration HTTP API
 

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -79,13 +79,13 @@ export function mountSwaggerUi(app: IRouter & PluginManager, path: string) {
       apiRecord = app.getPluginOpenApi(req.params.pluginId as PluginId)
     }
     const apiDoc = apiRecord?.apiDoc
-    const apiDocPath = apiRecord?.path
+    const apiPath = apiRecord?.path
 
-    if (apiDoc && apiDocPath !== undefined) {
+    if (apiDoc && apiPath !== undefined) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(apiDoc as any).servers = (apiDoc as any).servers ?? [
         {
-          url: `${apiDocPath}`
+          url: `${apiPath}`
         }
       ]
       res.json(apiDoc)

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -85,12 +85,7 @@ export function mountSwaggerUi(app: IRouter & PluginManager, path: string) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(apiDoc as any).servers = (apiDoc as any).servers ?? [
         {
-          url: `${process.env.PROTOCOL ? 'https' : req.protocol}://${req.get(
-            'Host'
-          )}${apiDocPath}`
-        },
-        {
-          url: `https://demo.signalk.org${apiDocPath}`
+          url: `${apiDocPath}`
         }
       ]
       res.json(apiDoc)

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -83,7 +83,7 @@ export function mountSwaggerUi(app: IRouter & PluginManager, path: string) {
 
     if (apiDoc && apiDocPath !== undefined) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(apiDoc as any).servers = [
+      ;(apiDoc as any).servers = (apiDoc as any).servers ?? [
         {
           url: `${process.env.PROTOCOL ? 'https' : req.protocol}://${req.get(
             'Host'


### PR DESCRIPTION
Currently when a plugin provides an openApi.json document, the swagger documentation defines the following `servers`:
- `https://demo.signalk.org${apiDocPath}`
- `${process.env.PROTOCOL ? 'https' : req.protocol}://${req.get(
            'Host'
          )}${apiDocPath}`

regardless of the `servers` attribute contained within `openApi.json`.


This PR changes the behaviour to only set `servers` to the the urls above when the plugin's `openApi.json` does NOT define a value.

_Plugin **openApi.json** defines value for `servers`:_
![image](https://user-images.githubusercontent.com/38519157/233523665-68c02d52-997d-464b-8731-375f9994fa83.png)

_Plugin **openApi.json** DOES NOT define value for `servers`:_
![image](https://user-images.githubusercontent.com/38519157/233523448-31a5023b-19f7-4771-bfc8-4a3454a67fa5.png)

