### PR TITLE
fix: nodejs 24.x for arm64 and amd64 not arm/v7

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -18,7 +18,12 @@ jobs:
             platform: linux/amd64
           - vm: ubuntu-24.04-arm
             arch: arm
+            node: 22.x
             platform: linux/arm64,linux/arm/v7
+          - vm: ubuntu-24.04-arm
+            arch: arm
+            node: 24.x
+            platform: linux/arm64
     runs-on: ${{ matrix.vm }}
     steps:
       - uses: actions/checkout@v4
@@ -102,5 +107,5 @@ jobs:
         with:
           packages: signalk-server-base
           delete-untagged: true
-          delete-tags: amd-24.04-22.x,arm-24.04-24.x
+          delete-tags: amd-24.04-24.x,amd-24.04-22.x,arm-24.04-24.x,arm-24.04-22.x
           token: ${{ secrets.GHCR_PAT }} # Need to have delete permission


### PR DESCRIPTION
Fixes build error with #2078 

Base image on Nodejs 24.x will support arm64 and amd64, not arm/v7
Base image on Nodejs22.x will support amr64, amd64 and arm/v7

