### PR TITLE
fix: fix streambundle error after port to TypeScript

### DIFF
--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -422,8 +422,8 @@ export interface ServerAPI
 export type PluginServerApp = ServerAPI
 
 export type DeltaInputHandler = (
-  delta: object,
-  next: (delta: object) => void
+  delta: Delta,
+  next: (delta: Delta) => void
 ) => void
 
 export interface Ports {

--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { DeltaInputHandler } from '@signalk/server-api'
+import { Delta, DeltaInputHandler } from '@signalk/server-api'
 
 export default class DeltaChain {
   chain: any
@@ -10,7 +10,7 @@ export default class DeltaChain {
     this.next = []
   }
 
-  process(msg: any) {
+  process(msg: Delta) {
     return this.doProcess(0, msg)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -307,7 +307,7 @@ class Server {
       }
     }
 
-    app.streambundle = new StreamBundle(app, app.selfId)
+    app.streambundle = new StreamBundle(app.selfId)
     new Zones(app.streambundle, (delta: Delta) =>
       app.handleMessage('self.notificationhandler', delta)
     )

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -29,7 +29,8 @@ import {
   SourceRef,
   PluginConstructor,
   Plugin,
-  Path
+  Path,
+  Delta
 } from '@signalk/server-api'
 import { getLogger } from '@signalk/streams/logging'
 import express, { Request, Response } from 'express'
@@ -489,7 +490,7 @@ module.exports = (theApp: any) => {
         }
       },
       debug: createDebug(packageName),
-      registerDeltaInputHandler: (handler: any) => {
+      registerDeltaInputHandler: (handler: Delta) => {
         onStopHandlers[plugin.id].push(app.registerDeltaInputHandler(handler))
       },
       setProviderStatus: deprecate((msg: string) => {

--- a/src/streambundle.ts
+++ b/src/streambundle.ts
@@ -19,7 +19,6 @@ import {
   Delta,
   NormalizedDelta,
   Path,
-  ServerAPI,
   Update,
   Value,
   NormalizedMetaDelta
@@ -36,11 +35,10 @@ export class StreamBundle implements IStreamBundle {
   selfAllPathsStream: Bacon.Bus<unknown, Value>
   keys: Bacon.Bus<unknown, Path>
   availableSelfPaths: { [key: Path]: true }
-  app: ServerAPI
   metaBus: Bacon.Bus<unknown, NormalizedMetaDelta>
   selfMetaBus: Bacon.Bus<unknown, NormalizedMetaDelta>
 
-  constructor(app: ServerAPI, selfId: string) {
+  constructor(selfId: string) {
     this.selfContext = 'vessels.' + selfId
     this.buses = {}
     this.allPathsBus = new Bacon.Bus()
@@ -50,7 +48,6 @@ export class StreamBundle implements IStreamBundle {
     this.selfAllPathsStream = new Bacon.Bus()
     this.keys = new Bacon.Bus()
     this.availableSelfPaths = {}
-    this.app = app
     this.metaBus = new Bacon.Bus()
     this.selfMetaBus = new Bacon.Bus()
   }
@@ -87,7 +84,7 @@ export class StreamBundle implements IStreamBundle {
               })
             })
           }
-        }, this)
+        })
       }
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
This fixes an [error reported](https://discord.com/channels/1170433917761892493/1360533803533340704/1361802762987372614) by @KEGustafsson introduced in #1918. I have not been able to recreate it, but apparently there are instances where `update.values` is present, but is not an array. Looking back at #1918, it looks like the old code [did have an `if` conditional](https://github.com/SignalK/signalk-server/pull/1918/files#diff-fb03df6f129b4ff2d3608e512e7ca174c9d92d6fe93307c984c730b45903889bL38), so there must be instances where it is `null`/`undefined`. ~~I updated the types to be consistent with the implementation as well.~~

While I was looking at that, I noticed that `app` is injected into stream bundle, but is unused, so I removed it in another commit.