### PR TITLE
feat: Allow for users without password

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -163,7 +163,7 @@ export interface SecurityStrategy {
   getUsers: (theConfig: SecurityConfig) => UserData[]
   addUser: (
     theConfig: SecurityConfig,
-    user: UserWithPassword,
+    user: User,
     cb: ICallback<SecurityConfig>
   ) => void
   updateUser: (

--- a/src/security.ts
+++ b/src/security.ts
@@ -63,7 +63,7 @@ export interface ACL {
 export interface User {
   username: string
   type: string
-  password: string
+  password?: string
 }
 export interface UserData {
   userId: string

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -417,7 +417,7 @@ module.exports = function (app, config) {
     assertConfigImmutability()
     const newUser = {
       username: user.userId,
-      type: user.type,
+      type: user.type
     }
 
     function finish(newUser, err) {
@@ -434,12 +434,12 @@ module.exports = function (app, config) {
         if (err) {
           callback(err)
         } else {
-          newUser.password = hash;
-          finish(newUser, err);
+          newUser.password = hash
+          finish(newUser, err)
         }
       })
     } else {
-      finish(newUser, undefined);
+      finish(newUser, undefined)
     }
   }
 

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -277,6 +277,10 @@ module.exports = function (app, config) {
         resolve({ statusCode: 401, message: LOGIN_FAILED_MESSAGE })
         return
       }
+      if (!user.password) {
+        resolve({ statusCode: 401, message: LOGIN_FAILED_MESSAGE })
+        return
+      }
 
       bcrypt.compare(password, user.password, (err, matches) => {
         if (err) {

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -415,23 +415,32 @@ module.exports = function (app, config) {
 
   function addUser(theConfig, user, callback) {
     assertConfigImmutability()
-    bcrypt.hash(user.password, passwordSaltRounds, (err, hash) => {
-      if (err) {
-        callback(err)
-      } else {
-        const newuser = {
-          username: user.userId,
-          type: user.type,
-          password: hash
-        }
-        if (!theConfig.users) {
-          theConfig.users = []
-        }
-        theConfig.users.push(newuser)
-        options = theConfig
-        callback(err, theConfig)
+    const newUser = {
+      username: user.userId,
+      type: user.type,
+    }
+
+    function finish(newUser, err) {
+      if (!theConfig.users) {
+        theConfig.users = []
       }
-    })
+      theConfig.users.push(newUser)
+      options = theConfig
+      callback(err, theConfig)
+    }
+
+    if (user.password) {
+      bcrypt.hash(user.password, passwordSaltRounds, (err, hash) => {
+        if (err) {
+          callback(err)
+        } else {
+          newUser.password = hash;
+          finish(newUser, err);
+        }
+      })
+    } else {
+      finish(newUser, undefined);
+    }
   }
 
   strategy.updateUser = (theConfig, username, updates, callback) => {

--- a/test/security.js
+++ b/test/security.js
@@ -2,12 +2,8 @@ const chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
 const freeport = require('freeport-promise')
-const Server = require('../lib')
 const fetch = require('node-fetch')
-const http = require('http')
-const { promisify } = require('util')
 const WebSocket = require('ws')
-const _ = require('lodash')
 const {
   startServerP,
   getReadOnlyToken,

--- a/test/servertestutilities.js
+++ b/test/servertestutilities.js
@@ -2,6 +2,7 @@ const WebSocket = require('ws')
 const _ = require('lodash')
 const promisify = require('util').promisify
 const fetch = require('node-fetch')
+const jwt = require('jsonwebtoken')
 
 // Connects to the url via ws
 // and provides Promises that are either resolved within
@@ -105,6 +106,7 @@ const LIMITED_USER_NAME = 'testuser'
 const LIMITED_USER_PASSWORD = 'verylimited'
 const ADMIN_USER_NAME = 'adminuser'
 const ADMIN_USER_PASSWORD = 'admin'
+const NOPASSWORD_USER_NAME = 'nopassword'
 
 const serverTestConfigDirectory = () => require('path').join(
   __dirname,
@@ -157,7 +159,11 @@ module.exports = {
               userId: ADMIN_USER_NAME,
               type: 'admin',
               password: ADMIN_USER_PASSWORD
-            })
+            }),
+            promisify(s.app.securityStrategy.addUser)(props.securityConfig, {
+              userId: NOPASSWORD_USER_NAME,
+              type: 'admin',
+            }),
           ])
             .then(() => {
               resolve(s)
@@ -181,6 +187,14 @@ module.exports = {
   WRITE_USER_PASSWORD,
   getAdminToken: server => {
     return login(server, ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+  },
+  NOPASSWORD_USER_NAME,
+  getToken: (server, username) => {
+    return jwt.sign({
+      id: username
+    }, server.app.securityStrategy.securityConfig.secretKey, {
+      expiresIn: '1h'
+    })
   }
 }
 


### PR DESCRIPTION
This commit updates the security code to allow for users to be configured in `security.json` without a password value. These users can then only be logged in with using the `signalk-generate-token` script.

Fixes https://github.com/SignalK/signalk-server/issues/1714.