### PR TITLE
fix: canboat analyzerOutEvent event name & minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs/*
 bower_components
 settings/ssl-key.pem
 settings/ssl-cert.pem
+/*.iml
 
 *.tgz
 work/

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -49,6 +49,10 @@ function N2KAnalyzer(options) {
   this.linereader.on('line', function (data) {
     try {
       let parsed = JSON.parse(data)
+      if ( parsed.version ) {
+        console.log('Connected to analyzer v'+parsed.version);
+        return;
+      }
       that.push(parsed)
       options.app.emit(that.analyzerOutEvent, parsed)
     } catch (ex) {

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -50,7 +50,7 @@ function N2KAnalyzer(options) {
     try {
       parsed = JSON.parse(data)
       that.push(parsed)
-      options.app.emit(this.analyzerOutEvent, parsed)
+      options.app.emit(that.analyzerOutEvent, parsed)
     } catch (ex) {
       console.error(data)
       console.error(ex.stack)

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -49,9 +49,9 @@ function N2KAnalyzer(options) {
   this.linereader.on('line', function (data) {
     try {
       let parsed = JSON.parse(data)
-      if ( parsed.version ) {
-        console.log('Connected to analyzer v'+parsed.version);
-        return;
+      if (parsed.version) {
+        console.log('Connected to analyzer v' + parsed.version)
+        return
       }
       that.push(parsed)
       options.app.emit(that.analyzerOutEvent, parsed)

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -48,7 +48,7 @@ function N2KAnalyzer(options) {
   const that = this
   this.linereader.on('line', function (data) {
     try {
-      parsed = JSON.parse(data)
+      let parsed = JSON.parse(data)
       that.push(parsed)
       options.app.emit(that.analyzerOutEvent, parsed)
     } catch (ex) {


### PR DESCRIPTION
- fix analyzerOutEvent event name so that raw analyzer output is emitted correctly when using canboat
- output canboat version in server log on startup
- ignore IDEA project file
- fix accidental global variable