### PR TITLE
fix: plain res.send calls

### DIFF
--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -91,7 +91,7 @@ export function mountSwaggerUi(app: IRouter & PluginManager, path: string) {
       res.json(apiDoc)
     } else {
       res.status(404)
-      res.send('Not found')
+      res.json('Not found')
     }
   }
   app.get(

--- a/src/interfaces/applicationData.js
+++ b/src/interfaces/applicationData.js
@@ -166,7 +166,7 @@ module.exports = function (app) {
         console.log(err)
         res.status(500).send(err.message)
       } else {
-        res.send()
+        res.json('ApplicationData saved')
       }
     })
   }

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -64,7 +64,7 @@ module.exports = function (app) {
                 !webapps.find(packageNameIs(name))
               ) {
                 res.status(404)
-                res.send('No such webapp or plugin available:' + name)
+                res.json('No such webapp or plugin available:' + name)
               } else {
                 if (moduleInstalling) {
                   moduleInstallQueue.push({ name: name, version: version })
@@ -72,14 +72,14 @@ module.exports = function (app) {
                 } else {
                   installSKModule(name, version)
                 }
-                res.send(`Installing ${name}...`)
+                res.json(`Installing ${name}...`)
               }
             })
             .catch((error) => {
               console.log(error.message)
               debug(error.stack)
               res.status(500)
-              res.send('<pre>' + error.message + '</pre>')
+              res.json(error.message)
             })
         }
       )
@@ -103,7 +103,7 @@ module.exports = function (app) {
                 !webapps.find(packageNameIs(name))
               ) {
                 res.status(404)
-                res.send('No such webapp or plugin available:' + name)
+                res.json('No such webapp or plugin available:' + name)
               } else {
                 if (moduleInstalling) {
                   moduleInstallQueue.push({ name: name, isRemove: true })
@@ -111,14 +111,14 @@ module.exports = function (app) {
                 } else {
                   removeSKModule(name)
                 }
-                res.send(`Removing ${name}...`)
+                res.json(`Removing ${name}...`)
               }
             })
             .catch((error) => {
               console.log(error.message)
               debug(error.stack)
               res.status(500)
-              res.send('<pre>' + error.message + '</pre>')
+              res.json(error.message)
             })
         }
       )
@@ -129,19 +129,19 @@ module.exports = function (app) {
             getLatestServerVersion(app.config.version)
               .then((serverVersion) => {
                 const result = getAllModuleInfo(plugins, webapps, serverVersion)
-                res.send(JSON.stringify(result))
+                res.json(result)
               })
               .catch(() => {
                 //could be that npmjs is down, so we can not get
                 //server version, but we have app store data
                 const result = getAllModuleInfo(plugins, webapps, '0.0.0')
-                res.send(JSON.stringify(result))
+                res.json(result)
               })
           })
           .catch((error) => {
             console.log(error.message)
             debug(error.stack)
-            res.send(emptyAppStoreInfo(false))
+            res.json(emptyAppStoreInfo(false))
           })
       })
     },

--- a/src/interfaces/logfiles.js
+++ b/src/interfaces/logfiles.js
@@ -35,7 +35,7 @@ function mountApi(app) {
       if (err) {
         console.error(err)
         res.status(500)
-        res.send('Error reading logfiles list')
+        res.json('Error reading logfiles list')
         return
       }
       res.json(files)

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -127,7 +127,7 @@ module.exports = (theApp: any) => {
           .catch((err) => {
             console.error(err)
             res.status(500)
-            res.send(err)
+            res.json(err)
           })
       })
     }
