### PR TITLE
Fix: Clear destination on empty or invalid position received via NMEA

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -240,8 +240,11 @@ export class CourseApi {
     }
 
     if (this.isCurrentCmdSource(cmdSource)) {
-      if (!pos) {
-        debug('parseStreamValue:', 'No position... Clear Destination...')
+      if (!this.isValidPosition(pos)) {
+        debug(
+          'parseStreamValue:',
+          'No or invalid position... Clear Destination...'
+        )
         this.clearDestination()
         return
       }


### PR DESCRIPTION
Use the improved position validity test (#1840) to determine when to clear `course.nextPoint.position` value.
Ensures the same validity test is used for both setting and clearing destination position.
