### PR TITLE
chore: fix docker dev build (typedoc-signalk-theme)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,18 +27,13 @@ jobs:
           npm install --package-lock-only
           npm ci && npm cache clean --force
           npm run build --workspaces --if-present
-          cd packages/server-admin-ui
-          npm pack && mv *.tgz ../../
-          cd ../server-api
-          npm pack && mv *.tgz ../../
-          cd ../streams
-          npm pack && mv *.tgz ../../
-          cd ../resources-provider-plugin
-          npm pack && mv *.tgz ../../
-          cd ../..
+          for dir in packages/*; do
+            pushd $dir && npm pack && mv *.tgz ../../ && popd
+          done
           jq '.workspaces=[]' package.json > _package.json && mv _package.json package.json
           npm i --save *.tgz
           npm run build
+          rm typedoc-signalk-theme*.tgz # This is only needed as a dev dependency
           npm pack
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.npmignore
+++ b/.npmignore
@@ -65,7 +65,8 @@ dist/**/*.test.js*
 
 packages
 
-signalk-server-*.tgz
+# Build artifacts from build-docker.yml workflow
+*.tgz
 
 publishing.md
 


### PR DESCRIPTION
[This workflow](https://github.com/SignalK/signalk-server/actions/runs/14300603875/job/40074310389#step:4:1153) is failing after #1914 because it can't find the `typedoc-signalk-theme` package. The workflow creates local packs of the modules in `packages/` and then [clears out the `workspaces` config from `package.json`](https://github.com/SignalK/signalk-server/blob/1785734d9438a490782dccf00664f7e00d455feb/.github/workflows/build-docker.yml#L39). This updates the action to make local packs for all `packages/*`, and then just deletes the `typedoc-signalk-theme` package, which is only a devDependency.

I also noticed that several of the `*.tgz` files were ending up in the final `signalk-server` package, so I updated the npm ignore config.
