### PR TITLE
feature: add reportOutputMessages to server plugin API

### DIFF
--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -178,4 +178,21 @@ export interface ServerAPI extends PluginServerApp {
     dest: (PointDestination & { arrivalCircle?: number }) | null
   ) => Promise<void>
   activateRoute: (dest: RouteDestination | null) => Promise<void>
+
+  /**
+   * A plugin can report that it has handled output messages. This will
+   * update the output message rate and icon in the Dashboard.
+   *
+   * This is for traffic that the plugin is sending outside the server,
+   * for example network packets, http calls or messages sent to
+   * a broker. This should NOT be used for deltas that the plugin
+   * sends with handleMessage, they are reported as input from the
+   * server's perspective.
+   *
+   * @param count optional count of handled messages between the last
+   * call and this one. If omitted the call will count as one output
+   * message.
+   */
+
+  reportOutputMessages: (count?: number) => void
 }

--- a/src/deltastats.ts
+++ b/src/deltastats.ts
@@ -19,9 +19,11 @@ import { isUndefined, values } from 'lodash'
 import { EventEmitter } from 'node:events'
 
 const STATS_UPDATE_INTERVAL_SECONDS = 5
+export const CONNECTION_WRITE_EVENT_NAME = 'connectionwrite'
 
-interface ConnectionWriteEvent {
+export interface ConnectionWriteEvent {
   providerId: string
+  count?: number
 }
 
 class ProviderStats {
@@ -57,10 +59,13 @@ export function startDeltaStatistics(
   app.lastIntervalDeltaCount = 0
   app.providerStatistics = {}
 
-  app.on('connectionwrite', (msg: ConnectionWriteEvent) => {
+  app.on(CONNECTION_WRITE_EVENT_NAME, (msg: ConnectionWriteEvent) => {
     const stats =
       app.providerStatistics[msg.providerId] ||
       (app.providerStatistics[msg.providerId] = new ProviderStats())
+    if (msg.count !== undefined) {
+      stats.writeCount += msg.count
+    }
     stats.writeCount++
   })
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -40,6 +40,10 @@ const debug = createDebug('signalk-server:interfaces:plugins')
 
 import { modulesWithKeyword } from '../modules'
 import { OpenApiDescription, OpenApiRecord } from '../api/swagger'
+import {
+  CONNECTION_WRITE_EVENT_NAME,
+  ConnectionWriteEvent
+} from '../deltastats'
 
 const put = require('../put')
 const _putPath = put.putPath
@@ -502,7 +506,13 @@ module.exports = (theApp: any) => {
       },
       getSerialPorts,
       supportsMetaDeltas: true,
-      getMetadata
+      getMetadata,
+      reportOutputMessages: (count?: number) => {
+        app.emit(CONNECTION_WRITE_EVENT_NAME, {
+          providerId: plugin.id,
+          count
+        } as ConnectionWriteEvent)
+      }
     })
     appCopy.putPath = putPath
 


### PR DESCRIPTION
Add a way for plugins to report that they are handling outgoing (out = from the server to the outside world) traffic to update the output rate & icon on the dashboard.