### PR TITLE
refactor: minor optimisations

### DIFF
--- a/packages/streams/canboatjs.js
+++ b/packages/streams/canboatjs.js
@@ -32,7 +32,7 @@ function CanboatJs(options) {
   })
 
   this.fromPgn.on('error', (pgn, err) => {
-    console.log(err)
+    console.error(pgn.input, err.message)
   })
 
   this.app = options.app

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -266,7 +266,7 @@ function getLeafObject(
 ) {
   let current = start
 
-  for (const i in contextAndPathParts) {
+  for (let i = 0; i < contextAndPathParts.length; i++) {
     const p = contextAndPathParts[i]
     if (isUndefined(current[p])) {
       if (createIfMissing) {

--- a/src/streambundle.js
+++ b/src/streambundle.js
@@ -25,7 +25,7 @@ function StreamBundle(app, selfId) {
   this.selfStreams = {}
   this.selfAllPathsStream = new Bacon.Bus()
   this.keys = new Bacon.Bus()
-  this.availableSelfPaths = []
+  this.availableSelfPaths = {}
   this.app = app
   this.metaSent = {}
 }
@@ -64,8 +64,8 @@ StreamBundle.prototype.pushDelta = function (delta) {
 }
 
 StreamBundle.prototype.push = function (path, pathValueWithSourceAndContext) {
-  if (this.availableSelfPaths.indexOf(path) === -1) {
-    this.availableSelfPaths.push(path)
+  if (!this.availableSelfPaths[path]) {
+    this.availableSelfPaths[path] = true
   }
   this.getBus().push(pathValueWithSourceAndContext)
   this.getBus(path).push(pathValueWithSourceAndContext)
@@ -117,7 +117,7 @@ StreamBundle.prototype.getSelfBus = function (path) {
 }
 
 StreamBundle.prototype.getAvailablePaths = function () {
-  return this.availableSelfPaths
+  return Object.keys(this.availableSelfPaths)
 }
 
 function toDelta(normalizedDeltaData) {


### PR DESCRIPTION
See the commit messages for individual optimizations. Each of these improved measurably the throughput of the server that was replaying n2k data repeatedled. Less string splits mean also less temporary memory allocations.