### PR TITLE
feature: show accessRequests in Security menu

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -111,6 +111,7 @@ class Sidebar extends Component {
           >
             <i className={item.icon} />
             {item.name}
+            {badge(item.badge)}
           </a>
           <ul className="nav-dropdown-items">{navList(item.children)}</ul>
         </li>


### PR DESCRIPTION
Fixes #1752.

Not perfect, because the > is over the badge, but maybe good enough.

<img width="208" alt="image" src="https://github.com/SignalK/signalk-server/assets/1049678/93fc56a1-5a64-4b95-888e-aec9c0598b29">
