### PR TITLE
fix: send notification after the value update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,9 @@ class Server {
 
     app.streambundle = new StreamBundle(app.selfId)
     new Zones(app.streambundle, (delta: Delta) =>
-      app.handleMessage('self.notificationhandler', delta)
+      process.nextTick(() =>
+        app.handleMessage('self.notificationhandler', delta)
+      )
     )
     app.signalk.on('delta', app.streambundle.pushDelta.bind(app.streambundle))
     app.subscriptionmanager = new SubscriptionManager(app)


### PR DESCRIPTION
Schedule sending the notification on nextTick so that processing the update that triggered the notification is first handled and then immediately after the current operation finishes.

Fixes #2009.