### PR TITLE
feature: add client side cookie to expose login info

### DIFF
--- a/docs/src/develop/webapps.md
+++ b/docs/src/develop/webapps.md
@@ -197,6 +197,8 @@ The login endpoint has an optional `rememberMe` request parameter. By default, w
 
 As the cookie is set to be [`HttpOnly`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#security) webapp JavaScript has no access to it. Including it in server requests and persisting its value is managed by the browser, governed by the `Set-Cookie` headers sent by the server.
 
+Additionally the server sets cookie `skLoginInfo` when the user logs in and removes it when the user logs out. A webapp can poll for changes of this cookie to be notified of the browser's cookie based login status.
+
 For **token based sessions** a webapp may manage the authentication token itself. It must include it explicitly in fetch call headers.
 As JavaScript has no access to headers but cookies are included automatically by browsers when opening WebSocket connections the server will use the server-set, HttpOnly cookie. Normally browsers do not allow shadowing the server-set cookie with a new value. The only option for WebSocket connections is using a query parameter to override the cookie with a token.
 


### PR DESCRIPTION
Webapps are often used in multiple windows and the browser's login status in session cookie may change in another window or in another webapp (Admin UI vs Freeboard, Kip etc). The regular session cookie is set to be httpOnly, so it is not available for clientside code.

This adds a separate cookie that is set and removed by the server when the user's login status changes. A webapp can poll for changes of this cookie to react. One notable use case for this is applicationData that is available only when the user/browser is logged in.