### PR TITLE
Allow Notes to contain both href and position attributes.

### DIFF
--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -406,7 +406,7 @@
             "$ref": "#/components/schemas/NoteBaseModel"
           }
         ],
-        "oneOf": [
+        "anyOf": [
           {
             "$ref": "#/components/schemas/HrefAttribute"
           },


### PR DESCRIPTION
Change the Notes resource definition to be **anyOf** `href ` & `position` attributes instead of **oneOf**.

This now allows a note resource containing both a position and a link (href) to another resource to be saved to the server.
