### PR TITLE
chore: fix react-json-tree usage after update

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import JSONTree from 'react-json-tree'
+import { JSONTree } from 'react-json-tree'
 import {
   Card,
   CardHeader,
@@ -441,6 +441,7 @@ class DataBrowser extends Component {
               <JSONTree
                 data={this.state.sources}
                 theme="default"
+                invertTheme={true}
                 sortObjectKeys
                 hideRoot
               />


### PR DESCRIPTION
This fixes the usage of react-json-tree after the update to 0.20.0 in #1925. The latest version changes the import and uses a dark theme by default.

@tkurki Opening this a separate PR since I don't have access to push to the original PR. Let me know if prefer a different workflow.