### PR TITLE
feat: Expose weather api methods to plugins

### DIFF
--- a/packages/server-api/src/weatherapi.ts
+++ b/packages/server-api/src/weatherapi.ts
@@ -3,6 +3,108 @@ import { Position } from '.'
 export interface WeatherApi {
   register: (pluginId: string, provider: WeatherProvider) => void
   unRegister: (pluginId: string) => void
+
+  /**
+   * Retrieves observation data from the weather provider for the supplied position.
+   * The returned array of observations should be ordered in descending date order.
+   *
+   * @category Weather API
+   * 
+   * @param position Location of interest 
+   * @param options Options
+   * 
+   * @example
+    ```javascript
+    getObservations({latitude: 16.34765, longitude: 12.5432}, {maxCount: 1});
+    ```
+
+    ```JSON
+    [
+        {
+            "date": "2024-05-03T06:00:00.259Z",
+            "type": "observation",
+            "outside": { ... }
+        },
+        {
+            "date": "2024-05-03T05:00:00.259Z",
+            "type": "observation",
+            "outside": { ... }
+        }
+    ]
+    ```
+  */
+  getObservations: (
+    position: Position,
+    options?: WeatherReqParams
+  ) => Promise<WeatherData[]>
+
+  /**
+   * Retrieves forecast data from the weather provider for the supplied position, forecast type and number of intervals.
+   * The returned array of forecasts should be ordered in ascending date order.
+   * 
+   * @category Weather API
+   * 
+   * @param position Location of interest 
+   * @param type Type of forecast point | daily
+   * @param options Options
+   * 
+   * @example
+   * Retrieve point forecast data for the next eight point intervalss
+    ```javascript
+    getForecasts(
+      {latitude: 16.34765, longitude: 12.5432}, 
+      'point',
+      {maxCount: 8}
+    );
+    ```
+
+    ```JSON
+    [
+        {
+            "date": "2024-05-03T06:00:00.259Z",
+            "type": "point",
+            "outside": { ... }
+        },
+        {
+            "date": "2024-05-03T05:00:00.259Z",
+            "type": "point",
+            "outside": { ... }
+        }
+    ]
+    ```
+  */
+  getForecasts: (
+    position: Position,
+    type: WeatherForecastType,
+    options?: WeatherReqParams
+  ) => Promise<WeatherData[]>
+
+  /**
+   * Retrieves warning data from the weather provider for the supplied position.
+   * The returned array of warnings should be ordered in ascending date order.
+   *
+   * @category Weather API
+   * 
+   * @param position Location of interest 
+   *
+   * @example
+    ```javascript
+    getWarnings({latitude: 16.34765, longitude: 12.5432});
+    ```
+
+    ```JSON
+    [
+      {
+        "startTime": "2024-05-03T05:00:00.259Z",
+        "endTime": "2024-05-03T08:00:00.702Z",
+        "details": "Strong wind warning.",
+        "source": "MyWeatherService",
+        "type": "Warning"
+      }
+    ]
+    ```
+  */
+  getWarnings: (position: Position) => Promise<WeatherWarning[]>
 }
 
 export interface WeatherProviderRegistry {
@@ -13,6 +115,12 @@ export interface WeatherProviderRegistry {
    * @category Weather API
    */
   registerWeatherProvider: (provider: WeatherProvider) => void
+  /**
+   * Access the Weather API to get observations, forcasts and warnings.
+   *
+   * @category Weather API
+   */
+  weatherApi: WeatherApi
 }
 
 /**

--- a/src/api/weather/index.ts
+++ b/src/api/weather/index.ts
@@ -15,7 +15,8 @@ import {
   WeatherData,
   isWeatherProvider,
   Position,
-  WeatherReqParams
+  WeatherReqParams,
+  WeatherForecastType
 } from '@signalk/server-api'
 
 const WEATHER_API_PATH = `/signalk/v2/api/weather`
@@ -88,6 +89,85 @@ export class WeatherApi {
       'defaultProvider =',
       this.defaultProviderId
     )
+  }
+
+  /** Server API methods */
+
+  /**
+   * @description Return array of observations for the provided location
+   * @param position Location for which to retrieve observation data
+   * @param options Parameters to filter the returned data
+   */
+  async getObservations(position: Position, options?: WeatherReqParams) {
+    const q = this.parseQueryOptions({
+      position: position,
+      options: options
+    })
+    if (
+      this.defaultProviderId &&
+      this.weatherProviders.has(this.defaultProviderId)
+    ) {
+      debug(`Using default provider...${this.defaultProviderId}`)
+      return await this.weatherProviders
+        .get(this.defaultProviderId as string)
+        ?.methods.getObservations(q.position, q.options)
+    } else {
+      throw new Error(`Provider not found!`)
+    }
+  }
+
+  /**
+   * @description Return array of forecasts for the provided location
+   * @param position Location for which to retrieve forecast data
+   * @param type Type of forecast point | daily
+   * @param options Parameters to filter the returned data
+   */
+  async getForecasts(
+    position: Position,
+    type: WeatherForecastType,
+    options?: WeatherReqParams
+  ) {
+    const q = this.parseQueryOptions({
+      position: position,
+      options: options
+    })
+    if (
+      this.defaultProviderId &&
+      this.weatherProviders.has(this.defaultProviderId)
+    ) {
+      debug(`Using default provider...${this.defaultProviderId}`)
+      const fdata = await this.weatherProviders
+        .get(this.defaultProviderId as string)
+        ?.methods.getForecasts(q.position, type, q.options)
+      return fdata
+        ? fdata.filter((i: WeatherData) => {
+            return i.type === type
+          })
+        : []
+    } else {
+      throw new Error(`Provider not found!`)
+    }
+  }
+
+  /**
+   * @description Return array of warnings for the provided location
+   * @param position Location for which to retrieve warning data
+   */
+  async getWarnings(position: Position) {
+    const q = this.parseQueryOptions({
+      position: position
+    })
+    if (
+      this.defaultProviderId &&
+      this.weatherProviders.has(this.defaultProviderId)
+    ) {
+      debug(`Using default provider...${this.defaultProviderId}`)
+      return await this.weatherProviders
+        .get(this.defaultProviderId as string)
+        ?.methods.getWarnings(q.position)
+    } else {
+      throw new Error(`Provider not found!`)
+    }
   }
 
   // *************************************


### PR DESCRIPTION
Make the  `getObservations()`, `getForecasts()` and `getWarnings()` methods available to plugins.