### PR TITLE
chore: fix error when running `npm run build` in development

### DIFF
--- a/packages/server-api/tsconfig.json
+++ b/packages/server-api/tsconfig.json
@@ -70,5 +70,6 @@
   "ts-node": {
     "files": true
   },
+  "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
This sets the `include` path in the tsconfig.json for the server-api. Otherwise it tries to compile files `dist` and fails with a warning.

```
❯ npm run build

> signalk-server@2.13.5 build
> tsc --build && npm run build:docs

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/autopilotapi.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/autopilotapi.guard.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/coursetypes.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/deltas.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/index.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/propertyvalues.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/resourcesapi.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/resourcetypes.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bkeepers/projects/signalk/signalk-server/packages/server-api/dist/types.d.ts' because it would overwrite input file.


Found 9 errors.
```