### PR TITLE
Resources Provider: Set outDir in tsconfig to './dist'  for plugin files.

### DIFF
--- a/packages/resources-provider-plugin/tsconfig.json
+++ b/packages/resources-provider-plugin/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": false
+    "allowJs": false,
+    "outDir": "./dist"
   },
   "include": ["./src/**/*"],
   "references": [


### PR DESCRIPTION
Compiled plugin files were not being placed in the correct location.
Updated the plugin's` tsconfig.json` file  to specify the  `outDir` as './dist'.