### PR TITLE
Fix: Resolve uncaught errors when not logged in

### DIFF
--- a/packages/server-admin-ui/src/actions.js
+++ b/packages/server-admin-ui/src/actions.js
@@ -114,18 +114,17 @@ export function restart() {
   }
 }
 
-// Build actions that perform a basic authFetch to the backend. Pull #514.
-export const buildFetchAction = (endpoint, type, prefix) => (dispatch) =>
-  authFetch(
-    `${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`
-  )
-    .then((response) => response.json())
-    .then((data) =>
-      dispatch({
-        type,
-        data,
-      })
-    )
+export const buildFetchAction = (endpoint, type, prefix) => async (dispatch) => {
+  const response = await authFetch(`${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`);
+
+  if(response.status === 200) {
+    const data = await response.json();
+    dispatch({
+      type,
+      data,
+    })
+  }
+}
 
 export const fetchLoginStatus = buildFetchAction(
   '/loginStatus',

--- a/packages/server-admin-ui/src/actions.js
+++ b/packages/server-admin-ui/src/actions.js
@@ -114,17 +114,20 @@ export function restart() {
   }
 }
 
-export const buildFetchAction = (endpoint, type, prefix) => async (dispatch) => {
-  const response = await authFetch(`${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`);
+export const buildFetchAction =
+  (endpoint, type, prefix) => async (dispatch) => {
+    const response = await authFetch(
+      `${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`
+    )
 
-  if(response.status === 200) {
-    const data = await response.json();
-    dispatch({
-      type,
-      data,
-    })
+    if (response.status === 200) {
+      const data = await response.json()
+      dispatch({
+        type,
+        data,
+      })
+    }
   }
-}
 
 export const fetchLoginStatus = buildFetchAction(
   '/loginStatus',


### PR DESCRIPTION
When you are not logged in, several api-endpoints return the message "You do not have permission to view this resource, <a href='/admin/#/login'>Please Login</a>" which results in an uncaught error because it can't be parsed to JSON.

This PR resolves this issue by checking the status (and using await/async syntax for cleaner code)