### PR TITLE
feature: Add NMEA stream handling to Course API.

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -36,6 +36,7 @@ class ServerSettings extends Component {
     }
     this.fetchSettings = fetchSettings.bind(this)
     this.handleChange = this.handleChange.bind(this)
+    this.handleCourseApiChange = this.handleCourseApiChange.bind(this)
     this.handleOptionChange = this.handleOptionChange.bind(this)
     this.handleInterfaceChange = this.handleInterfaceChange.bind(this)
     this.handleSaveSettings = this.handleSaveSettings.bind(this)
@@ -51,6 +52,15 @@ class ServerSettings extends Component {
         ? event.target.checked
         : event.target.value
     this.setState({ [event.target.name]: value })
+  }
+
+  handleCourseApiChange(event) {
+    const value =
+      event.target.type === 'checkbox'
+        ? event.target.checked
+        : event.target.value
+    this.state.courseApi[event.target.name] = value
+    this.setState({ courseApi: this.state.courseApi })
   }
 
   handleOptionChange(event) {
@@ -301,6 +311,39 @@ class ServerSettings extends Component {
                     <FormText color="muted">
                       How many hourly files to keep
                     </FormText>
+                  </Col>
+                </FormGroup>
+                <FormGroup row>
+                  <Col md="2">
+                    <Label>
+                      API Only Mode
+                      <br />
+                      <i>(Course API)</i>
+                    </Label>
+                  </Col>
+                  <Col>
+                    <FormGroup check>
+                      <Label className="switch switch-text switch-primary">
+                        <Input
+                          type="checkbox"
+                          name="apiOnly"
+                          id="apiOnly"
+                          className="switch-input"
+                          onChange={this.handleCourseApiChange}
+                          checked={this.state.courseApi.apiOnly}
+                        />
+                        <span
+                          className="switch-label"
+                          data-on="On"
+                          data-off="Off"
+                        />
+                        <span className="switch-handle" />
+                      </Label>
+                      <FormText color="muted">
+                        Accept course operations only via HTTP requests.
+                        Destination data from NMEA sources is not used.
+                      </FormText>
+                    </FormGroup>
                   </Col>
                 </FormGroup>
               </Form>

--- a/packages/server-api/src/deltas.ts
+++ b/packages/server-api/src/deltas.ts
@@ -52,6 +52,14 @@ export type Update = {
   $source?: SourceRef
 } & ({ values: PathValue[] } | { meta: Meta[] }) // require either values or meta or both
 
+export function hasValues(u: Update): u is Update & { values: PathValue[] } {
+  return 'values' in u && Array.isArray(u.values)
+}
+
+export function hasMeta(u: Update): u is Update & { meta: Meta[] } {
+  return 'meta' in u && Array.isArray(u.meta)
+}
+
 // Update delta
 export interface PathValue {
   path: Path

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -7,9 +7,10 @@ import _ from 'lodash'
 
 import { SignalKMessageHub, WithConfig } from '../../app'
 import { WithSecurityStrategy } from '../../security'
+import { getSourceId } from '@signalk/signalk-schema'
+import { Unsubscribes } from '../../types'
 
 import {
-  Delta,
   GeoJsonPoint,
   PathValue,
   Position,
@@ -20,7 +21,11 @@ import {
   ActiveRoute,
   RouteDestination,
   CourseInfo,
-  COURSE_POINT_TYPES
+  COURSE_POINT_TYPES,
+  Update,
+  Delta,
+  hasValues,
+  SourceRef
 } from '@signalk/server-api'
 
 const { Location, RoutePoint, VesselPosition } = COURSE_POINT_TYPES
@@ -31,11 +36,17 @@ import { Store } from '../../serverstate/store'
 import { buildSchemaSync } from 'api-schema-builder'
 import courseOpenApi from './openApi.json'
 import { ResourcesApi } from '../resources'
+import { writeSettingsFile } from '../../config/config'
 
 const COURSE_API_SCHEMA = buildSchemaSync(courseOpenApi)
 
 const SIGNALK_API_PATH = `/signalk/v2/api`
 const COURSE_API_PATH = `${SIGNALK_API_PATH}/vessels/self/navigation/course`
+
+const API_CMD_SRC: CommandSource = {
+  $source: 'courseApi' as SourceRef,
+  type: 'API'
+}
 
 export const COURSE_API_V2_DELTA_COUNT = 13
 export const COURSE_API_V1_DELTA_COUNT = 8
@@ -48,6 +59,13 @@ interface CourseApplication
     WithSecurityStrategy,
     SignalKMessageHub {}
 
+interface CommandSource {
+  type: string
+  $source: SourceRef
+  msg?: string
+  path?: string
+}
+
 export class CourseApi {
   private courseInfo: CourseInfo = {
     startTime: null,
@@ -59,12 +77,16 @@ export class CourseApi {
   }
 
   private store: Store
+  private cmdSource: CommandSource | null = null // source which set the destination
+  private unsubscribes: Unsubscribes = []
+  private settings!: { apiOnly?: boolean }
 
   constructor(
-    private server: CourseApplication,
+    private app: CourseApplication,
     private resourcesApi: ResourcesApi
   ) {
-    this.store = new Store(server, 'course')
+    this.store = new Store(app, 'course')
+    this.parseSettings()
   }
 
   async start() {
@@ -77,15 +99,155 @@ export class CourseApi {
         storeData = await this.store.read()
         debug('Found persisted course data')
         this.courseInfo = this.validateCourseInfo(storeData)
+        this.cmdSource = this.courseInfo.nextPoint ? API_CMD_SRC : null
       } catch (error) {
         debug('No persisted course data (using default)')
       }
-      debug(this.courseInfo)
-      if (storeData) {
+      debug(
+        '** courseInfo **',
+        this.courseInfo,
+        '** cmdSource **',
+        this.cmdSource
+      )
+      if (this.courseInfo.nextPoint) {
         this.emitCourseInfo(true)
       }
+
+      ;(this.app as any).subscriptionmanager.subscribe(
+        {
+          context: 'vessels.self',
+          subscribe: [
+            {
+              path: 'navigation.courseRhumbline.nextPoint.position',
+              period: 500
+            },
+            {
+              path: 'navigation.courseGreatCircle.nextPoint.position',
+              period: 500
+            }
+          ]
+        },
+        this.unsubscribes,
+        (err: Error) => {
+          console.log(`Course API: Subscribe failed: ${err}`)
+        },
+        (msg: Delta) => {
+          this.processV1DestinationDeltas(msg)
+        }
+      )
       resolve()
     })
+  }
+
+  // parse server settings
+  private parseSettings() {
+    const defaultSettings = {
+      apiOnly: false
+    }
+    if (!('courseApi' in this.app.config.settings)) {
+      debug('***** Applying Default Settings ********')
+      this.app.config.settings.courseApi = defaultSettings
+    }
+    if (
+      this.app.config.settings.courseApi &&
+      typeof this.app.config.settings.courseApi.apiOnly === 'undefined'
+    ) {
+      debug('***** Applying missing apiOnly attribute to Settings ********')
+      this.app.config.settings.courseApi.apiOnly = false
+    }
+    this.settings = this.app.config.settings.courseApi ?? { apiOnly: false }
+    debug('** Parsed App Settings ***', this.app.config.settings)
+    debug('** Applied cmdSource ***', this.cmdSource)
+  }
+
+  // write to server settings file
+  private saveSettings() {
+    writeSettingsFile(this.app as any, this.app.config.settings, () =>
+      debug('***SETTINGS SAVED***')
+    )
+  }
+
+  /** Process deltas for <destination>.nextPoint data
+   * Note: Delta source cannot override destination set by API!
+   * Destination is set when:
+   * 1. There is no current destination
+   * 2. msg source matches current Destination source
+   * 3. Destination Position is changed.
+   */
+  private async processV1DestinationDeltas(delta: Delta) {
+    if (
+      !Array.isArray(delta.updates) ||
+      this.isAPICmdSource() ||
+      (!this.cmdSource && this.settings?.apiOnly)
+    ) {
+      return
+    }
+    delta.updates.forEach((update: Update) => {
+      if (hasValues(update)) {
+        update.values.forEach((pathValue: PathValue) => {
+          if (
+            update.source &&
+            update.source.type &&
+            ['NMEA0183', 'NMEA2000'].includes(update.source.type)
+          ) {
+            this.parseStreamValue(
+              {
+                type: update.source.type,
+                $source: update.$source || getSourceId(update.source),
+                msg:
+                  update.source.type === 'NMEA0183'
+                    ? `${update.source.sentence}`
+                    : `${update.source.pgn}`,
+                path: pathValue.path
+              },
+              pathValue.value as Position
+            )
+          }
+        })
+      }
+    })
+  }
+
+  /** Process stream value and take action
+   * @param cmdSource Object describing the source of the update
+   * @param pos Destination location value in the update
+   */
+  private async parseStreamValue(cmdSource: CommandSource, pos: Position) {
+    if (!this.cmdSource) {
+      // New source
+      if (!pos) {
+        return
+      }
+      debug('parseStreamValue:', 'Setting Destination...')
+      const result = await this.setDestination({ position: pos }, cmdSource)
+      debug('parseStreamValue: Source set...', this.cmdSource)
+      if (result) {
+        this.emitCourseInfo()
+        return
+      }
+    }
+
+    if (this.isCurrentCmdSource(cmdSource)) {
+      if (!pos) {
+        debug('parseStreamValue:', 'No position... Clear Destination...')
+        this.clearDestination()
+        return
+      }
+
+      if (
+        this.courseInfo.nextPoint?.position?.latitude !== pos.latitude ||
+        this.courseInfo.nextPoint?.position?.longitude !== pos.longitude
+      ) {
+        debug(
+          'parseStreamValue:',
+          'Position changed... Updating Destination...'
+        )
+        const result = await this.setDestination({ position: pos }, cmdSource)
+        if (result) {
+          this.emitCourseInfo()
+        }
+      }
+    }
   }
 
   /** Get course (exposed to plugins) */
@@ -94,14 +256,15 @@ export class CourseApi {
     return this.courseInfo
   }
 
-  /** Clear destination / route (exposed to plugins)  */
-  async clearDestination(): Promise<void> {
+  /** Clear destination / route (exposed to plugins) */
+  async clearDestination(persistState?: boolean): Promise<void> {
     this.courseInfo.startTime = null
     this.courseInfo.targetArrivalTime = null
     this.courseInfo.activeRoute = null
     this.courseInfo.nextPoint = null
     this.courseInfo.previousPoint = null
-    this.emitCourseInfo()
+    this.emitCourseInfo(!persistState)
+    this.cmdSource = null
   }
 
   /** Set course (exposed to plugins)
@@ -139,11 +302,15 @@ export class CourseApi {
   }
 
   private getVesselPosition() {
-    return _.get((this.server.signalk as any).self, 'navigation.position')
+    return _.get((this.app.signalk as any).self, 'navigation.position')
   }
 
   private validateCourseInfo(info: CourseInfo) {
-    if (info.activeRoute && info.nextPoint && info.previousPoint) {
+    if (
+      typeof info.activeRoute !== 'undefined' &&
+      typeof info.nextPoint !== 'undefined' &&
+      typeof info.previousPoint !== 'undefined'
+    ) {
       return info
     } else {
       debug(`** Error: Loaded course data is invalid!! (using default) **`)
@@ -152,7 +319,7 @@ export class CourseApi {
   }
 
   private updateAllowed(request: Request): boolean {
-    return this.server.securityStrategy.shouldAllowPut(
+    return this.app.securityStrategy.shouldAllowPut(
       request,
       'vessels.self',
       null,
@@ -163,20 +330,67 @@ export class CourseApi {
   private initCourseRoutes() {
     debug(`** Initialise ${COURSE_API_PATH} path handlers **`)
 
-    // return current course information
-    this.server.get(
-      `${COURSE_API_PATH}`,
+    // Return current course information
+    this.app.get(`${COURSE_API_PATH}`, async (req: Request, res: Response) => {
+      debug(`** ${req.method} ${req.path}`)
+      res.json(this.courseInfo)
+    })
+
+    // Return course api config
+    this.app.get(
+      `${COURSE_API_PATH}/_config`,
       async (req: Request, res: Response) => {
-        debug(`** GET ${COURSE_API_PATH}`)
-        res.json(this.courseInfo)
+        debug(`** ${req.method} ${req.path}`)
+        res.json((this.app.config.settings as any)['courseApi'])
+      }
+    )
+
+    // Set apiOnly mode
+    this.app.post(
+      `${COURSE_API_PATH}/_config/apiOnly`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          ;(this.settings as any).apiOnly = true
+          if (!this.isAPICmdSource()) {
+            this.clearDestination(true)
+          }
+          this.saveSettings()
+          res.status(200).json(Responses.ok)
+        } catch {
+          res.status(400).json(Responses.invalid)
+        }
+      }
+    )
+
+    // Clear apiOnly mode
+    this.app.delete(
+      `${COURSE_API_PATH}/_config/apiOnly`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          ;(this.settings as any).apiOnly = false
+          this.saveSettings()
+          res.status(200).json(Responses.ok)
+        } catch {
+          res.status(400).json(Responses.invalid)
+        }
       }
     )
 
     // course metadata
-    this.server.get(
+    this.app.get(
       `${COURSE_API_PATH}/arrivalCircle/meta`,
       async (req: Request, res: Response) => {
-        debug(`** GET ${COURSE_API_PATH}/arrivalCircle/meta`)
+        debug(`** ${req.method} ${req.path}`)
         res.json({
           arrivalCircle: {
             description:
@@ -187,10 +401,10 @@ export class CourseApi {
       }
     )
 
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/arrivalCircle`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/arrivalCircle`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -205,10 +419,10 @@ export class CourseApi {
       }
     )
 
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/restart`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/restart`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -248,10 +462,10 @@ export class CourseApi {
       }
     )
 
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/targetArrivalTime`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/targetArrivalTime`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -267,24 +481,24 @@ export class CourseApi {
     )
 
     // clear / cancel course
-    this.server.delete(
+    this.app.delete(
       `${COURSE_API_PATH}`,
       async (req: Request, res: Response) => {
-        debug(`** DELETE ${COURSE_API_PATH}`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
         }
-        this.clearDestination()
+        this.clearDestination(true)
         res.status(200).json(Responses.ok)
       }
     )
 
     // set destination
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/destination`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/destination`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -315,10 +529,10 @@ export class CourseApi {
     )
 
     // set activeRoute
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/activeRoute`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/activeRoute`)
+        debug(`** ${req.method} ${req.path}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -342,10 +556,10 @@ export class CourseApi {
       }
     )
 
-    this.server.put(
+    this.app.put(
       `${COURSE_API_PATH}/activeRoute/:action`,
       async (req: Request, res: Response) => {
-        debug(`** PUT ${COURSE_API_PATH}/activeRoute/${req.params.action}`)
+        debug(`** ${req.method} ${req.path}, ${req.params.action}`)
         if (!this.updateAllowed(req)) {
           res.status(403).json(Responses.unauthorised)
           return
@@ -446,7 +660,7 @@ export class CourseApi {
               return false
             }
           } catch (err) {
-            console.log(`** Error: unable to retrieve vessel position!`)
+            console.log(`** Course API: Unable to retrieve vessel position!`)
             res.status(400).json(Responses.invalid)
             return false
           }
@@ -474,7 +688,10 @@ export class CourseApi {
     )
   }
 
-  private async activateRoute(route: RouteDestination): Promise<boolean> {
+  private async activateRoute(
+    route: RouteDestination,
+    src: CommandSource = API_CMD_SRC
+  ): Promise<boolean> {
     const { href, reverse } = route
     let rte: any
 
@@ -538,12 +755,17 @@ export class CourseApi {
       }
     }
 
+    if (this.isSourceChange(src)) {
+      this.clearDestination(true)
+    }
     this.courseInfo = newCourse
+    this.cmdSource = src
     return true
   }
 
   private async setDestination(
-    dest: PointDestination & { arrivalCircle?: number }
+    dest: PointDestination & { arrivalCircle?: number },
+    src: CommandSource = API_CMD_SRC
   ): Promise<boolean> {
     const newCourse: CourseInfo = { ...this.courseInfo }
 
@@ -615,7 +837,11 @@ export class CourseApi {
       throw new Error(`Error: Unable to retrieve vessel position!`)
     }
 
+    if (this.isSourceChange(src)) {
+      this.clearDestination(true)
+    }
     this.courseInfo = newCourse
+    this.cmdSource = src
     return true
   }
 
@@ -719,8 +945,6 @@ export class CourseApi {
     const values: Array<{ path: string; value: any }> = []
     const navPath = 'navigation.course'
 
-    debug(this.courseInfo)
-
     if (
       paths.length === 0 ||
       (paths && (paths.includes('activeRoute') || paths.includes('nextPoint')))
@@ -742,13 +966,6 @@ export class CourseApi {
       values.push({
         path: `${navPath}.activeRoute`,
         value: this.courseInfo.activeRoute
-      })
-    }
-
-    if (paths.length === 0 || (paths && paths.includes('nextPoint'))) {
-      values.push({
-        path: `${navPath}.nextPoint`,
-        value: this.courseInfo.nextPoint
       })
     }
 
@@ -780,17 +997,14 @@ export class CourseApi {
     const navGC = 'navigation.courseGreatCircle'
     const navRL = 'navigation.courseRhumbline'
 
-    if (
-      this.courseInfo.activeRoute &&
-      (paths.length === 0 || (paths && paths.includes('activeRoute')))
-    ) {
+    if (paths.length === 0 || (paths && paths.includes('activeRoute'))) {
       values.push({
         path: `${navGC}.activeRoute.href`,
-        value: this.courseInfo.activeRoute.href
+        value: this.courseInfo.activeRoute?.href ?? null
       })
       values.push({
         path: `${navRL}.activeRoute.href`,
-        value: this.courseInfo.activeRoute.href
+        value: this.courseInfo.activeRoute?.href ?? null
       })
 
       values.push({
@@ -802,35 +1016,32 @@ export class CourseApi {
         value: this.courseInfo.startTime
       })
     }
-    if (
-      this.courseInfo.nextPoint &&
-      (paths.length === 0 || (paths && paths.includes('nextPoint')))
-    ) {
+    if (paths.length === 0 || (paths && paths.includes('nextPoint'))) {
       values.push({
         path: `${navGC}.nextPoint.value.href`,
-        value: this.courseInfo.nextPoint.href ?? null
+        value: this.courseInfo.nextPoint?.href ?? null
       })
       values.push({
         path: `${navRL}.nextPoint.value.href`,
-        value: this.courseInfo.nextPoint.href ?? null
+        value: this.courseInfo.nextPoint?.href ?? null
       })
 
       values.push({
         path: `${navGC}.nextPoint.value.type`,
-        value: this.courseInfo.nextPoint.type
+        value: this.courseInfo.nextPoint?.type ?? null
       })
       values.push({
         path: `${navRL}.nextPoint.value.type`,
-        value: this.courseInfo.nextPoint.type
+        value: this.courseInfo.nextPoint?.type ?? null
       })
 
       values.push({
         path: `${navGC}.nextPoint.position`,
-        value: this.courseInfo.nextPoint.position
+        value: this.courseInfo.nextPoint?.position ?? null
       })
       values.push({
         path: `${navRL}.nextPoint.position`,
-        value: this.courseInfo.nextPoint.position
+        value: this.courseInfo.nextPoint?.position ?? null
       })
     }
     if (paths.length === 0 || (paths && paths.includes('arrivalCircle'))) {
@@ -843,26 +1054,23 @@ export class CourseApi {
         value: this.courseInfo.arrivalCircle
       })
     }
-    if (
-      this.courseInfo.previousPoint &&
-      (paths.length === 0 || (paths && paths.includes('previousPoint')))
-    ) {
+    if (paths.length === 0 || (paths && paths.includes('previousPoint'))) {
       values.push({
         path: `${navGC}.previousPoint.position`,
-        value: this.courseInfo.previousPoint.position
+        value: this.courseInfo.previousPoint?.position ?? null
       })
       values.push({
         path: `${navRL}.previousPoint.position`,
-        value: this.courseInfo.previousPoint.position
+        value: this.courseInfo.previousPoint?.position ?? null
       })
 
       values.push({
         path: `${navGC}.previousPoint.value.type`,
-        value: this.courseInfo.previousPoint.type
+        value: this.courseInfo.previousPoint?.type ?? null
       })
       values.push({
         path: `${navRL}.previousPoint.value.type`,
-        value: this.courseInfo.previousPoint.type
+        value: this.courseInfo.previousPoint?.type ?? null
       })
     }
 
@@ -875,21 +1083,50 @@ export class CourseApi {
     }
   }
 
-  private emitCourseInfo(noSave = false, ...paths: string[]) {
-    this.server.handleMessage(
-      'courseApi',
+  private emitCourseInfo(noSave?: boolean, ...paths: string[]) {
+    this.app.handleMessage(
+      API_CMD_SRC.$source,
       this.buildV1DeltaMsg(paths),
       SKVersion.v1
     )
-    this.server.handleMessage(
-      'courseApi',
-      this.buildDeltaMsg(paths),
+
+    const v2Delta = this.buildDeltaMsg(paths)
+    v2Delta.updates[0].$source = API_CMD_SRC.$source
+    v2Delta.updates.push({
+      $source: this.cmdSource ? this.cmdSource.$source : API_CMD_SRC.$source,
+      values: [
+        {
+          path: `navigation.course.nextPoint`,
+          value: this.courseInfo.nextPoint
+        }
+      ]
+    })
+    this.app.handleMessage(
+      'N/A', //no-op as updates already have $source
+      v2Delta,
       SKVersion.v2
     )
-    if (!noSave) {
+
+    const p = typeof noSave === 'undefined' ? this.isAPICmdSource() : !noSave
+    if (p) {
+      debug('*** persisting state **')
       this.store.write(this.courseInfo).catch((error) => {
-        console.log(error)
+        console.log('Course API: Unable to persist destination details!')
+        debug(error)
       })
     }
   }
+
+  private isAPICmdSource = () => this.cmdSource?.type === API_CMD_SRC.type
+
+  private isSourceChange = (newSource: CommandSource): boolean =>
+    this.cmdSource !== null &&
+    (this.cmdSource.type !== newSource.type ||
+      this.cmdSource.$source !== newSource.$source)
+
+  private isCurrentCmdSource = (cmdSource: CommandSource) =>
+    this.cmdSource?.type === cmdSource.type &&
+    this.cmdSource?.$source === cmdSource.$source &&
+    this.cmdSource?.path === cmdSource.path &&
+    this.cmdSource?.msg === cmdSource.msg
 }

--- a/src/api/course/openApi.json
+++ b/src/api/course/openApi.json
@@ -34,6 +34,10 @@
     {
       "name": "calculations",
       "description": "Calculated course data"
+    },
+    {
+      "name": "configuration",
+      "description": "Course API settings."
     }
   ],
   "components": {
@@ -680,6 +684,62 @@
                 }
               }
             }
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/course/_config": {
+      "get": {
+        "tags": ["configuration"],
+        "summary": "Retrieve Course API configuration.",
+        "description": "Returns the current Course API configuration settings.",
+        "responses": {
+          "200": {
+            "description": "Course data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "apiOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["apiOnly"]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/course/_config/apiOnly": {
+      "post": {
+        "tags": ["configuration"],
+        "summary": "Set API Only mode.",
+        "description": "Accept REST API requests only. Ignores NMEA sources.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["configuration"],
+        "summary": "Clear API Only mode.",
+        "description": "Accept both REST API requests and NMEA source data.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
           },
           "default": {
             "$ref": "#/components/responses/ErrorResponse"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -75,6 +75,9 @@ export interface Config {
     enablePluginLogging?: boolean
     loggingDirectory?: string
     sourcePriorities?: any
+    courseApi?: {
+      apiOnly?: boolean
+    }
   }
   defaults: object
 }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -494,7 +494,10 @@ module.exports = function (
         isUndefined(app.config.settings.keepMostRecentLogsOnly) ||
         app.config.settings.keepMostRecentLogsOnly,
       logCountToKeep: app.config.settings.logCountToKeep || 24,
-      runFromSystemd: process.env.RUN_FROM_SYSTEMD === 'true'
+      runFromSystemd: process.env.RUN_FROM_SYSTEMD === 'true',
+      courseApi: {
+        apiOnly: app.config.settings.courseApi?.apiOnly || false
+      }
     }
 
     if (!settings.runFromSystemd) {
@@ -637,6 +640,12 @@ module.exports = function (
     if (!isUndefined(settings.logCountToKeep)) {
       app.config.settings.logCountToKeep = Number(settings.logCountToKeep)
     }
+
+    forIn(settings.courseApi, (enabled, name) => {
+      const courseApi: { [index: string]: boolean | string | number } =
+        app.config.settings.courseApi || (app.config.settings.courseApi = {})
+      courseApi[name] = enabled
+    })
 
     writeSettingsFile(app, app.config.settings, (err: Error) => {
       if (err) {

--- a/test/ts-servertestutilities.ts
+++ b/test/ts-servertestutilities.ts
@@ -10,6 +10,7 @@ import {
 } from './servertestutilities'
 import { SERVERSTATEDIRNAME } from '../src/serverstate/store'
 import { expect } from 'chai'
+import { Delta, hasValues, PathValue } from '@signalk/server-api'
 
 export const DATETIME_REGEX = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)Z?$/
 
@@ -100,13 +101,26 @@ export const startServer = async () => {
   }
 }
 
-export const deltaHasPathValue = (delta: any, path: string, value: any) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const deltaHasPathValue = (delta: Delta, path: string, value: any) => {
   try {
-    const pathValue = delta.updates[0].values.find((x: any) => x.path === path)
-    expect(pathValue.value).to.deep.equal(value)
+    const pathValue = delta.updates.reduce<PathValue | undefined>(
+      (acc, update) => {
+        if (!acc && hasValues(update)) {
+          acc = update.values.find((x: PathValue) => x.path === path)
+        }
+        return acc
+      },
+      undefined
+    )
+    expect(pathValue?.value).to.deep.equal(value)
   } catch (e) {
     throw new Error(
-      `No such pathValue ${path}:${JSON.stringify(value)} in ${JSON.stringify(delta, null, 2)}`
+      `No such pathValue ${path}:${JSON.stringify(value)} in ${JSON.stringify(
+        delta,
+        null,
+        2
+      )}`
     )
   }
 }


### PR DESCRIPTION
Provide the ability for the Course API to set the destination based on the data received from NMEA connections. This allows application developers to use V2 Course API with course data coming from NMEA 0183 and NMEA 2000 sources.

Delta messages with a _source.type_ of NMEA0183 or NMEA2000 containing path values for
- `navigation.courseRhumbline.nextPoint.position` OR 
- `navigation.courseGreatCircle.nextPoint.position` 

will trigger invoke the course `setDestination()` method.

#### Source priorities:
The following priorities are applied when determining whether a destination will be set from an NMEA delta:
1. Destination requests via Course API endpoints have the highest priority and will ALWAYS be actioned!
2. If a destination is set, only updates from the same source are actioned (unless it is an API request)
3. If no destination is currently set, the first NMEA delta containing `nextPoint.position` data will be used
4. If `apiOnly` mode is enabled then NMEA sources are ignored.

#### Approach:
A subscription has been added to the Course API for the paths `navigation.courseRhumbline.nextPoint.position` OR `navigation.courseGreatCircle.nextPoint.position` to listen for deltas generated by NMEA data connections and set / clear the destination using API methods.

**Note: The destination set by an NMEA source WILL NOT be cleared when the NMEA source sentence contains no data due to a `nmea0183-tosignalk` plugin processing issue** (See https://github.com/SignalK/nmea0183-signalk/pull/255)

In the default mode _(apiOnly=false)_
Clearing a destination using an API request, when an NMEA source still has an active destination, will see the destination set to the value provided by the NMEA data.

Enabling **apiOnly mode** using `HTTP POST ./course/_config/apiOnly` will:
1. Clear the NMEA sourced destination
2. Only process requests via HTTP API
3. Cause delta messages from NMEA sources to be ignored

Disabling **apiOnly mode** (default) using `HTTP DELETE ./course/_config/apiOnly` will:
1. Enable processing of both HTTP API request and delta messages from NMEA sources
