### PR TITLE
chore: add test docker builds based on Ubuntu 24.04 images for development and release phases

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -94,3 +94,52 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
+
+  build_test_docker_images:
+    runs-on: ubuntu-latest
+    needs: [signalk-server_npm_files]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            signalk/signalk-server
+            ghcr.io/signalk/signalk-server
+          flavor: |
+            suffix=-24.04
+          tags: |
+            type=ref,event=branch
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
+      - uses: actions/download-artifact@v4
+        with:
+          name: packed-modules
+
+      - name: Modify Dockerfile for test image
+        run: |
+          sed -i 's/:latest/:testing/g' ./docker/Dockerfile
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -85,7 +85,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packed-modules
-
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -94,15 +93,8 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
-
-  build_test_docker_images:
-    runs-on: ubuntu-latest
-    needs: [signalk-server_npm_files]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Docker meta
-        id: docker_meta
+      - name: Docker meta for test image
+        id: docker_meta_test
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -113,33 +105,14 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: signalkci
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
-      - uses: actions/download-artifact@v4
-        with:
-          name: packed-modules
-
       - name: Modify Dockerfile for test image
         run: |
           sed -i 's/:latest/:testing/g' ./docker/Dockerfile
-      - name: Build and push
+      - name: Build and push test image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.docker_meta_test.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,57 @@ jobs:
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 
+  docker_image_test:
+    runs-on: ubuntu-latest
+    needs: signalk-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            signalk/signalk-server
+            ghcr.io/signalk/signalk-server
+          flavor: |
+            suffix=-24.04
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, 'beta') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref, 'beta') }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
+      - name: Set TAG for build-args
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Modify Dockerfile_rel for test image
+        run: |
+          sed -i 's/:latest/:testing/g' ./docker/Dockerfile_rel
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          file: ./docker/Dockerfile_rel
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            TAG=${{ steps.vars.outputs.tag }}
+
   deploy_fly:
     runs-on: ubuntu-latest
     needs: docker_image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,16 +191,9 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           build-args: |
-            TAG=${{ steps.vars.outputs.tag }}
-
-  docker_image_test:
-    runs-on: ubuntu-latest
-    needs: signalk-server
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Docker meta
-        id: docker_meta
+            TAG=${{ steps.vars.outputs.tag }}        
+      - name: Docker meta for test image
+        id: docker_meta_test
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -213,34 +206,16 @@ jobs:
             type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, 'beta') }}
             type=raw,value=latest,enable=${{ !contains(github.ref, 'beta') }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: signalkci
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
-      - name: Set TAG for build-args
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Modify Dockerfile_rel for test image
         run: |
           sed -i 's/:latest/:testing/g' ./docker/Dockerfile_rel
-      - name: Build and push
+      - name: Build and push test image
         uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile_rel
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.docker_meta_test.outputs.tags }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 


### PR DESCRIPTION
Add test docker image builds for development and release phases
- use SK Ubuntu 24.04 base image ([cr.signalk.io/signalk/signalk-server-base:testing](cr.signalk.io/signalk/signalk-server-base:testing))
- add `-24.04` suffix for test image tags