### PR TITLE
fix: check ws max send buffer size over time

### DIFF
--- a/docs/src/installation/command_line.md
+++ b/docs/src/installation/command_line.md
@@ -35,7 +35,8 @@ Signal K Server provides the following command line options and environment vari
 | `PLUGINS_WITH_UPDATE_DISABLED` | A comma separated list of plugin that will not be updated. |
 | `SECURITYSTRATEGY` | Override the security strategy module name. |
 | `WSCOMPRESSION` | Compress websocket messages _(default is false)_. |
-| `MAXSENDBUFFERSIZE` | The maximum number of bytes allowed in the server's send buffer of a WebSocket connection. The connection will be terminated if this is exceeded. Guards against slow or dysfunctional clients that can not cope with the message volume _(default is 512 * 1024 bytes)_. |
+| `MAXSENDBUFFERSIZE` | The maximum number of bytes allowed in the server's send buffer of a WebSocket connection. The connection will be terminated if this is exceeded for MAXSENDBUFFERCHECKTIME milliseconds. Guards against slow or dysfunctional clients that can not cope with the message volume _(default is 512 * 1024 bytes)_. |
+| `MAXSENDBUFFERCHECKTIME` | The maximum number of bytes allowed in the server's send buffer of a WebSocket connection. The connection will be terminated if this is exceeded. Guards against slow or dysfunctional clients that can not cope with the message volume _(default is 512 * 1024 bytes)_. |
 | `SIGNALK_SERVER_IS_UPDATABLE` | Allows the server to be updated through the GUI even if it is not installed in the standard paths _(default is false)_. If set to true, the server must have been installed with `npm install -g signalk-server`. |
 | `SIGNALK_DISABLE_SERVER_UPDATES` | Disables server updates in the GUI _(default is false)_. |
 | `DEBUG` | A comma-separated list of tags for debugging the specified module _(e.g signalk-server*,signalk-provider-tcp)_. Can now be defined directly in the graphical interface.  More help on how to use the debug here: `https://www.npmjs.com/package/debug#wildcards` |

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -736,6 +736,10 @@ function startServerLog(app, spark) {
 function getAssertBufferSize(config) {
   const MAXSENDBUFFERSIZE =
     process.env.MAXSENDBUFFERSIZE || config.maxSendBufferSize || 4 * 512 * 1024
+  const MAXSENDBUFFERCHECKTIME =
+    process.env.MAXSENDBUFFERCHECKTIME ||
+    config.maxSendBufferCheckTime ||
+    30 * 1000
   debug(`MAXSENDBUFFERSIZE:${MAXSENDBUFFERSIZE}`)
 
   if (MAXSENDBUFFERSIZE === 0) {
@@ -745,10 +749,23 @@ function getAssertBufferSize(config) {
   return (spark) => {
     debug(spark.id + ' ' + spark.request.socket.bufferSize)
     if (spark.request.socket.bufferSize > MAXSENDBUFFERSIZE) {
-      spark.end({
-        errorMessage: 'Server outgoing buffer overflow, terminating connection'
-      })
-      console.error('Send buffer overflow, terminating connection ' + spark.id)
+      if (!spark.bufferSizeExceeded) {
+        console.warn(
+          `${spark.id} outgoing buffer > max:${spark.request.socket.bufferSize}`
+        )
+        spark.bufferSizeExceeded = Date.now()
+      }
+      if (Date.now() - spark.bufferSizeExceeded > MAXSENDBUFFERCHECKTIME) {
+        spark.end({
+          errorMessage:
+            'Server outgoing buffer overflow, terminating connection'
+        })
+        console.error(
+          'Send buffer overflow, terminating connection ' + spark.id
+        )
+      }
+    } else {
+      spark.bufferSizeExceeded = undefined
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/SignalK/signalk-server/issues/1718

Do not immediately hand ws up if the max send buffer size is exceeded, but start monitoring for MAXSENDBUFFERCHECKTIME milliseconds. If the buffer remains above the threshold all the time terminate the connection. If the buffer has dropped below the threshold during subsequent writes to the ws connection the timer is reset.