### PR TITLE
Fix the path for autopilot availableActions message.

### DIFF
--- a/src/api/autopilot/index.ts
+++ b/src/api/autopilot/index.ts
@@ -173,7 +173,7 @@ export class AutopilotApi {
           if (Array.isArray(actions)) {
             const av = actions.filter((i) => i?.available).map((i) => i?.id)
             values.push({
-              path: `notifications.steering.autopilot.availableActions` as Path,
+              path: `steering.autopilot.availableActions` as Path,
               value: av
             })
           }


### PR DESCRIPTION
Corrected the path for `steering.autopilot.availableActions` which incorrectly started with `notifications.`.