### PR TITLE
Keep only recent data log files by default

### DIFF
--- a/packages/server-admin-ui/src/views/Configuration/Configuration.js
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.js
@@ -231,7 +231,7 @@ class PluginCard extends Component {
                     </Label>
                   </Col>
                   <Col xs="3">
-                    Log plugin output
+                    Data Logging
                     <Label
                       style={labelStyle}
                       className="switch switch-text switch-primary"

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -271,7 +271,7 @@ class LoggingInput extends Component {
     return (
       <FormGroup row>
         <Col xs="3" md="3">
-          <Label>Logging</Label>
+          <Label>Data Logging</Label>
         </Col>
         <Col xs="2" md="3">
           <Label className="switch switch-text switch-primary">

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -250,7 +250,7 @@ class ProvidersConfiguration extends Component {
                       <th>ID</th>
                       <th>Data Type</th>
                       <th>Enabled</th>
-                      <th>Logging</th>
+                      <th>Data Logging</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -299,7 +299,7 @@ class ProvidersConfiguration extends Component {
                   <th>ID</th>
                   <th>Data Type</th>
                   <th>Enabled</th>
-                  <th>Logging</th>
+                  <th>Data Logging</th>
                 </tr>
               </thead>
               <tbody>

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -273,7 +273,7 @@ class ServerSettings extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Col md="2">
-                    <Label>Keep only most recent logs</Label>
+                    <Label>Keep only most recent data log files</Label>
                   </Col>
                   <Col>
                     <FormGroup check>

--- a/packages/streams/logging.js
+++ b/packages/streams/logging.js
@@ -18,6 +18,7 @@ const { FileTimestampStream } = require('file-timestamp-stream')
 const path = require('path')
 let debug = require('debug')('signalk:streams:logging')
 const fs = require('fs')
+const { isUndefined } = require('lodash')
 
 const filenamePattern = /skserver\-raw\_\d\d\d\d\-\d\d\-\d\dT\d\d\.log/
 const loggers = {}
@@ -85,7 +86,10 @@ function getLogger(app, discriminator = '', logdir) {
     debug(`logging to ${fileName}`)
 
     let fileTimestampStream
-    if (app.config.settings.keepMostRecentLogsOnly) {
+    if (
+      isUndefined(app.config.settings.keepMostRecentLogsOnly) ||
+      app.config.settings.keepMostRecentLogsOnly
+    ) {
       // Delete old logs
       fileTimestampStream = new FileTimestampStreamWithDelete(
         app,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -70,7 +70,7 @@ export interface Config {
     mdns?: boolean
     sslport?: number
     port?: number
-    keepMostRecentLogsOnly?: number
+    keepMostRecentLogsOnly?: boolean
     logCountToKeep?: number
     enablePluginLogging?: boolean
     loggingDirectory?: string

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -481,7 +481,8 @@ module.exports = function (
       loggingDirectory: app.config.settings.loggingDirectory,
       pruneContextsMinutes: app.config.settings.pruneContextsMinutes || 60,
       keepMostRecentLogsOnly:
-        app.config.settings.keepMostRecentLogsOnly || false,
+        isUndefined(app.config.settings.keepMostRecentLogsOnly) ||
+        app.config.settings.keepMostRecentLogsOnly,
       logCountToKeep: app.config.settings.logCountToKeep || 24,
       runFromSystemd: process.env.RUN_FROM_SYSTEMD === 'true'
     }


### PR DESCRIPTION
Occasionally people have trouble with data log files filling
their storage. This changes the default from keeping the data log
files forever to keeping only 24 last hourly log files.

In addition the terminology in the Admin UI is changed to talk about 'Data Logging'.