### PR TITLE
docs: Update repository link on resources-provider plugin

### DIFF
--- a/packages/resources-provider-plugin/package.json
+++ b/packages/resources-provider-plugin/package.json
@@ -13,7 +13,7 @@
         "regions",
         "notes"
     ],
-    "repository": "https://github.com/SignalK/resources-provider",
+    "repository": "git+https://github.com/SignalK/signalk-server.git",
     "author": "AdrianP",
     "contributors": [
         {


### PR DESCRIPTION
I was trying to get to the code from npmjs.com and it links to a repository that doesn't exist.