### PR TITLE
fix timestamp 8601 error in debug log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ class Server {
       status.type = type
       status.id = providerId
       status.statusType = statusType
-      status.timeStamp = new Date().toLocaleString()
+      status.timeStamp = new Date().toISOString()
 
       status.message = statusMessage
 


### PR DESCRIPTION
related to issue: https://github.com/SignalK/signalk-server/issues/2139

# Issue: Plugin status timestamps not ISO 8601 compliant

## Problem

Plugin status messages display timestamps in locale-dependent format (e.g., `11/10/2025, 1:40:38 PM`) instead of ISO 8601 format (`2025-11-10T13:40:38.000Z`).

This causes:

1. **Ambiguous dates**: `11/10/2025` could be Nov 10 or Oct 11 depending on locale
2. **Inconsistent formatting**: Different servers show different formats based on system locale
3. **Inconsistency with other logs**: `app.debug()` already uses ISO 8601 via the `debug` module

### Example log output

```
2025-12-07T02:39:56.989Z signalk:wasm:sockets [@mayara/signalk-radar] Socket 1 bound...  <-- ISO 8601 (good)
11/10/2025, 1:40:38 PM: No GPS position data for 15 minutes.                             <-- locale format (bad)
11/10/2025, 11:04:35 PM: Failed to fetch StormGlass.io: Payment Required                 <-- locale format (bad)
```

### After Fix

```
Dec 07 15:34:57 pi5 signalk-server[1099239]: 2025-12-07T03:34:57.853Z signalk-tides Fetching StormGlass.io: https://api.stormglass.io/v2/tide/extremes/point?start=2025-12-06&end=2025-12-13&lat=-17.6814471&lng=177.383824
Dec 07 15:45:56 pi5 signalk-server[1099829]: 2025-12-07T03:45:56.969Z signalk-tides Starting tides-api: {"source":"stormglass","stormglassApiKey":"716da4d8-cbf9-11f0-b5c3-0242ac130003-716da550-cbf9-11f0-b5c3-0242ac130003","worldtidesApiKey":"930c78df-cc70-499a-8a85-c13759bf29fd","period":180,"stationSwitchThreshold":10,"enableOfflineFallback":true,"offlineMode":"auto","showOfflineWarning":true,"datum":"MLLW"}
Dec 07 15:46:00 pi5 signalk-server[1099829]: 2025-12-07T03:46:00.769Z signalk-tides Fetching StormGlass.io: https://api.stormglass.io/v2/tide/extremes/point?start=2025-12-06&end=2025-12-13&lat=-17.6815&lng=177.3839166
```

## Root Cause

In `src/index.ts`, the `doSetProviderStatus()` function uses `toLocaleString()`:

```typescript
// Line 205
status.timeStamp = new Date().toLocaleString()
```

## Solution

Change line 205 in `src/index.ts` from:

```typescript
status.timeStamp = new Date().toLocaleString()
```

to:

```typescript
status.timeStamp = new Date().toISOString()
```

## Files to modify

- `src/index.ts` - line 205

## Testing

Sucessfuly tested with the signalk-tides plugin that the user mentioned as example in his issue report.

## Additional considerations

- `lastErrorTimeStamp` on line 199 copies from the previous `status.timeStamp`, so it will automatically use ISO 8601 format once the fix is deployed (no additional changes needed).

## Related

- `app.debug()` already uses ISO 8601 via the `debug` npm module
- `app.error()` in `src/interfaces/plugins.ts` does not add timestamps (just prefixes with package name)
