### PR TITLE
fix: use multiplexed file timestamps in deltas

### DIFF
--- a/packages/streams/autodetect.js
+++ b/packages/streams/autodetect.js
@@ -113,6 +113,9 @@ Splitter.prototype._transform = function (msg, encoding, _done) {
       default:
         try {
           const parsed = JSON.parse(msg.data)
+          const timestamp = new Date(Number(msg.timestamp))
+          parsed.updates &&
+            parsed.updates.forEach((update) => (update.timestamp = timestamp))
           this.push(parsed)
           this.demuxEmitData(parsed)
         } catch (e) {


### PR DESCRIPTION
If the original delta data has timestamps use them, otherwise use the timestamp of the multiplexed data also in deltas instead of letting the server fill in the current time.

Fixes #1659.