### PR TITLE
chore: Increase dependabot limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'monthly'
+    open-pull-requests-limit: 50
 
   # Enable version updates for Docker
   - package-ecosystem: 'docker'


### PR DESCRIPTION
There are still a lot of outdated dependencies, but currently dependabot is only going to open 5/month. At that rate we'll never get caught up.

This rips the bandaid off and bumps it to 50. It's going to be overwhelming at first, but I volunteer to take a first pass through them.