### PR TITLE
chore: run tests with node 16,18 and 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
In preparation for phasing out 16 and eventual adoption of 20 let's run tests with all these versions for now.