### PR TITLE
chore: Revert body-parser from 2.2.0 back to 1.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "api-schema-builder": "^2.0.11",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
-    "body-parser": "^2.2.0",
+    "body-parser": "^1.14.1",
     "busboy": "^1.6.0",
     "chalk": "^3.0.0",
     "clear": "^0.1.0",


### PR DESCRIPTION
node-red has a bug with body-parser 2.2.0. They tried to update node-red@4 and ended up reverting it in https://github.com/node-red/node-red/commit/ba0299abf92c31288f94e15122762b7ba1da8001

This reverts commit 29cfc73018e49603b171322e441414f7bb726224

cc @sbender9 