### PR TITLE
feat: enable node source map support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node bin/signalk-server -s ./settings/n2k-from-file-settings.json
+web: bin/signalk-server -s ./settings/n2k-from-file-settings.json

--- a/bin/log2sk
+++ b/bin/log2sk
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 if (process.argv.length < 3) {
   console.log('Usage: log2sk <yourlogfilename>')

--- a/bin/signalk-generate-token
+++ b/bin/signalk-generate-token
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 const minimist = require('minimist')
 const fs = require('fs')

--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 /*
  * Copyright 2014-2015 Fabian Tollenaar <fabian@starting-point.nl>

--- a/bin/signalk-server-setup
+++ b/bin/signalk-server-setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 const spawn = require('child_process').spawnSync
 const clear = require('clear')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci-lint": "eslint && prettier --check .",
     "prepublishOnly": "npm run lint && npm run build:all",
     "update-latest-release": "git checkout master && git branch -D latest-release || git checkout -b latest-release && git push -f origin/latest-release",
-    "start": "node bin/signalk-server",
+    "start": "bin/signalk-server",
     "test-only": "mocha 'test/**/*.[jt]s' 'dist/**/*.test.js'",
     "test": "npm run build && npm run test-only && npm run ci-lint",
     "heroku-postbuild": "npm run build:all",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,8 @@
     "resolveJsonModule": true,
     "composite": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "sourceMap": true
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION
This adds the [--enable-source-maps](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) to node invocations, which will show real source locations for errors in the server, and any plugin that includes source maps.

Here's a diff of the stack trace from #1957 with source maps enabled:

```diff
     at /Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:100:24
     at String.replace (<anonymous>)
     at debug (/Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:91:22)
-    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:84:17)
-    at emitWithEmitterId (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:137:9)
-    at Function.emit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:157:20)
-    at storeOutput (/Users/bkeepers/projects/signalk/signalk-server/dist/logging.js:36:13)
-    at process.stdout.write (/Users/bkeepers/projects/signalk/signalk-server/dist/logging.js:45:9)
+    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/src/events.ts:149:9)
+    at emitWithEmitterId (/Users/bkeepers/projects/signalk/signalk-server/src/events.ts:214:5)
+    at Function.emit (/Users/bkeepers/projects/signalk/signalk-server/src/events.ts:243:14)
+    at storeOutput (/Users/bkeepers/projects/signalk/signalk-server/src/logging.js:41:9)
+    at WriteStream.process.stdout.write (/Users/bkeepers/projects/signalk/signalk-server/src/logging.js:52:5)
     at console.value (node:internal/console/constructor:303:16)
     at console.log (node:internal/console/constructor:378:26)
     at debug (/Users/bkeepers/projects/signalk/signalk-server/node_modules/debug/src/common.js:113:10)
-    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/dist/events.js:84:17)
+    at safeEmit (/Users/bkeepers/projects/signalk/signalk-server/src/events.ts:149:9)
```