### PR TITLE
feature: add preinstalled plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,10 @@
     "@signalk/set-system-time": "^1.2.0",
     "@signalk/signalk-to-nmea0183": "^1.0.0",
     "@signalk/vesselpositions": "^1.0.0",
+    "@signalk/udp-nmea-plugin": "^2.0.0",
     "@signalk/zones": "^1.0.0",
+    "signalk-to-nmea2000": "^2.16.0",
+    "signalk-n2kais-to-nmea0183": "^1.3.1",
     "mdns": "^2.5.1",
     "serialport": "^11.0.0"
   },


### PR DESCRIPTION
Add more features to the default install:
- UDP NMEA0183 sender
- NMEA2000 AIS to NMEA 0183
- Signal K to NMEA2000