### PR TITLE
fix: use default systemd logging

### DIFF
--- a/bin/signalk-server-setup
+++ b/bin/signalk-server-setup
@@ -302,8 +302,6 @@ function promptForVesselName(configDirectory, updateExisting) {
                 let serverd = `[Service]
 ExecStart=${startupLocation}
 Restart=always
-StandardOutput=syslog
-StandardError=syslog
 WorkingDirectory=${configDirectory}
 User=${process.env.SUDO_USER}
 Environment=EXTERNALPORT=${primaryPort}


### PR DESCRIPTION
Fixes #1814. On modern systems logging is alredy using journal under the hood, so remove the superfluous
config that does nothing, only generates a warning.