@@ -694,10 +694,10 @@ module.exports = (theApp: any) => {
         if (err) {
           console.error(err)
           res.status(500)
-          res.send(err)
+          res.json(err)
           return
         }
-        res.send('Saved configuration for plugin ' + plugin.id)
+        res.json('Saved configuration for plugin ' + plugin.id)
         stopPlugin(plugin)
         const options = getPluginOptions(plugin.id)
         plugin.enableLogging = options.enableLogging

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -35,7 +35,7 @@ module.exports = function (app) {
   app.put(`${SERVERROUTESPREFIX}/runDiscovery`, (req, res) => {
     app.discoveredProviders = []
     runDiscovery(app)
-    res.send('Discovery started')
+    res.json('Discovery started')
   })
 
   function getProviders(source, wasDiscovered) {
@@ -91,6 +91,7 @@ module.exports = function (app) {
         console.error(err)
         res.status(500).send('Unable to save to settings file')
       } else {
+        res.type('text/plain')
         res.send('Connection deleted')
       }
     })
@@ -159,6 +160,7 @@ module.exports = function (app) {
           console.error(err)
           res.status(500).send('Unable to save to settings file')
         } else {
+          res.type('text/plain')
           res.send('Connection ' + (isNew ? 'added' : 'updated'))
         }
       })

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -122,6 +122,7 @@ module.exports = function (
         if (err) {
           console.error(err)
           res.status(500)
+          res.type('text/plain')
           res.send('Could not handle admin ui root request')
         }
         res.type('html')
@@ -165,7 +166,7 @@ module.exports = function (
 
   app.put(`${SERVERROUTESPREFIX}/restart`, (req: Request, res: Response) => {
     if (app.securityStrategy.allowRestart(req)) {
-      res.send('Restarting...')
+      res.json('Restarting...')
       setTimeout(function () {
         process.exit(0)
       }, 2000)
@@ -223,10 +224,10 @@ module.exports = function (
           if (err) {
             console.log(err)
             res.status(500)
-            res.send('Unable to save configuration change')
+            res.json('Unable to save configuration change')
             return
           }
-          res.send('security config saved')
+          res.json('security config saved')
         })
       } else {
         res.status(401).send('Security config not allowed')
@@ -240,7 +241,7 @@ module.exports = function (
     return (err: any, config: any) => {
       if (err) {
         console.log(err)
-        res.status(500).send(failure)
+        res.status(500).type('text/plain').send(failure)
       } else if (config) {
         saveSecurityConfig(app, config, (theError) => {
           if (theError) {
@@ -248,10 +249,10 @@ module.exports = function (
             res.status(500).send('Unable to save configuration change')
             return
           }
-          res.send(success)
+          res.type('text/plain').send(success)
         })
       } else {
-        res.send(success)
+        res.type('text/plain').send(success)
       }
     }
   }
@@ -465,7 +466,7 @@ module.exports = function (
       .catch((err: any) => {
         console.log(err)
         res.status(500)
-        res.send(`Unable to check request: ${err.message}`)
+        res.type('text/plain').send(`Unable to check request: ${err.message}`)
       })
   })
 
@@ -637,7 +638,7 @@ module.exports = function (
       if (err) {
         res.status(500).send('Unable to save to settings file')
       } else {
-        res.send('Settings changed')
+        res.type('text/plain').send('Settings changed')
       }
     })
   })
@@ -749,7 +750,7 @@ module.exports = function (
       if (err) {
         res.status(500).send('Unable to save to defaults file')
       } else {
-        res.send('Vessel changed')
+        res.type('text/plain').send('Vessel changed')
       }
     })
   }
@@ -822,7 +823,7 @@ module.exports = function (
     } else {
       writeBaseDeltasFile(app)
         .then(() => {
-          res.send('Vessel changed')
+          res.type('text/plain').send('Vessel changed')
         })
         .catch(() => {
           res.status(500).send('Unable to save to defaults file')
@@ -1085,7 +1086,7 @@ module.exports = function (
                     fs.unlinkSync(zipFile)
                     listSafeRestoreFiles(restoreFilePath)
                       .then((files) => {
-                        res.send(files)
+                        res.type('text/plain').send(files)
                       })
                       .catch((err) => {
                         console.error(err)

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -126,9 +126,9 @@ module.exports = function (app, config) {
     res.status(401)
     if (req.accepts('application/json') && !req.accepts('text/html')) {
       res.set('Content-Type', 'application/json')
-      res.send('{ "error": "Permission Denied"}')
+      res.json({ error: 'Permission Denied' })
     } else {
-      res.send(permissionDeniedMessage)
+      res.type('text/plain').send(permissionDeniedMessage)
     }
   }
 
@@ -350,7 +350,7 @@ module.exports = function (app, config) {
     const token = jwt.sign(payload, configuration.secretKey, {
       expiresIn: theExpiration
     })
-    res.send(token)
+    res.type('text/plain').send(token)
   }
 
   strategy.allowReadOnly = function () {

--- a/test/httpprovider.js
+++ b/test/httpprovider.js
@@ -35,7 +35,7 @@ HttpProvider.prototype._transform = function (chunk, encoding, done) {
 }
 
 function handleDelta (req, res, next) {
-  res.send('ok')
+  res.type('text/plain').send('ok')
   // eslint-disable-next-line no-invalid-this
   this.push(req.body)
 }


### PR DESCRIPTION
Replace plain res.send calls that set mime type to text/html with res.json or set mime type explicitly to text/plain so that there is less chance of injecting html content.