### PR TITLE
fix: docker build tag variable name corrected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
           file: ./docker/Dockerfile_rel
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 


### PR DESCRIPTION
Docker meta is using `id: docker_meta` while `tags: ${{ steps.meta.outputs.tags }}`
Corrected to `tags: ${{ steps.docker_meta.outputs.tags }}`