### PR TITLE
chore: update docker build process update, Ubuntu 24.04 and Node versions 22.x & 24.x

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -9,7 +9,8 @@ jobs:
   build-images:
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
         vm: [ubuntu-latest, ubuntu-24.04-arm]
         include:
           - vm: ubuntu-latest
@@ -38,12 +39,14 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}
+            ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.node }}
+          build-args: |
+            NODE=${{ matrix.node }}
 
       - name: Modify Dockerfile_rel for testing
         run: |
           sed -i \
-            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}|g" \
+            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.node }}|g" \
             ./docker/Dockerfile_rel
 
       - name: Build Signal K test docker image
@@ -60,7 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
 
     steps:
       - name: Login to ghcr.io
@@ -80,11 +84,11 @@ jobs:
         uses: int128/docker-manifest-create-action@v2
         with:
           tags: |
-            ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}
-            signalk/signalk-server-base:latest-${{ matrix.os }}
+            ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}-${{ matrix.node }}
+            signalk/signalk-server-base:latest-${{ matrix.os }}-${{ matrix.node }}
           sources: |
-            ghcr.io/signalk/signalk-server-base:amd-${{ matrix.os }}
-            ghcr.io/signalk/signalk-server-base:arm-${{ matrix.os }}
+            ghcr.io/signalk/signalk-server-base:amd-${{ matrix.os }}-${{ matrix.node }}
+            ghcr.io/signalk/signalk-server-base:arm-${{ matrix.os }}-${{ matrix.node }}
 
   housekeeping:
     needs: create-and-push-manifest
@@ -98,5 +102,5 @@ jobs:
         with:
           packages: signalk-server-base
           delete-untagged: true
-          delete-tags: amd-22.04,arm-22.04,amd-24.04,arm-24.04
+          delete-tags: amd-24.04-22.x,arm-24.04-24.x
           token: ${{ secrets.GHCR_PAT }} # Need to have delete permission

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - name: Build npm files locally and upload artifacts
         run: |
           npm cache clean -f
@@ -44,7 +44,8 @@ jobs:
     needs: signalk-server_npm_files
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
         vm: [ubuntu-latest, ubuntu-24.04-arm]
         include:
           - vm: ubuntu-latest
@@ -52,7 +53,12 @@ jobs:
             platform: linux/amd64
           - vm: ubuntu-24.04-arm
             arch: arm
+            node: 22.x
             platform: linux/arm64,linux/arm/v7
+          - vm: ubuntu-24.04-arm
+            arch: arm
+            node: 24.x
+            platform: linux/arm64 #,linux/arm/v7 Nodejs 24.x is working correctly and therefore disabled for now
     runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
@@ -76,20 +82,23 @@ jobs:
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ github.run_id }}
+          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
           build-args: |
             REGISTRY=ghcr.io
-            UBUNTU_VERSION=${{ matrix.os }}
+            UBUNTU_VERSION=${{ matrix.os }}-${{ matrix.node }}
+
   create-and-push-manifest:
     needs: docker_images
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
         include:
           - os: 24.04
-            suffix: -24.04
+            node: 24.x
+            suffix: -24.x
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -124,8 +133,8 @@ jobs:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
           sources: |
-            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}-${{ github.run_id }}
-            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-${{ github.run_id }}
+            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
+            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
 
   housekeeping:
     if: github.event_name != 'pull_request'
@@ -139,5 +148,5 @@ jobs:
         with:
           packages: signalk-server
           delete-untagged: true
-          delete-tags: amd-22.04-${{ github.run_id }},arm-22.04-${{ github.run_id }},amd-24.04-${{ github.run_id }},arm-24.04-${{ github.run_id }}
+          delete-tags: amd-24.04-22.x-${{ github.run_id }},arm-24.04-24.x-${{ github.run_id }}
           token: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install and build all
@@ -115,7 +115,8 @@ jobs:
     needs: build_and_publish
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
         vm: [ubuntu-latest, ubuntu-24.04-arm]
         include:
           - vm: ubuntu-latest
@@ -123,7 +124,12 @@ jobs:
             platform: linux/amd64
           - vm: ubuntu-24.04-arm
             arch: arm
+            node: 22.x
             platform: linux/arm64,linux/arm/v7
+          - vm: ubuntu-24.04-arm
+            arch: arm
+            node: 24.x
+            platform: linux/arm64 #,linux/arm/v7 Nodejs 24.x is working correctly and therefore disabled for now
     runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
@@ -142,7 +148,7 @@ jobs:
       - name: Modify Dockerfile_rel for build
         run: |
           sed -i \
-            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}|g" \
+            "s|cr.signalk.io/signalk/signalk-server-base:latest|ghcr.io/signalk/signalk-server-base:latest-${{ matrix.os }}-${{ matrix.node }}|g" \
             ./docker/Dockerfile_rel
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -151,7 +157,7 @@ jobs:
           file: ./docker/Dockerfile_rel
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ github.run_id }}
+          tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
           build-args: |
             TAG=${{ steps.vars.outputs.tag }}
 
@@ -160,13 +166,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [22.04, 24.04]
+        os: [24.04]
+        node: [22.x, 24.x]
         include:
-          - os: 22.04
+          - os: 24.04
+            node: 22.x
             tag: latest
           - os: 24.04
+            node: 24.x
             tag: latest
-            suffix: -24.04
+            suffix: -24.x
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -203,8 +212,8 @@ jobs:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
           sources: |
-            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}-${{ github.run_id }}
-            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-${{ github.run_id }}
+            ghcr.io/signalk/signalk-server:amd-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
+            ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-${{ matrix.node }}-${{ github.run_id }}
 
   housekeeping:
     needs: create-and-push-manifest
@@ -217,7 +226,7 @@ jobs:
         with:
           packages: signalk-server
           delete-untagged: true
-          delete-tags: amd-22.04-${{ github.run_id }},arm-22.04-${{ github.run_id }},amd-24.04-${{ github.run_id }},arm-24.04-${{ github.run_id }}
+          delete-tags: amd-24.04-22.x-${{ github.run_id }},arm-24.04-24.x-${{ github.run_id }}
           token: ${{ secrets.GHCR_PAT }}
 
   deploy_fly:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY="cr.signalk.io"
-ARG UBUNTU_VERSION="24.04"
+ARG UBUNTU_VERSION="24.04-22.x"
 
 FROM ${REGISTRY}/signalk/signalk-server-base:latest-${UBUNTU_VERSION} AS base
 

--- a/docker/Dockerfile_base_24.04
+++ b/docker/Dockerfile_base_24.04
@@ -1,4 +1,5 @@
 FROM ubuntu:24.04
+ARG NODE
 
 RUN userdel -r ubuntu
 RUN groupadd --gid 1000 node \
@@ -11,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 # Modification to set time without need to use sudo
 RUN chmod u+s /usr/bin/date
 
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_$NODE | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs \
   && npm config rm proxy \
   && npm config rm https-proxy \


### PR DESCRIPTION
Changelog:
- use Ubuntu 24.04 as a base image
- remove Ubuntu 22.04 support
- use Node 22.x as a main node version
- add Node 24.x for development purposes
- optimize build process
- add testing to cover Node 24.x