### PR TITLE
fix: make serialport module optional

### DIFF
--- a/src/serialports.ts
+++ b/src/serialports.ts
@@ -17,7 +17,6 @@
 
 import { Ports } from '@signalk/server-api'
 import fs from 'fs'
-import { SerialPort } from 'serialport'
 
 export const listAllSerialPorts = (): Promise<Ports> => {
   return new Promise((resolve, reject) => {
@@ -36,8 +35,8 @@ export const listAllSerialPorts = (): Promise<Ports> => {
 
 function listSerialPorts() {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return SerialPort.list()
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    return require('serialport').SerialPort.list()
   } catch (_err) {
     return Promise.resolve([])
   }


### PR DESCRIPTION
serialport module has been optional, as it is platform specific and its install may fail but otherwise the server would be in working order.

However when converting serialports.js to ts using import had made it a hard dependency - the server would not start without it, even if npm install had completed without errors but without serialport still installed.

Use dynamic require to load it so that even if the module is missing the server starts.