### PR TITLE
fix: Resources API - Send delta message when resources are added / deleted via the plugin interface.

### DIFF
--- a/packages/resources-provider-plugin/src/index.ts
+++ b/packages/resources-provider-plugin/src/index.ts
@@ -221,7 +221,7 @@ module.exports = (server: ResourceProviderApp): Plugin => {
   const apiGetResources = async (
     resType: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    params?: any
+    params: any = {}
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> => {
     if (typeof params.position === 'undefined') {

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -152,19 +152,21 @@ export class ResourcesApi {
       }
     }
     if (provider) {
-      try {
-        const r = await this.resProvider[resType]
-          ?.get(provider)
-          ?.setResource(resId, data)
-        this.app.handleMessage(
-          provider as string,
-          this.buildDeltaMsg(resType, resId, data),
-          SKVersion.v2
-        )
-        return r
-      } catch (e) {
-        return Promise.reject(new Error(`Error deleting ${resType} ${resId}`))
-      }
+      this.resProvider[resType]
+        ?.get(provider)
+        ?.setResource(resId, data)
+        .then((r) => {
+          this.app.handleMessage(
+            provider as string,
+            this.buildDeltaMsg(resType, resId, data),
+            SKVersion.v2
+          )
+          return r
+        })
+        .catch((e: Error) => {
+          debug(e)
+          return Promise.reject(new Error(`Error writing ${resType} ${resId}`))
+        })
     } else {
       return Promise.reject(new Error(`No provider for ${resType}`))
     }
@@ -184,19 +186,21 @@ export class ResourcesApi {
       provider = await this.getProviderForResourceId(resType, resId)
     }
     if (provider) {
-      try {
-        const r = await this.resProvider[resType]
-          ?.get(provider)
-          ?.deleteResource(resId)
-        this.app.handleMessage(
-          provider as string,
-          this.buildDeltaMsg(resType, resId, null),
-          SKVersion.v2
-        )
-        return r
-      } catch (e) {
-        return Promise.reject(new Error(`Error deleting ${resType} ${resId}`))
-      }
+      this.resProvider[resType]
+        ?.get(provider)
+        ?.deleteResource(resId)
+        .then((r) => {
+          this.app.handleMessage(
+            provider as string,
+            this.buildDeltaMsg(resType, resId, null),
+            SKVersion.v2
+          )
+          return r
+        })
+        .catch((e: Error) => {
+          debug(e)
+          return Promise.reject(new Error(`Error deleting ${resType} ${resId}`))
+        })
     } else {
       return Promise.reject(new Error(`No provider for ${resType}`))
     }

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -32,8 +32,10 @@ interface ResourceApplication
 export class ResourcesApi {
   private resProvider: { [key: string]: Map<string, ResourceProviderMethods> } =
     {}
+  private app: ResourceApplication
 
   constructor(app: ResourceApplication) {
+    this.app = app
     this.initResourceRoutes(app)
   }
 
@@ -106,6 +108,7 @@ export class ResourcesApi {
     debug(`** listResources(${resType}, ${JSON.stringify(params)})`)
 
     const provider = this.checkForProvider(resType, providerId)
+    debug(`** provider = ${provider}`)
     if (!provider) {
       return Promise.reject(new Error(`No provider for ${resType}`))
     }
@@ -149,7 +152,19 @@ export class ResourcesApi {
       }
     }
     if (provider) {
-      return this.resProvider[resType]?.get(provider)?.setResource(resId, data)
+      try {
+        const r = await this.resProvider[resType]
+          ?.get(provider)
+          ?.setResource(resId, data)
+        this.app.handleMessage(
+          provider as string,
+          this.buildDeltaMsg(resType, resId, data),
+          SKVersion.v2
+        )
+        return r
+      } catch (e) {
+        return Promise.reject(new Error(`Error deleting ${resType} ${resId}`))
+      }
     } else {
       return Promise.reject(new Error(`No provider for ${resType}`))
     }
@@ -169,7 +184,19 @@ export class ResourcesApi {
       provider = await this.getProviderForResourceId(resType, resId)
     }
     if (provider) {
-      return this.resProvider[resType]?.get(provider)?.deleteResource(resId)
+      try {
+        const r = await this.resProvider[resType]
+          ?.get(provider)
+          ?.deleteResource(resId)
+        this.app.handleMessage(
+          provider as string,
+          this.buildDeltaMsg(resType, resId, null),
+          SKVersion.v2
+        )
+        return r
+      } catch (e) {
+        return Promise.reject(new Error(`Error deleting ${resType} ${resId}`))
+      }
     } else {
       return Promise.reject(new Error(`No provider for ${resType}`))
     }


### PR DESCRIPTION
The `setResource()` and `deleteResource()` interface functions exposed by Resources API to plugins does not trigger the sending of a delta to notify clients that a resource change had occurred.

This PR updates these functions to send a delta when the operation is successful.
This now aligns with the behaviour when using the API HTTP endpoints.
