### PR TITLE
fix: default cors, add * as an allow-all configuration, don't add localhost to allowed cors hosts

### DIFF
--- a/packages/server-admin-ui/src/views/security/Settings.js
+++ b/packages/server-admin-ui/src/views/security/Settings.js
@@ -210,13 +210,14 @@ class Settings extends Component {
                     <FormGroup row>
                       <Col md="12">
                         <Label>
-                          Simple CORS requests are allowed from all hosts by
-                          default. You can restrict CORS requests to named hosts
-                          by configuring allowed CORS origins below. The host
-                          where this page is loaded from is automatically
-                          included in the allowed CORS origins so that the Admin
-                          UI continues to work. Changes to the Allowed CORS
-                          origins requires a server restart.
+                          With no configuration all CORS origins are accepted,
+                          but client requests with credentials:include do not
+                          work. Add a single * origin to allow all origins with
+                          credentials. You can also restrict CORS requests to
+                          specific origins. The origin that this UI was loaded
+                          from is automatically added to the allowed origins so
+                          that requests from the UI work. Changes to the Allowed
+                          CORS origins requires a server restart.
                         </Label>
                       </Col>
                     </FormGroup>{' '}
@@ -232,7 +233,8 @@ class Settings extends Component {
                           value={this.state.allowedCorsOrigins}
                         />
                         <FormText color="muted">
-                          Use comma delimited list, example:
+                          Use either * or a comma delimited list of origins,
+                          example:
                           http://host1.name.com:3000,http://host2.name.com:3000
                         </FormText>
                       </Col>

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -9,15 +9,20 @@ export function setupCors(
 ) {
   const corsDebug = createDebug('signalk-server:cors')
 
+  const corsOptions: CorsOptions = {
+    credentials: true,
+  }
   const corsOrigins = allowedCorsOrigins
     ? allowedCorsOrigins
         .split(',')
         .map((s: string) => s.trim().replace(/\/*$/, ''))
     : []
   corsDebug(`corsOrigins:${corsOrigins.toString()}`)
-  const corsOptions: CorsOptions = {
-    credentials: true,
-    origin: corsOrigins
+  // set origin only if corsOrigins are set so that
+  // we get the default cors module functionality
+  // for simple requests by default
+  if (corsOrigins.length) {
+    corsOptions.origin = corsOrigins
   }
 
   app.use(cors(corsOptions))

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -49,7 +49,11 @@ export const handleAdminUICORSOrigin = (
     securityConfig.allowedCorsOrigins.length > 0
   ) {
     allowedCorsOrigins = securityConfig.allowedCorsOrigins?.split(',')
-    if (allowedCorsOrigins.indexOf(securityConfig.adminUIOrigin) === -1) {
+    const adminUIOriginUrl = new URL(securityConfig.adminUIOrigin)
+    if (
+      allowedCorsOrigins.indexOf(securityConfig.adminUIOrigin) === -1 &&
+      adminUIOriginUrl.hostname !== 'localhost'
+    ) {
       allowedCorsOrigins.push(securityConfig.adminUIOrigin)
     }
   }


### PR DESCRIPTION
- Fixes #1640 : #1581 accidentally disabled the default CORS behavior, that allows all CORS origins with `Access-Control-Allow-Origin: *`
- fix: do not add `localhost` addresses to the CORS origins when saved from the Admin UI
- feature: add a new special `*` value for allowed CORS origins. This will allow all origins and echo back the origin in `Access-Control-Allow-Origin` instead of the default *. This allows configuring the server to work with security enabled and `credentials:include` requests from all origins