### PR TITLE
PoC of unit conversions in DataBrowser

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -20,6 +20,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@signalk/formula-evaluator": "file:./signalk-formula-evaluator-1.0.0.tgz",
     "@signalk/server-admin-ui-dependencies": "1.0.1",
     "ansi-to-html": "^0.6.14",
     "babel-loader": "^8.1.0",

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -53,6 +53,15 @@ function fetchSources() {
     })
 }
 
+async function fetchSelfPaths() {
+  fetch(`/signalk/v2/api/selfPaths`, {
+    credentials: 'include'
+  }).then((response) => response.json()).then((paths) => {
+    this.setState({ ...this.state, paths })
+    console.log(paths)
+  })
+}
+
 class DataBrowser extends Component {
   constructor(props) {
     super(props)
@@ -70,10 +79,12 @@ class DataBrowser extends Component {
         JSON.parse(localStorage.getItem(selectedSourcesStorageKey) || '[]')
       ),
       sourceFilterActive:
-        localStorage.getItem(sourceFilterActiveStorageKey) === 'true'
+        localStorage.getItem(sourceFilterActiveStorageKey) === 'true',
+      paths: {}
     }
 
     this.fetchSources = fetchSources.bind(this)
+    this.fetchSelfPaths = fetchSelfPaths.bind(this)
     this.handlePause = this.handlePause.bind(this)
     this.handleMessage = this.handleMessage.bind(this)
     this.handleContextChange = this.handleContextChange.bind(this)
@@ -203,6 +214,7 @@ class DataBrowser extends Component {
 
   componentDidMount() {
     this.fetchSources()
+    this.fetchSelfPaths()
     this.subscribeToDataIfNeeded()
   }
 
@@ -666,6 +678,7 @@ class DataBrowser extends Component {
                                     <DefaultValueRenderer
                                       value={data.value}
                                       units={units}
+                                      pathInfo={this.state.paths[data.path]}
                                     />
                                   )
                                 })()}


### PR DESCRIPTION
Use https://github.com/motamman/signalk-units-preference as the backend and code on the clientside to implement conversion to preferred units on the client side in DataBrowser.

Based on https://github.com/motamman/signalk-units-preference/pull/16

Kinda works: (except we are missing /s from m/s...)
<img width="829" height="91" alt="image" src="https://github.com/user-attachments/assets/d6750f20-ccc6-4b21-a731-0a395d898a4a" />
