### PR TITLE
docker: document local build, refactor & improve build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -71,11 +71,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packed-modules
-      - name: Modify Dockerfile for build
-        run: |
-          sed -i \
-            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}|g" \
-            ./docker/Dockerfile
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -84,7 +79,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ github.run_id }}
-          
+          build-args: |
+            REGISTRY=ghcr.io
+            UBUNTU_VERSION=$${matrix.os}
   create-and-push-manifest:
     needs: docker_images
     runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ COPY --chown=node docker/startup.sh startup.sh
 RUN chmod +x startup.sh
 
 EXPOSE 3000
-ENV IS_IN_DOCKER true
-ENV SKIP_ADMINUI_VERSION_CHECK true
+ENV IS_IN_DOCKER=true
+ENV SKIP_ADMINUI_VERSION_CHECK=true
 WORKDIR /home/node/.signalk
-ENTRYPOINT /home/node/signalk/startup.sh
+ENTRYPOINT ["/home/node/signalk/startup.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM cr.signalk.io/signalk/signalk-server-base:latest AS base
+ARG REGISTRY="cr.signalk.io"
+ARG UBUNTU_VERSION="24.04"
+
+FROM ${REGISTRY}/signalk/signalk-server-base:latest-${UBUNTU_VERSION} AS base
 
 USER node
 RUN mkdir -p /home/node/.signalk/ \

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,3 +54,26 @@ docker run --init --name signalk-server -p 3000:3000 -v $(pwd):/home/node/.signa
 * settings files and plugins: `/home/node/.signalk`
 
 You most probably want to mount `/home/node/.signalk` from the host or as a volume to persist your settings.
+
+## Building from source
+
+To build a docker image locally from source, first build and pack the server:
+
+```sh
+npm install
+npm run build:all
+npm pack --workspaces
+npm pack
+```
+
+Then build the docker image:
+
+```sh
+$ docker build -t signalk-server:master -f docker/Dockerfile .
+```
+
+Now you can run the local image:
+
+```sh
+docker run --init --name signalk-server -p 3000:3000 -v $(pwd):/home/node/.signalk signalk-server:master
+```


### PR DESCRIPTION
It took me a minute to figure out how to build the docker image locally from source, so I added some brief docs for it.

This also updates the docker file to use [docker build variables](https://docs.docker.com/build/building/variables/) instead of running `sed` during the build process.

Lastly, this also fixes these warnings I was getting when building the images:

```sh
$ docker --version
Docker version 27.4.0, build bde2b89
$ docker build -t signalk-server:master -f docker/Dockerfile .
...
 3 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 41)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 42)
 - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 44)
```

cc @KEGustafsson 