### PR TITLE
feature: add support to DELETE meta data

### DIFF
--- a/src/interfaces/playground.js
+++ b/src/interfaces/playground.js
@@ -20,7 +20,7 @@
 
 const Parser0183 = require('@signalk/nmea0183-signalk')
 const N2kMapper = require('@signalk/n2k-signalk').N2kMapper
-const { putPath } = require('../put')
+const { putPath, deletePath } = require('../put')
 const {
   isN2KString,
   FromPgn,
@@ -67,7 +67,7 @@ module.exports = function (app) {
 
         if (first.pgn) {
           type = 'n2k-json'
-        } else if (first.updates || first.put) {
+        } else if (first.updates || first.put || first.delete) {
           type = 'signalk'
         } else {
           return { error: 'unknown JSON format' }
@@ -129,6 +129,26 @@ module.exports = function (app) {
                   msg.context,
                   msg.put.path,
                   msg.put,
+                  req,
+                  msg.requestId,
+                  (reply) => {
+                    if (reply.state !== 'PENDING') {
+                      resolve(reply)
+                    }
+                  }
+                )
+              })
+            )
+          } else if (msg.delete) {
+            puts.push(
+              new Promise((resolve) => {
+                setTimeout(() => {
+                  resolve('Timed out waiting for put result')
+                }, 5000)
+                deletePath(
+                  app,
+                  msg.context,
+                  msg.delete.path,
                   req,
                   msg.requestId,
                   (reply) => {

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -235,7 +235,7 @@ module.exports = function (app) {
                 processPutRequest(spark, msg)
               }
 
-              if ( msg.delete) {
+              if (msg.delete) {
                 processDeleteRequest(spark, msg)
               }
 

--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -23,7 +23,7 @@ const {
   updateRequest,
   queryRequest
 } = require('../requestResponse')
-const { putPath } = require('../put')
+const { putPath, deletePath } = require('../put')
 import { createDebug } from '../debug'
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { startEvents, startServerEvents } from '../events'
@@ -235,6 +235,10 @@ module.exports = function (app) {
                 processPutRequest(spark, msg)
               }
 
+              if ( msg.delete) {
+                processDeleteRequest(spark, msg)
+              }
+
               if (msg.requestId && msg.query) {
                 processReuestQuery(spark, msg)
               }
@@ -331,6 +335,28 @@ module.exports = function (app) {
       msg.context,
       msg.put.path,
       msg.put,
+      spark.request,
+      msg.requestId,
+      (reply) => {
+        debug('sending put update %j', reply)
+        spark.write(reply)
+      }
+    ).catch((err) => {
+      console.error(err)
+      spark.write({
+        requestId: msg.requestId,
+        state: 'COMPLETED',
+        statusCode: 502,
+        message: err.message
+      })
+    })
+  }
+
+  function processDeleteRequest(spark, msg) {
+    deletePath(
+      app,
+      msg.context,
+      msg.delete.path,
       spark.request,
       msg.requestId,
       (reply) => {

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,0 +1,158 @@
+const chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+const _ = require('lodash')
+const assert = require('assert')
+const freeport = require('freeport-promise')
+const { startServerP, WsPromiser, sendDelta } = require('./servertestutilities')
+const fetch = require('node-fetch')
+
+describe('Delete Requests', () => {
+  let server, port, deltaUrl, url
+
+  before(async () => {
+    port = await freeport()
+    url = `http://localhost:${port}`
+    deltaUrl = 'http://localhost:' + port + '/signalk/v1/api/_test/delta'
+    server = await startServerP(port, false, { settings: {disableSchemaMetaDeltas: true} })
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+
+  it('HTTP delete to unhandled path fails', async function () {
+    await sendDelta({
+      context: 'vesssels.self',
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.logTrip',
+              value: 43374
+            }
+          ]
+        }
+      ]
+    }, deltaUrl)
+   
+    const result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+
+    result.status.should.equal(405)
+  })
+
+  it('HTTP successful DELETE', async function () {
+    let result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          value: 'My Log Trip'
+        })
+      }
+    )
+
+    result.status.should.equal(202)
+
+    result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result.status.should.equal(200)
+    let name = await result.json()
+    name.should.equal('My Log Trip')
+
+    result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+
+    result.status.should.equal(202)
+
+    result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result.status.should.equal(404)
+  })
+
+  it('WS delete to unhandled path fails', async function () {
+    const ws = new WsPromiser(
+      'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
+    )
+
+    let msg = await ws.nextMsg()
+
+    ws.send({
+      context: 'vessels.self',
+      delete: {
+        path: 'navigation.logTrip'
+      }
+    })
+
+    msg = await ws.nextMsg()
+    msg.should.not.equal('timeout')
+    const response = JSON.parse(msg)
+    response.should.have.property('statusCode')
+    response.statusCode.should.equal(405)
+  })
+
+  it('WS successful DELETE', async function () {
+    let result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          value: 'My Log Trip'
+        })
+      }
+    )
+    
+    result.status.should.equal(202)
+    
+    result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result.status.should.equal(200)
+    let name = await result.json()
+    name.should.equal('My Log Trip')
+
+    const ws = new WsPromiser(
+      'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
+    )
+    
+    let msg = await ws.nextMsg()
+
+    ws.send({
+      context: 'vessels.self',
+      delete: {
+        path: 'navigation.logTrip.meta.displayName'
+      }
+    })
+
+    msg = await ws.nthMessage(4)
+    msg.should.not.equal('timeout')
+    const response = JSON.parse(msg)
+    response.should.have.property('statusCode')
+    response.statusCode.should.equal(202)
+
+    result = await fetch(
+      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result.status.should.equal(404)
+  })
+})

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,34 +1,27 @@
 const chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
