### PR TITLE
Fix: Resources API - Handle requests to GET  chart tiles.

### DIFF
--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -348,6 +348,12 @@ export class ResourcesApi {
       async (req: Request, res: Response, next: NextFunction) => {
         debug(`** GET ${RESOURCES_API_PATH}/:resourceType/:resourceId/*`)
 
+        if (req.path.match(`/charts/(\\w*\\W*)+/[0-9]*/[0-9]*/[0-9]*`)) {
+          debug('*** CHART TILE request -> next()')
+          next()
+          return
+        }
+
         if (!this.hasRegisteredProvider(req.params.resourceType)) {
           next()
           return


### PR DESCRIPTION
As requests for chart tiles do not return a JSON response, they will be passed through to the `chart provider` by calling next().

Chart provider should ensure it has a handler for requests to: `/signalk/v2/api/resources/charts/(\\w*\\W*)+/[0-9]*/[0-9]*/[0-9]*`