### PR TITLE
doc: Fix broken link in plugin deprecation warning

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -34,6 +34,7 @@ import {
 import { getLogger } from '@signalk/streams/logging'
 import express, { Request, Response } from 'express'
 import fs from 'fs'
+import { deprecate } from 'util'
 import _ from 'lodash'
 import path from 'path'
 import { AutopilotApi } from '../api/autopilot'
@@ -498,15 +499,6 @@ module.exports = (theApp: any) => {
     location: string
   ) {
     let plugin: PluginInfo
-    let setProviderUseLogged = false
-    const logSetProviderUsage = () => {
-      if (!setProviderUseLogged) {
-        console.log(
-          `Note: ${plugin.name} is using deprecated setProviderStatus/Error https://github.com/SignalK/signalk-server/blob/master/SERVERPLUGINS.md#appsetproviderstatusmsg`
-        )
-        setProviderUseLogged = true
-      }
-    }
     const appCopy: ServerAPI = _.assign({}, app, {
       getSelfPath,
       getPath,
@@ -522,14 +514,12 @@ module.exports = (theApp: any) => {
       registerDeltaInputHandler: (handler: any) => {
         onStopHandlers[plugin.id].push(app.registerDeltaInputHandler(handler))
       },
-      setProviderStatus: (msg: string) => {
-        logSetProviderUsage()
+      setProviderStatus: deprecate((msg: string) => {
         app.setPluginStatus(plugin.id, msg)
-      },
-      setProviderError: (msg: string) => {
-        logSetProviderUsage()
+      }, `[${packageName}] setProviderStatus() is deprecated, use setPluginStatus() instead`),
+      setProviderError: deprecate((msg: string) => {
         app.setPluginError(plugin.id, msg)
-      },
+      }, `[${packageName}] setProviderError() is deprecated, use setPluginError() instead`),
       setPluginStatus: (msg: string) => {
         app.setPluginStatus(plugin.id, msg)
       },


### PR DESCRIPTION
The link in the deprecated `setProviderStatus`/`setProviderError` messages is broken, so this updates the message to explictly say what to use instead. It also switches to using the `deprecate` function from node's `util` module to do the deprecation, which support showing a stack trace.

Run `NODE_OPTIONS='--trace-deprecation' signalk-server` to see a full stack trace.

```
(node:76180) DeprecationWarning: setProviderStatus() is deprecated, use setPluginStatus() instead
    at plugin.start (/Users/bkeepers/projects/signalk/signalk-tides-api/src/index.js:68:9)
    at doPluginStart (/Users/bkeepers/projects/signalk/signalk-server/lib/interfaces/plugins.js:312:20)
    at doRegisterPlugin (/Users/bkeepers/projects/signalk/signalk-server/lib/interfaces/plugins.js:480:13)
    at registerPlugin (/Users/bkeepers/projects/signalk/signalk-server/lib/interfaces/plugins.js:259:13)
    at /Users/bkeepers/projects/signalk/signalk-server/lib/interfaces/plugins.js:210:13
    [...truncated...]
```