### PR TITLE
 Build and publish all packages and server in one job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,15 @@ jobs:
         run: npm install
       - name: Build server and packages
         run: npm run build:all
-      - name: Publish all workspaces
-        run: npm publish --workspaces --access public
+      - name: Publish workspaces
+        run: |
+          for workspace in packages/*; do
+            name=$(jq -r .name $workspace/package.json)
+            v1=$(jq -r .version $workspace/package.json)
+            v2=$(npm view $name version)
+            # Only publish if local version and published version do not match
+            [ "$v1" == "v2" ] || npm publish --workspace=$workspace --access public
+          done
       - name: Publish server
         run: |
           if [[ "$GITHUB_REF_NAME" == *beta* ]];

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,124 +7,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  server-admin-ui-dependencies:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          if [[ "$(npm view @signalk/server-admin-ui-dependencies version)" !=  "$(awk '/"version":/{gsub(/("|",)/,"",$2);print $2}' packages/server-admin-ui-dependencies/package.json)" ]]; then
-            cd packages/server-admin-ui-dependencies
-            npm install --package-lock-only
-            npm ci && npm cache clean --force
-            npm publish --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  server-admin-ui:
-    runs-on: ubuntu-latest
-    needs: server-admin-ui-dependencies
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          if [[ "$(npm view @signalk/server-admin-ui version)" !=  "$(awk '/"version":/{gsub(/("|",)/,"",$2);print $2}' packages/server-admin-ui/package.json)" ]]; then
-            cd packages/server-admin-ui
-            npm install --package-lock-only
-            npm ci && npm cache clean --force
-            npm publish --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  server-api:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          if [[ "$(npm view @signalk/server-api version)" !=  "$(awk '/"version":/{gsub(/("|",)/,"",$2);print $2}' packages/server-api/package.json)" ]]; then
-            cd packages/server-api
-            npm install --package-lock-only
-            npm ci && npm cache clean --force
-            npm publish --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  streams:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          if [[ "$(npm view @signalk/streams version)" !=  "$(awk '/"version":/{gsub(/("|",)/,"",$2);print $2}' packages/streams/package.json)" ]]; then
-            cd packages/streams
-            npm install --package-lock-only
-            npm ci && npm cache clean --force
-            npm publish --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  resources-provider-plugin:
-    needs: server-api
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          if [[ "$(npm view @signalk/resources-provider version)" !=  "$(awk '/"version":/{gsub(/("|",)/,"",$2);print $2}' packages/resources-provider-plugin/package.json)" ]]; then
-            # to disable workspaces, otherwise npm will not install @signalk/server-api
-            rm package.json
-            cd packages/resources-provider-plugin
-            npm install --package-lock-only
-            npm ci && npm cache clean --force
-            npm publish --access public
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   signalk-server:
     runs-on: ubuntu-latest
-    needs: [server-admin-ui, server-api, streams, resources-provider-plugin]
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Set tag variable
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: Install, build & publish
+      - name: Install dependencies
+        run: npm install
+      - name: Build server and packages
+        run: npm run build:all
+      - name: Publish all workspaces
+        run: npm publish --workspaces --access public
+      - name: Publish server
         run: |
-          npm install --package-lock-only
-          npm ci && npm cache clean --force
-          if [[ "$tag" == *beta* ]];
+          if [[ "$GITHUB_REF_NAME" == *beta* ]];
             then
               npm publish --tag beta
             else
               npm publish
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
     permissions:

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+for workspace in packages/*; do
+  name=$(jq -r .name $workspace/package.json)
+  v1=$(jq -r .version $workspace/package.json)
+  v2=$(npm view $name version)
+  # Only publish if local version and published version do not match
+  if [[ "$v1" != "$v2" ]]; then
+    echo npm publish --workspace=$workspace --access public
+  fi
+done


### PR DESCRIPTION
The latest [publish workflow](https://github.com/SignalK/signalk-server/actions/runs/15378949725) is failing due to changes all the way back in #1913, specifically d3a54ad, which removed the mis-matched TypeScript dependencies from each individual workspace package. This works as long as `npm install` is run from the top level repo, but this action was trying to build each package individually, which is different than how the build works everywhere else.

So this pull request updates the publish action to use the same install/build steps that are used everywhere (`npm install`/`npm run build:all`), and then uses `npm publish --worskspaces` to publish all the workspace packages.

I _think_ this should work, but there's not a way for me to test it.