### PR TITLE
fix: Add missing shell option when running npm on Windows system

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -182,8 +182,12 @@ export function runNpm(
   }
   let npm
 
-  const opts: { cwd?: string } = {}
+  const opts: { cwd?: string; shell?: boolean } = {}
   let packageString
+
+  if (process.platform === 'win32') {
+    opts['shell'] = true
+  }
 
   if (name) {
     packageString = version ? `${name}@${version}` : name


### PR DESCRIPTION
fix #2229

As `npm.cmd` is a batch file, it must be called with the `shell = true` option.
https://nodejs.org/docs/latest-v22.x/api/child_process.html#spawning-bat-and-cmd-files-on-windows