### PR TITLE
fix: prevent race condition in resources-provider-plugin startup

### DIFF
--- a/packages/resources-provider-plugin/src/index.ts
+++ b/packages/resources-provider-plugin/src/index.ts
@@ -158,6 +158,17 @@ module.exports = (server: ResourceProviderApp): Plugin => {
         `** Enabled resource types: ${JSON.stringify(apiProviderFor)}`
       )
 
+      // register as provider for enabled resource types
+      const result = registerProviders(apiProviderFor)
+
+      if (result.length !== 0) {
+        server.setPluginError(
+          `Error registering providers: ${result.toString()}`
+        )
+      } else {
+        server.setPluginStatus(`Providing: ${apiProviderFor.toString()}`)
+      }
+
       // initialise resource storage
       db.init({ settings: config, basePath: server.getDataDirPath() })
         .then((res: { error: boolean; message: string }) => {
@@ -170,17 +181,6 @@ module.exports = (server: ResourceProviderApp): Plugin => {
           server.debug(
             `** ${plugin.name} started... ${!res.error ? 'OK' : 'with errors!'}`
           )
-
-          // register as provider for enabled resource types
-          const result = registerProviders(apiProviderFor)
-
-          if (result.length !== 0) {
-            server.setPluginError(
-              `Error registering providers: ${result.toString()}`
-            )
-          } else {
-            server.setPluginStatus(`Providing: ${apiProviderFor.toString()}`)
-          }
         })
         .catch((e: Error) => {
           server.debug(e.message)


### PR DESCRIPTION
Register resource providers synchronously before database initialization to prevent 404 errors when requests arrive during async initialization.

- Move registerProviders() call before db.init() in plugin startup
- Add initPromise/waitForInit() pattern in FileStore to ensure file operations wait for directory creation to complete
- Replace forEach with for-of loop in createSavePaths() to properly await async directory creation
- Add waitForInit() guard to getResource(), getResources(), and setResource() methods

This fixes intermittent failures in CI where resource requests would fail with 404 if they arrived before the async initialization completed.