### PR TITLE
Weather API: Open API definition updates

### DIFF
--- a/packages/server-api/src/weatherapi.ts
+++ b/packages/server-api/src/weatherapi.ts
@@ -176,13 +176,11 @@ export interface WeatherWarning {
  *
  * @prop maxCount Maximum number of records to return
  * @prop startDate Start date of forecast / observation data (format: YYYY-MM-DD)
- * @prop custom Additional query parameters in the API request
  * @category  Weather API
  */
 export interface WeatherReqParams {
   maxCount?: number
   startDate?: string
-  custom?: { [key: string]: string | number | boolean | object | null }
 }
 
 /**

--- a/src/api/weather/index.ts
+++ b/src/api/weather/index.ts
@@ -446,24 +446,18 @@ export class WeatherApi {
       },
       options: {}
     }
-    delete query.lat
-    delete query.lon
-    delete query.provider
     if ('count' in query) {
       const n = this.parseValueAsNumber(query.count)
       if (typeof n === 'number') {
         q.options.maxCount = n
       }
-      delete query.count
     }
     if ('date' in query) {
       const pattern = /[0-9]{4}-[0-9]{2}-[0-9]{2}/
       if ((query.date as string).match(pattern)) {
         q.options.startDate = query.date?.toString()
       }
-      delete query.date
     }
-    Object.assign(q.options, { custom: query })
     return q
   }
 


### PR DESCRIPTION
Updated OpenAPI definition to contain SI base units for:
- absoluteHumidity (% -> ratio)
- relativeHumitiy (% -> ratio)
- cloudCover (% -> ratio)
- waterSalinity (% -> ratio)
- precipitationVolume (mm -> m)
