### PR TITLE
feature: redirect to webapp by displayName

### DIFF
--- a/docs/src/develop/webapps.md
+++ b/docs/src/develop/webapps.md
@@ -42,7 +42,7 @@ You can also include the following section in `package.json` to control how your
 
 where:
 - `appIcon` is the path (relative to the `public` directory) to an image within the package to display in the webapp list. The image should be at least 72x72 pixels in size.
-- `displayName` is the text you want to appear as the name in the webapp list. _(By default the _name_ attribute in the `package.json` is used.)_
+- `displayName` is the text you want to appear as the name in the webapp list. _(By default the _name_ attribute in the `package.json` is used.)_. Displayname is also used in an automatic redirect from the root of the server: if you have a webapp with displayName `foo` and you access it using for example the url http://foo.bar.org:3000 the first part of the hostname matches the webapp's displayName and you will be redirected to it instead of the default landingPage, the Admin webapp. With this mechanism you can add easy to access DNS names to each webapp, including .local names.
 
 See also [Working Offline](./developer_notes.md#offline-use).
 

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -157,7 +157,24 @@ module.exports = function (
   )
 
   app.get('/', (req: Request, res: Response) => {
-    res.redirect(app.config.settings.landingPage || '/admin/')
+    let landingPage = '/admin/'
+
+    // if accessed with hostname that starts with a webapp's displayName redirect there
+    //strip possible port number
+    const firstHostName = (req.headers?.host || '')
+      .split(':')[0]
+      .split('.')[0]
+      .toLowerCase()
+    const targetWebapp = app.webapps.find(
+      (webapp) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (webapp as any).signalk?.displayName.toLowerCase() === firstHostName
+    )
+    if (targetWebapp) {
+      landingPage = `/${targetWebapp.name}/`
+    }
+
+    res.redirect(app.config.settings.landingPage || landingPage)
   })
 
   app.get('/@signalk/server-admin-ui', (req: Request, res: Response) => {


### PR DESCRIPTION
Signal K webapps have displayName property. This PR adds automatic redirect to that webapp when the server's root is accessed with a hostname whose first element is the webapp's displayName.

So if you have a webapp whose displayName is foo and you access the server using url like http://foo.bar.org:3000/ you will be redirected to that webapp instead of the default landingPage that is the Admin webapp.