### PR TITLE
feature: override for MFD addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ To enable debugging without going through the Admin UI, see the file `~/.signalk
 - `ALLOW_NEW_USER_REGISTRATION` (default is true).
 - `ADMINUSER` force a account for admin user (username:password format).
 - `PRESERIALCOMMAND` command to run before opening a serial port.
+- `MFD_ADDRESS_SCRIPT` command to run to provide a comma separate list of server addresses to advertise to (Navico) MFDs.
 - `SIGNALK_NODE_SETTINGS` override the path to the settings file.
 - `SIGNALK_NODE_CONFIG_DIR` override the path to find server configuration. Includes all run-time changing content: configuration files, plugins, plugin configuration files, webapps, and so forth.
 


### PR DESCRIPTION
Add env variable MFD_ADDRESS_SCRIPT to allow overriding the default MFD advertisement addresses with a shell script that outputs a comma delimited list of addresses to advertise.