-const _ = require('lodash')
-const assert = require('assert')
-//const freeport = require('freeport-promise')
-//const { startServerP, WsPromiser, sendDelta } = require('./servertestutilities')
 
 import { startServer } from './ts-servertestutilities'
 
 const fetch = require('node-fetch')
 
 describe('Delete Requests', () => {
-  let doStop, doSendDelta, theHost, doSelfPut, doSelfGetJson, doGet, doCreateWsPromiser
+  let doStop, doSendDelta, theHost, doSelfPut, doGet, doCreateWsPromiser
 
   before(async () => {
     const {
       createWsPromiser,
-      selfGetJson,
       selfPutV1,
       sendDelta,
       stop,
       host,
-      selfGetJsonV1,
       getV1
     } = await startServer()
     doStop = stop
     doSendDelta = sendDelta
     theHost = host
     doSelfPut = selfPutV1
-    doSelfGetJson = selfGetJsonV1
     doGet = getV1
     doCreateWsPromiser = createWsPromiser
   })

--- a/test/delete.js
+++ b/test/delete.js
@@ -3,42 +3,45 @@ chai.Should()
 chai.use(require('chai-things'))
 const _ = require('lodash')
 const assert = require('assert')
-const freeport = require('freeport-promise')
-const { startServerP, WsPromiser, sendDelta } = require('./servertestutilities')
+//const freeport = require('freeport-promise')
+//const { startServerP, WsPromiser, sendDelta } = require('./servertestutilities')
+
+import { startServer } from './ts-servertestutilities'
+
 const fetch = require('node-fetch')
 
 describe('Delete Requests', () => {
-  let server, port, deltaUrl, url
+  let doStop, doSendDelta, theHost, doSelfPut, doSelfGetJson, doGet, doCreateWsPromiser
 
   before(async () => {
-    port = await freeport()
-    url = `http://localhost:${port}`
-    deltaUrl = 'http://localhost:' + port + '/signalk/v1/api/_test/delta'
-    server = await startServerP(port, false, { settings: {disableSchemaMetaDeltas: true} })
+    const {
+      createWsPromiser,
+      selfGetJson,
+      selfPutV1,
+      sendDelta,
+      stop,
+      host,
+      selfGetJsonV1,
+      getV1
+    } = await startServer()
+    doStop = stop
+    doSendDelta = sendDelta
+    theHost = host
+    doSelfPut = selfPutV1
+    doSelfGetJson = selfGetJsonV1
+    doGet = getV1
+    doCreateWsPromiser = createWsPromiser
   })
 
   after(async function () {
-    await server.stop()
+    await doStop()
   })
 
-
   it('HTTP delete to unhandled path fails', async function () {
-    await sendDelta({
-      context: 'vesssels.self',
-      updates: [
-        {
-          values: [
-            {
-              path: 'navigation.logTrip',
-              value: 43374
-            }
-          ]
-        }
-      ]
-    }, deltaUrl)
+    await doSendDelta('navigation.logTrip', 43374)
    
     const result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip`,
+      `${theHost}/signalk/v1/api/vessels/self/navigation/logTrip`,
       {
         method: 'DELETE',
         headers: {
@@ -51,48 +54,35 @@ describe('Delete Requests', () => {
   })
 
   it('HTTP successful DELETE', async function () {
-    let result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          value: 'My Log Trip'
-        })
-      }
-    )
+    let result = await doSelfPut('navigation/logTrip/meta/displayName', {
+      value: 'My Log Trip'
+    })
 
     result.status.should.equal(202)
 
-    result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result = await doGet('/vessels/self/navigation/logTrip/meta/displayName')
     result.status.should.equal(200)
     let name = await result.json()
     name.should.equal('My Log Trip')
 
     result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
+      `${theHost}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
       {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
         }
       }
-    )
+      )
 
     result.status.should.equal(202)
 
-    result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result = await doGet('/vessels/self/navigation/logTrip/meta/displayName')
     result.status.should.equal(404)
   })
-
+  
   it('WS delete to unhandled path fails', async function () {
-    const ws = new WsPromiser(
-      'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
-    )
+    const ws = doCreateWsPromiser()
 
     let msg = await ws.nextMsg()
 
@@ -110,31 +100,20 @@ describe('Delete Requests', () => {
     response.statusCode.should.equal(405)
   })
 
+ 
   it('WS successful DELETE', async function () {
-    let result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          value: 'My Log Trip'
-        })
-      }
-    )
+    let result = await doSelfPut('navigation/logTrip/meta/displayName', {
+      value: 'My Log Trip'
+    })
     
     result.status.should.equal(202)
-    
-    result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+
+    result = await doGet('/vessels/self/navigation/logTrip/meta/displayName')
     result.status.should.equal(200)
     let name = await result.json()
     name.should.equal('My Log Trip')
 
-    const ws = new WsPromiser(
-      'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
-    )
+    const ws = doCreateWsPromiser()
     
     let msg = await ws.nextMsg()
 
@@ -145,14 +124,15 @@ describe('Delete Requests', () => {
       }
     })
 
