### PR TITLE
fix: removing last zone was not reflected in full data

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.js
@@ -338,7 +338,7 @@ export default function Meta({ meta, path }) {
           />
         )}
         <Zones
-          zones={zones}
+          zones={zones !== undefined && zones !== null ? zones : []}
           isEditing={isEditing}
           setZones={(zones) => setLocalMeta({ ...localMeta, zones })}
         ></Zones>

--- a/src/put.js
+++ b/src/put.js
@@ -108,6 +108,13 @@ module.exports = {
         metaPath = parts.slice(0, parts.length - 1).join('.')
       }
 
+      // set empty zones array explicitly to null
+      for (const prop in metaValue) {
+        if (Array.isArray(metaValue[prop]) && metaValue[prop].length === 0) {
+          metaValue[prop] = null
+        }
+      }
+
       app.config.baseDeltaEditor.setMeta(context, metaPath, metaValue)
 
       let full_meta = getMetadata('vessels.self.' + metaPath)

--- a/src/zones.ts
+++ b/src/zones.ts
@@ -35,9 +35,31 @@ export class Zones {
     streambundle.getSelfMetaBus().onValue((metaMessage: any) => {
       debug(`${JSON.stringify(metaMessage)}`)
       const { path, value } = metaMessage
+
+      //send normal notification to clear out any previous notification
+      //when zones field is reset
+      if (value.zones === null) {
+        this.sendNormalDelta(path)
+        return
+      }
       if (value.zones) {
         this.watchForZones(path, value.zones, value as ZoneMethods)
       }
+    })
+  }
+
+  sendNormalDelta(path: Path) {
+    this.sendDelta({
+      updates: [
+        {
+          values: [
+            {
+              path: `notifications.${path}` as Path,
+              value: { state: 'normal', method: [] }
+            }
+          ]
+        }
+      ]
     })
   }
 


### PR DESCRIPTION
This changes the behavior of saving metadata so that an empty zones array resulting from removing the last, previously added zone, will be handled as null value. The code handling full model deals properly with nulls, while empty arrays are silently ignored as updates.