### PR TITLE
fix: guard against undefined webapp.displayName

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -190,7 +190,7 @@ module.exports = function (
     const targetWebapp = app.webapps.find(
       (webapp) =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (webapp as any).signalk?.displayName.toLowerCase() === firstHostName
+        (webapp as any).signalk?.displayName?.toLowerCase() === firstHostName
     )
     if (targetWebapp) {
       landingPage = `/${targetWebapp.name}/`


### PR DESCRIPTION
If some webapp does not have a displayname the redirect from / will fail when trying to do the special
hostname-webapp lookup.