### PR TITLE
fix: python3-pip added for node-gyp

### DIFF
--- a/docker/Dockerfile_base_test
+++ b/docker/Dockerfile_base_test
@@ -4,7 +4,7 @@ RUN userdel -r ubuntu
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python3-venv python3-pip build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
   && groupadd -r docker -g 991 && groupadd -r i2c -g 990 && groupadd -r spi -g 989 && usermod -a -G dialout,i2c,spi,netdev,docker node
   
 # RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \


### PR DESCRIPTION
Node-gyp failing to install needed modules without python3-pip. Same time added python3-env.