### PR TITLE
fix: Ensure course destination is updated when active route is changed.

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -196,6 +196,19 @@ export class CourseApi {
                   this.courseInfo.activeRoute.name = rte.name as string
                   this.courseInfo.activeRoute.pointTotal =
                     rte.feature.geometry.coordinates.length
+
+                  const pointIndex = this.parsePointIndex(
+                    this.courseInfo.activeRoute.pointIndex as number,
+                    rte
+                  )
+                  this.courseInfo.nextPoint = {
+                    type: RoutePoint,
+                    position: this.getRoutePoint(
+                      rte,
+                      pointIndex,
+                      !!this.courseInfo.activeRoute.reverse
+                    )
+                  }
                   this.emitCourseInfo()
                 }
               }


### PR DESCRIPTION
Fixes an issue where the active route has been modified and the coordinates of  `nextPoint.position`  were not updated to reflect changes in the  route points.
