### PR TITLE
Fix: Course API - check loaded state href values more rigorously

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -66,16 +66,17 @@ interface CommandSource {
   msg?: string
   path?: string
 }
+const NO_COURSE_INFO: CourseInfo = {
+  startTime: null,
+  targetArrivalTime: null,
+  arrivalCircle: 0,
+  activeRoute: null,
+  nextPoint: null,
+  previousPoint: null
+}
 
 export class CourseApi {
-  private courseInfo: CourseInfo = {
-    startTime: null,
-    targetArrivalTime: null,
-    arrivalCircle: 0,
-    activeRoute: null,
-    nextPoint: null,
-    previousPoint: null
-  }
+  private courseInfo = NO_COURSE_INFO
 
   private store: Store
   private cmdSource: CommandSource | null = null // source which set the destination
@@ -274,13 +275,8 @@ export class CourseApi {
 
   /** Clear destination / route (exposed to plugins) */
   async clearDestination(persistState?: boolean): Promise<void> {
-    this.courseInfo.startTime = null
-    this.courseInfo.targetArrivalTime = null
-    this.courseInfo.activeRoute = null
-    this.courseInfo.nextPoint = null
-    this.courseInfo.previousPoint = null
+    this.courseInfo = NO_COURSE_INFO
     this.emitCourseInfo(!persistState)
-    this.cmdSource = null
   }
 
   /** Set course (exposed to plugins)
@@ -337,7 +333,7 @@ export class CourseApi {
     ) {
       return info
     }
-    return this.courseInfo
+    return NO_COURSE_INFO
   }
 
   private async isValidRouteCourse(info: CourseInfo): Promise<boolean> {

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -275,7 +275,10 @@ export class CourseApi {
 
   /** Clear destination / route (exposed to plugins) */
   async clearDestination(persistState?: boolean): Promise<void> {
-    this.courseInfo = NO_COURSE_INFO
+    this.courseInfo = {
+      ...NO_COURSE_INFO,
+      arrivalCircle: this.courseInfo.arrivalCircle
+    }
     this.cmdSource = null
     this.emitCourseInfo(!persistState)
   }

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -320,12 +320,10 @@ export class CourseApi {
 
   private async validateCourseInfo(info: CourseInfo) {
     if (
-      typeof info.activeRoute === 'undefined' ||
-      typeof info.nextPoint === 'undefined' ||
-      typeof info.previousPoint === 'undefined'
+      !hasAllProperties(info, ['activeRoute', 'nextPoint', 'previousPoint'])
     ) {
       debug(`** Error: Loaded course data is invalid!! **`)
-      return this.courseInfo
+      return NO_COURSE_INFO
     }
 
     if (
@@ -1176,4 +1174,8 @@ export class CourseApi {
     this.cmdSource?.$source === cmdSource.$source &&
     this.cmdSource?.path === cmdSource.path &&
     this.cmdSource?.msg === cmdSource.msg
+}
+
+const hasAllProperties = (info: CourseInfo, propNames: string[]) => {
+  return !propNames.find((propName) => !(propName in info))
 }

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -276,6 +276,7 @@ export class CourseApi {
   /** Clear destination / route (exposed to plugins) */
   async clearDestination(persistState?: boolean): Promise<void> {
     this.courseInfo = NO_COURSE_INFO
+    this.cmdSource = null
     this.emitCourseInfo(!persistState)
   }
 


### PR DESCRIPTION
Addresses #1873 

Perform check on resource references (`href`) when loading stored state to ensure the resources still exist.