-    msg = await ws.nthMessage(4)
+    await ws.nextMsg() //skip the meta delta
+    msg = await ws.nextMsg()
+    console.log(msg)
     msg.should.not.equal('timeout')
     const response = JSON.parse(msg)
     response.should.have.property('statusCode')
-    response.statusCode.should.equal(202)
+    response.statusCode.should.equal(200)
 
-    result = await fetch(
-      `${url}/signalk/v1/api/vessels/self/navigation/logTrip/meta/displayName`)
+    result = await doGet('/vessels/self/navigation/logTrip/meta/displayName')
     result.status.should.equal(404)
   })
 })

--- a/test/ts-servertestutilities.ts
+++ b/test/ts-servertestutilities.ts
@@ -25,6 +25,7 @@ export const startServer = async () => {
   const host = 'http://localhost:' + port
   const sendDeltaUrl = host + '/signalk/v1/api/_test/delta'
   const api = host + '/signalk/v2/api'
+  const v1Api = host + '/signalk/v1/api'
 
   await emptyConfigDirectory()
   const server = await startServerP(port, false, {
@@ -48,11 +49,18 @@ export const startServer = async () => {
         body: JSON.stringify(body),
         headers: { 'Content-Type': 'application/json' }
       }),
+    selfPutV1: (path: string, body: object) =>
+      fetch(`${v1Api}/vessels/self/${path}`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' }
+      }),
     selfDelete: (path: string) =>
       fetch(`${api}/vessels/self/${path}`, {
         method: 'DELETE'
       }),
     get: (path: string) => fetch(`${api}${path}`),
+    getV1: (path: string) => fetch(`${v1Api}${path}`),
     post: (path: string, body: object) =>
       fetch(`${api}${path}`, {
         method: 'POST',
@@ -67,6 +75,9 @@ export const startServer = async () => {
       }),
     selfGetJson: (path: string) =>
       fetch(`${api}/vessels/self/${path}`).then(r => r.json()),
+    selfGetJsonV1: (path: string) =>
+      fetch(`${v1Api}/vessels/self/${path}`).then(r => r.json()),
+    host,    
     sendDelta: (path: string, value: any) =>
       sendDelta(
         {


### PR DESCRIPTION
There is one issue... When there is the same meta data from baseDeltas and from another source (like a plugin). This will delete the plugins meta for that field until restart or the plugin sends it again.

I think we can live with that...?