### PR TITLE
fix: Use https for NPM request to avoid redirect

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -265,7 +265,7 @@ function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
         `searching ${keyword} from ${fetchedCount + 1} of ${toFetchCount}`
       )
       fetch(
-        `http://registry.npmjs.org/-/v1/search?size=250&from=${
+        `https://registry.npmjs.org/-/v1/search?size=250&from=${
           fetchedCount > 0 ? fetchedCount : 0
         }&text=keywords:${keyword}`
       )
@@ -287,7 +287,7 @@ function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
 }
 
 function doFetchDistTags() {
-  return fetch('http://registry.npmjs.org/-/package/signalk-server/dist-tags')
+  return fetch('https://registry.npmjs.org/-/package/signalk-server/dist-tags')
 }
 
 function getLatestServerVersion(


### PR DESCRIPTION
I noticed that the AppStore is making requests to `http` instead of `https`.  npmjs.org redirects all requests to https, so this removes an extra request.

```
$ curl -I http://registry.npmjs.org/-/v1/search\?text\=signalk
HTTP/1.1 301 Moved Permanently
Date: Thu, 20 Mar 2025 20:21:02 GMT
Content-Type: text/plain;charset=UTF-8
Connection: keep-alive
Location: https://registry.npmjs.org/-/v1/search?text=signalk
Set-Cookie: _cfuvid=aV51wGwtAGUgO1T7zwNPoHtMwfDQWFLWI0B77b1TLms-1742502062613-0.0.1.1-604800000; path=/; domain=.npmjs.org; HttpOnly
Server: cloudflare
CF-RAY: 9237e9e33ef6dab9-MIA
```