### PR TITLE
OpenAPI: Rename waypoint "type" attribute.

### DIFF
--- a/docs/src/develop/plugins/server_plugin_api.md
+++ b/docs/src/develop/plugins/server_plugin_api.md
@@ -529,7 +529,7 @@ app.resourcesApi.setResource(
   'waypoints',
   'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a',
   {
-    "position": {"longitude": 138.5, "latitude": -38.6}, 
+    "name": "My Waypoint"
     "feature": {
       "type":"Feature", 
       "geometry": {

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -307,7 +307,7 @@
             "type": "string",
             "description": "A description of the waypoint"
           },
-          "type": {
+          "pointType": {
             "type": "string",
             "description": "The type of point (e.g. Waypoint, PoI, Race Mark, etc)"
           },


### PR DESCRIPTION
Rename the Wapoint "type" attribute to `pointType` to avoid JSON deserialization issues where empty string is returned for the attrbute named `type` at the root level of the JSON object.
