### PR TITLE
Remove unused lodash.get from server-admin-ui devDependencies.

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -35,7 +35,6 @@
     "font-awesome": "^4.7.0",
     "html-webpack-plugin": "^5.0.0-alpha.6",
     "jsonlint-mod": "^1.7.6",
-    "lodash.get": "^4.4.2",
     "lodash.remove": "^4.7.0",
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",


### PR DESCRIPTION
I noticed npm install shows a deprecation warning for lodash.get. While investigating, I found that lodash.get is listed in `packages/server-admin-ui/package.json` but never actually imported or used in the source code.

Other lodash packages (lodash.remove, lodash.set, lodash.uniq) are actively used and remain unchanged.

Note: The lodash.get warning will still appear because it's also a transitive dependency of api-schema-builder → z-schema. I will address this in a separate PR. 
