### PR TITLE
fix: prevent stack too deep error with DEBUG=*

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -137,7 +137,7 @@ export function wrapEmitter(targetEmitter: EventEmitter): WrappedEmitter {
   let emittedCount = 0
 
   function safeEmit(this: any, eventName: string, ...args: any[]): boolean {
-    if (eventName !== 'serverlog') {
+    if (!/serverlog$/.test(eventName)) {
       let eventDebug = eventDebugs[eventName]
       if (!eventDebug) {
         eventDebugs[eventName] = eventDebug = createDebug(


### PR DESCRIPTION
Setting `DEBUG=signalk-server*` causes the following error. This is caused by `logging.js` overwriting `process.stdout.write`, which triggers an event, and when debug is enabled for `signalk-server:events:NO_EMITTER_ID*`, it creates an infinite loop.

```
RangeError: Maximum call stack size exceeded
    at formatRaw (node:internal/util/inspect:1086:50)
    at formatValue (node:internal/util/inspect:864:10)
    at Object.inspect (node:internal/util/inspect:372:10)
    at formatters.O (/Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/node.js:262:14)
    at /Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:100:24
    at String.replace (<anonymous>)
    at debug (/Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:91:22)
    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:84:17)
    at emitWithEmitterId (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:137:9)
    at Function.emit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:157:20)
    at storeOutput (/Users/bkeepers/projects/signalk/signalk-server/dist/logging.js:36:13)
    at process.stdout.write (/Users/bkeepers/projects/signalk/signalk-server/dist/logging.js:45:9)
    at console.value (node:internal/console/constructor:303:16)
    at console.log (node:internal/console/constructor:378:26)
    at debug (/Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:113:10)
    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:84:17)
```

Here's the beginning of the log messages before this error is raised:

```
  signalk-server Starting server to serve only http +0ms
  signalk-server:events:NO_EMITTER_ID:serverlog {
  signalk-server:events:NO_EMITTER_ID:serverlog   type: 'LOG',
  signalk-server:events:NO_EMITTER_ID:serverlog   data: {
  signalk-server:events:NO_EMITTER_ID:serverlog     ts: 'Apr 28 12:04:17',
  signalk-server:events:NO_EMITTER_ID:serverlog     row: '  \x1B[38;5;57;1msignalk-server \x1B[0mStarting server to serve only http \x1B[38;5;57m+0ms\x1B[0m\n'
  signalk-server:events:NO_EMITTER_ID:serverlog   }
  signalk-server:events:NO_EMITTER_ID:serverlog } +0ms
  signalk-server:events:NO_EMITTER_ID:serverlog {
  signalk-server:events:NO_EMITTER_ID:serverlog   type: 'LOG',
  signalk-server:events:NO_EMITTER_ID:serverlog   data: {
  signalk-server:events:NO_EMITTER_ID:serverlog     ts: 'Apr 28 12:04:17',
  signalk-server:events:NO_EMITTER_ID:serverlog     row: '  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m{\n' +
  signalk-server:events:NO_EMITTER_ID:serverlog       "  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m  type: \x1B[32m'LOG'\x1B[39m,\n" +
  signalk-server:events:NO_EMITTER_ID:serverlog       '  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m  data: {\n' +
  signalk-server:events:NO_EMITTER_ID:serverlog       "  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m    ts: \x1B[32m'Apr 28 12:04:17'\x1B[39m,\n" +
  signalk-server:events:NO_EMITTER_ID:serverlog       "  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m    row: \x1B[32m'  \\x1B[38;5;57;1msignalk-server \\x1B[0mStarting server to serve only http \\x1B[38;5;57m+0ms\\x1B[0m\\n'\x1B[39m\n" +
  signalk-server:events:NO_EMITTER_ID:serverlog       '  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m  }\n' +
  signalk-server:events:NO_EMITTER_ID:serverlog       '  \x1B[38;5;209;1msignalk-server:events:NO_EMITTER_ID:serverlog \x1B[0m} \x1B[38;5;209m+0ms\x1B[0m\n'
  signalk-server:events:NO_EMITTER_ID:serverlog   }
  signalk-server:events:NO_EMITTER_ID:serverlog } +2ms
```