### PR TITLE
fix: race condition in Course API initialization

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -172,7 +172,7 @@ export class CourseApi {
    * 2. active route
    * are reflected in course deltas.
    */
-  private processResourceDeltas(delta: Delta) {
+  private async processResourceDeltas(delta: Delta) {
     let h: string[]
     if (this.courseInfo.activeRoute?.href) {
       h = this.courseInfo.activeRoute?.href.split('/').slice(-3)
@@ -184,9 +184,9 @@ export class CourseApi {
     const ref = h ? h.join('.') : undefined
     const refType = h ? h[1] : undefined
 
-    delta.updates.forEach((update: Update) => {
+    for (const update of delta.updates) {
       if (hasValues(update)) {
-        update.values.forEach(async (pathValue: PathValue) => {
+        for (const pathValue of update.values) {
           if (ref === pathValue.path) {
             if (refType === 'routes') {
               if (this.courseInfo.activeRoute) {
@@ -227,9 +227,9 @@ export class CourseApi {
               }
             }
           }
-        })
+        }
       }
-    })
+    }
   }
 
   // parse server settings


### PR DESCRIPTION
The Course API had two race conditions that caused flaky test failures, particularly visible on Node.js 24. These are the same patterns that were recently fixed in resources-provider-plugin.

First issue: the Store class was calling init() in its constructor but not waiting for it. If read() or write() was called before the directory was created, the operation would fail. Now Store keeps track of the init promise and waits for it before any file operation.

Second issue: processResourceDeltas() was using forEach with an async callback. This fires off all the async operations but returns immediately without waiting for them. Multiple resource updates would race each other and corrupt the courseInfo state. Replaced with for-of loops that properly await each operation in sequence.