### PR TITLE
docs:  Explain preserve packages and Adds format/lint step to PR submission guideline

### DIFF
--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -46,6 +46,23 @@ As you work on your changes, you may need to re-build changes. To continuously w
 
 You may also need to restart the server to see some changes reflected.
 
+### Developing workspace packages
+
+When making changes to packages in the `packages/` directory (e.g., `server-admin-ui`, `streams`, `server-api`), use:
+
+```shell
+npm run build:all
+```
+
+This builds your local workspace packages and the server.
+
+| Script      | What it does            | Use case                           |
+| ----------- | ----------------------- | ---------------------------------- |
+| `build:all` | workspaces + tsc + docs | When working on workspace packages |
+| `build`     | tsc only                | Quick recompile (server code only) |
+
+**Important:** Avoid running `npm install` after making local changes to workspace packages, as it may overwrite your changes with registry versions. If you need to add new dependencies, install them individually with `npm install <package-name>`.
+
 ### Using sample data
 
 Start the server with sample data by running:
@@ -74,6 +91,15 @@ Before you submit your Pull Request (PR) consider the following guidelines:
    ```
 
 1. Create your patch.
+1. Format and lint your code before committing:
+
+   ```shell
+   npm run format
+   npm run lint
+   ```
+
+   Fix any lint errors before proceeding.
+
 1. Commit your changes using a descriptive commit message that follows the
    [conventions outlined here](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits). Whilst we are not 100% strict about this, it really helps when reviewing the PR and in making the commit history readable. The TL;DR of it is below.
    - The subject line should be in the format `<type>: <subject>`, where `<type>` should be one of:


### PR DESCRIPTION
Thank you for your latest PR #2167, I learned a lot from it and how I have to do it the way you want it.
With this PR I would love to add my lessons learned, as I am new to the "game" and not yet used to "old habbits". 
I hope this contribution is valuable for you and others can benefit from it. 


# PR: Improve contributing documentation

## Summary

Add documentation for developing workspace packages and format/lint requirements.

## Changes

**docs/develop/contributing.md** (documentation only, no code changes):

1. **Added "Developing workspace packages" section** - Documents how to work with packages in the `packages/` directory without losing local changes

2. **Added format/lint step to PR submission guidelines** - Instructs contributors to run `npm run format` and `npm run lint` before committing

## Developing workspace packages

When making changes to packages in the `packages/` directory, use `npm run build:all` instead of just `npm run build`.

| Script      | What it does            | Use case                           |
| ----------- | ----------------------- | ---------------------------------- |
| `build:all` | workspaces + tsc + docs | When working on workspace packages |
| `build`     | tsc only                | Quick recompile (server code only) |

**Important:** Avoid running `npm install` after making local changes to workspace packages, as it may overwrite your changes with registry versions.

## Commit Message

```
docs: add workspace development and format/lint guidelines

Add documentation for developing workspace packages using build:all
and add format/lint step to PR submission guidelines.

Motivation: Help contributors understand how to work with packages/
directory without losing local changes, and ensure PRs are properly
formatted before submission.
```

## Checklist

- [x] `npm run format` executed
- [x] `npm run lint` executed (no errors)
- [x] Follows commit message conventions (`docs: <subject>`)
- [x] Documentation only change (no code changes)
- [x] Pushed to fork

## Notes

- The Node 18.x test failure (`Resources Api - Create route with route point metadata`) is a pre-existing issue unrelated to this PR (our changes are documentation only)
