### PR TITLE
Update mdbook version for multiarch support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc --build && npm run build:docs",
     "build:all": "npm run build:workspaces && npm run build && npm run build-declaration && npm run build:docs",
-    "build:docs": "USER_INFO=$(id -u):$(id -g) docker run --rm -v ${PWD}/docs:/book peaceiris/mdbook:v0.4.34 build",
+    "build:docs": "USER_INFO=$(id -u):$(id -g) docker run --rm -v ${PWD}/docs:/book peaceiris/mdbook:v0.4.40 build",
     "build:workspaces": "npm run build --workspaces --if-present",
     "build-declaration": "tsc --declaration",
     "watch": "tsc --build -w",


### PR DESCRIPTION
v0.4.34 doesn't have multi-arch images, so for those of us running on arm boxes (such as, for instance, lima on a new Mac) - running build:doc doesn't so much work. The latest mdbook release, v.0.4.40 seems to build things just fine and has multi-arch images, so update the pin.