### PR TITLE
Fix: revert plugin API change that broke plugin configuration saving

### DIFF
--- a/test/plugins.js
+++ b/test/plugins.js
@@ -6,31 +6,26 @@ const Server = require('../lib/')
 const fs = require('fs')
 const path = require('path')
 
-let pluginConfig;
-
 describe('Demo plugin ', () => {
-  beforeEach(() => {
+  it('works', async () => {
     process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
       __dirname,
       'plugin-test-config'
     )
-     pluginConfig = {
+    const pluginConfig = {
       enabled: true,
       configuration: {
         testOption: 'testValue'
       }
     }
-    mkDirSync(path.join(`${__dirname}/plugin-test-config/plugin-config-data`))
-  })
 
-  it('works', async () => {
+    mkDirSync(path.join(`${__dirname}/plugin-test-config/plugin-config-data`))
     writePluginConfig(pluginConfig)
 
     const port = await freeport()
     const server = new Server({
       config: { settings: { port } }
     })
-
     await server.start()
     const plugins = await fetch(`http://0.0.0.0:${port}/skServer/plugins`).then(res =>
       res.json()
@@ -95,78 +90,10 @@ describe('Demo plugin ', () => {
     assert.equal(outputValues[2], 3)
 
     await server.stop()
-  }),
-
-    it('registerWithRouter only on plugin Start', async () => {
-      pluginConfig.enabled = false;
-      writePluginConfig(pluginConfig)
-
-      const port = await freeport()
-      const server = new Server({
-        config: { settings: { port } }
-      })
-      await server.start()
-      const plugins = await fetch(`http://0.0.0.0:${port}/skServer/plugins/`).then(res =>
-        res.json()
-      )
-
-      assert(plugins.find(plugin => plugin.id === 'testplugin'))
-      const plugin = server.app.plugins.find(plugin => plugin.id === 'testplugin')
-      assert(plugin)
-      assert(!plugin.started)
-
-      const response = await fetch(`http://0.0.0.0:${port}/skServer/plugins/testplugin/demopluginGet`, {
-        method: 'GET',
-      }).then(res => res.ok
-      )
-
-      assert(!response)
-    }),
-
-    it('deactivates API interface when plugin has stopped', async () => {
-      writePluginConfig(pluginConfig)
-
-      const port = await freeport()
-      const server = new Server({
-        config: { settings: { port } }
-      })
-      await server.start()
-      const plugins = await fetch(`http://0.0.0.0:${port}/skServer/plugins/`).then(res =>
-        res.json()
-      )
-
-      assert(plugins.find(plugin => plugin.id === 'testplugin'))
-      const plugin = server.app.plugins.find(plugin => plugin.id === 'testplugin')
-      assert(plugin)
-      assert(plugin.started)
-
-      const response = await fetch(`http://0.0.0.0:${port}/skServer/plugins/testplugin/demopluginGet`, {
-        method: 'GET',
-      }).then(res => res.ok
-      )
-
-      assert(response)
-
-      pluginConfig.enabled = false
-      await postPluginConfig(port, pluginConfig)
-
-
-      const stoppedPlugin = server.app.plugins.find(plugin => plugin.id === 'testplugin')
-      assert(stoppedPlugin)
-
-      const status = await fetch(`http://0.0.0.0:${port}/skServer/plugins/testplugin/demopluginGet`, {
-        method: 'GET',
-      }).then(res => {
-        return res.status
-      })
-
-      assert.equal(status, 500)
-
-
-    })
+  })
 })
 
-function mkDirSync(dirPath) {
+function mkDirSync (dirPath) {
   try {
     fs.mkdirSync(dirPath)
   } catch (err) {
@@ -176,7 +103,7 @@ function mkDirSync(dirPath) {
   }
 }
 
-function writePluginConfig(config) {
+function writePluginConfig (config) {
   fs.writeFileSync(
     path.join(
       `${__dirname}/plugin-test-config/plugin-config-data/testplugin.json`
@@ -185,7 +112,7 @@ function writePluginConfig(config) {
   )
 }
 
-async function postPluginConfig(port, config) {
+async function postPluginConfig (port, config) {
   await fetch(`http://0.0.0.0:${port}/skServer/plugins/testplugin/config`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Revert "Fix: disabled plugins no longer have an active API interface (#1684)"

This reverts commit c119539e5031fd082ca9b61eb6d6229b07622014.