### PR TITLE
fix: test baseimage docker after build by building SK release docker image without pushing it to registry

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -11,45 +11,56 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: signalkci
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry. 
-      - name: Build and push
+
+      - name: Build baseimages and push with test tag
         uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile_base
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: |
-            signalk/signalk-server-base:latest
-            ghcr.io/signalk/signalk-server-base:latest
+            signalk/signalk-server-base:test
+            ghcr.io/signalk/signalk-server-base:test
 
-  docker_image_test:
-    runs-on: ubuntu-latest
-    needs: build_docker_base_images
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build and push
+      - name: Modify Dockerfile_rel for testing
+        run: |
+          sed -i 's/:latest/:test/g' ./docker/Dockerfile_rel
+
+      - name: Build Signal K test dockers
         uses: docker/build-push-action@v5
         with:
+          context: .
           file: ./docker/Dockerfile_rel
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           build-args: |
             TAG=latest
+
+      - name: Push baseimages to registries with latest tag
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile_base
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            signalk/signalk-server-base:latest
+            ghcr.io/signalk/signalk-server-base:latest

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -35,3 +35,21 @@ jobs:
           tags: |
             signalk/signalk-server-base:latest
             ghcr.io/signalk/signalk-server-base:latest
+
+  docker_image_test:
+    runs-on: ubuntu-latest
+    needs: build_docker_base_images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile_rel
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          build-args: |
+            TAG=latest


### PR DESCRIPTION
Base image build is chained with validation step, which verify that base image is valid and SK docker release images can be build based on it successfully.