### PR TITLE
fix: resource-provider server-api dependency

### DIFF
--- a/packages/resources-provider-plugin/package.json
+++ b/packages/resources-provider-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@signalk/resources-provider",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Resources provider plugin for Signal K server.",
     "main": "plugin/index.js",
     "keywords": [
@@ -33,6 +33,7 @@
         "test": "npm run build && npm run build-declaration && npm run ci-lint"
     },
     "dependencies": {
+        "@signalk/server-api": "^2.1.0",
         "geojson-validation": "^0.2.0",
         "geolib": "^3.3.3",
         "ngeohash": "^0.6.3"


### PR DESCRIPTION
Add `@signalk/server-api` as a dependency rather than a dev-dependency.

This fix is included as part of v1.2.1 release.