### PR TITLE
feature: rememberme expires to NEVER

### DIFF
--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -44,7 +44,7 @@ module.exports = function (app, config) {
   const strategy = {}
 
   let {
-    expiration = '3m',
+    expiration = 'NEVER',
     users = [],
     immutableConfig = false,
     allowDeviceAccessRequests = true,


### PR DESCRIPTION
Let's assume that the user's intention when checking Remember Me in the login form is that they don't want their login to expire, ever.

This changes the default for the remember me expire to be NEVER.