### PR TITLE
fix: ActionHandler types

### DIFF
--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -359,14 +359,14 @@ export interface ServerAPI
   registerPutHandler(
     context: string,
     path: string,
-    callback: () => void,
+    callback: ActionHandler,
     source: string
   ): void
 
   registerActionHandler(
     context: string,
     path: string,
-    callback: () => void,
+    callback: ActionHandler,
     source: string
   ): void
 
@@ -443,4 +443,20 @@ export interface SelfIdentity {
 export interface Metadata {
   units?: string
   description?: string
+}
+
+// Command Types
+export type ActionHandler = (
+  context: string,
+  path: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any,
+  callback?: (result: ActionResult) => void
+) => ActionResult;
+
+export interface ActionResult {
+  state: 'COMPLETED' | 'PENDING' | 'FAILED';
+  statusCode?: number;
+  message?: string;
+  timestamp: string;
 }


### PR DESCRIPTION
The inline documentation has the correct types, but the actual callback types in registerPutHandler and registerActionHandler were just () => void.