### PR TITLE
fix: add missing Bacon import

### DIFF
--- a/packages/server-api/src/streambundle.ts
+++ b/packages/server-api/src/streambundle.ts
@@ -1,4 +1,5 @@
 import { NormalizedDelta, Path, Value } from './deltas'
+import * as Bacon from 'baconjs'
 
 export interface StreamBundle {
   /**


### PR DESCRIPTION
Using the API gives now error for missing
namespace Bacon.