### PR TITLE
feature: ubuntu 24.04 and node22 for docker image

### DIFF
--- a/.github/workflows/build-base-image-test.yml
+++ b/.github/workflows/build-base-image-test.yml
@@ -1,0 +1,66 @@
+name: Build Docker base test image
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  build_docker_base_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry. 
+
+      - name: Build baseimages and push with test tag
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile_base_test
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            signalk/signalk-server-base:test_
+            ghcr.io/signalk/signalk-server-base:test_
+
+      - name: Modify Dockerfile_rel for testing
+        run: |
+          sed -i 's/:latest/:test_/g' ./docker/Dockerfile_rel_test
+
+      - name: Build Signal K test dockers
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile_rel_test
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          build-args: |
+            TAG=latest_test
+
+      - name: Push baseimages to registries with latest tag
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile_base_test
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            signalk/signalk-server-base:latest_test
+            ghcr.io/signalk/signalk-server-base:latest_test

--- a/.github/workflows/build-docker-test.yml
+++ b/.github/workflows/build-docker-test.yml
@@ -1,4 +1,4 @@
-name: Build Docker development test container
+name: Build Docker development test image
 
 on:
   push:

--- a/.github/workflows/build-docker-test.yml
+++ b/.github/workflows/build-docker-test.yml
@@ -1,0 +1,89 @@
+name: Build Docker development test container
+
+on:
+  push:
+    branches:
+    - master
+    - "build-docker"
+    - metadata-editing
+    tags:
+      - '*'
+      - '!v*'
+  workflow_dispatch:
+
+jobs:
+  signalk-server_npm_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Build npm files locally and upload artifacts
+        run: |
+          npm cache clean -f
+          npm install npm@latest -g
+          npm install --package-lock-only
+          npm ci && npm cache clean --force
+          npm run build --workspaces --if-present
+          cd packages/server-admin-ui
+          npm pack && mv *.tgz ../../
+          cd ../server-api
+          npm pack && mv *.tgz ../../
+          cd ../streams
+          npm pack && mv *.tgz ../../
+          cd ../resources-provider-plugin
+          npm pack && mv *.tgz ../../
+          cd ../..
+          jq '.workspaces=[]' package.json > _package.json && mv _package.json package.json
+          npm i --save *.tgz
+          npm run build
+          npm pack
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: packed-modules
+          path: |
+            *.tgz
+
+  build_docker_images:
+    runs-on: ubuntu-latest
+    needs: [signalk-server_npm_files]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
+      - uses: actions/download-artifact@v4
+        with:
+          name: packed-modules
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile_test
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            signalk/signalk-server:latest_test
+            ghcr.io/signalk/signalk-server:latest_test

--- a/.github/workflows/build-docker-test.yml
+++ b/.github/workflows/build-docker-test.yml
@@ -58,6 +58,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            signalk/signalk-server
+            ghcr.io/signalk/signalk-server
+          tags: |
+            type=ref,event=branch,suffix=-test
+            type=sha,suffix=-test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -84,6 +94,4 @@ jobs:
           file: ./docker/Dockerfile_test
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: |
-            signalk/signalk-server:latest_test
-            ghcr.io/signalk/signalk-server:latest_test
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -1,12 +1,13 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
+RUN userdel -r ubuntu
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
-  && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
+  && groupadd -r docker -g 991 && groupadd -r i2c -g 990 && groupadd -r spi -g 989 && usermod -a -G dialout,i2c,spi,netdev,docker node
   
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \
   && npm config rm proxy \
   && npm config rm https-proxy \

--- a/docker/Dockerfile_base_test
+++ b/docker/Dockerfile_base_test
@@ -1,12 +1,13 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
+RUN userdel -r ubuntu
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
-  && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
+  && groupadd -r docker -g 991 && groupadd -r i2c -g 990 && groupadd -r spi -g 989 && usermod -a -G dialout,i2c,spi,netdev,docker node
   
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \
   && npm config rm proxy \
   && npm config rm https-proxy \

--- a/docker/Dockerfile_rel_test
+++ b/docker/Dockerfile_rel_test
@@ -1,0 +1,25 @@
+FROM cr.signalk.io/signalk/signalk-server-base:latest_test
+
+RUN npm config rm proxy \
+  && npm config rm https-proxy \
+  && npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 60000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm cache clean -f
+
+ARG TAG
+  
+RUN npm i -g signalk-server@$TAG \
+  && ln -s /usr/lib/node_modules/signalk-server /home/node/signalk
+
+WORKDIR /home/node/signalk
+COPY docker/startup_test.sh startup.sh
+RUN chmod +x startup.sh
+
+USER node
+RUN mkdir -p /home/node/.signalk
+
+EXPOSE 3000
+ENV IS_IN_DOCKER true
+WORKDIR /home/node/.signalk
+ENTRYPOINT /home/node/signalk/startup.sh

--- a/docker/Dockerfile_test
+++ b/docker/Dockerfile_test
@@ -1,0 +1,41 @@
+FROM cr.signalk.io/signalk/signalk-server-base:latest_test AS base
+
+USER node
+RUN mkdir -p /home/node/.signalk/ \
+  && mkdir -p /home/node/signalk/
+
+WORKDIR /home/node/signalk
+
+RUN npm config rm proxy \
+  && npm config rm https-proxy \
+  && npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 60000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm cache clean -f
+
+FROM base AS tarballs_installed
+WORKDIR /home/node/signalk
+COPY *.tgz .
+USER root
+
+RUN npm i -g signalk-server-*.tgz
+# move server-admin-ui that gets installed as sibling of signalk-server
+RUN mv /usr/lib/node_modules/@signalk/* /usr/lib/node_modules/signalk-server/node_modules/@signalk/
+
+FROM base
+
+USER root
+# add signalk-server on path like in production build
+RUN ln -s /usr/lib/node_modules/signalk-server/bin/signalk-server /usr/bin/signalk-server
+# all -g installed modules
+COPY --from=tarballs_installed /usr/lib/node_modules /usr/lib/node_modules
+
+USER node
+COPY --chown=node docker/startup_test.sh startup.sh
+RUN chmod +x startup.sh
+
+EXPOSE 3000
+ENV IS_IN_DOCKER true
+ENV SKIP_ADMINUI_VERSION_CHECK true
+WORKDIR /home/node/.signalk
+ENTRYPOINT /home/node/signalk/startup.sh

--- a/docker/startup_test.sh
+++ b/docker/startup_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+service dbus restart
+/usr/sbin/avahi-daemon -k
+/usr/sbin/avahi-daemon --no-drop-root &
+service bluetooth restart
+node --trace-deprecation /usr/lib/node_modules/signalk-server/bin/signalk-server --securityenabled


### PR DESCRIPTION
**Content**
Upgrades to two major components for docker images
- Ubuntu 24.04 LTS base image
- Node upgrade from 20.x LTS to 22.x LTS

I know this is big change and will need lot of further testing.

**Notes:**
Default user `ubuntu:x:1000:` remove and replaced with `node:x:1000:`
Reserved groups in Ubuntu 24.04.  
`
node:x:1000:
systemd-journal:x:999:
systemd-network:x:998:
systemd-timesync:x:997:
input:x:996:
sgx:x:995:
kvm:x:994:
render:x:993:
systemd-resolve:x:992:
`
Therefore old `docker`, `i2c` and `spi` groups need to be changed.

**Testing**
Some `DeprecationWarning` will appear with this upgrade, but that is more or less expected.
So far tested in `amd64` and `arm64` platforms without finding breaking changes.