### PR TITLE
feature: add supportsPut meta data to paths that have put handlers

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -618,6 +618,21 @@ module.exports = (theApp: any) => {
     appCopy.getDataDirPath = () => dirForPluginId(plugin.id)
 
     appCopy.registerPutHandler = (context, aPath, callback, source) => {
+      appCopy.handleMessage(plugin.id, {
+        updates: [
+          {
+            meta: [
+              {
+                path: aPath,
+                value: {
+                  supportsPut: true
+                }
+              }
+            ]
+          }
+        ]
+      })
+
       onStopHandlers[plugin.id].push(
         app.registerActionHandler(context, aPath, source || plugin.id, callback)
       )


### PR DESCRIPTION
Adds "supportsPut: true" meta for any paths that support put. Allows clients to detect and list these.

(Needed for Wilhelm SK Shortcut/Siri integration)