### PR TITLE
chore: @signalk/typedoc-signalk-theme

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,7 +30,7 @@ jobs:
           npm ci && npm cache clean --force
           npm run build:all
           npm pack --workspaces
-          rm typedoc-signalk-theme*.tgz # This is only needed as a dev dependency
+          rm signalk-typedoc-signalk-theme*.tgz # This is only needed as a dev dependency
           npm pack
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^1.45.1",
     "@eslint/js": "^9.24.0",
+    "@signalk/typedoc-signalk-theme": "^0.3.0",
     "@tsconfig/node20": "^20.1.5",
     "@types/baconjs": "^0.7.34",
     "@types/busboy": "^1.5.0",
@@ -170,7 +171,6 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.28.1",
     "typedoc-plugin-mdn-links": "^5.0.1",
-    "typedoc-signalk-theme": "^0.3.0",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.29.1"
   },

--- a/packages/typedoc-theme/package.json
+++ b/packages/typedoc-theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typedoc-signalk-theme",
+  "name": "@signalk/typedoc-signalk-theme",
   "description": "A TypeDoc theme for SignalK",
   "version": "0.3.0",
   "main": "./dist/index.js",

--- a/typedoc.json
+++ b/typedoc.json
@@ -56,7 +56,7 @@
   ],
   "alwaysCreateEntryPointModule": true,
   "theme": "signalk",
-  "plugin": ["typedoc-signalk-theme", "typedoc-plugin-mdn-links"],
+  "plugin": ["@signalk/typedoc-signalk-theme", "typedoc-plugin-mdn-links"],
   "lightHighlightTheme": "github-light-default",
   "darkHighlightTheme": "github-dark-dimmed",
   "highlightLanguages": [


### PR DESCRIPTION
In preparation for publishing it so that it is
a proper, installable module and not just a
ghost move the module under @signalk organisation.