### PR TITLE
feature: introducing optional canbus Mfg code, fixing canbus provider UniqueNumber logic

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -794,6 +794,7 @@ const NMEA2000 = (props) => {
       )}
       {(props.value.options.type === 'canbus' ||
         props.value.options.type === 'canbus-canboatjs') && (
+        <div>
         <TextInput
           title="Interface"
           name="options.interface"
@@ -801,6 +802,21 @@ const NMEA2000 = (props) => {
           value={props.value.options.interface}
           onChange={props.onChange}
         />
+          <TextInput
+          title="UniqueNumber"
+          name="options.uniqueNumber"
+          helpText="Example: any number from 1 to 2097151, will be equal to SerialNumber of a SignalK NMEA2000 device. Leave empty for random (default). Set a fixed value if you have problem with source identification on some B&G MFD's after SignalK restart."
+          value={props.value.options.uniqueNumber}
+          onChange={props.onChange}
+        />
+          <TextInput
+          title="ManufacturerCode"
+          name="options.mfgCode"
+          helpText="Example: 999 - Unknown (default), 0 - Internal, or any other mabufacturer code to emulate. Leave empty for default 999.  Set to 0 if you have problem with source identification on some B&G MFD's after SignalK restart."
+          value={props.value.options.mfgCode}
+          onChange={props.onChange}
+        />
+        </div>
       )}
       {(props.value.options.type === 'ngt-1-canboatjs' ||
         props.value.options.type === 'ikonvert-canboatjs' ||

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -795,27 +795,27 @@ const NMEA2000 = (props) => {
       {(props.value.options.type === 'canbus' ||
         props.value.options.type === 'canbus-canboatjs') && (
         <div>
-        <TextInput
-          title="Interface"
-          name="options.interface"
-          helpText="Example: can0"
-          value={props.value.options.interface}
-          onChange={props.onChange}
-        />
           <TextInput
-          title="UniqueNumber"
-          name="options.uniqueNumber"
-          helpText="Example: any number from 1 to 2097151, will be equal to SerialNumber of a SignalK NMEA2000 device. Leave empty for random (default). Set a fixed value if you have problem with source identification on some B&G MFD's after SignalK restart."
-          value={props.value.options.uniqueNumber}
-          onChange={props.onChange}
-        />
+            title="Interface"
+            name="options.interface"
+            helpText="Example: can0"
+            value={props.value.options.interface}
+            onChange={props.onChange}
+          />
           <TextInput
-          title="ManufacturerCode"
-          name="options.mfgCode"
-          helpText="Example: 999 - Unknown (default), 0 - Internal, or any other mabufacturer code to emulate. Leave empty for default 999.  Set to 0 if you have problem with source identification on some B&G MFD's after SignalK restart."
-          value={props.value.options.mfgCode}
-          onChange={props.onChange}
-        />
+            title="UniqueNumber"
+            name="options.uniqueNumber"
+            helpText="Example: any number from 1 to 2097151, will be equal to SerialNumber of a SignalK NMEA2000 device. Leave empty for random (default). Set a fixed value if you have problem with source identification on some B&G MFD's after SignalK restart."
+            value={props.value.options.uniqueNumber}
+            onChange={props.onChange}
+          />
+          <TextInput
+            title="ManufacturerCode"
+            name="options.mfgCode"
+            helpText="Example: 999 - Unknown (default), 0 - Internal, or any other mabufacturer code to emulate. Leave empty for default 999.  Set to 0 if you have problem with source identification on some B&G MFD's after SignalK restart."
+            value={props.value.options.mfgCode}
+            onChange={props.onChange}
+          />
         </div>
       )}
       {(props.value.options.type === 'ngt-1-canboatjs' ||

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -145,18 +145,15 @@ module.exports = function (app) {
 
     if (provider.options.type === 'canbus-canboatjs') {
       if (isNumber(provider.options.uniqueNumber)) {
-        provider.options.uniqueNumber = parseInt(provider.options.uniqueNumber);
-      }
-      else {
-        provider.options.uniqueNumber = Math.floor(Math.random() * 2097151);
+        provider.options.uniqueNumber = parseInt(provider.options.uniqueNumber)
+      } else {
+        provider.options.uniqueNumber = Math.floor(Math.random() * 2097151)
       }
 
       if (isNumber(provider.options.mfgCode)) {
-        provider.options.mfgCode = parseInt(provider.options.mfgCode);
-      }
-      else {
-        if (provider.options.mfgCode !== '')
-          delete provider.options.mfgCode; //if value is not empty or not a number then removing property
+        provider.options.mfgCode = parseInt(provider.options.mfgCode)
+      } else {
+        if (provider.options.mfgCode !== '') delete provider.options.mfgCode //if value is not empty or not a number then removing property
       }
     }
 
@@ -179,10 +176,15 @@ module.exports = function (app) {
 }
 
 function isNumber(s) {
-  return typeof s == 'number' ? true
-    : typeof s == 'string' ? (s.trim() === '' ? false : !isNaN(s))
-      : (typeof s).match(/object|function/) ? false
-        : !isNaN(s)
+  return typeof s == 'number'
+    ? true
+    : typeof s == 'string'
+    ? s.trim() === ''
+      ? false
+      : !isNaN(s)
+    : (typeof s).match(/object|function/)
+    ? false
+    : !isNaN(s)
 }
 
 function applyProviderSettings(target, source, res) {

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -143,12 +143,14 @@ module.exports = function (app) {
       ]
     }
 
-    if (
-      provider.options.type === 'canbus-canboatjs' &&
-      !provider.options.uniqueNumber
-    ) {
-      provider.options.uniqueNumber = Math.floor(Math.random() * 2097151)
-    }
+    if (provider.options.type === 'canbus-canboatjs') {
+      if (isNaN(provider.options.uniqueNumber)) {
+          provider.options.uniqueNumber = Math.floor(Math.random() * 2097151);
+      }
+      if (isNaN(provider.options.mfgCode)) {
+          provider.options.mfgCode = 999;
+      }
+  }
 
     if (applyProviderSettings(updatedProvider, provider, res)) {
       if (isNew) {

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -144,14 +144,16 @@ module.exports = function (app) {
     }
 
     if (provider.options.type === 'canbus-canboatjs') {
-      if (isNumber(provider.options.uniqueNumber)) {
-        provider.options.uniqueNumber = parseInt(provider.options.uniqueNumber)
+      const uniqueNumber = parseInt(provider.options.uniqueNumber, 10)
+      if (!isNaN(uniqueNumber)) {
+        provider.options.uniqueNumber = uniqueNumber
       } else {
         provider.options.uniqueNumber = Math.floor(Math.random() * 2097151)
       }
 
-      if (isNumber(provider.options.mfgCode)) {
-        provider.options.mfgCode = parseInt(provider.options.mfgCode)
+      const mfgCode = parseInt(provider.options.mfgCode, 10)
+      if (!isNaN(mfgCode)) {
+        provider.options.mfgCode = mfgCode
       } else {
         if (provider.options.mfgCode !== '') delete provider.options.mfgCode //if value is not empty or not a number then removing property
       }
@@ -173,18 +175,6 @@ module.exports = function (app) {
       })
     }
   }
-}
-
-function isNumber(s) {
-  return typeof s == 'number'
-    ? true
-    : typeof s == 'string'
-    ? s.trim() === ''
-      ? false
-      : !isNaN(s)
-    : (typeof s).match(/object|function/)
-    ? false
-    : !isNaN(s)
 }
 
 function applyProviderSettings(target, source, res) {

--- a/src/interfaces/providers.js
+++ b/src/interfaces/providers.js
@@ -144,13 +144,21 @@ module.exports = function (app) {
     }
 
     if (provider.options.type === 'canbus-canboatjs') {
-      if (isNaN(provider.options.uniqueNumber)) {
-          provider.options.uniqueNumber = Math.floor(Math.random() * 2097151);
+      if (isNumber(provider.options.uniqueNumber)) {
+        provider.options.uniqueNumber = parseInt(provider.options.uniqueNumber);
       }
-      if (isNaN(provider.options.mfgCode)) {
-          provider.options.mfgCode = 999;
+      else {
+        provider.options.uniqueNumber = Math.floor(Math.random() * 2097151);
       }
-  }
+
+      if (isNumber(provider.options.mfgCode)) {
+        provider.options.mfgCode = parseInt(provider.options.mfgCode);
+      }
+      else {
+        if (provider.options.mfgCode !== '')
+          delete provider.options.mfgCode; //if value is not empty or not a number then removing property
+      }
+    }
 
     if (applyProviderSettings(updatedProvider, provider, res)) {
       if (isNew) {
@@ -168,6 +176,13 @@ module.exports = function (app) {
       })
     }
   }
+}
+
+function isNumber(s) {
+  return typeof s == 'number' ? true
+    : typeof s == 'string' ? (s.trim() === '' ? false : !isNaN(s))
+      : (typeof s).match(/object|function/) ? false
+        : !isNaN(s)
 }
 
 function applyProviderSettings(target, source, res) {


### PR DESCRIPTION
**fix:**
```
if (
      provider.options.type === 'canbus-canboatjs' &&
      !provider.options.uniqueNumber
    ) {
      provider.options.uniqueNumber = Math.floor(Math.random() * 2097151)
    }
```
this statement never set`provider.options.uniqueNumber` as if not assigned `!provider.options.uniqueNumber` always evaluates to `false`

**feature:**
introducing new input parameter for `canbus-canboatjs` input provider, adding UI setup fields and comments to set. By default it follow current logic.

background for this feature:
B&G MFD displays (eg Triton2) can display information from different NMEA2000 sources. For example to display GPS coordinates need to go to setup menu, select Sources, Navigation position and then select which NMEA2000 device we want to use as a source (SignalK server, Garmin GPS 24xd or any other available in the network). Similar setup need to do for all other parameters e.g. wind, depth, speed etc. There is no such thing as default source, each input source have to be configured.
The problem: after restart SignalK server is treated as a new device and old configured sources pointing to SignalK are displayed as [source is OFFLINE]. Needless to say MFD does not display anything. After comprehensive testing I found that to be able for MFD to recognize SignalK as the same source Serial Number of SignalK device should be the same as previous (in current implementation SignalK set SN to new random number after each start/restart). Also in addition to than Manufacturer (code) should be one of the real ones. Manufacturer code also can be `0` - in this case SignalK device is detected as "internal manufacturer". So if we set SerialNumber and Mfg Code to static and valid values then after restart MFD picks up SignalK source, successfully match it with previously configured and display all parameters.
Corresponding changes in canboat repo: https://github.com/canboat/canboatjs/pull/287