### PR TITLE
fix: Make padding consistent in Admin UI

### DIFF
--- a/packages/server-admin-ui/scss/core/_grid.scss
+++ b/packages/server-admin-ui/scss/core/_grid.scss
@@ -11,6 +11,6 @@
 }
 
 .main .container-fluid {
-  padding: 0 30px;
+  padding: 30px;
   height: 100%;
 }

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.js
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.js
@@ -91,9 +91,11 @@ const Apps = function (props) {
 
   return (
     <div className="appstore animated fadeIn">
-      <section className="appstore__warning section">
-        {warning && <WarningBox>{warning}</WarningBox>}
-      </section>
+      {warning && (
+        <section className="appstore__warning section">
+          <WarningBox>{warning}</WarningBox>
+        </section>
+      )}
 
       <Card>
         <CardHeader className="appstore__header">

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -1,5 +1,4 @@
 .appstore {
-  padding: 20px;
   height: 100%;
 
   .card {
@@ -44,7 +43,7 @@
   }
 
   &__warning {
-    margin: 10px 0;
+    margin-bottom: 20px;
 
     .message__container {
       padding: 10px;


### PR DESCRIPTION
This is a small fix to the Admin UI to make the padding consistent between pages and states. Previously the App Store had its own top padding and extra horizontal padding, and none of the other pages had top padding.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="1178" alt="image" src="https://github.com/user-attachments/assets/c458c59a-b983-4e93-bf33-726cd827c489" /></td>
<td><img width="1180" alt="image" src="https://github.com/user-attachments/assets/5d8d0eb9-b820-4797-9f38-4fd2ac0364ac" /></td>
</tr>
<tr>
<td>
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/5c8f38a9-452f-4fce-b448-5e96b354958e" />
</td>
<td><img width="1181" alt="image" src="https://github.com/user-attachments/assets/cb423b07-278f-4b0e-b52b-71a133cc6d99" /></td>
<td>
</tr>
<tr>
<td><img width="1180" alt="image" src="https://github.com/user-attachments/assets/9fbaf328-221c-458a-93b4-ac4b981e4a1b" /></td>
<td><img width="1180" alt="image" src="https://github.com/user-attachments/assets/1f8eb020-2831-45c1-9a0e-b527e9e5c3b0" /></td>
</tr>
</table>


