### PR TITLE
update: Resources API OpenAPI definition for charts

### DIFF
--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -475,7 +475,7 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "wms", "wmts"],
+            "enum": ["tilejson", "wms", "wmts", "mapstyleJSON"],
             "default": "wms",
             "example": "wms"
           }

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -20,10 +20,6 @@
   ],
   "tags": [
     {
-      "name": "providers",
-      "description": "Resource Providers"
-    },
-    {
       "name": "resources",
       "description": "Signal K resources"
     },
@@ -212,12 +208,6 @@
               }
             ]
           }
-        }
-      },
-      "Providers": {
-        "type": "array",
-        "items": {
-          "type": "string"
         }
       },
       "Route": {
@@ -485,7 +475,7 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "wms", "wmts", "s-57"],
+            "enum": ["tilejson", "wms", "wmts"],
             "default": "wms",
             "example": "wms"
           }
@@ -1412,7 +1402,7 @@
       },
       "post": {
         "tags": ["charts"],
-        "summary": "New Chart",
+        "summary": "Add a new Chart source",
         "requestBody": {
           "description": "Chart resource entry",
           "required": true,
@@ -1425,8 +1415,8 @@
           }
         },
         "responses": {
-          "201": {
-            "$ref": "#/components/responses/201ActionResponse"
+          "200": {
+            "$ref": "#/components/responses/200ActionResponse"
           },
           "default": {
             "$ref": "#/components/responses/ErrorResponse"
@@ -1451,7 +1441,7 @@
       ],
       "get": {
         "tags": ["charts"],
-        "summary": "Retrieve chart with supplied id",
+        "summary": "Retrieve chart metadata for the supplied id",
         "responses": {
           "200": {
             "$ref": "#/components/responses/ChartResponse"
@@ -1463,7 +1453,7 @@
       },
       "put": {
         "tags": ["charts"],
-        "summary": "Add / update a new Chart with supplied id",
+        "summary": "Add / update a new Chart source with supplied id",
         "requestBody": {
           "description": "Chart resource entry",
           "required": true,
@@ -1483,78 +1473,13 @@
             "$ref": "#/components/responses/ErrorResponse"
           }
         }
-      }
-    },
-    "/resources/providers": {
-      "get": {
-        "tags": ["providers"],
-        "summary": "List of registered resource providers",
-        "responses": {
-          "default": {
-            "description": "An object containing registered resource providers, keyed by resource types.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/Providers"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/resources/providers/default/{resourceType}": {
-      "post": {
-        "tags": ["providers"],
-        "summary": "Set the default provider for a resource type.",
-        "requestBody": {
-          "description": "Set the default provider to handle PUT / POST requests for a resource type.",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["value"],
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
+      },
+      "delete": {
+        "tags": ["charts"],
+        "summary": "Remove Chart source with supplied id",
         "responses": {
           "200": {
-            "description": "PUT, DELETE OK response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "state": {
-                      "type": "string",
-                      "enum": ["COMPLETED"]
-                    },
-                    "statusCode": {
-                      "type": "number",
-                      "enum": [200]
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["statusCode", "state"]
-                }
-              }
-            }
+            "$ref": "#/components/responses/200ActionResponse"
           },
           "default": {
             "$ref": "#/components/responses/ErrorResponse"

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -484,7 +484,6 @@
       "Chart": {
         "description": "Signal K Chart resource",
         "type": "object",
-        "required": ["identifier"],
         "properties": {
           "identifier": {
             "type": "string",

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -475,7 +475,7 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "wms", "wmts", "mapstyleJSON"],
+            "enum": ["tilejson", "wms", "wmts", "mapstyleJSON", "s-57"],
             "default": "wms",
             "example": "wms"
           }

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -20,6 +20,10 @@
   ],
   "tags": [
     {
+      "name": "providers",
+      "description": "Resource Providers"
+    },
+    {
       "name": "resources",
       "description": "Signal K resources"
     },
@@ -208,6 +212,12 @@
               }
             ]
           }
+        }
+      },
+      "Providers": {
+        "type": "array",
+        "items": {
+          "type": "string"
         }
       },
       "Route": {
@@ -475,7 +485,7 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "wms", "wmts"],
+            "enum": ["tilejson", "wms", "wmts", "s-57"],
             "default": "wms",
             "example": "wms"
           }
@@ -1399,6 +1409,29 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": ["charts"],
+        "summary": "New Chart",
+        "requestBody": {
+          "description": "Chart resource entry",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Chart"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/201ActionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
       }
     },
     "/resources/charts/{id}": {
@@ -1445,6 +1478,83 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/200ActionResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/resources/providers": {
+      "get": {
+        "tags": ["providers"],
+        "summary": "List of registered resource providers",
+        "responses": {
+          "default": {
+            "description": "An object containing registered resource providers, keyed by resource types.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Providers"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resources/providers/default/{resourceType}": {
+      "post": {
+        "tags": ["providers"],
+        "summary": "Set the default provider for a resource type.",
+        "requestBody": {
+          "description": "Set the default provider to handle PUT / POST requests for a resource type.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "PUT, DELETE OK response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": ["COMPLETED"]
+                    },
+                    "statusCode": {
+                      "type": "number",
+                      "enum": [200]
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["statusCode", "state"]
+                }
+              }
+            }
           },
           "default": {
             "$ref": "#/components/responses/ErrorResponse"

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -475,9 +475,8 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "wms", "wmts", "mapstyleJSON", "s-57"],
-            "default": "wms",
-            "example": "wms"
+            "enum": ["tilejson", "WMS", "WMTS", "mapboxstyle", "S-57"],
+            "example": "WMTS"
           }
         }
       },


### PR DESCRIPTION
Updated OpenAPI definition for Charts to include:
1. Add PUT / POST / DELETE operation definitions for `chart` resources.
2. S-57, mapboxstyle chart types
3. Chart `identifier` is optional ((as per specification)
