### PR TITLE
doc: how to run the server for development & consolidate contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ To enable debugging without going through the Admin UI, see the file `~/.signalk
 
 ## Development
 
-### Further reading
-
 The documents provide more details about developing Webapps or Plugings for Signal K Server, as well as working on the server itself:
 
 * [Contributing to this repo](docs/src/develop/contributing.md)
@@ -210,27 +208,6 @@ The documents provide more details about developing Webapps or Plugings for Sign
 * [Working with the Resources API](docs/src/develop/rest-api/resources_api.md)
 * [Resource Provider Plugins](docs/src/develop/plugins/resource_provider_plugins.md)
 * [Security](docs/src/security.md)
-
-### Install from git
-
-```
-git clone https://github.com/SignalK/signalk-server.git
-cd signalk-server
-npm install
-npm run build:all
-```
-
-Start the server with sample data:
-* NMEA0183 sample data: `bin/nmea-from-file`
-* NMEA2000 sample data: `bin/n2k-from-file`
-
-This will start the server with a sample configuration file and the server will start playing back data from a sample file under `samples/`. The data is available immediately via the REST interface at https://localhost:3000/signalk/v1/api/.
-
-This small demo shows how to connect the Signal K Server WebSocket interface from the command line:
-```
-npm install -g wscat2
-wscat 'ws://localhost:3000/signalk/v1/stream?subscribe=all'
-```
 
 ## Sponsoring Signal K
 

--- a/docs/src/develop/contributing.md
+++ b/docs/src/develop/contributing.md
@@ -39,6 +39,21 @@ As you work on your changes, you may need to re-build changes. To continuously w
 
 You may also need to restart the server to see some changes reflected.
 
+### Using sample data
+
+Start the server with sample data by running:
+
+* NMEA0183 sample data: `bin/nmea-from-file`
+* NMEA2000 sample data: `bin/n2k-from-file`
+
+This will start the server with a sample configuration file and the server will start playing back data from a sample file under `samples/`. The data is available immediately via the REST interface at https://localhost:3000/signalk/v1/api/.
+
+This small demo shows how to connect the Signal K Server WebSocket interface from the command line:
+
+```
+npm install -g wscat2
+wscat 'ws://localhost:3000/signalk/v1/stream?subscribe=all'
+```
 
 ###  Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:

--- a/docs/src/develop/contributing.md
+++ b/docs/src/develop/contributing.md
@@ -10,6 +10,36 @@ You can learn how from this *free* series [How to Contribute to an Open Source P
 
 ---
 
+### Running the development server
+
+1. Clone the repository:
+    ```shell
+    git clone https://github.com/SignalK/signalk-server
+    cd signalk-server
+    ```
+
+1. Install dependencies:
+   ```shell
+   npm install
+   ```
+
+1. Build the server and related packages:
+   ```shell
+   npm run build:all
+   ```
+
+1. Start the server:
+   ```shell
+   npm start
+   ```
+
+The server should now be available at [http://localhost:3000](http://localhost:3000).
+
+As you work on your changes, you may need to re-build changes. To continuously watch for changes, open a new terminal and run `npm run watch` in either the project root, or from the relevant directory in `packages/*`.
+
+You may also need to restart the server to see some changes reflected.
+
+
 ###  Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 


### PR DESCRIPTION
I didn't see any docs on how to run the server in development, and it took me a bit to figure out I had to run `npm run build:all` and not just `build`. So this documents how to get the server running in development.

Also, it seems there isn't any form of hot reload or development server setup, is that right? Would you be open to a pull request that switches to something like [Vite](https://vite.dev) that supports hot module reloading and typescript natively?