### PR TITLE
Upgrade unzipper to fix fstream and rimraf deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "split": "^1.0.0",
     "stat-mode": "^1.0.0",
     "swagger-ui-express": "^4.5.0",
-    "unzipper": "^0.10.10",
+    "unzipper": "^0.12.3",
     "uuid": "^8.1.0",
     "ws": "^7.0.0"
   },


### PR DESCRIPTION
Upgrades unzipper from `0.10.x` to` 0.12.x` to eliminate deprecation warnings for:

- `fstream` - "This package is no longer supported"
- `rimraf@2` - "Rimraf versions prior to v4 are no longer supported"

The `0.12.x` version of unzipper replaced fstream with fs-extra internally, removing these deprecated transitive dependencies. The` Extract `API used by Signal K for backup restoration remains unchanged.

Tested:
- npm install
- npm run build:all
- npm run test-only
- backup config & restore