### PR TITLE
Fix: installed plugin/webapp version display

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/VersionCellRenderer.js
@@ -5,10 +5,7 @@ export default function NameCellRenderer(props) {
     <div className="cell__renderer cell-version center">
       <div className="version__container">
         <span className="version">
-          v
-          {props.data.newVersion
-            ? props.data.installedVersion
-            : props.data.version}
+          v{props.data.installedVersion || props.data.version}
         </span>
 
         {/* 

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -202,6 +202,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        text-align: center;
 
         .version--update {
           color: #00cd79;


### PR DESCRIPTION
Previously the installed version would show correctly only when there is
an update available. This makes sense for normal versions, because if
there is no update available you are running the latest version.

However, for beta versions there probably is no update yet available, as
you are have a prerelease version.

This comment changes the logic to always show installed version, if that
is available.

Fixes SignalK/freeboard-sk#291