### PR TITLE
fix: use ephemeral port for MFD webapp multicast publishing

### DIFF
--- a/src/interfaces/mfd_webapp.ts
+++ b/src/interfaces/mfd_webapp.ts
@@ -61,6 +61,10 @@ const send = (
   port: number
 ) => {
   const socket = dgram.createSocket('udp4')
+  socket.on('error', (err) => {
+    debug(`Socket error: ${err}`)
+    socket.close()
+  })
   socket.once('listening', () => {
     socket.send(msg, port, toAddress, () => {
       socket.close()


### PR DESCRIPTION
## Summary
Fix `EADDRINUSE` error when publishing webapp info to Navico MFDs

## Problem
When running Signal K in Docker, the` publishToNavico()` function (which runs every 10 seconds) was failing with:

`Error: bind EADDRINUSE 192.168.0.122:2053`

The issue: each call to `send()` created a new UDP socket bound to port 2053, but binding multiple sockets to the same port+address causes conflicts.

## Solution
Use an ephemeral port (0) for the sending socket instead of the fixed port 2053. The multicast destination port remains 2053 as required by Navico MFDs - only the source port changes, which doesn't affect the protocol.