### PR TITLE
chore: docker release image versions with full, major and latest tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
             type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, 'beta') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, 'beta') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5
@@ -160,6 +161,10 @@ jobs:
           images: |
             signalk/signalk-server
             ghcr.io/signalk/signalk-server
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref, 'beta') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -184,7 +189,7 @@ jobs:
           file: ./docker/Dockerfile_rel
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: $tag
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 


### PR DESCRIPTION
Release docker image will be tagged
- v2.12.0 (full version)
- v2 (major version)
- latest