### PR TITLE
fix: add security headers via helmet middleware

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -119,3 +119,25 @@ Many wifi networks allow communication between all connected computers, so your 
 So in the case that your server has a manually configured connection for _NMEA0183 over UDP_, NMEA0183 data broadcast by other devices will be received and written into your SIgnal K data.
 
 NMEA0183 connections over TCP and UDP are inherently unsafe. There are no options for authentication and / or secure communication. In comparison Signal K over TLS and HTTP / WebSockets can provide secure, authenticated read and write access to your data.
+
+## Security Headers
+
+Signal K Server uses the `helmet` middleware to set security-related HTTP headers:
+
+| Header                            | Value            | Purpose                                            |
+| --------------------------------- | ---------------- | -------------------------------------------------- |
+| X-Content-Type-Options            | nosniff          | Prevents MIME type sniffing attacks                |
+| X-Frame-Options                   | SAMEORIGIN       | Prevents clickjacking (allows same-origin iframes) |
+| X-DNS-Prefetch-Control            | off              | Privacy protection                                 |
+| X-Download-Options                | noopen           | Prevents IE from executing downloads               |
+| X-Permitted-Cross-Domain-Policies | none             | Blocks Flash/PDF cross-domain access               |
+| Referrer-Policy                   | no-referrer      | Privacy protection                                 |
+| Strict-Transport-Security         | max-age=15552000 | Forces HTTPS (only sent on HTTPS connections)      |
+
+### Intentionally Disabled
+
+The following helmet features are disabled to maintain compatibility with the SignalK ecosystem:
+
+- **Content-Security-Policy**: Would prevent webapps (Freeboard, Instrumentpanel) from loading external resources like map tiles and CDN scripts
+- **Cross-Origin-Embedder-Policy**: Would prevent chart plotters from embedding SignalK data
+- **Cross-Origin-Resource-Policy**: Would prevent legitimate cross-origin API access from instruments and apps

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci-lint": "eslint && prettier --check .",
     "update-latest-release": "git checkout master && git branch -D latest-release || git checkout -b latest-release && git push -f origin/latest-release",
     "start": "node bin/signalk-server",
-    "test-only": "mocha 'test/**/*.[jt]s' 'dist/**/*.test.js'",
+    "test-only": "NODE_ENV=test mocha 'test/**/*.[jt]s' 'dist/**/*.test.js'",
     "test": "npm run build && npm run test-only && npm run ci-lint",
     "heroku-postbuild": "npm run build:all",
     "master-changed-files": "git diff --name-status $(git tag | tail -1)..master"
@@ -101,6 +101,7 @@
     "figlet": "^1.2.0",
     "file-timestamp-stream": "^2.1.2",
     "geolib": "3.2.2",
+    "helmet": "^8.1.0",
     "inquirer": "^7.0.0",
     "json-patch": "^0.7.0",
     "jsonwebtoken": "^9.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ import { pipedProviders } from './pipedproviders'
 import { EventsActorId, WithWrappedEmitter, wrapEmitter } from './events'
 import { Zones } from './zones'
 import checkNodeVersion from './version'
+import helmet from 'helmet'
 const debug = createDebug('signalk-server')
 
 import { StreamBundle } from './streambundle'
@@ -91,6 +92,24 @@ class Server {
     const bodyParser = require('body-parser')
     const app = express() as any
     app.use(require('compression')())
+    app.use(
+      helmet({
+        // ENABLED (safe, no compatibility impact):
+        xContentTypeOptions: true,
+        xDnsPrefetchControl: true,
+        xDownloadOptions: true,
+        xPermittedCrossDomainPolicies: true,
+        referrerPolicy: true,
+        hsts: true,
+        frameguard: { action: 'sameorigin' },
+
+        // DISABLED (would break chart plotters, plugins, webapps):
+        contentSecurityPolicy: false,
+        crossOriginEmbedderPolicy: false,
+        crossOriginOpenerPolicy: false,
+        crossOriginResourcePolicy: false
+      })
+    )
     app.use(bodyParser.json({ limit: FILEUPLOADSIZELIMIT }))
 
     this.app = app


### PR DESCRIPTION
Add helmet middleware to set security HTTP headers on all responses. This prevents MIME sniffing attacks, clickjacking, and hides the Express server fingerprint.

Headers enabled:
- X-Content-Type-Options: nosniff
- X-Frame-Options: SAMEORIGIN
- Strict-Transport-Security (HTTPS only)
- Referrer-Policy: no-referrer
- X-DNS-Prefetch-Control, X-Download-Options, X-Permitted-Cross-Domain-Policies

Intentionally disabled for compatibility with chart plotters and plugins:
- Content-Security-Policy (would break external resource loading)
- Cross-Origin-Embedder-Policy (would break iframe embeds)
- Cross-Origin-Resource-Policy (would break cross-origin API access)

Set NODE_ENV=test in test script so rate limiters are skipped during tests.

Document security headers in docs/security.md.