### PR TITLE
feature: Expose a Course API interface to plugins.

### DIFF
--- a/packages/server-api/src/coursetypes.ts
+++ b/packages/server-api/src/coursetypes.ts
@@ -1,10 +1,14 @@
-import { Position } from '.'
+import { Brand, Position } from '.'
 
-export interface PointDestination {
-  href?: string
-  position?: Position
-  type?: string
+export interface HrefDestination {
+  href: string
 }
+
+export interface PositionDestination {
+  position: Position
+}
+
+export type PointDestination = HrefDestination | PositionDestination
 
 export interface RouteDestination {
   href: string
@@ -21,6 +25,13 @@ export interface ActiveRoute {
   name: string
 }
 
+export type CoursePointType = Brand<string, 'coursepointtype'>
+export const COURSE_POINT_TYPES = {
+  VesselPosition: 'VesselPosition' as CoursePointType,
+  RoutePoint: 'RoutePoint' as CoursePointType,
+  Location: 'Location' as CoursePointType
+}
+
 export interface CourseInfo {
   startTime: string | null
   targetArrivalTime: string | null
@@ -28,12 +39,12 @@ export interface CourseInfo {
   activeRoute: ActiveRoute | null
   nextPoint: {
     href?: string
-    type: string
+    type: CoursePointType
     position: Position
   } | null
   previousPoint: {
     href?: string
-    type: string
+    type: CoursePointType
     position: Position
   } | null
 }

--- a/packages/server-api/src/coursetypes.ts
+++ b/packages/server-api/src/coursetypes.ts
@@ -27,13 +27,13 @@ export interface CourseInfo {
   arrivalCircle: number
   activeRoute: ActiveRoute | null
   nextPoint: {
-    href?: string | null
-    type: string | null
-    position: Position | null
+    href?: string
+    type: string
+    position: Position
   } | null
   previousPoint: {
-    href?: string | null
-    type: string | null
-    position: Position | null
+    href?: string
+    type: string
+    position: Position
   } | null
 }

--- a/packages/server-api/src/coursetypes.ts
+++ b/packages/server-api/src/coursetypes.ts
@@ -1,0 +1,41 @@
+import { Position } from '.'
+
+interface DestinationBase {
+  href?: string
+}
+
+export interface Destination extends DestinationBase {
+  position?: Position
+  type?: string
+}
+
+export interface RouteDest extends DestinationBase {
+  reverse?: boolean
+  pointIndex?: number
+  arrivalCircle?: number
+}
+
+export interface ActiveRoute extends DestinationBase {
+  href: string //ActiveRoute always has href
+  pointIndex: number
+  pointTotal: number
+  reverse: boolean
+  name: string
+}
+
+export interface CourseInfo {
+  startTime: string | null
+  targetArrivalTime: string | null
+  arrivalCircle: number
+  activeRoute: ActiveRoute | null
+  nextPoint: {
+    href?: string | null
+    type: string | null
+    position: Position | null
+  } | null
+  previousPoint: {
+    href?: string | null
+    type: string | null
+    position: Position | null
+  } | null
+}

--- a/packages/server-api/src/coursetypes.ts
+++ b/packages/server-api/src/coursetypes.ts
@@ -1,22 +1,20 @@
 import { Position } from '.'
 
-interface DestinationBase {
+export interface PointDestination {
   href?: string
-}
-
-export interface Destination extends DestinationBase {
   position?: Position
   type?: string
 }
 
-export interface RouteDest extends DestinationBase {
+export interface RouteDestination {
+  href: string
   reverse?: boolean
   pointIndex?: number
   arrivalCircle?: number
 }
 
-export interface ActiveRoute extends DestinationBase {
-  href: string //ActiveRoute always has href
+export interface ActiveRoute {
+  href: string
   pointIndex: number
   pointTotal: number
   reverse: boolean

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -27,7 +27,7 @@ export * from './resourcetypes'
 export * from './resourcesapi'
 export { ResourceProviderRegistry } from './resourcesapi'
 import { ResourceProviderRegistry } from './resourcesapi'
-import { Destination, RouteDest, CourseInfo } from './coursetypes'
+import { PointDestination, RouteDestination, CourseInfo } from './coursetypes'
 
 export * from './autopilotapi'
 
@@ -174,7 +174,7 @@ export interface ServerAPI extends PluginServerApp {
   getSerialPorts: () => Promise<Ports>
   getCourse: () => CourseInfo
   setDestination: (
-    dest: (Destination & { arrivalCircle?: number }) | null
+    dest: (PointDestination & { arrivalCircle?: number }) | null
   ) => Promise<void>
-  activateRoute: (dest: RouteDest | null) => Promise<void>
+  activateRoute: (dest: RouteDestination | null) => Promise<void>
 }

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -173,8 +173,8 @@ export interface ServerAPI extends PluginServerApp {
   }) => void
   getSerialPorts: () => Promise<Ports>
   getCourse: () => CourseInfo
-  setCourse: (
+  destination: (
     dest: (Destination & { arrivalCircle?: number }) | null
   ) => Promise<void>
-  setRoute: (dest: RouteDest | null) => Promise<void>
+  activeRoute: (dest: RouteDest | null) => Promise<void>
 }

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -173,6 +173,7 @@ export interface ServerAPI extends PluginServerApp {
   }) => void
   getSerialPorts: () => Promise<Ports>
   getCourse: () => CourseInfo
+  clearDestination: () => void
   setDestination: (
     dest: (PointDestination & { arrivalCircle?: number }) | null
   ) => Promise<void>

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -172,8 +172,8 @@ export interface ServerAPI extends PluginServerApp {
     ) => void
   }) => void
   getSerialPorts: () => Promise<Ports>
-  getCourse: () => CourseInfo
-  clearDestination: () => void
+  getCourse: () => Promise<CourseInfo>
+  clearDestination: () => Promise<void>
   setDestination: (
     dest: (PointDestination & { arrivalCircle?: number }) | null
   ) => Promise<void>

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -22,10 +22,12 @@ export enum SKVersion {
 export type Brand<K, T> = K & { __brand: T }
 
 export * from './deltas'
+export * from './coursetypes'
 export * from './resourcetypes'
 export * from './resourcesapi'
 export { ResourceProviderRegistry } from './resourcesapi'
 import { ResourceProviderRegistry } from './resourcesapi'
+import { Destination, RouteDest, CourseInfo } from './coursetypes'
 
 export * from './autopilotapi'
 
@@ -170,4 +172,9 @@ export interface ServerAPI extends PluginServerApp {
     ) => void
   }) => void
   getSerialPorts: () => Promise<Ports>
+  getCourse: () => CourseInfo
+  setCourse: (
+    dest: (Destination & { arrivalCircle?: number }) | null
+  ) => Promise<void>
+  setRoute: (dest: RouteDest | null) => Promise<void>
 }

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -173,8 +173,8 @@ export interface ServerAPI extends PluginServerApp {
   }) => void
   getSerialPorts: () => Promise<Ports>
   getCourse: () => CourseInfo
