### PR TITLE
fix: don't subscribe to notifications in sk connections

### DIFF
--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -63,6 +63,7 @@ function MdnsWs(options) {
       port: options.port,
       useTLS: options.type === 'wss',
       reconnect: true,
+      notifications: false,
       autoConnect: false,
       deltaStreamBehaviour,
       rejectUnauthorized: !(options.selfsignedcert === true),


### PR DESCRIPTION
@signalk/client subscribes by default to notifications.*. This is confusing in the first place if the user enters an explicit subscription and gets more than they subscribed.

Furthermore this wreaks havoc if you have two interconnected SK servers. Their explicit subscriptions will not create a loop if they don't touch the same paths, but the default notifications subscription will if there is even one active notification.