### PR TITLE
fix: author in Appstore

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -42,15 +42,11 @@ interface NpmModuleData {
   package: NpmPackageData
 }
 
-interface PersonInPackage {
-  name: string
-  email: string
-}
-
 export interface Package {
   name: string
-  author?: PersonInPackage
-  contributors?: PersonInPackage[]
+  publisher?: {
+    username: string
+  }
   dependencies: { [key: string]: any }
   version: string
   description: string
@@ -302,16 +298,9 @@ export function checkForNewServerVersion(
 }
 
 export function getAuthor(thePackage: Package): string {
-  debug(thePackage.name + ' author: ' + thePackage.author)
-  return (
-    (thePackage.author && (thePackage.author.name || thePackage.author.email)) +
-    '' +
-    (thePackage.contributors || [])
-      .map((contributor: any) => contributor.name || contributor.email)
-      .join(',') +
-    '' +
-    (thePackage.name.startsWith('@signalk/') ? ' (Signal K team)' : '')
-  )
+  return `${thePackage.publisher?.username}${
+    thePackage.name.startsWith('@signalk/') ? ' (Signal K team)' : ''
+  }`
 }
 
 export function getKeywords(thePackage: NpmPackageData): string[] {


### PR DESCRIPTION
It seems npmjs no longer provides the author information from the module's original package.json. Instead let's use the publisher's username in npmjs instead, as that seems to be there consistently.