### PR TITLE
fix: getFeatures() invocation in plugin start() unhandled error

### DIFF
--- a/docs/src/develop/plugins/server_plugin_api.md
+++ b/docs/src/develop/plugins/server_plugin_api.md
@@ -18,7 +18,7 @@ These functions are available via the `app` object passed to the plugin when it 
 
 #### `app.getFeatures(enabed)`
 
-Returns an object detailing the available APIs and Plugins.
+Returns a Promise containing an object detailing the available APIs and Plugins.
 
 The `enabled` parameter is optional and has the following values:
 - `undefined` (not provided): list all features
@@ -27,7 +27,7 @@ The `enabled` parameter is optional and has the following values:
 
 _Example:_
 ```javascript
-let features = app.getFeatures();
+const features = await app.getFeatures();
 
 {
   "apis": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,9 +132,16 @@ class Server {
 
     // feature detection
     app.getFeatures = async (enabled?: boolean) => {
-      return {
-        apis: enabled === false ? [] : app.apis,
-        plugins: await app.getPluginsList(enabled)
+      if (typeof app.getPluginsList === 'function') {
+        return {
+          apis: enabled === false ? [] : app.apis,
+          plugins: await app.getPluginsList(enabled)
+        }
+      } else {
+        throw new Error(`
+          Plugin manager initialisation not complete!
+          Cannot call this  function until all plugins have been initialised!
+        `)
       }
     }
 


### PR DESCRIPTION
_(Addresses #1777)_ 
Add test to `getFeatures()` to check if pluginManager has been initalised prior to interrogating features.

Invoking `getFeatures()` in a plugin `start()` function causes an error as the pluginManager is still initialising plugins.

Added a test prior to features being interrogated and throw a meaningful error on exception.