### PR TITLE
chore: Docker image pipelines updates

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Node setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
       - name: Build npm files locally and upload artifacts
         run: |
           npm cache clean -f
@@ -31,7 +31,7 @@ jobs:
           rm signalk-typedoc-signalk-theme*.tgz # This is only needed as a dev dependency
           npm pack
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 1
           name: packed-modules
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to ghcr.io
@@ -70,7 +70,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: packed-modules
       - name: Build and push
@@ -98,7 +98,7 @@ jobs:
             suffix: -22.x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -115,7 +115,7 @@ jobs:
       - name: Save docker tags to artifact
         run: echo "${{ steps.docker_meta.outputs.tags }}" > docker_tags_${{ matrix.os }}_${{ matrix.node }}.txt
       - name: Upload tags
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 1
           name: docker_tags_${{ matrix.os }}_${{ matrix.node }}
@@ -148,7 +148,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
       - name: Download Docker tag artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: docker_tags_${{ matrix.os }}_${{ matrix.node }}
       - name: Normalize and filter GHCR tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
@@ -146,7 +146,7 @@ jobs:
     runs-on: ${{ matrix.vm }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to ghcr.io
@@ -191,7 +191,7 @@ jobs:
             tag: latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Docker meta
@@ -211,7 +211,7 @@ jobs:
       - name: Save docker tags to artifact
         run: echo "${{ steps.docker_meta.outputs.tags }}" > docker_tags_${{ matrix.os }}_${{ matrix.node }}.txt
       - name: Upload tags
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 1
           name: docker_tags_${{ matrix.os }}_${{ matrix.node }}
@@ -244,7 +244,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
       - name: Download Docker tag artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: docker_tags_${{ matrix.os }}_${{ matrix.node }}
       - name: Normalize and filter GHCR tags
@@ -287,7 +287,7 @@ jobs:
     needs: create-and-push-manifest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Set TAG for build-arg


### PR DESCRIPTION
Docker image process updated
- release and intermediate docker images release to ghcr.io and then copied to docker.io
-  default node version changed from 22.x to 24.x
- GA actions updates