### PR TITLE
chore: Resources - update plugin catagory keyword

### DIFF
--- a/packages/resources-provider-plugin/CHANGELOG.md
+++ b/packages/resources-provider-plugin/CHANGELOG.md
@@ -4,6 +4,15 @@ ___Note: Signal K server on which this plugin is installed must implement the `R
 
 ---
 
+## v1.1.2
+
+- **Update**: Change plugin category keyword to `signalk-category-utility`.
+
+## v1.1.0
+
+- **Fix**: Only process files in resource folders (ignore folders).
+
+
 ## v1.0.0
 
 Resource Provider plugin that facilitates the storage and retrieval of resources on the Signal K server filesystem.

--- a/packages/resources-provider-plugin/README.md
+++ b/packages/resources-provider-plugin/README.md
@@ -2,7 +2,7 @@
 
 __Signal K server plugin that implements the Resource Provider API__.
 
-_Note: This plugin should ONLY be installed on a Signal K server that implements the `Resources API`!_
+_Note: This plugin requires Signal K Server v2.0 or later!_
 
 ---
 

--- a/packages/resources-provider-plugin/package.json
+++ b/packages/resources-provider-plugin/package.json
@@ -1,11 +1,11 @@
 {
     "name": "@signalk/resources-provider",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Resources provider plugin for Signal K server.",
     "main": "plugin/index.js",
     "keywords": [
         "signalk-node-server-plugin",
-        "signalk-category-chart-plotters",
+        "signalk-category-utility",
         "signalk",
         "resources",
         "routes",


### PR DESCRIPTION
Update resources-provider plugin package keyword to `signalk-category-utility` so it is listed correctly in AppStore.