### PR TITLE
Appstore UI/column version

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.js
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.js
@@ -99,29 +99,31 @@ const Apps = function (props) {
         <CardHeader className="appstore__header">
           <div className="title__container">
             <CardTitle>Apps & Plugins</CardTitle>
-            <Button
-              color={view === 'All' ? 'primary' : 'secondary'}
-              onClick={() => setSelectedView('All')}
-            >
-              All
-            </Button>
-            <Button
-              color={view === 'Installed' ? 'primary' : 'secondary'}
-              onClick={() => setSelectedView('Installed')}
-            >
-              Installed
-            </Button>
-            <Button
-              color={view === 'Updates' ? 'primary' : 'secondary'}
-              onClick={() => setSelectedView('Updates')}
-            >
-              Updates
-              {props.appStore.updates.length > 0 && (
-                <span className="badge__update">
-                  {props.appStore.updates.length}
-                </span>
-              )}
-            </Button>
+            <div className="button-wrapper">
+              <Button
+                color={view === 'All' ? 'primary' : 'secondary'}
+                onClick={() => setSelectedView('All')}
+              >
+                All
+              </Button>
+              <Button
+                color={view === 'Installed' ? 'primary' : 'secondary'}
+                onClick={() => setSelectedView('Installed')}
+              >
+                Installed
+              </Button>
+              <Button
+                color={view === 'Updates' ? 'primary' : 'secondary'}
+                onClick={() => setSelectedView('Updates')}
+              >
+                Updates
+                {props.appStore.updates.length > 0 && (
+                  <span className="badge__update">
+                    {props.appStore.updates.length}
+                  </span>
+                )}
+              </Button>
+            </div>
           </div>
 
           <div className="action__container">

--- a/packages/server-admin-ui/src/views/appstore/AppsList.js
+++ b/packages/server-admin-ui/src/views/appstore/AppsList.js
@@ -31,7 +31,11 @@ class AppsList extends Component {
             >
               <div>Type</div>
             </th>
-            <th className={window.innerWidth < S_WIDTH ? 'd-none' : ''}>
+            <th
+              className={
+                'text-center ' + (window.innerWidth < S_WIDTH ? 'd-none' : '')
+              }
+            >
               Version
             </th>
             <th className="text-center">Action</th>

--- a/packages/server-admin-ui/src/views/appstore/AppsList.js
+++ b/packages/server-admin-ui/src/views/appstore/AppsList.js
@@ -18,6 +18,13 @@ class AppsList extends Component {
         <thead>
           <tr>
             <th>Name</th>
+            <th
+              className={
+                'text-center ' + (window.innerWidth < S_WIDTH ? 'd-none' : '')
+              }
+            >
+              Version
+            </th>
             <th className={window.innerWidth < L_WIDTH ? 'd-none' : ''}>
               Description
             </th>
@@ -31,13 +38,7 @@ class AppsList extends Component {
             >
               <div>Type</div>
             </th>
-            <th
-              className={
-                'text-center ' + (window.innerWidth < S_WIDTH ? 'd-none' : '')
-              }
-            >
-              Version
-            </th>
+
             <th className="text-center">Action</th>
           </tr>
         </thead>
@@ -45,10 +46,13 @@ class AppsList extends Component {
           {this.props.apps.map((app) => (
             <tr key={app.name}>
               <td>
-                <NameCellRenderer
-                  data={app}
-                  value={app.name}
-                ></NameCellRenderer>
+                <NameCellRenderer data={app} value={app.name} />
+              </td>
+              <td
+                col-id="version"
+                className={window.innerWidth < S_WIDTH ? 'd-none' : ''}
+              >
+                <VersionCellRenderer data={app} />
               </td>
               <td className={window.innerWidth < L_WIDTH ? 'd-none' : ''}>
                 {app.description}
@@ -62,12 +66,7 @@ class AppsList extends Component {
               >
                 <TypeCellRenderer data={app} />
               </td>
-              <td
-                col-id="version"
-                className={window.innerWidth < S_WIDTH ? 'd-none' : ''}
-              >
-                <VersionCellRenderer data={app} />
-              </td>
+
               <td col-id="action">
                 <ActionCellRenderer data={app} />
               </td>

--- a/packages/server-admin-ui/src/views/appstore/AppsList.js
+++ b/packages/server-admin-ui/src/views/appstore/AppsList.js
@@ -1,13 +1,15 @@
 import React, { Component } from 'react'
 
-import { Button, Table } from 'reactstrap'
+import { Table } from 'reactstrap'
 import NameCellRenderer from './Grid/cell-renderers/NameCellRenderer'
 import TypeCellRenderer from './Grid/cell-renderers/TypeCellRenderer'
 import ActionCellRenderer from './Grid/cell-renderers/ActionCellRenderer'
+import VersionCellRenderer from './Grid/cell-renderers/VersionCellRenderer'
 
 const XL_WIDTH = 1200
 const L_WIDTH = 992
 const M_WIDTH = 768
+const S_WIDTH = 576
 
 class AppsList extends Component {
   render() {
@@ -28,6 +30,9 @@ class AppsList extends Component {
               }
             >
               <div>Type</div>
+            </th>
+            <th className={window.innerWidth < S_WIDTH ? 'd-none' : ''}>
+              Version
             </th>
             <th className="text-center">Action</th>
           </tr>
@@ -51,10 +56,16 @@ class AppsList extends Component {
                 col-id="type"
                 className={window.innerWidth < M_WIDTH ? 'd-none' : ''}
               >
-                <TypeCellRenderer data={app}></TypeCellRenderer>
+                <TypeCellRenderer data={app} />
+              </td>
+              <td
+                col-id="version"
+                className={window.innerWidth < S_WIDTH ? 'd-none' : ''}
+              >
+                <VersionCellRenderer data={app} />
               </td>
               <td col-id="action">
-                <ActionCellRenderer data={app}></ActionCellRenderer>
+                <ActionCellRenderer data={app} />
               </td>
             </tr>
           ))}

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.js
@@ -93,7 +93,17 @@ function ActionCellRenderer(props) {
       </Button>
     )
   }
-  return <div className="cell__renderer cell-action center">{content}</div>
+  return (
+    <div className="cell__renderer cell-action center">
+      <div>{content}</div>
+      <div className="last-update">
+        <p>
+          <span>Last update : </span>
+          {props.data.updated.substring(0, 10)}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 const mapStateToProps = ({ appStore }) => ({ appStore })

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.js
@@ -96,12 +96,6 @@ function ActionCellRenderer(props) {
   return (
     <div className="cell__renderer cell-action center">
       <div>{content}</div>
-      <div className="last-update">
-        <p>
-          <span>Last update : </span>
-          {props.data.updated.substring(0, 10)}
-        </p>
-      </div>
     </div>
   )
 }

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/NameCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/NameCellRenderer.js
@@ -1,36 +1,17 @@
 import React from 'react'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faArrowUpRightFromSquare,
-  faArrowRight,
-} from '@fortawesome/free-solid-svg-icons'
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 
 export default function NameCellRenderer(props) {
   return (
     <div className="cell__renderer cell-name">
       <span className="name">{props.value}</span>
-      <div className="version__container">
-        <span className="version">
-          v{props.data.installedVersion || props.data.version}
-        </span>
-        &nbsp; ({props.data.updated.substring(0, 10)})
-        {props.data.updateAvailable && (
-          <>
-            <span className="update__arrow">
-              <FontAwesomeIcon icon={faArrowRight} />
-            </span>
-            <span className="version version--update">
-              v{props.data.updateAvailable}
-            </span>
-          </>
-        )}
-        {props.data.npmUrl && (
-          <a className="link" href={props.data.npmUrl} target="_blank">
-            <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
-          </a>
-        )}
-      </div>
+      {props.data.npmUrl && (
+        <a className="link" href={props.data.npmUrl} target="_blank">
+          <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+        </a>
+      )}
     </div>
   )
 }

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default function NameCellRenderer(props) {
+  return (
+    <div className="cell__renderer cell-version">
+      <div className="version__container">
+        <span className="version">
+          v{props.data.installedVersion || props.data.version}
+        </span>
+        {/* &nbsp; ({props.data.updated.substring(0, 10)}) */}
+        {props.data.newVersion && (
+          <span className="version version--update">
+            v{props.data.newVersion}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
@@ -17,6 +17,9 @@ export default function NameCellRenderer(props) {
           </span>
         )}
       </div>
+      <p className="last-update">({props.data.updated.substring(0, 10)})</p>
+
+      <div className="last-update"></div>
     </div>
   )
 }

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
@@ -7,7 +7,9 @@ export default function NameCellRenderer(props) {
         <span className="version">
           v{props.data.installedVersion || props.data.version}
         </span>
-        {/* &nbsp; ({props.data.updated.substring(0, 10)}) */}
+        {/* 
+         // TODO: Maybe think about a better way to display this information
+        &nbsp; ({props.data.updated.substring(0, 10)}) */}
         {props.data.newVersion && (
           <span className="version version--update">
             v{props.data.newVersion}

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
@@ -2,11 +2,12 @@ import React from 'react'
 
 export default function NameCellRenderer(props) {
   return (
-    <div className="cell__renderer cell-version">
+    <div className="cell__renderer cell-version center">
       <div className="version__container">
         <span className="version">
           v{props.data.installedVersion || props.data.version}
         </span>
+
         {/* 
          // TODO: Maybe think about a better way to display this information
         &nbsp; ({props.data.updated.substring(0, 10)}) */}

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -69,6 +69,26 @@
     align-items: center;
     flex-wrap: wrap;
 
+    @media (max-width: 1080px) {
+      flex-direction: column;
+
+      .title__container {
+        width: 100%;
+        justify-content: space-between;
+        margin-bottom: 10px;
+      }
+
+      .action__container {
+        width: 100%;
+        flex-direction: row-reverse;
+
+        .search {
+          min-width: none;
+          justify-self: flex-start;
+        }
+      }
+    }
+
     .title__container {
       display: flex;
       align-items: center;
@@ -77,18 +97,20 @@
         margin: 0 10px 0 0;
       }
 
-      .badge__update {
-        color: white;
-        font-size: 10px;
-        border-radius: 3px;
-        background-color: #00cd79;
-        margin-left: 5px;
-        padding: 3px;
-        vertical-align: middle;
-      }
+      .button-wrapper {
+        .badge__update {
+          color: white;
+          font-size: 10px;
+          border-radius: 3px;
+          background-color: #00cd79;
+          margin-left: 5px;
+          padding: 3px;
+          vertical-align: middle;
+        }
 
-      button {
-        margin: 0 5px;
+        button {
+          margin: 0 2px;
+        }
       }
     }
 
@@ -97,13 +119,14 @@
       align-items: center;
 
       button {
-        margin: 0;
+        margin: 0 5px;
       }
 
       .search {
-        min-width: 350px;
+        // min-width: 350px;
         height: 100%;
         position: relative;
+        margin: 0 5px;
 
         &__icon {
           position: absolute;
@@ -151,31 +174,14 @@
 
     .cell-name {
       display: flex;
-      flex-direction: column;
       .name {
         font-size: 14px;
         color: black;
       }
-
-      .version__container {
-        display: flex;
-        width: 80%;
-
-        .version--update {
-          color: #00cd79;
-          font-weight: 700;
-        }
-
-        .update__arrow {
-          height: 10px;
-          margin: 0 5px;
-        }
-
-        .link {
-          cursor: pointer;
-          color: blue;
-          margin-left: 5px;
-        }
+      .link {
+        cursor: pointer;
+        color: blue;
+        margin-left: 5px;
       }
     }
 
@@ -185,11 +191,30 @@
       white-space: normal;
     }
 
+    .cell-version {
+      min-width: 80px;
+
+      .version__container {
+        display: flex;
+        flex-direction: column;
+
+        .version--update {
+          color: #00cd79;
+          font-weight: 700;
+          font-style: italic;
+        }
+
+        .update__arrow {
+          height: 10px;
+          margin: 0 5px;
+        }
+      }
+    }
+
     .cell-action {
       .proress__wrapper {
         display: flex;
         flex-direction: column;
-        // justify-content: center;
       }
       .progress__status {
         text-align: center;

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -173,6 +173,7 @@
 
     .cell-name {
       display: flex;
+
       .name {
         font-size: 14px;
         color: black;
@@ -192,15 +193,22 @@
 
     .cell-version {
       min-width: 80px;
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
 
       .version__container {
         display: flex;
         flex-direction: column;
+        align-items: center;
 
         .version--update {
           color: #00cd79;
           font-weight: 700;
           font-style: italic;
+          // font-size: 10px;
+          // margin-left: 5px;
         }
 
         .update__arrow {
@@ -211,9 +219,22 @@
     }
 
     .cell-action {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
       .proress__wrapper {
         display: flex;
         flex-direction: column;
+      }
+      .last-update {
+        margin-top: 10px;
+        text-align: center;
+        font-size: 10px;
+        justify-content: center;
+        span {
+          font-weight: 700;
+        }
       }
 
       .progress__status {
@@ -240,6 +261,10 @@
         path {
           color: #00cd79;
         }
+      }
+
+      p {
+        margin: 0;
       }
     }
 

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -194,6 +194,7 @@
     .cell-version {
       min-width: 80px;
       display: flex;
+      flex-direction: column;
       height: 100%;
       align-items: center;
       justify-content: center;
@@ -207,14 +208,18 @@
           color: #00cd79;
           font-weight: 700;
           font-style: italic;
-          // font-size: 10px;
-          // margin-left: 5px;
         }
 
         .update__arrow {
           height: 10px;
           margin: 0 5px;
         }
+      }
+
+      .last-update {
+        text-align: center;
+        font-size: 12px;
+        margin: 0;
       }
     }
 
@@ -226,15 +231,6 @@
       .proress__wrapper {
         display: flex;
         flex-direction: column;
-      }
-      .last-update {
-        margin-top: 10px;
-        text-align: center;
-        font-size: 10px;
-        justify-content: center;
-        span {
-          font-weight: 700;
-        }
       }
 
       .progress__status {
@@ -261,10 +257,6 @@
         path {
           color: #00cd79;
         }
-      }
-
-      p {
-        margin: 0;
       }
     }
 

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -123,7 +123,6 @@
       }
 
       .search {
-        // min-width: 350px;
         height: 100%;
         position: relative;
         margin: 0 5px;
@@ -216,6 +215,7 @@
         display: flex;
         flex-direction: column;
       }
+
       .progress__status {
         text-align: center;
         width: 100%;


### PR DESCRIPTION
Created a dedicated column version on the appstore page. This aims at resolving the confusion from user while browsing for plugins. 

Few users complained about the version number being detrimental to plugin search.

Also improved the responsivity of the search bar on mobile version. 

NOTE: I also removed the last updated date as it is not working well with the new column. Maybe we should display that information with a tooltip or differently. 

