### PR TITLE
feat: use --ignore-scripts for AppStore plugin installs

### DIFF
--- a/docs/develop/plugins/publishing.md
+++ b/docs/develop/plugins/publishing.md
@@ -66,6 +66,12 @@ _Example: package.json_
 }
 ```
 
+### Important: Avoid install-time scripts
+
+The Signal K AppStore installs plugins using `npm install --ignore-scripts` for security reasons. This means any `preinstall`, `install`, or `postinstall` scripts in your plugin's `package.json` will not run when users install your plugin through the AppStore.
+
+Ensure your npm package is ready to use without requiring install-time scripts. If you need build steps, use `prepublishOnly` instead - this runs before publishing to npm, so your package already contains everything it needs.
+
 #### Publishing your Plugin
 
 Once you have developed and tested your Plugin / WebApp you can publish it to make it visible in the AppStore.

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -220,7 +220,7 @@ export function runNpm(
 
   const npmArgs = isTheServerModule(name, config)
     ? [command, '-g']
-    : ['--save', command]
+    : ['--save', '--ignore-scripts', command]
 
   if (packageString) {
     npmArgs.push(packageString)


### PR DESCRIPTION
Addresses [Issue #2181](https://github.com/SignalK/signalk-server/issues/2181) 

Install plugins with npm's --ignore-scripts flag to improve security by preventing arbitrary code execution during installation.

Plugin developers should use prepublishOnly instead of postinstall scripts to ensure their packages work correctly when installed via the AppStore.