### PR TITLE
Fix: multiplexed file detection & semicolon handling

### DIFF
--- a/packages/streams/autodetect.js
+++ b/packages/streams/autodetect.js
@@ -137,10 +137,12 @@ function ToTimestamped(deMultiplexer, options) {
 }
 require('util').inherits(ToTimestamped, Transform)
 
+// runs only once, self-assigns the actual transform functions
+// on first call
 ToTimestamped.prototype._transform = function (msg, encoding, done) {
   const line = msg.toString()
   this.multiplexedFormat =
-    line.length > 16 && line.charAt(13) === ';' && line.charAt(15) === ';'
+    line.length > 16 && line.charAt(13) === ';' && line.split(';').length >= 3
   if (this.multiplexedFormat) {
     if (this.options.noThrottle) {
       this.deMultiplexer.toTimestamped.pipe(this.deMultiplexer.splitter)

--- a/packages/streams/autodetect.js
+++ b/packages/streams/autodetect.js
@@ -178,7 +178,11 @@ ToTimestamped.prototype.handleMixed = function (msg, encoding, done) {
 ToTimestamped.prototype.handleMultiplexed = function (msg, encoding, done) {
   const line = msg.toString()
   const parts = line.split(';')
-  this.push({ timestamp: parts[0], discriminator: parts[1], data: parts[2] })
+  this.push({
+    timestamp: parts[0],
+    discriminator: parts[1],
+    data: parts.slice(2).join(';'),
+  })
   done()
 }
 


### PR DESCRIPTION
Logged output from plugins has the plugin id in the
discriminator field instead of the one letter data type
discriminator. If the first line of the multiplexed file
is from a plugin the file type detection does not work
and the file fails to play back silently.

Assert the minimum number of ; delimiters to be 3
instead of checking that charAt(15) is ;.

If a multiplexed file line contains ; in the data, which is
perfectly possible for delta JSON, the part of the data
after ; would get thrown away.

Fix by joining the back with ; as delimiter.