### PR TITLE
ResourceProvider: Add support to filter ResourceSet features

### DIFF
--- a/packages/resources-provider-plugin/CHANGELOG.md
+++ b/packages/resources-provider-plugin/CHANGELOG.md
@@ -4,7 +4,11 @@ ___Note: Can only be used with Signal K server version 2.0.0 or later.___
 
 ---
 
-## v1.2.0
+## v1.3.1
+
+- **Added**: Filter `ResourceSet` features based on `distance` query.
+
+## v1.3.0
 
 - **Update**: Update plugin configuration to include `charts`.
 

--- a/packages/resources-provider-plugin/package.json
+++ b/packages/resources-provider-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@signalk/resources-provider",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Resources provider plugin for Signal K server.",
     "main": "plugin/index.js",
     "keywords": [


### PR DESCRIPTION
### Background
Resources defined in the Signal K specification support only one GeoJSON feature per resource entry i.e.
- Waypoints = a single Point feature
- Routes = a single LineString feature
- Regions = a single Polygon feature

To enable the use of more than one feature per resource entry **Freeboard-SK** supports the use of [ResourceSets](https://github.com/SignalK/freeboard-sk/wiki/Working-with-Resources#resource-sets).
ResourceSets employ GeoJSON `FeatureCollections` to allow the definition of multiple features of varied geometry types.
 
### Issue
When providing a filter to a resource request, the operation only supports single feature resource types (e.g. waypoints, routes) so when the request is targeting a `ResourceSet`, it's features are not correctly processed and an empty result is returned.
`e.g. /signalk/v2/api/resources/<my_resource_type>?position=[109.5711467220878,-9.33075032178624]&distance=185200`

_Noting that a ResourceSet is not currently part of the Signal K specification, there is an opportunity to define and formalise a JSON schema to support a resource entry containing more than one feature._

### Implementation
This PR  adds the necessary support to filter features in a ResourceSet and return only those that match the query based on the current [ResourceSet definition](https://github.com/SignalK/freeboard-sk/wiki/Working-with-Resources#resource-sets).
If no features match then the ResourceSet is returned with an empty feature array.
```JSON
{
    "name": "My resource Set 1",
    "description": "My set of resources.",
    "type": "ResourceSet",
    "styles": {},
    "values": {
      "type": "FeatureCollection",
      "features": []
},
```

