### PR TITLE
fix: guard against missing plugin schema

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -184,6 +184,11 @@ module.exports = (theApp: any) => {
         .then(([schema, uiSchema]) => {
           const status = providerStatus.find((p: any) => p.id === plugin.name)
           const statusMessage = status ? status.message : ''
+          if (schema === undefined) {
+            console.error(
+              `Error: plugin ${plugin.id} is missing configuration schema`
+            )
+          }
           resolve({
             id: plugin.id,
             name: plugin.name,
@@ -191,7 +196,7 @@ module.exports = (theApp: any) => {
             keywords: plugin.keywords,
             version: plugin.version,
             description: plugin.description,
-            schema,
+            schema: schema || {},
             statusMessage,
             uiSchema,
             state: plugin.state,


### PR DESCRIPTION
Loading the configuration form for a plugin with no schema would crash the configuration ui and the browser would persist the configuration ui state so that subsequent attempts to navigate to plugin configuration would try to open the problematic plugin's configuration, again resulting in a ui crash.

Change the server to always provide an empty schema in case the plugin is not defining one and log an error message about it when the plugin configuration page is loaded.