### PR TITLE
fix: logfiles directory traversal and authentication

### DIFF
--- a/src/interfaces/logfiles.js
+++ b/src/interfaces/logfiles.js
@@ -42,8 +42,9 @@ function mountApi(app) {
     })
   })
   app.get(`${SERVERROUTESPREFIX}/logfiles/:filename`, function (req, res) {
+    const sanitizedFilename = req.params.filename.replaceAll(/\.\.(\\|\/)/g, '')
     const sanitizedLogfile = path
-      .join(getFullLogDir(app), req.params.filename)
+      .join(getFullLogDir(app), sanitizedFilename)
       .replace(/\.\./g, '')
     res.sendFile(sanitizedLogfile)
   })

--- a/src/interfaces/logfiles.js
+++ b/src/interfaces/logfiles.js
@@ -29,7 +29,7 @@ module.exports = function (app) {
 }
 
 function mountApi(app) {
-  app.securityStrategy.addAdminMiddleware('/logfiles')
+  app.securityStrategy.addAdminMiddleware(`${SERVERROUTESPREFIX}/logfiles/`)
   app.get(`${SERVERROUTESPREFIX}/logfiles/`, function (req, res) {
     listLogFiles(app, (err, files) => {
       if (err) {


### PR DESCRIPTION
The logfiles endpoint was missing admin authentication and allowed directory traversal.