### PR TITLE
Revert docker pr builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - '*'
       - '!v*'
-  pull_request:
-
   workflow_dispatch:
 
 jobs:
@@ -75,14 +73,13 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: github.event_name != 'pull_request'
+          push: true
           tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ github.run_id }}
           build-args: |
             REGISTRY=ghcr.io
             UBUNTU_VERSION=${{ matrix.os }}
   create-and-push-manifest:
     needs: docker_images
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -128,7 +125,6 @@ jobs:
             ghcr.io/signalk/signalk-server:arm-${{ matrix.os }}-${{ github.run_id }}
 
   housekeeping:
-    if: github.event_name != 'pull_request'
     needs: create-and-push-manifest
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -75,7 +75,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: github.event_name != 'pull_request'
           tags: ghcr.io/signalk/signalk-server:${{ matrix.arch }}-${{ matrix.os }}-${{ github.run_id }}
           build-args: |
             REGISTRY=ghcr.io


### PR DESCRIPTION
It seems that getting Docker builds to work in PRs requires a nontrivial amount of work. PRs breaking docker build have not been a frequent problem,  so let's revert these.

