### PR TITLE
Feature: Add zoom query parameter to Resources OpenAPI definition

### DIFF
--- a/docs/src/develop/rest-api/resources_api.md
+++ b/docs/src/develop/rest-api/resources_api.md
@@ -33,6 +33,7 @@ A filtered list of entries can be retrieved based on criteria such as:
 - being within a bounded area
 - distance from vessel
 - total entries returned
+- map zoom level
 
 by supplying a query string containing `key | value` pairs in the request.
 
@@ -54,6 +55,13 @@ _Example 3: Retrieve waypoints within a bounded area. Note: the bounded area is 
 HTTP GET 'http://hostname:3000/signalk/v2/api/resources/waypoints?bbox=[-135.5,38,-134,38.5]'
 ```
 
+_Example 4: Return notes for display on a map view at zoom level 5. 
+
+```typescript
+HTTP GET 'http://hostname:3000/signalk/v2/api/resources/notes?zoom=5'
+```
+
+It is up to the provider to determine which resource entries are returned for any given zoom level. As a guide we recommend alignment with the criteria in the following document: https://wiki.openstreetmap.org/wiki/Zoom_levels_.
 
 ### Deleting Resources
 ---

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -798,7 +798,7 @@
       "ZoomParam": {
         "in": "query",
         "name": "zoom",
-        "description": "Limit response to entries that should only appear above the supplied zoom level.",
+        "description": "Zoom level of the map used by the client to display the returned resource entries. Refer: [OSM Zoom Levels](https://wiki.openstreetmap.org/wiki/Zoom_levels)",
         "schema": {
           "type": "integer",
           "format": "int32",
@@ -839,7 +839,7 @@
         "summary": "Retrieve list of available resource types",
         "responses": {
           "default": {
-            "description": "List of avaialble resource types identified by name",
+            "description": "List of available resource types identified by name",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -795,6 +795,17 @@
           "example": [135.5, -25.2]
         }
       },
+      "ZoomParam": {
+        "in": "query",
+        "name": "zoom",
+        "description": "Limit response to entries that should only appear above the supplied zoom level.",
+        "schema": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "example": 4
+        }
+      },
       "ProviderParam": {
         "in": "query",
         "name": "provider",
@@ -872,6 +883,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/ZoomParam"
           }
         ],
         "responses": {
@@ -1002,6 +1016,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/ZoomParam"
           }
         ],
         "responses": {
@@ -1132,6 +1149,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/ZoomParam"
           }
         ],
         "responses": {
@@ -1262,6 +1282,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/ZoomParam"
           },
           {
             "name": "href",


### PR DESCRIPTION
Update the Resources API OpenAPI definition to support a zoom query parameter to allow a zoom level to be provided in a resource request.

Zoom levels equate to the resolution in the following document: https://wiki.openstreetmap.org/wiki/Zoom_levels

Example requests:
`GET ./signalk/v2/api/resources/notes?zoom=9`
`GET ./signalk/v2/api/resources/notes?position=[5.562490300291487,53.01296548279345]&distance=92000&zoom=9`

Ref: #1851