### PR TITLE
chore: upgrade the serialport library to use version 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@signalk/vesselpositions": "^1.0.0",
     "@signalk/zones": "^1.0.0",
     "mdns": "^2.5.1",
-    "serialport": "^9.0.1"
+    "serialport": "^11.0.0"
   },
   "devDependencies": {
     "@types/busboy": "^1.5.0",
@@ -157,7 +157,7 @@
     "@types/node-fetch": "^2.5.3",
     "@types/rmfr": "^2.0.1",
     "@types/semver": "^7.1.0",
-    "@types/serialport": "^8.0.1",
+    "@types/serialport": "^8.0.2",
     "@types/split": "^1.0.0",
     "@types/swagger-ui-express": "^4.1.3",
     "@types/unzipper": "^0.10.5",

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -37,7 +37,7 @@
     "stream-throttle": "^0.1.3"
   },
   "optionalDependencies": {
-    "serialport": "^9.0.1"
+    "serialport": "^11.0.0"
   },
   "devDependencies": {
     "prettier": "2.5.1"

--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -60,7 +60,8 @@
 const Transform = require('stream').Transform
 const child_process = require('child_process')
 const shellescape = require('any-shell-escape')
-const SerialPort = require('serialport')
+const {SerialPort} = require('serialport')
+const { ReadlineParser } = require('@serialport/parser-readline')
 const isArray = require('lodash').isArray
 const isBuffer = require('lodash').isBuffer
 
@@ -104,7 +105,8 @@ SerialStream.prototype.start = function () {
     )
   }
 
-  this.serial = new SerialPort(this.options.device, {
+  this.serial = new SerialPort({
+    path: this.options.device,
     baudRate: this.options.baudrate,
   })
 
@@ -117,7 +119,7 @@ SerialStream.prototype.start = function () {
         `Connected to ${this.options.device}`
       )
       this.isFirstError = true
-      const parser = new SerialPort.parsers.Readline()
+      const parser = new ReadlineParser({ delimiter: '\r\n' })
       this.serial.pipe(parser).pipe(this)
     }.bind(this)
   )

--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -119,7 +119,7 @@ SerialStream.prototype.start = function () {
         `Connected to ${this.options.device}`
       )
       this.isFirstError = true
-      const parser = new ReadlineParser({ delimiter: '\r\n' })
+      const parser = new ReadlineParser()
       this.serial.pipe(parser).pipe(this)
     }.bind(this)
   )

--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -60,7 +60,7 @@
 const Transform = require('stream').Transform
 const child_process = require('child_process')
 const shellescape = require('any-shell-escape')
-const {SerialPort} = require('serialport')
+const { SerialPort } = require('serialport')
 const { ReadlineParser } = require('@serialport/parser-readline')
 const isArray = require('lodash').isArray
 const isBuffer = require('lodash').isBuffer

--- a/src/serialports.ts
+++ b/src/serialports.ts
@@ -17,6 +17,7 @@
 
 import { Ports } from '@signalk/server-api'
 import fs from 'fs'
+const {SerialPort} = require('serialport')
 
 export const listAllSerialPorts = (): Promise<Ports> => {
   return new Promise((resolve, reject) => {
@@ -36,7 +37,7 @@ export const listAllSerialPorts = (): Promise<Ports> => {
 function listSerialPorts() {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('serialport').list()
+    return SerialPort.list()
   } catch (err) {
     return Promise.resolve([])
   }

--- a/src/serialports.ts
+++ b/src/serialports.ts
@@ -17,7 +17,7 @@
 
 import { Ports } from '@signalk/server-api'
 import fs from 'fs'
-const {SerialPort} = require('serialport')
+import { SerialPort } from 'serialport'
 
 export const listAllSerialPorts = (): Promise<Ports> => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
The serialport library being used was using 9.0.1, which is no longer maintained. Upgrading to version 11 allows users installing signalk-server on node-18 to use the prebuilt binaries.