### PR TITLE
fix: remove plugin config form autoscroll

### DIFF
--- a/packages/server-admin-ui/src/views/Configuration/Configuration.js
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.js
@@ -326,10 +326,4 @@ class PluginCard extends Component {
       </div>
     )
   }
-
-  componentDidMount() {
-    if (this.props.isOpen) {
-      window.scrollTo({ top: this.card.offsetTop - 54, behavior: 'smooth' })
-    }
-  }
 }


### PR DESCRIPTION
People have reported that the autoscroll of the plugin configuration form when pressing Submit is annoying, so let's remove that.