### PR TITLE
feature: newServer notification as normal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,7 +375,7 @@ class Server {
               {
                 path: 'notifications.server.newVersion',
                 value: {
-                  state: 'alert',
+                  state: 'normal',
                   method: [],
                   message: msg
                 }


### PR DESCRIPTION
Reduce the notification state severity to normal.

There being a new version available is a pretty low severity notification. Just the fact that there is a notification for is probably enough.

See also https://github.com/SignalK/instrumentpanel/issues/245