### PR TITLE
fix: @js-temporal/polyfill as runtime dep

### DIFF
--- a/packages/server-api/package.json
+++ b/packages/server-api/package.json
@@ -20,9 +20,11 @@
   },
   "author": "teppo.kurki@iki.fi",
   "license": "Apache-2.0",
-  "devDependencies": {
-    "ts-auto-guard": "^5.0.1",
+  "dependencies": {
     "@js-temporal/polyfill": "^0.5.1"
+  },
+  "devDependencies": {
+    "ts-auto-guard": "^5.0.1"
   },
   "peerDependencies": {
     "baconjs": "^1.0.1"


### PR DESCRIPTION
@js-temporal/polyfill is a runtime dependency,
as it provides the implementations, not just
types.