### PR TITLE
Databrowser layout & responsiveness improvements

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -426,7 +426,7 @@ class DataBrowser extends Component {
                       })}
                   </Input>
                 </Col>
-                <Col xs="8" md="2">
+                <Col xs="6" md="2">
                   <Label className="switch switch-text switch-primary">
                     <Input
                       type="checkbox"
@@ -443,9 +443,9 @@ class DataBrowser extends Component {
                     />
                     <span className="switch-handle" />
                   </Label>{' '}
-                  Meta Data
+                  <span style={{ whiteSpace: 'nowrap' }}>Meta data</span>
                 </Col>
-                <Col xs="8" md="2">
+                <Col xs="6" md="2">
                   <Label className="switch switch-text switch-primary">
                     <Input
                       type="checkbox"

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -16,7 +16,8 @@ import moment from 'moment'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import Meta from './Meta'
 
-const timestampFormat = 'MM/DD HH:mm:ss'
+const TIMESTAMP_FORMAT = 'MM/DD HH:mm:ss'
+const TIME_ONLY_FORMAT = 'HH:mm:ss'
 
 const metaStorageKey = 'admin.v1.dataBrowser.meta'
 const pauseStorageKey = 'admin.v1.dataBrowser.v1.pause'
@@ -103,6 +104,11 @@ class DataBrowser extends Component {
             update.source.sentence &&
             `(${update.source.sentence})`
           update.values.forEach((vp) => {
+            const timestamp = moment(update.timestamp)
+            const formattedTimestamp = timestamp.isSame(moment(), 'day')
+              ? timestamp.format(TIME_ONLY_FORMAT)
+              : timestamp.format(TIMESTAMP_FORMAT)
+
             if (vp.path === '') {
               Object.keys(vp.value).forEach((k) => {
                 context[k] = {
@@ -111,7 +117,7 @@ class DataBrowser extends Component {
                   $source: update.$source,
                   pgn,
                   sentence,
-                  timestamp: moment(update.timestamp).format(timestampFormat)
+                  timestamp: formattedTimestamp
                 }
               })
             } else {
@@ -121,7 +127,7 @@ class DataBrowser extends Component {
                 value: vp.value,
                 pgn,
                 sentence,
-                timestamp: moment(update.timestamp).format(timestampFormat)
+                timestamp: formattedTimestamp
               }
             }
           })

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -356,7 +356,6 @@ class DataBrowser extends Component {
                       <tr>
                         <th>Path</th>
                         <th>Value</th>
-                        <th>Units</th>
                         <th>Timestamp</th>
                         <th>Source</th>
                       </tr>
@@ -375,7 +374,11 @@ class DataBrowser extends Component {
                         .sort()
                         .map((key) => {
                           const data = this.state.data[this.state.context][key]
-                          const formatted = JSON.stringify(
+                          const meta =
+                            this.state.meta[this.state.context][data.path]
+                          const units = meta && meta.units ? meta.units : ''
+
+                          let formattedValue = JSON.stringify(
                             data.value,
                             null,
                             typeof data.value === 'object' &&
@@ -383,9 +386,10 @@ class DataBrowser extends Component {
                               ? 2
                               : 0
                           )
-                          const meta =
-                            this.state.meta[this.state.context][data.path]
-                          const units = meta && meta.units ? meta.units : ''
+
+                          if (typeof data.value === 'number' && units) {
+                            formattedValue = `${data.value} ${units}`
+                          }
 
                           return (
                             <tr key={key}>
@@ -401,10 +405,9 @@ class DataBrowser extends Component {
                                   className="text-primary"
                                   style={{ whiteSpace: 'pre-wrap' }}
                                 >
-                                  {formatted}
+                                  {formattedValue}
                                 </pre>
                               </td>
-                              <td>{units}</td>
                               <TimestampCell
                                 timestamp={data.timestamp}
                                 isPaused={this.state.pause}

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -555,7 +555,7 @@ class DataBrowser extends Component {
                           )
 
                           if (typeof data.value === 'number' && units) {
-                            formattedValue = `${data.value} ${units}`
+                            formattedValue = `${data.value} `
                           }
 
                           return (
@@ -575,6 +575,8 @@ class DataBrowser extends Component {
                                 ) : (
                                   <span className="text-primary">
                                     {formattedValue}
+                                    {typeof data.value === 'number' &&
+                                      units && <strong>{units}</strong>}
                                   </span>
                                 )}
                               </td>

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -266,6 +266,133 @@ class DataBrowser extends Component {
                 opacity: 0;
               }
             }
+
+            .responsive-table {
+              font-size: 0.875rem;
+            }
+
+            .responsive-table td {
+              padding: 0.5rem 0.25rem;
+              vertical-align: top;
+              word-wrap: break-word;
+              word-break: break-word;
+            }
+
+            .responsive-table th {
+              padding: 0.5rem 0.25rem;
+              font-size: 0.8rem;
+              font-weight: 600;
+            }
+
+            .responsive-table .path-cell {
+              min-width: 150px;
+              max-width: 200px;
+            }
+
+            .responsive-table .value-cell {
+              min-width: 120px;
+              max-width: 300px;
+            }
+
+            .responsive-table .timestamp-cell {
+              min-width: 80px;
+              max-width: 100px;
+              white-space: nowrap;
+            }
+
+            .responsive-table .source-cell {
+              min-width: 100px;
+              max-width: 150px;
+            }
+
+            .responsive-table pre {
+              margin: 0;
+              padding: 0;
+              font-size: 0.8rem;
+              white-space: pre-wrap;
+              word-wrap: break-word;
+              word-break: break-word;
+            }
+
+            @media (max-width: 1200px) {
+              .responsive-table {
+                font-size: 0.8rem;
+              }
+              
+              .responsive-table td {
+                padding: 0.4rem 0.2rem;
+              }
+              
+              .responsive-table th {
+                padding: 0.4rem 0.2rem;
+                font-size: 0.75rem;
+              }
+            }
+
+            @media (max-width: 992px) {
+              .responsive-table .path-cell {
+                max-width: 150px;
+              }
+              
+              .responsive-table .value-cell {
+                max-width: 200px;
+              }
+              
+              .responsive-table .source-cell {
+                max-width: 120px;
+              }
+            }
+
+            @media (max-width: 768px) {
+              .responsive-table {
+                font-size: 0.75rem;
+              }
+              
+              .responsive-table td {
+                padding: 0.3rem 0.15rem;
+              }
+              
+              .responsive-table th {
+                padding: 0.3rem 0.15rem;
+                font-size: 0.7rem;
+              }
+              
+              .responsive-table .path-cell {
+                max-width: 120px;
+              }
+              
+              .responsive-table .value-cell {
+                max-width: 150px;
+              }
+              
+              .responsive-table .source-cell {
+                max-width: 100px;
+              }
+              
+              .responsive-table pre {
+                font-size: 0.7rem;
+              }
+            }
+
+            @media (max-width: 576px) {
+              .responsive-table {
+                font-size: 0.7rem;
+              }
+              
+              .responsive-table td {
+                padding: 0.25rem 0.1rem;
+              }
+              
+              .responsive-table th {
+                padding: 0.25rem 0.1rem;
+                font-size: 0.65rem;
+              }
+              
+              .responsive-table .timestamp-cell {
+                min-width: 70px;
+                max-width: 80px;
+              }
+            }
           `}
         </style>
         <Card>
@@ -357,13 +484,19 @@ class DataBrowser extends Component {
               {!this.state.includeMeta &&
                 this.state.context &&
                 this.state.context !== 'none' && (
-                  <Table responsive bordered striped size="sm">
+                  <Table
+                    responsive
+                    bordered
+                    striped
+                    size="sm"
+                    className="responsive-table"
+                  >
                     <thead>
                       <tr>
-                        <th>Path</th>
-                        <th>Value</th>
-                        <th>Timestamp</th>
-                        <th>Source</th>
+                        <th className="path-cell">Path</th>
+                        <th className="value-cell">Value</th>
+                        <th className="timestamp-cell">Timestamp</th>
+                        <th className="source-cell">Source</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -399,26 +532,30 @@ class DataBrowser extends Component {
 
                           return (
                             <tr key={key}>
-                              <td>
+                              <td className="path-cell">
                                 <CopyToClipboardWithFade text={data.path}>
                                   <span>
                                     {data.path} <i className="far fa-copy"></i>
                                   </span>
                                 </CopyToClipboardWithFade>
                               </td>
-                              <td>
-                                <pre
-                                  className="text-primary"
-                                  style={{ whiteSpace: 'pre-wrap' }}
-                                >
-                                  {formattedValue}
-                                </pre>
+                              <td className="value-cell">
+                                {typeof data.value === 'object' ? (
+                                  <pre className="text-primary">
+                                    {formattedValue}
+                                  </pre>
+                                ) : (
+                                  <span className="text-primary">
+                                    {formattedValue}
+                                  </span>
+                                )}
                               </td>
                               <TimestampCell
                                 timestamp={data.timestamp}
                                 isPaused={this.state.pause}
+                                className="timestamp-cell"
                               />
-                              <td>
+                              <td className="source-cell">
                                 <CopyToClipboardWithFade text={data.$source}>
                                   {data.$source} <i className="far fa-copy"></i>
                                 </CopyToClipboardWithFade>{' '}
@@ -545,11 +682,11 @@ class TimestampCell extends Component {
   render() {
     return (
       <td
-        className={
+        className={`${this.props.className || ''} ${
           this.state.isUpdated && !this.props.isPaused
             ? 'timestamp-updated'
             : ''
-        }
+        }`}
         key={this.state.animationKey}
       >
         {this.props.timestamp}


### PR DESCRIPTION
* Combine unit with value in DataBrowser: append the unit to numeric values to make the layout a bit more compact and readable.
* Update timestamp formatting logic to display only the time for same-day timestamps and the full date-time format for others
* Overall table responsiveness improvements: see 9441e783164f2f0ad58421818a849f411dab9c85 for details
* Use React Select in Context menu to allow searching and include context name.


<img width="576" alt="image" src="https://github.com/user-attachments/assets/61963cd4-225b-4b99-b64c-d1e528eb6e39" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/d56b8165-6116-4c88-88a1-d44e8a0d909a" />

