### PR TITLE
feature: add sudoers entry to allow 'node' user to run /bin/date without password

### DIFF
--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -4,7 +4,8 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo \
-  && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node
+  && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node \
+  && echo 'node ALL=(ALL) NOPASSWD:/bin/date' >> /etc/sudoers
   
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \


### PR DESCRIPTION
Add sudoers entry to allow 'node' user to run /bin/date without password.
set-system-time plugin requires this to work properly in docker. 