### PR TITLE
feature: Remember Me improvements

### DIFF
--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -187,11 +187,9 @@ class Settings extends Component {
                     </FormGroup>
                     <FormGroup row>
                       <Col md="3">
-                        <Label htmlFor="text-input">
-                          Login Session Timeout
-                        </Label>
+                        <Label htmlFor="text-input">Remember Me timeout</Label>
                       </Col>
-                      <Col xs="12" md="2">
+                      <Col xs="12" md="3">
                         <Input
                           type="text"
                           name="expiration"
@@ -200,6 +198,12 @@ class Settings extends Component {
                         />
                         <FormText color="muted">
                           Examples: 60s, 1m, 1h, 1d
+                        </FormText>
+                      </Col>
+                      <Col md="6">
+                        <FormText color="muted">
+                          How long server keeps you logged when Remember Me is
+                          checked in login.
                         </FormText>
                       </Col>
                     </FormGroup>

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -44,7 +44,7 @@ module.exports = function (app, config) {
   const strategy = {}
 
   let {
-    expiration = '1d',
+    expiration = '3m',
     users = [],
     immutableConfig = false,
     allowDeviceAccessRequests = true,


### PR DESCRIPTION
<img width="774" alt="image" src="https://github.com/SignalK/signalk-server/assets/1049678/fb594c59-8372-4fc9-ade0-c9aad514e66f">

    Security Settings says 'login session timeout', which is misleading:
    if you don't check Remember Me login session has no timeout and
    is alive for browser session duration. The value is used to set
    maxAge of session cookie when RememberMe is checked.

    The current default value of 1d for Remember Me timeout is not
    very intuitive: without RememberMe checked the login lasts for
    the browser session, which often is much longer than 1d. With
    the default 1d and Remember Me checked your login session will
    timeout in 1d, when you probably wanted that the server would
    remember you over browser restarts for quite a bit longer.
    
    This changes the default value to 3 months, trying to strike
    a balance between security (eventual timeout) and convenience
    (the server actually remembering you over browser session
    resets).

