### PR TITLE
chore: convert src/logging.{js,ts}

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,16 @@
 import { Delta, FeatureInfo, ServerAPI, SKVersion } from '@signalk/server-api'
 import { FullSignalK } from '@signalk/signalk-schema'
 import { EventEmitter } from 'node:events'
-
 import { Config } from './config/config'
 import DeltaCache from './deltacache'
+import { WithSecurityStrategy } from './security'
+import { IRouter } from 'express'
 
-export interface ServerApp extends ServerAPI {
+export interface ServerApp
+  extends ServerAPI,
+    WithSecurityStrategy,
+    IRouter,
+    WithConfig {
   started: boolean
   interfaces: { [key: string]: any }
   intervals: NodeJS.Timeout[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import { pipedProviders } from './pipedproviders'
 import { EventsActorId, WithWrappedEmitter, wrapEmitter } from './events'
 import { Zones } from './zones'
 const debug = createDebug('signalk-server')
+import logging from './logging'
 
 import { StreamBundle } from './streambundle'
 
@@ -95,7 +96,7 @@ class Server {
     _.merge(app, opts)
 
     load(app)
-    app.logging = require('./logging')(app)
+    app.logging = logging(app)
     app.version = '0.0.1'
 
     setupCors(app, getSecurityConfig(app))

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -51,6 +51,7 @@ import {
 import { listAllSerialPorts } from './serialports'
 import { StreamBundle } from './streambundle'
 import { WithWrappedEmitter } from './events'
+import { Logging } from './logging'
 const readdir = util.promisify(fs.readdir)
 const debug = createDebug('signalk-server:serverroutes')
 import { getAISShipTypeName } from '@signalk/signalk-schema'
@@ -75,10 +76,7 @@ interface App
     PluginManager,
     WithWrappedEmitter {
   webapps: Package[]
-  logging: {
-    rememberDebug: (r: boolean) => void
-    enableDebug: (r: string) => boolean
-  }
+  logging: Logging
   activateSourcePriorities: () => void
   streambundle: StreamBundle
 }


### PR DESCRIPTION
As a way of getting familiar with the SignalK internals, I'm working on converting some of the remaining code to TypeScript. This converts `src/logging.js` to TypeScript.