### PR TITLE
feature: Add base delta config for anchor roller height

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
@@ -288,6 +288,23 @@ class VesselConfiguration extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Col md="2">
+                    <Label htmlFor="anchorRollerHeight">Anchor Roller Height</Label>
+                  </Col>
+                  <Col xs="12" md="4">
+                    <Input
+                      type="text"
+                      name="height"
+                      onChange={this.handleChange}
+                      value={this.state.anchorRollerHeight}
+                    />
+                    <FormText color="muted">
+                      The height above the waterline of the anchor roller or bridle
+	              connection point in meters{' '}
+                    </FormText>
+                  </Col>
+                </FormGroup>
+                <FormGroup row>
+                  <Col md="2">
                     <Label htmlFor="gpsFromBow">GPS Distance From Bow</Label>
                   </Col>
                   <Col xs="12" md="4">

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -644,6 +644,7 @@ module.exports = function (
       length: length && length.overall,
       beam: de.getSelfValue('design.beam'),
       height: de.getSelfValue('design.airHeight'),
+      anchorRollerHeight: de.getSelfValue('design.anchorRollerHeight'),
       gpsFromBow: de.getSelfValue('sensors.gps.fromBow'),
       gpsFromCenter: de.getSelfValue('sensors.gps.fromCenter'),
       aisShipType: type && type.id,
@@ -706,6 +707,7 @@ module.exports = function (
     setNumber('design.length.value.overall', 'design.length', newVessel.length)
     setNumber('design.beam.value', 'design.beam', newVessel.beam)
     setNumber('design.airHeight.value', 'design.airHeight', newVessel.height)
+    setNumber('design.anchorRollerHeight.value', 'design.anchorRollerHeight', newVessel.anchorRollerHeight)
     setNumber(
       'sensors.gps.fromBow.value',
       'sensors.gps.fromBow',
@@ -776,6 +778,7 @@ module.exports = function (
     )
     de.setSelfValue('design.beam', makeNumber(vessel.beam))
     de.setSelfValue('design.airHeight', makeNumber(vessel.height))
+    de.setSelfValue('design.anchorRollerHeight', makeNumber(vessel.anchorRollerHeight))
     de.setSelfValue('sensors.gps.fromBow', makeNumber(vessel.gpsFromBow))
     de.setSelfValue('sensors.gps.fromCenter', makeNumber(vessel.gpsFromCenter))
     de.setSelfValue(


### PR DESCRIPTION
When calculating scope for anchoring, distance of the anchor roller (or bridle connection point) above the water line should be added to the depth before applying whatever formula or multiplier the sailor is using. Like beam and draft, it's a fixed quality of the vessel, so isn't going to come from a sensor. Having it as a base delta would allow deriving an "anchoring depth" value from draft and depthBelowSurface.