### PR TITLE
fix: test run on Node v24

### DIFF
--- a/test/deltaPriority.ts
+++ b/test/deltaPriority.ts
@@ -1,9 +1,6 @@
 import { SourceRef } from '@signalk/server-api'
 import assert from 'assert'
-import {
-  getToPreferredDelta,
-  SourcePrioritiesData
-} from '../dist/deltaPriority.js'
+import { getToPreferredDelta, SourcePrioritiesData } from '../src/deltaPriority'
 import chai from 'chai'
 chai.should()
 


### PR DESCRIPTION
Import from ts instead of js to avoid

SyntaxError: Named export 'SourcePrioritiesData' not found. The requested module '../dist/deltaPriority.js' is a CommonJS module, which may not support all module.exports as named exports. C