### PR TITLE
fix: fly.io deployment job order change and tag fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           - os: 22.04
             tag: latest
           - os: 24.04
-            tag: latest-24.04
+            tag: latest
             suffix: -24.04
     steps:
       - name: Checkout
@@ -259,7 +259,7 @@ jobs:
 
   deploy_fly:
     runs-on: ubuntu-latest
-    needs: docker_images
+    needs: create-and-push-manifest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fly.io deployment will run too early and caused build failure.
Minor fix for 24.04 tag.