### PR TITLE
chore: SK docker images build pipelines upgrades

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,12 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Node setup
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-
       - name: Build npm files locally and upload artifacts
         run: |
           npm cache clean -f
@@ -42,7 +40,6 @@ jobs:
           npm i --save *.tgz
           npm run build
           npm pack
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -51,12 +48,62 @@ jobs:
           path: |
             *.tgz
 
-  build_docker_images:
-    runs-on: ubuntu-latest
-    needs: [signalk-server_npm_files]
+  docker_images:
+    needs: signalk-server_npm_files
+    strategy:
+      matrix:
+        os: [22.04, 24.04]
+        vm: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - vm: ubuntu-latest
+            arch: amd
+            platform: linux/amd64
+          - vm: ubuntu-24.04-arm
+            arch: arm
+            platform: linux/arm64,linux/arm/v7
+    runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: packed-modules
+      - name: Modify Dockerfile for build
+        run: |
+          sed -i \
+            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}|g" \
+            ./docker/Dockerfile
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-dev
+          
+  create-and-push-manifest:
+    needs: docker_images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [22.04, 24.04]
+        include:
+          - os: 24.04
+            suffix: -24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5
@@ -67,10 +114,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+          flavor: |
+            suffix=${{ matrix.suffix }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -81,16 +126,26 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
-      - uses: actions/download-artifact@v4
+          password: ${{ secrets.GHCR_PAT }}
+      - name: Create and push multi-arch manifest to GHCR and Docker Hub
+        uses: int128/docker-manifest-create-action@v2
         with:
-          name: packed-modules
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          sources: |
+            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}-dev
+            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-dev
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
+  housekeeping:
+    needs: create-and-push-manifest
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Remove Docker Image from GHCR
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          context: .
-          file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          packages: signalk-server
+          delete-untagged: true
+          delete-tags: amd-22.04-dev,arm-22.04-dev,amd-24.04-dev,arm-24.04-dev
+          token: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
       contents: write
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    needs: signalk-server
     steps:
       - name: Build Changelog
         id: github_release
@@ -147,9 +148,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
-  docker_image:
-    runs-on: ubuntu-latest
+  docker_images:
     needs: signalk-server
+    strategy:
+      matrix:
+        os: [22.04, 24.04]
+        vm: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - vm: ubuntu-latest
+            arch: amd
+            platform: linux/amd64
+          - vm: ubuntu-24.04-arm
+            arch: arm
+            platform: linux/arm64,linux/arm/v7
+    runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -164,9 +176,7 @@ jobs:
             type=semver,pattern={{raw}}
             type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, 'beta') }}
-            type=raw,value=latest,enable=${{ !contains(github.ref, 'beta') }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+            type=raw,value=${{ matrix.tag }},enable=${{ !contains(github.ref, 'beta') }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -179,23 +189,113 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }} # Personal access tokens (classic) with a scope of "write:packages" is needed to release ghcr.io package registry.
+          password: ${{ secrets.GHCR_PAT }}
       - name: Set TAG for build-args
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Modify Dockerfile_rel for build
+        run: |
+          sed -i "s/:latest/:latest-${{ matrix.os }}/g" ./docker/Dockerfile_rel
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./docker/Dockerfile_rel
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: |
+            signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
+            ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 
+  create-and-push-manifest:
+    needs: docker_images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [22.04, 24.04]
+        include:
+          - os: 22.04
+            tag: latest
+          - os: 24.04
+            tag: latest-24.04
+            suffix: -24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            signalk/signalk-server
+            ghcr.io/signalk/signalk-server
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern=v{{major}},enable=${{ !contains(github.ref, 'beta') }}
+            type=semver,pattern=v{{major}}.{{minor}},enable=${{ !contains(github.ref, 'beta') }}
+            type=raw,value=${{ matrix.tag }},enable=${{ !contains(github.ref, 'beta') }}
+          flavor: |
+            suffix=${{ matrix.suffix }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: signalkci
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+      - name: Create and push multi-arch manifest to GHCR and Docker Hub
+        uses: int128/docker-manifest-create-action@v2
+        with:
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          sources: |
+            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}
+            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}
+            signalk/signalk-server:amd-${{ matrix.os }}
+            signalk/signalk-server:arm-${{ matrix.os }}
+
+  housekeeping:
+    needs: create-and-push-manifest
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:	
+      - name: Delete Docker Hub Tag
+        env:
+          IMAGE_NAME: "signalk/signalk-server"
+          TAG1: "amd-22.04"
+          TAG2: "arm-22.04"
+          TAG3: "amd-24.04"
+          TAG4: "arm-24.04"
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
+            -d '{"username": "signalkci", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+          for TAG in $TAG1 $TAG2 $TAG3 $TAG4; do
+            curl -X DELETE \
+              -H "Authorization: JWT $TOKEN" \
+              "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$TAG/"
+          done
+            
+      - name: Remove Docker Image from GHCR
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: signalk-server
+          delete-untagged: true
+          delete-tags: amd-22.04,arm-22.04,amd-24.04,arm-24.04
+          token: ${{ secrets.GHCR_PAT }}
+
   deploy_fly:
     runs-on: ubuntu-latest
-    needs: docker_image
+    needs: docker_images
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Modify Dockerfile_rel for build
         run: |
           sed -i \
-            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}|g" \
+            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}|g" \
             ./docker/Dockerfile_rel
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -199,8 +199,7 @@ jobs:
           file: ./docker/Dockerfile_rel
           platforms: ${{ matrix.platform }}
           push: true
-          tags: |
-            ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
+          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,11 +179,6 @@ jobs:
             type=raw,value=${{ matrix.tag }},enable=${{ !contains(github.ref, 'beta') }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: signalkci
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -195,7 +190,9 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Modify Dockerfile_rel for build
         run: |
-          sed -i "s/:latest/:latest-${{ matrix.os }}/g" ./docker/Dockerfile_rel
+          sed -i \
+            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}|g" \
+            ./docker/Dockerfile_rel
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -203,7 +200,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
             ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
@@ -258,33 +254,13 @@ jobs:
           sources: |
             ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}
             ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}
-            signalk/signalk-server:amd-${{ matrix.os }}
-            signalk/signalk-server:arm-${{ matrix.os }}
 
   housekeeping:
     needs: create-and-push-manifest
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    steps:	
-      - name: Delete Docker Hub Tag
-        env:
-          IMAGE_NAME: "signalk/signalk-server"
-          TAG1: "amd-22.04"
-          TAG2: "arm-22.04"
-          TAG3: "amd-24.04"
-          TAG4: "arm-24.04"
-        run: |
-          sudo apt-get update && sudo apt-get install -y jq
-          TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
-            -d '{"username": "signalkci", "password": "${{ secrets.DOCKERHUB_TOKEN }}"}' \
-            https://hub.docker.com/v2/users/login/ | jq -r .token)
-          for TAG in $TAG1 $TAG2 $TAG3 $TAG4; do
-            curl -X DELETE \
-              -H "Authorization: JWT $TOKEN" \
-              "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$TAG/"
-          done
-            
+    steps:
       - name: Remove Docker Image from GHCR
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:


### PR DESCRIPTION
Signal K docker images pipelines:
- release pipeline
- development pipeline

Upgrades:
- amd64 (ubuntu-latest) and arm64 (ubuntu-24.04-arm) virtual machines to enhance build speed (no more qemu)
- parallel build processes for each images
- Ubuntu 22.04 and 24.04 OS bases
- housekeeping process to clean up repositories (ghcr.io & docker hub) from untagged and temporary build images files
