### PR TITLE
fix: Fix `app.getFeatures` on startup

### DIFF
--- a/packages/server-api/src/features.ts
+++ b/packages/server-api/src/features.ts
@@ -1,7 +1,7 @@
 /**
  * @ignore this is extended by {@link ServerAPI}, no need to document separately
  */
-export interface Features {
+export interface WithFeatures {
   /**
    * Returns the available APIs and Plugins.
    *
@@ -47,7 +47,7 @@ export interface Features {
    * - `true`: list only enabled features
    * - `false`: list only disabled features
    */
-  getFeatures(onlyEnabled?: boolean): FeatureInfo
+  getFeatures(onlyEnabled?: boolean): Promise<FeatureInfo>
 }
 
 /**

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -1,7 +1,7 @@
 import {
   SKVersion,
   AutopilotProviderRegistry,
-  Features,
+  WithFeatures,
   PropertyValuesEmitter,
   ResourceProviderRegistry,
   Delta
@@ -28,7 +28,7 @@ export interface ServerAPI
   extends PropertyValuesEmitter,
     ResourceProviderRegistry,
     AutopilotProviderRegistry,
-    Features,
+    WithFeatures,
     CourseApi,
     SelfIdentity {
   /**

--- a/src/api/discovery/index.ts
+++ b/src/api/discovery/index.ts
@@ -1,9 +1,8 @@
+import { WithFeatures } from '@signalk/server-api'
 import { createDebug } from '../../debug'
 const debug = createDebug('signalk-server:api:features')
 
 import { IRouter, Request, Response } from 'express'
-
-import { WithFeatures } from '../../app'
 
 const FEATURES_API_PATH = `/signalk/v2/features`
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,11 +1,11 @@
 import { IRouter } from 'express'
-import { SignalKMessageHub, WithConfig, WithFeatures } from '../app'
+import { SignalKMessageHub, WithConfig } from '../app'
 import { WithSecurityStrategy } from '../security'
 import { CourseApi } from './course'
 import { FeaturesApi } from './discovery'
 import { ResourcesApi } from './resources'
 import { AutopilotApi } from './autopilot'
-import { SignalKApiId } from '@signalk/server-api'
+import { SignalKApiId, WithFeatures } from '@signalk/server-api'
 
 export interface ApiResponse {
   state: 'FAILED' | 'COMPLETED' | 'PENDING'

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Delta, FeatureInfo, ServerAPI, SKVersion } from '@signalk/server-api'
+import { Delta, ServerAPI, SKVersion } from '@signalk/server-api'
 import { FullSignalK } from '@signalk/signalk-schema'
 import { EventEmitter } from 'node:events'
 
@@ -30,8 +30,4 @@ export interface SignalKMessageHub extends EventEmitter {
 
 export interface WithConfig {
   config: Config
-}
-
-export interface WithFeatures {
-  getFeatures: (enabledOnly?: boolean) => FeatureInfo
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ import {
   SignalKApiId,
   SourceRef,
   Timestamp,
-  Update
+  Update,
+  WithFeatures
 } from '@signalk/server-api'
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
 import express, { IRouter, Request, Response } from 'express'
@@ -41,7 +42,7 @@ import https from 'https'
 import _ from 'lodash'
 import path from 'path'
 import { startApis } from './api'
-import { ServerApp, SignalKMessageHub, WithConfig, WithFeatures } from './app'
+import { ServerApp, SignalKMessageHub, WithConfig } from './app'
 import { ConfigApp, load, sendBaseDeltas } from './config/config'
 import { createDebug } from './debug'
 import DeltaCache from './deltacache'

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -94,8 +94,6 @@ module.exports = (theApp: any) => {
     async start() {
       ensureExists(path.join(theApp.config.configPath, 'plugin-config-data'))
 
-      await startPlugins(theApp)
-
       theApp.getPluginsList = async (enabled?: boolean) => {
         return await getPluginsList(enabled)
       }
@@ -114,6 +112,8 @@ module.exports = (theApp: any) => {
             res.json(err)
           })
       })
+
+      await startPlugins(theApp)
     }
   }
 


### PR DESCRIPTION
This fixes the following error when a plugin calls `app.getFeatures` on startup. 

```
TypeError: app.getPluginsList is not a function
    at Server.app.getFeatures (/Users/bkeepers/projects/signalk/signalk-server/dist/index.js:86:36)
    at Object.start (/Users/bkeepers/projects/signalk/signalk-bathymetry/dist/index.js:26:35)
    at doPluginStart (/Users/bkeepers/projects/signalk/signalk-server/dist/interfaces/plugins.js:304:20)
    at doRegisterPlugin (/Users/bkeepers/projects/signalk/signalk-server/dist/interfaces/plugins.js:473:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async registerPlugin (/Users/bkeepers/projects/signalk/signalk-server/dist/interfaces/plugins.js:251:13)
    at async Promise.all (index 8)
    at async startPlugins (/Users/bkeepers/projects/signalk/signalk-server/dist/interfaces/plugins.js:198:9)
    at async Object.start (/Users/bkeepers/projects/signalk/signalk-server/dist/interfaces/plugins.js:36:13)
```

This error was introduced in https://github.com/SignalK/signalk-server/pull/1913. The issue is that that `src/interfaces/plugins.ts` is now awaiting the call to `startPlugins(theApp)`, and then defines the `getPluginsList` after the plugins are loaded. This moves the `startPlugins` call to the end of that method after the method has been defined.

This also fixes the return type for `app.getFeatures`, which was missing a `Promise`, and removes a duplicate interface definition.