### PR TITLE
chore: base Dockerfile updates

### DIFF
--- a/docker/Dockerfile_base_22.04
+++ b/docker/Dockerfile_base_22.04
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python3-venv python3-pip python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
   && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node
   
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \

--- a/docker/Dockerfile_base_22.04
+++ b/docker/Dockerfile_base_22.04
@@ -5,7 +5,10 @@ RUN groupadd --gid 1000 node \
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python3-venv python3-pip python2 build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
   && groupadd -r docker -g 998 && groupadd -r i2c -g 997 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi,netdev,docker node
-  
+
+# Modification to set time without need to use sudo
+RUN chmod u+s /usr/bin/date
+
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \
   && npm config rm proxy \

--- a/docker/Dockerfile_base_22.04
+++ b/docker/Dockerfile_base_22.04
@@ -24,3 +24,5 @@ RUN mkdir -p /var/run/dbus/ \
   && mkdir -p /var/run/avahi-daemon/ \
   && chmod -R 777 /var/run/avahi-daemon/ \
   && chown -R avahi:avahi /var/run/avahi-daemon/ 
+
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/Dockerfile_base_24.04
+++ b/docker/Dockerfile_base_24.04
@@ -6,7 +6,10 @@ RUN groupadd --gid 1000 node \
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git python3 python3-venv python3-pip build-essential avahi-daemon avahi-discover avahi-utils libnss-mdns mdns-scan libavahi-compat-libdnssd-dev sysstat procps nano curl libcap2-bin sudo dbus bluez\
   && groupadd -r docker -g 991 && groupadd -r i2c -g 990 && groupadd -r spi -g 989 && usermod -a -G dialout,i2c,spi,netdev,docker node
-  
+
+# Modification to set time without need to use sudo
+RUN chmod u+s /usr/bin/date
+
 # RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \

--- a/docker/Dockerfile_base_24.04
+++ b/docker/Dockerfile_base_24.04
@@ -26,3 +26,5 @@ RUN mkdir -p /var/run/dbus/ \
   && mkdir -p /var/run/avahi-daemon/ \
   && chmod -R 777 /var/run/avahi-daemon/ \
   && chown -R avahi:avahi /var/run/avahi-daemon/ 
+
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Dockerfile_base_22.04 & Dockerfile_base_24.04:
- Added chmod u+s /usr/bin/date. No need to use `sudo` to set time.
- Cleaned up apt cache and temporary files.

Dockerfile_base_22.04:
-  Added installation of python3-venv and python3-pip.