### PR TITLE
fix : security endpoints http fails logged when security is disabled

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -433,6 +433,13 @@ module.exports = function (
       '/security/access/requests/:identifier/:status' // for backwards compatibly with existing clients
     ],
     (req: Request, res: Response) => {
+      if (!app.securityStrategy.setAccessRequestStatus) {
+        res.status(404).json({
+          message:
+            'Access requests not available. Server security may not be enabled.'
+        })
+        return
+      }
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)
         app.securityStrategy.setAccessRequestStatus(
@@ -453,6 +460,13 @@ module.exports = function (
   app.get(
     `${SERVERROUTESPREFIX}/security/access/requests`,
     (req: Request, res: Response) => {
+      if (!app.securityStrategy.getAccessRequestsResponse) {
+        res.status(404).json({
+          message:
+            'Access requests not available. Server security may not be enabled.'
+        })
+        return
+      }
       if (checkAllowConfigure(req, res)) {
         res.json(app.securityStrategy.getAccessRequestsResponse())
       }


### PR DESCRIPTION
# Fix: Security Endpoints Return 401 When Security is Disabled

## Status: FIXED

## Problem

When SignalK server security is disabled (dummy security mode), the admin UI makes requests to `/skServer/security/access/requests` which returns `401 Unauthorized`, causing console errors in the browser.

**Symptom**: Browser console shows:
```
XHR GET http://192.168.0.10:3000/skServer/security/access/requests [HTTP/1.1 401 Unauthorized 11ms]
```

**Impact**: Low severity - cosmetic browser console error, doesn't break functionality but confuses users.

## Root Cause

In `src/serverroutes.ts`, the GET endpoint for access requests uses `checkAllowConfigure()` which calls `app.securityStrategy.allowConfigure(req)`.

When security is disabled, `src/dummysecurity.ts` is used, which:
1. Returns `false` from `allowConfigure()` (line 30-32)
2. Does NOT define `getAccessRequestsResponse()` method

This causes the endpoint to return 401 even though there's no security to configure.

**Inconsistency**: The POST endpoint at `/signalk/v1/access/requests` already handles this correctly by checking if the method exists before calling it.

## Solution

Follow the same pattern as the POST endpoint - check if the security method exists before attempting to use it. If the method doesn't exist (dummy security), return 404 with a helpful message instead of 401.

### Changes Made

**File**: `src/serverroutes.ts`

**GET `/skServer/security/access/requests`** (around line 460):
```typescript
app.get(
  `${SERVERROUTESPREFIX}/security/access/requests`,
  (req: Request, res: Response) => {
    if (!app.securityStrategy.getAccessRequestsResponse) {
      res.status(404).json({
        message:
          'Access requests not available. Server security may not be enabled.'
      })
      return
    }
    if (checkAllowConfigure(req, res)) {
      res.json(app.securityStrategy.getAccessRequestsResponse())
    }
  }
)
```

**PUT `/skServer/security/access/requests/:identifier/:status`** (around line 436):
```typescript
app.put(
  [
    `${SERVERROUTESPREFIX}/security/access/requests/:identifier/:status`,
    '/security/access/requests/:identifier/:status'
  ],
  (req: Request, res: Response) => {
    if (!app.securityStrategy.setAccessRequestStatus) {
      res.status(404).json({
        message:
          'Access requests not available. Server security may not be enabled.'
      })
      return
    }
    if (checkAllowConfigure(req, res)) {
      // ... existing code
    }
  }
)
```

## Why 404 Instead of Other Options?

| Option | Pros | Cons |
|--------|------|------|
| **404 with message** (chosen) | Consistent with existing POST endpoint pattern, clear error message | - | | 200 with empty array | Simpler for UI | Misleading - implies security is enabled but no requests | | Modify dummysecurity.ts | Centralized fix | Changes semantics of `allowConfigure` |

## Verification

- `npm run build` - passes
- `npm test` - passes (1 pre-existing unrelated failure)
- `npx prettier --write src/serverroutes.ts` - no changes needed

## Testing

1. Run SignalK server with security disabled
2. Open admin UI in browser
3. Open browser developer console
4. Verify no 401 errors on `/skServer/security/access/requests`
5. Should see 404 instead (which the UI handles gracefully)

## Related Files

- `src/serverroutes.ts` - Fixed endpoints
- `src/dummysecurity.ts` - Dummy security strategy (unchanged)
- `src/tokensecurity.js` - Real security strategy (reference)