### PR TITLE
fix: Align chart server type OpenAPI definitions.

### DIFF
--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -479,7 +479,7 @@
           "type": {
             "type": "string",
             "description": "Source type of map data.",
-            "enum": ["tilejson", "WMS", "WMTS", "mapboxstyle", "S-57"],
+            "enum": ["tileJSON", "WMS", "WMTS", "mapstyleJSON", "S-57"],
             "example": "WMTS"
           }
         }


### PR DESCRIPTION
The chart server types defined in the openapi definition are used to validate request payloads.
They do not match the values used in practise by charts-plugin, etc and need to be aligned to allow chart entries to be written via the resources API.
