### PR TITLE
doc: drop the dollar prefixes

### DIFF
--- a/docs/src/installation/raspberry_pi_installation.md
+++ b/docs/src/installation/raspberry_pi_installation.md
@@ -28,18 +28,18 @@ Once the OS installation has been completed, you are ready to commence.
 
 1. Update the list of install packages.
     ```
-    $ sudo apt update
+    sudo apt update
     ```
 
 1. Install NodeJS and npm.
     ```
-    $ curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-    $ sudo apt-get install -y nodejs
+    curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    sudo apt-get install -y nodejs
     ```
 
 1. Ensure that we're using the latest version of npm.
     ```
-    $ sudo npm install -g npm@latest
+    sudo npm install -g npm@latest
     ```
     
     Use the following command to check the versions of NodeJS and npm installed.
@@ -51,25 +51,25 @@ Once the OS installation has been completed, you are ready to commence.
 
 1. Install a Bonjour (mDNS) service for Linux called Avahi, which allows Apps and other network devices to Discover the Signal K server.
     ```
-    $ sudo apt install libnss-mdns avahi-utils libavahi-compat-libdnssd-dev
+    sudo apt install libnss-mdns avahi-utils libavahi-compat-libdnssd-dev
     ```
     
 ## Install Signal K Server
 
 ```
-$ sudo npm install -g signalk-server
+sudo npm install -g signalk-server
 ```
     
 You can test that installation was successful by starting the server using some 
 sample data.
 
 ```
-$ signalk-server --sample-nmea0183-data
+signalk-server --sample-nmea0183-data
 ```
 
 You should see the terminal output "signalk-server running at 0.0.0.0:3000" as shown below...
 ``` 
-$ signalk-server --sample-nmea0183-data
+signalk-server --sample-nmea0183-data
 Using sample data from /usr/lib/node_modules/signalk-server/samples/plaka.log
 signalk-server running at 0.0.0.0:3000
 ```
@@ -101,7 +101,7 @@ Now that you have Signal K server installed, you will want to generate a setting
 and configure your RPi to start the server automatically. To do this run the setup script by entering the  following command and follow the prompts.
 
 ```
-$ sudo signalk-server-setup
+sudo signalk-server-setup
 ```
 
 You can re-run this command at any time in the future to change the settings.
@@ -114,20 +114,20 @@ Signal K server will now be started automatically when your RPi boots up.
 
 If you want to temporarily stop the Signal K server, you can do so by entering the following commands:
 ```
-$ sudo systemctl stop signalk.service
-$ sudo systemctl stop signalk.socket
+sudo systemctl stop signalk.service
+sudo systemctl stop signalk.socket
 ```
 
 To start Signal K server again enter the following commands:
 ```
-$ sudo systemctl start signalk.service
-$ sudo systemctl start signalk.socket
+sudo systemctl start signalk.service
+sudo systemctl start signalk.socket
 ```
 
 To stop Signal K server from starting automatically enter the following commands:
 ```
-$ sudo systemctl disable signalk.service
-$ sudo systemctl disable signalk.socket
+sudo systemctl disable signalk.service
+sudo systemctl disable signalk.socket
 ```
 
 


### PR DESCRIPTION
Docs at https://demo.signalk.io/documentation/installation/raspberry_pi_installation.html now include a one click button to copy the commands, but including the $ breaks the commands, so let's remove them.