### PR TITLE
chore: remove unused token generation endpoint

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -386,19 +386,6 @@ module.exports = function (
     }
   )
 
-  app.get(
-    `${SERVERROUTESPREFIX}/security/token/:id/:expiration`,
-    (req: Request, res: Response, next: NextFunction) => {
-      app.securityStrategy.generateToken(
-        req,
-        res,
-        next,
-        req.params.id,
-        req.params.expiration
-      )
-    }
-  )
-
   app.put(
     [
       `${SERVERROUTESPREFIX}/security/access/requests/:identifier/:status`,


### PR DESCRIPTION
The endpoint was using GET and unused, so let's remove it.