### PR TITLE
Fix: Resource provider list returns empty array.

### DIFF
--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -445,7 +445,7 @@ export class ResourcesApi {
   /** Return array of provider ids for supplied resource type */
   private getProvidersForResourceType(resType: string): Array<string> {
     const result: string[] = this.resProvider[resType]
-      ? Object.keys(this.resProvider[resType])
+      ? Array.from(this.resProvider[resType].keys())
       : []
     debug(`getProvidersForResourceType().result = ${result}`)
     return result


### PR DESCRIPTION
A request  to `/signalk/v2/api/resources/{resourceType}/_providers` would always return an emtpy array.

Fixed generation of the array for inclusion in the response.