-  destination: (
+  setDestination: (
     dest: (Destination & { arrivalCircle?: number }) | null
   ) => Promise<void>
-  activeRoute: (dest: RouteDest | null) => Promise<void>
+  activateRoute: (dest: RouteDest | null) => Promise<void>
 }

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -19,8 +19,11 @@ import {
   PointDestination,
   ActiveRoute,
   RouteDestination,
-  CourseInfo
+  CourseInfo,
+  COURSE_POINT_TYPES
 } from '@signalk/server-api'
+
+const { Location, RoutePoint, VesselPosition } = COURSE_POINT_TYPES
 import { isValidCoordinate } from 'geolib'
 import { Responses } from '../'
 import { Store } from '../../serverstate/store'
@@ -224,7 +227,7 @@ export class CourseApi {
           if (position && position.value) {
             this.courseInfo.previousPoint = {
               position: position.value,
-              type: 'VesselPosition'
+              type: VesselPosition
             }
             this.emitCourseInfo(false, 'previousPoint')
             res.status(200).json(Responses.ok)
@@ -426,7 +429,7 @@ export class CourseApi {
             this.courseInfo.activeRoute.pointIndex as number,
             this.courseInfo.activeRoute.reverse
           ),
-          type: 'RoutePoint'
+          type: RoutePoint
         }
 
         // set previousPoint
@@ -436,7 +439,7 @@ export class CourseApi {
             if (position && position.value) {
               this.courseInfo.previousPoint = {
                 position: position.value,
-                type: 'VesselPosition'
+                type: VesselPosition
               }
             } else {
               res.status(400).json(Responses.invalid)
@@ -454,7 +457,7 @@ export class CourseApi {
               (this.courseInfo.activeRoute.pointIndex as number) - 1,
               this.courseInfo.activeRoute.reverse
             ),
-            type: 'RoutePoint'
+            type: RoutePoint
           }
         }
         this.emitCourseInfo()
@@ -500,7 +503,7 @@ export class CourseApi {
     }
     newCourse.activeRoute = activeRoute
     newCourse.nextPoint = {
-      type: `RoutePoint`,
+      type: RoutePoint,
       position: this.getRoutePoint(rte, pointIndex, !!reverse)
     }
     newCourse.startTime = new Date().toISOString()
@@ -516,7 +519,7 @@ export class CourseApi {
         if (position && position.value) {
           newCourse.previousPoint = {
             position: position.value,
-            type: 'VesselPosition'
+            type: VesselPosition
           }
         } else {
           throw new Error(`Error: Unable to retrieve vessel position!`)
@@ -531,7 +534,7 @@ export class CourseApi {
           activeRoute.pointIndex - 1,
           activeRoute.reverse
         ),
-        type: 'RoutePoint'
+        type: RoutePoint
       }
     }
 
@@ -550,7 +553,7 @@ export class CourseApi {
       newCourse.arrivalCircle = dest.arrivalCircle as number
     }
 
-    if (dest.href) {
+    if ('href' in dest) {
       const typedHref = this.parseHref(dest.href)
       if (typedHref) {
         debug(`fetching ${JSON.stringify(typedHref)}`)
@@ -579,11 +582,11 @@ export class CourseApi {
       } else {
         throw new Error(`Invalid href! (${dest.href})`)
       }
-    } else if (dest.position) {
+    } else if ('position' in dest) {
       if (isValidCoordinate(dest.position)) {
         newCourse.nextPoint = {
           position: dest.position,
-          type: 'Location'
+          type: Location
         }
       } else {
         throw new Error(`Error: position is not valid`)
@@ -601,7 +604,7 @@ export class CourseApi {
       if (position && position.value) {
         newCourse.previousPoint = {
           position: position.value,
-          type: 'VesselPosition'
+          type: VesselPosition
         }
       } else {
         throw new Error(

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -94,8 +94,8 @@ export class CourseApi {
   /** Set / clear course (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
-  async setCourse(dest: (Destination & { arrivalCircle?: number }) | null) {
-    debug(`** setCourse(${dest})`)
+  async destination(dest: (Destination & { arrivalCircle?: number }) | null) {
+    debug(`** destination(${dest})`)
 
     if (!dest) {
       this.clearDestination()
@@ -112,8 +112,8 @@ export class CourseApi {
   /** Set / clear route (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
-  async setRoute(dest: RouteDest | null) {
-    debug(`** setCourse(${dest})`)
+  async activeRoute(dest: RouteDest | null) {
+    debug(`** activeRoute(${dest})`)
 
     if (!dest) {
       this.clearDestination()

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -16,9 +16,9 @@ import {
   Route,
   SignalKResourceType,
   SKVersion,
-  Destination,
+  PointDestination,
   ActiveRoute,
-  RouteDest,
+  RouteDestination,
   CourseInfo
 } from '@signalk/server-api'
 import { isValidCoordinate } from 'geolib'
@@ -94,7 +94,7 @@ export class CourseApi {
   /** Set / clear course (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
-  async destination(dest: (Destination & { arrivalCircle?: number }) | null) {
+  async destination(dest: (PointDestination & { arrivalCircle?: number }) | null) {
     debug(`** destination(${dest})`)
 
     if (!dest) {
@@ -112,7 +112,7 @@ export class CourseApi {
   /** Set / clear route (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
-  async activeRoute(dest: RouteDest | null) {
+  async activeRoute(dest: RouteDestination | null) {
     debug(`** activeRoute(${dest})`)
 
     if (!dest) {
@@ -464,7 +464,7 @@ export class CourseApi {
     )
   }
 
-  private async activateRoute(route: RouteDest): Promise<boolean> {
+  private async activateRoute(route: RouteDestination): Promise<boolean> {
     const { href, reverse } = route
     let rte: any
 
@@ -533,7 +533,7 @@ export class CourseApi {
   }
 
   private async setDestination(
-    dest: Destination & { arrivalCircle?: number }
+    dest: PointDestination & { arrivalCircle?: number }
   ): Promise<boolean> {
     const newCourse: CourseInfo = { ...this.courseInfo }
 

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -86,13 +86,13 @@ export class CourseApi {
   }
 
   /** Get course (exposed to plugins) */
-  getCourse(): CourseInfo {
+  async getCourse(): Promise<CourseInfo> {
     debug(`** getCourse()`)
     return this.courseInfo
   }
 
   /** Clear destination / route (exposed to plugins)  */
-  public clearDestination() {
+  async clearDestination(): Promise<void> {
     this.courseInfo.startTime = null
     this.courseInfo.targetArrivalTime = null
     this.courseInfo.activeRoute = null

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -91,16 +91,24 @@ export class CourseApi {
     return this.courseInfo
   }
 
-  /** Set / clear course (exposed to plugins)
+  /** Clear destination / route (exposed to plugins)  */
+  public clearDestination() {
+    this.courseInfo.startTime = null
+    this.courseInfo.targetArrivalTime = null
+    this.courseInfo.activeRoute = null
+    this.courseInfo.nextPoint = null
+    this.courseInfo.previousPoint = null
+    this.emitCourseInfo()
+  }
+
+  /** Set course (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
   async destination(dest: (PointDestination & { arrivalCircle?: number }) | null) {
     debug(`** destination(${dest})`)
 
     if (!dest) {
-      this.clearDestination()
-      this.emitCourseInfo()
-      return
+      throw new Error('No destination information supplied!')
     }
 
     const result = await this.setDestination(dest)
@@ -116,9 +124,7 @@ export class CourseApi {
     debug(`** activeRoute(${dest})`)
 
     if (!dest) {
-      this.clearDestination()
-      this.emitCourseInfo()
-      return
+      throw new Error('No route information supplied!')
     }
 
     const result = await this.activateRoute(dest)
@@ -265,7 +271,6 @@ export class CourseApi {
           return
         }
         this.clearDestination()
-        this.emitCourseInfo()
         res.status(200).json(Responses.ok)
       }
     )
@@ -607,14 +612,6 @@ export class CourseApi {
 
     this.courseInfo = newCourse
     return true
-  }
-
-  private clearDestination() {
-    this.courseInfo.startTime = null
-    this.courseInfo.targetArrivalTime = null
-    this.courseInfo.activeRoute = null
-    this.courseInfo.nextPoint = null
-    this.courseInfo.previousPoint = null
   }
 
   private isValidArrivalCircle(value: number | undefined): boolean {

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -104,7 +104,9 @@ export class CourseApi {
   /** Set course (exposed to plugins)
    * @param dest Setting to null clears the current destination
    */
-  async destination(dest: (PointDestination & { arrivalCircle?: number }) | null) {
+  async destination(
+    dest: (PointDestination & { arrivalCircle?: number }) | null
+  ) {
     debug(`** destination(${dest})`)
 
     if (!dest) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -43,5 +43,7 @@ export const startApis = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(app as any).resourcesApi = resourcesApi
   const courseApi = new CourseApi(app, resourcesApi)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).courseApi = courseApi
   Promise.all([resourcesApi.start(), courseApi.start()])
 }

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -517,6 +517,9 @@ module.exports = (theApp: any) => {
     appCopy.getCourse = () => {
       return courseApi.getCourse()
     }
+    appCopy.clearDestination = () => {
+      return courseApi.clearDestination()
+    }
     appCopy.setDestination = (
       dest: (PointDestination & { arrivalCircle?: number }) | null
     ) => {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -517,12 +517,12 @@ module.exports = (theApp: any) => {
     appCopy.getCourse = () => {
       return courseApi.getCourse()
     }
-    appCopy.destination = (
+    appCopy.setDestination = (
       dest: (Destination & { arrivalCircle?: number }) | null
     ) => {
       return courseApi.destination(dest)
     }
-    appCopy.activeRoute = (dest: RouteDest | null) => {
+    appCopy.activateRoute = (dest: RouteDest | null) => {
       return courseApi.activeRoute(dest)
     }
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -21,8 +21,8 @@ import {
   PropertyValuesCallback,
   ResourceProvider,
   ServerAPI,
-  Destination,
-  RouteDest
+  PointDestination,
+  RouteDestination
 } from '@signalk/server-api'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -518,11 +518,11 @@ module.exports = (theApp: any) => {
       return courseApi.getCourse()
     }
     appCopy.setDestination = (
-      dest: (Destination & { arrivalCircle?: number }) | null
+      dest: (PointDestination & { arrivalCircle?: number }) | null
     ) => {
       return courseApi.destination(dest)
     }
-    appCopy.activateRoute = (dest: RouteDest | null) => {
+    appCopy.activateRoute = (dest: RouteDestination | null) => {
       return courseApi.activeRoute(dest)
     }
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -20,7 +20,9 @@ import {
   PropertyValues,
   PropertyValuesCallback,
   ResourceProvider,
-  ServerAPI
+  ServerAPI,
+  Destination,
+  RouteDest
 } from '@signalk/server-api'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -30,6 +32,7 @@ import fs from 'fs'
 import _ from 'lodash'
 import path from 'path'
 import { ResourcesApi } from '../api/resources'
+import { CourseApi } from '../api/course'
 import { SERVERROUTESPREFIX } from '../constants'
 import { createDebug } from '../debug'
 import { listAllSerialPorts } from '../serialports'
@@ -507,6 +510,20 @@ module.exports = (theApp: any) => {
     _.omit(appCopy, 'resourcesApi') // don't expose the actual resource api manager
     appCopy.registerResourceProvider = (provider: ResourceProvider) => {
       resourcesApi.register(plugin.id, provider)
+    }
+
+    const courseApi: CourseApi = app.courseApi
+    _.omit(appCopy, 'courseApi') // don't expose the actual course api manager
+    appCopy.getCourse = () => {
+      return courseApi.getCourse()
+    }
+    appCopy.setCourse = (
+      dest: (Destination & { arrivalCircle?: number }) | null
+    ) => {
+      return courseApi.setCourse(dest)
+    }
+    appCopy.setRoute = (dest: RouteDest | null) => {
+      return courseApi.setRoute(dest)
     }
 
     try {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -517,13 +517,13 @@ module.exports = (theApp: any) => {
     appCopy.getCourse = () => {
       return courseApi.getCourse()
     }
-    appCopy.setCourse = (
+    appCopy.destination = (
       dest: (Destination & { arrivalCircle?: number }) | null
     ) => {
-      return courseApi.setCourse(dest)
+      return courseApi.destination(dest)
     }
-    appCopy.setRoute = (dest: RouteDest | null) => {
-      return courseApi.setRoute(dest)
+    appCopy.activeRoute = (dest: RouteDest | null) => {
+      return courseApi.activeRoute(dest)
     }
 
     try {


### PR DESCRIPTION
Create an interface for the Course API to expose to plugins to enable them to interact with the Course API.

The functions accept parameters and return values of the same type as the equivalent REST API function.

Functions include: 
- `getCourse()`: retrieve current course details
- `setCourse()`: Set position / waypoint as current destination
- `setRoute()`: Follow a route.

_Note: `server-api` types have been updated as part of this PR and will require a new version to be published when this is merged_