### PR TITLE
feat: Add Radar API for radar device control

### DIFF
--- a/docs/develop/rest-api/README.md
+++ b/docs/develop/rest-api/README.md
@@ -5,6 +5,7 @@ children:
   - autopilot_api.md
   - course_api.md
   - history_api.md
+  - radar_api.md
   - resources_api.md
   - weather_api.md
   - plugin_api.md
@@ -26,6 +27,7 @@ APIs are available via `/signalk/v2/api/<endpoint>`
 | [`Autopilot`](./autopilot_api.md) | Provide the ability to send common commands to an autopilot via a provider plugin. | `vessels/self/autopilot`         |
 | [Course](./course_api.md)         | Set a course, follow a route, advance to next point, etc.                          | `vessels/self/navigation/course` |
 | [History](./history_api.md)       | Query historical data.                                                             | `history`                        |
+| [Radar](./radar_api.md)           | View and control marine radar equipment via a provider plugin. _(In development)_  | `vessels/self/radars`            |
 | [Resources](./resources_api.md)   | Create, view, update and delete waypoints, routes, etc.                            | `resources`                      |
 
 ---

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -1,0 +1,1177 @@
+---
+title: Radar API
+---
+
+# Radar API
+
+The Signal K server Radar API provides a unified interface for viewing and controlling marine radar equipment from any manufacturer. The API is **chartplotter-friendly**: clients can build dynamic UIs that automatically adapt to any radar's capabilities without hardcoding support for specific brands or models.
+
+Radar functionality is provided by "provider plugins" that handle the interaction with radar hardware and stream spoke data to connected clients.
+
+Requests to the Radar API are made to HTTP REST endpoints rooted at `/signalk/v2/api/vessels/self/radars`.
+
+## Design Philosophy: Capabilities-Driven API
+
+This API uses a **self-describing schema** pattern that benefits both radar provider developers and client/chartplotter developers.
+
+### For Client/Chartplotter Developers
+
+Build a **single, adaptive UI** that works with any radar—now and in the future—without hardcoding brand-specific logic.
+
+**How it works:**
+
+1. **Fetch capabilities once** when a radar connects — this tells you what the radar can do
+2. **Generate UI widgets from the schema:**
+   - `type: "boolean"` → Toggle switch
+   - `type: "number"` with `range` → Slider with min/max/step
+   - `type: "enum"` with `values` → Dropdown or button group (hide values where `readOnly: true`)
+   - `type: "compound"` → Nested panel (e.g., mode selector + value slider)
+   - `readOnly: true` on control → Display-only label (for info like serial number)
+   - `readOnly: true` on enum value → Value can be reported but not set (e.g., "off", "warming" for power)
+3. **Apply constraints dynamically** — gray out controls when conditions are met, show reasons
+4. **Poll state for current values** — the schema tells you what to expect
+
+**Example: Rendering a Gain Control**
+
+```typescript
+// Capability definition tells you everything needed:
+const gainControl = {
+  id: 'gain',
+  name: 'Gain',
+  type: 'compound',
+  modes: ['auto', 'manual'],
+  properties: {
+    mode: { type: 'enum', values: [{ value: 'auto' }, { value: 'manual' }] },
+    value: { type: 'number', range: { min: 0, max: 100, unit: 'percent' } }
+  }
+}
+
+// Your UI renders:
+// - Mode toggle: [Auto] [Manual]
+// - Value slider: 0 ----[50]---- 100 (disabled when mode=auto)
+```
+
+Whether it's a Furuno DRS4D-NXT with 20+ controls or a basic radar with 5 controls, the same client code handles both.
+
+### For Radar Provider Developers (Plugin Authors)
+
+Different manufacturers have vastly different hardware capabilities, control sets, value ranges, and operating modes. Instead of clients hardcoding knowledge about each model, your provider plugin **declares** what the radar can do:
+
+1. **Characteristics** — hardware capabilities (Doppler, dual-range, no-transmit zones, supported ranges)
+2. **Controls** — schema for each control (type, valid values, modes, read-only status)
+3. **Constraints** — dependencies between controls (e.g., "gain is read-only when preset mode is active")
+
+### Control Categories
+
+| Category       | Description                  | Examples                                                      |
+| -------------- | ---------------------------- | ------------------------------------------------------------- |
+| `base`         | Available on all radars      | power, range, gain, sea, rain                                 |
+| `extended`     | Model-specific features      | dopplerMode, beamSharpening, targetExpansion, noTransmitZones |
+| `installation` | Setup/configuration settings | antennaHeight, bearingAlignment                               |
+
+Read-only information (serialNumber, firmwareVersion, operatingHours) is exposed as controls with `readOnly: true`.
+
+_Note: Clients should consider showing `installation` category controls in a separate setup panel, potentially with confirmation dialogs, as these are typically configured once during radar installation._
+
+## API Overview
+
+```
+/signalk/v2/api/vessels/self/radars
+├── GET                              → List all radar IDs
+├── /_providers
+│   └── GET                          → List registered providers
+└── /{id}
+    ├── /capabilities GET            → Get radar schema (characteristics, controls)
+    ├── /state GET                   → Get current values for all controls
+    ├── /controls
+    │   ├── GET                      → Get all control values
+    │   ├── PUT                      → Set multiple controls
+    │   └── /{controlId}
+    │       ├── GET                  → Get single control value
+    │       └── PUT                  → Set single control value
+    ├── /stream                      → WebSocket (binary spoke data)
+    └── /targets                     → ARPA target tracking
+        ├── GET                      → List tracked targets with CPA/TCPA
+        ├── POST                     → Manual target acquisition
+        ├── WS                       → Stream target updates
+        └── /{targetId}
+            └── DELETE               → Cancel target tracking
+```
+
+## Radar Information
+
+### Listing All Radars
+
+Retrieve a list of all available radar IDs:
+
+```typescript
+HTTP GET "/signalk/v2/api/vessels/self/radars"
+```
+
+_Response:_
+
+```json
+["Furuno-6424", "Navico-HALO"]
+```
+
+### Getting Radar Capabilities
+
+The capability manifest describes everything a radar can do. Clients should fetch this once and cache it.
+
+```typescript
+HTTP GET "/signalk/v2/api/vessels/self/radars/{id}/capabilities"
+```
+
+_Response:_
+
+```json
+{
+  "id": "Furuno-6424",
+  "make": "Furuno",
+  "model": "DRS4D-NXT",
+  "modelFamily": "DRS-NXT",
+  "serialNumber": "6424",
+  "characteristics": {
+    "maxRange": 74080,
+    "minRange": 50,
+    "supportedRanges": [
+      50, 75, 100, 250, 500, 750, 1000, 1500, 2000, 3000, 4000, 6000, 8000,
+      12000, 16000, 24000, 36000, 48000, 64000, 74080
+    ],
+    "spokesPerRevolution": 2048,
+    "maxSpokeLength": 512,
+    "hasDoppler": true,
+    "hasDualRange": true,
+    "maxDualRange": 22224,
+    "noTransmitZoneCount": 2
+  },
+  "controls": [
+    {
+      "id": "power",
+      "name": "Power",
+      "description": "Radar power state",
+      "category": "base",
+      "type": "enum",
+      "values": [
+        { "value": "off", "label": "Off", "readOnly": true },
+        { "value": "standby", "label": "Standby" },
+        { "value": "transmit", "label": "Transmit" },
+        { "value": "warming", "label": "Warming Up", "readOnly": true }
+      ]
+    },
+    {
+      "id": "range",
+      "name": "Range",
+      "description": "Detection range in meters",
+      "category": "base",
+      "type": "enum",
+      "values": [
+        { "value": 50, "label": "50m" },
+        { "value": 1852, "label": "1nm" },
+        { "value": 3704, "label": "2nm" }
+      ]
+    },
+    {
+      "id": "gain",
+      "name": "Gain",
+      "description": "Receiver gain adjustment",
+      "category": "base",
+      "type": "compound",
+      "modes": ["auto", "manual"],
+      "defaultMode": "auto",
+      "properties": {
+        "mode": { "type": "string" },
+        "value": {
+          "type": "number",
+          "range": { "min": 0, "max": 100, "unit": "percent" }
+        }
+      }
+    },
+    {
+      "id": "serialNumber",
+      "name": "Serial Number",
+      "description": "Radar hardware serial number",
+      "category": "base",
+      "type": "string",
+      "readOnly": true
+    },
+    {
+      "id": "firmwareVersion",
+      "name": "Firmware Version",
+      "description": "Radar firmware version",
+      "category": "base",
+      "type": "string",
+      "readOnly": true
+    },
+    {
+      "id": "operatingHours",
+      "name": "Operating Hours",
+      "description": "Total hours of radar operation",
+      "category": "base",
+      "type": "number",
+      "range": { "min": 0, "max": 999999, "step": 0.1, "unit": "hours" },
+      "readOnly": true
+    },
+    {
+      "id": "dopplerMode",
+      "name": "Doppler Mode",
+      "description": "Target velocity color coding",
+      "category": "extended",
+      "type": "enum",
+      "values": [
+        { "value": "off", "label": "Off" },
+        { "value": "normal", "label": "Normal" },
+        { "value": "approaching", "label": "Approaching Only" }
+      ]
+    }
+  ],
+  "constraints": [
+    {
+      "controlId": "gain",
+      "condition": {
+        "type": "read_only_when",
+        "dependsOn": "presetMode",
+        "operator": "!=",
+        "value": "custom"
+      },
+      "effect": {
+        "readOnly": true,
+        "reason": "Controlled by preset mode"
+      }
+    }
+  ],
+  "supportedFeatures": ["arpa", "guardZones", "trails"]
+}
+```
+
+### Getting Radar State
+
+Current values for all controls, plus operational status:
+
+```typescript
+HTTP GET "/signalk/v2/api/vessels/self/radars/{id}/state"
+```
+
+_Response:_
+
+```json
+{
+  "id": "Furuno-6424",
+  "timestamp": "2025-01-15T10:30:00Z",
+  "status": "transmit",
+  "controls": {
+    "power": "transmit",
+    "range": 1852,
+    "gain": { "mode": "auto", "value": 50 },
+    "sea": { "mode": "auto", "value": 30 },
+    "rain": { "mode": "manual", "value": 0 },
+    "serialNumber": "6424",
+    "firmwareVersion": "01.05",
+    "operatingHours": 29410.6,
+    "dopplerMode": "normal"
+  },
+  "disabledControls": []
+}
+```
+
+## Radar Control
+
+All control operations require appropriate security permissions.
+
+### Setting a Single Control
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/{id}/controls/{controlId}"
+```
+
+**Setting power state:**
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/Furuno-6424/controls/power"
+```
+
+_Request body:_
+
+```json
+{ "value": "transmit" }
+```
+
+**Setting range:**
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/Furuno-6424/controls/range"
+```
+
+_Request body:_
+
+```json
+{ "value": 1852 }
+```
+
+**Setting gain (compound control):**
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/Furuno-6424/controls/gain"
+```
+
+_Request body:_
+
+```json
+{ "value": { "mode": "manual", "value": 75 } }
+```
+
+### Setting Multiple Controls
+
+Update multiple controls in a single request:
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/{id}/controls"
+```
+
+_Request body:_
+
+```json
+{
+  "gain": { "mode": "manual", "value": 60 },
+  "sea": { "mode": "auto" },
+  "rain": { "mode": "manual", "value": 20 }
+}
+```
+
+## Streaming (WebSocket)
+
+Radar spoke data is streamed via WebSocket as binary frames. The state response includes an optional `streamUrl` field indicating where to connect.
+
+### Connection Logic
+
+```javascript
+// Fetch radar state
+const state = await fetch(
+  '/signalk/v2/api/vessels/self/radars/Furuno-6424/state'
+).then((r) => r.json())
+
+// Determine WebSocket URL
+const wsUrl =
+  state.streamUrl ??
+  `ws://${location.host}/signalk/v2/api/vessels/self/radars/${state.id}/stream`
+
+// Connect to stream
+const socket = new WebSocket(wsUrl)
+socket.binaryType = 'arraybuffer'
+
+socket.onmessage = (event) => {
+  const spokeData = new Uint8Array(event.data)
+  // Process binary spoke data...
+}
+```
+
+### Stream URL Patterns
+
+| Scenario          | streamUrl | Description                                |
+| ----------------- | --------- | ------------------------------------------ |
+| External server   | Present   | High-bandwidth streams bypass Signal K     |
+| Integrated plugin | Absent    | Signal K handles everything via `/stream`  |
+| WASM plugin       | Present   | Points to dedicated binary stream endpoint |
+
+## ARPA Target Tracking
+
+The Radar API has ARPA (Automatic Radar Plotting Aid) target tracking with CPA/TCPA calculations and SignalK notification integration.
+
+### Listing Tracked Targets
+
+```typescript
+HTTP GET "/signalk/v2/api/vessels/self/radars/{id}/targets"
+```
+
+_Response:_
+
+```json
+{
+  "radarId": "Furuno-6424",
+  "timestamp": "2025-01-15T10:30:00Z",
+  "targets": [
+    {
+      "id": 1,
+      "status": "tracking",
+      "position": {
+        "bearing": 45.2,
+        "distance": 1852,
+        "latitude": 52.3702,
+        "longitude": 4.8952
+      },
+      "motion": {
+        "course": 180.0,
+        "speed": 6.5
+      },
+      "danger": {
+        "cpa": 150,
+        "tcpa": 324
+      },
+      "acquisition": "auto",
+      "firstSeen": "2025-01-15T10:25:00Z",
+      "lastSeen": "2025-01-15T10:30:00Z"
+    },
+    {
+      "id": 3,
+      "status": "tracking",
+      "position": {
+        "bearing": 270.0,
+        "distance": 3500
+      },
+      "motion": {
+        "course": 90.0,
+        "speed": 4.2
+      },
+      "danger": {
+        "cpa": 820,
+        "tcpa": 450
+      },
+      "acquisition": "manual",
+      "firstSeen": "2025-01-15T10:20:00Z",
+      "lastSeen": "2025-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Manual Target Acquisition
+
+Acquire a target at a specific bearing and distance:
+
+```typescript
+HTTP POST "/signalk/v2/api/vessels/self/radars/{id}/targets"
+```
+
+_Request body:_
+
+```json
+{
+  "bearing": 45.0,
+  "distance": 2000
+}
+```
+
+_Response:_
+
+```json
+{
+  "success": true,
+  "targetId": 5,
+  "status": "acquiring"
+}
+```
+
+### Cancel Target Tracking
+
+```typescript
+HTTP DELETE "/signalk/v2/api/vessels/self/radars/{id}/targets/{targetId}"
+```
+
+_Response:_
+
+```json
+{
+  "success": true
+}
+```
+
+### Target Stream (WebSocket)
+
+Stream real-time target updates:
+
+```typescript
+WS "/signalk/v2/api/vessels/self/radars/{id}/targets"
+```
+
+_Server sends messages:_
+
+```json
+// Target position/motion update
+{
+  "type": "target_update",
+  "target": {
+    "id": 1,
+    "status": "tracking",
+    "position": { "bearing": 45.5, "distance": 1800 },
+    "motion": { "course": 180.0, "speed": 6.5 },
+    "danger": { "cpa": 140, "tcpa": 310 }
+  }
+}
+
+// New target acquired
+{
+  "type": "target_acquired",
+  "target": { /* full ArpaTarget */ }
+}
+
+// Target tracking lost
+{
+  "type": "target_lost",
+  "targetId": 3,
+  "reason": "no_return",
+  "lastPosition": { "bearing": 120.5, "distance": 3500 }
+}
+```
+
+### Target Grace Period
+
+When a target temporarily disappears (behind waves, in rain clutter), the tracker maintains prediction for a configurable grace period before marking it as lost.
+
+Configure via radar state:
+
+```typescript
+HTTP PUT "/signalk/v2/api/vessels/self/radars/{id}/state"
+```
+
+```json
+{
+  "arpaSettings": {
+    "targetLostTimeout": 45,
+    "cpaAlertThreshold": 500,
+    "tcpaAlertThreshold": 600
+  }
+}
+```
+
+| Setting              | Default | Description                              |
+| -------------------- | ------- | ---------------------------------------- |
+| `targetLostTimeout`  | 45      | Seconds before marking target lost       |
+| `cpaAlertThreshold`  | 500     | CPA (meters) triggering alert state      |
+| `tcpaAlertThreshold` | 600     | TCPA (seconds) within which to check CPA |
+
+## SignalK Notifications
+
+ARPA targets publish collision warnings to SignalK's notification system, enabling chart plotters to display radar-based alerts alongside AIS alerts.
+
+### Notification Paths
+
+```
+notifications.navigation.closestApproach.radar:{radarId}:target:{targetId}
+notifications.navigation.radarGuardZone.radar:{radarId}:zone:{zoneId}
+notifications.navigation.radarTargetLost.radar:{radarId}:target:{targetId}
+```
+
+### Closest Approach Alert
+
+Published when a target's CPA crosses a threshold. States follow SignalK conventions:
+
+| State       | CPA Threshold | Description                  |
+| ----------- | ------------- | ---------------------------- |
+| `normal`    | > 1000m       | Target tracked, no danger    |
+| `alert`     | < 1000m       | Approaching, monitor closely |
+| `warn`      | < 500m        | Getting close                |
+| `alarm`     | < 200m        | Danger, take action          |
+| `emergency` | < 100m        | Imminent collision           |
+
+_Example notification:_
+
+```json
+{
+  "path": "notifications.navigation.closestApproach.radar:Furuno-6424:target:3",
+  "value": {
+    "state": "warn",
+    "method": ["visual", "sound"],
+    "message": "ARPA target 3: CPA 320m in 5m 24s",
+    "timestamp": "2025-01-15T10:30:00Z",
+    "data": {
+      "cpa": 320,
+      "tcpa": 324,
+      "bearing": 45.2,
+      "distance": 1852,
+      "targetCourse": 180,
+      "targetSpeed": 6.5
+    }
+  }
+}
+```
+
+### Guard Zone Alert
+
+Published when a target enters a guard zone:
+
+```json
+{
+  "path": "notifications.navigation.radarGuardZone.radar:Furuno-6424:zone:1",
+  "value": {
+    "state": "alarm",
+    "method": ["visual", "sound"],
+    "message": "Target in guard zone 1",
+    "timestamp": "2025-01-15T10:30:00Z",
+    "data": {
+      "zoneId": 1,
+      "zoneName": "Starboard sector",
+      "targetBearing": 45.2,
+      "targetDistance": 500
+    }
+  }
+}
+```
+
+### Target Lost Alert
+
+Published when tracking is lost on a **manually-acquired** target. Auto-acquired targets silently drop without notification.
+
+```json
+{
+  "path": "notifications.navigation.radarTargetLost.radar:Furuno-6424:target:5",
+  "value": {
+    "state": "warn",
+    "method": ["visual"],
+    "message": "ARPA target 5 lost",
+    "timestamp": "2025-01-15T10:30:00Z",
+    "data": {
+      "targetId": 5,
+      "lastBearing": 120.5,
+      "lastDistance": 3500,
+      "trackedDuration": 324
+    }
+  }
+}
+```
+
+### Subscribing to Radar Notifications
+
+Use standard SignalK delta subscription to receive radar notifications:
+
+```json
+{
+  "context": "vessels.self",
+  "subscribe": [
+    {
+      "path": "notifications.navigation.closestApproach.radar:*",
+      "policy": "instant"
+    },
+    {
+      "path": "notifications.navigation.radarGuardZone.*",
+      "policy": "instant"
+    },
+    {
+      "path": "notifications.navigation.radarTargetLost.*",
+      "policy": "instant"
+    }
+  ]
+}
+```
+
+## Data Types
+
+### SupportedFeature
+
+Optional features a radar provider may implement. This declares what API capabilities are available, NOT hardware capabilities (those are in `characteristics`).
+
+```typescript
+type SupportedFeature = 'arpa' | 'guardZones' | 'trails' | 'dualRange'
+```
+
+| Feature      | Description                        | Related Endpoints                         |
+| ------------ | ---------------------------------- | ----------------------------------------- |
+| `arpa`       | ARPA target tracking with CPA/TCPA | `GET/POST/DELETE /targets`, `WS /targets` |
+| `guardZones` | Guard zone alerting                | `GET/PUT /guardZones`                     |
+| `trails`     | Target history/trail data          | `GET /trails`                             |
+| `dualRange`  | Dual-range simultaneous display    | Secondary range controls                  |
+
+**Important distinction:**
+
+- `characteristics.hasDoppler = true` means the hardware supports Doppler
+- `supportedFeatures.includes('trails')` means the provider implements the `/trails` endpoint
+
+A radar may have Doppler hardware but the provider might not implement trails. Clients should check both when deciding what UI to show.
+
+**Client usage example:**
+
+```typescript
+const caps = await fetch(`/radars/${id}/capabilities`).then((r) => r.json())
+
+// Use optional chaining for backward compatibility
+const hasArpa = caps.supportedFeatures?.includes('arpa') ?? false
+const hasGuardZones = caps.supportedFeatures?.includes('guardZones') ?? false
+
+if (hasArpa) {
+  // Show ARPA target panel, enable target acquisition
+}
+```
+
+### CapabilityManifest
+
+```typescript
+interface CapabilityManifest {
+  id: string
+  make: string
+  model: string
+  modelFamily?: string
+  serialNumber?: string
+  firmwareVersion?: string
+  characteristics: Characteristics
+  controls: ControlDefinition[]
+  constraints?: ControlConstraint[]
+  supportedFeatures?: SupportedFeature[] // Optional API features this provider implements
+}
+```
+
+### Characteristics
+
+```typescript
+interface Characteristics {
+  maxRange: number // Maximum detection range in meters
+  minRange: number // Minimum detection range in meters
+  supportedRanges: number[] // Discrete range values in meters
+  spokesPerRevolution: number
+  maxSpokeLength: number
+  hasDoppler: boolean
+  hasDualRange: boolean
+  maxDualRange?: number // Max range in dual-range mode (meters), omitted if 0
+  noTransmitZoneCount: number
+}
+```
+
+### ControlDefinition
+
+```typescript
+interface ControlDefinition {
+  id: string // Semantic ID (e.g., "gain", "beamSharpening")
+  name: string // Human-readable name
+  description: string // Tooltip/help text
+  category: 'base' | 'extended' | 'installation'
+  type: 'boolean' | 'number' | 'enum' | 'compound' | 'string'
+  range?: RangeSpec // For number types
+  values?: EnumValue[] // For enum types
+  properties?: Record<string, PropertyDefinition> // For compound types
+  modes?: string[] // e.g., ["auto", "manual"]
+  defaultMode?: string
+  readOnly?: boolean // True for info fields
+  default?: any
+}
+
+interface RangeSpec {
+  min: number
+  max: number
+  step?: number
+  unit?: string // e.g., "percent", "meters", "hours"
+}
+
+interface EnumValue {
+  value: string | number
+  label: string
+  description?: string
+  readOnly?: boolean // True if this value can be reported but not set by clients
+}
+
+interface PropertyDefinition {
+  type: string
+  description?: string
+  range?: RangeSpec
+  values?: EnumValue[]
+}
+```
+
+### RadarState
+
+```typescript
+interface RadarState {
+  id: string
+  timestamp: string // ISO 8601
+  status: 'off' | 'standby' | 'transmit' | 'warming'
+  controls: Record<string, any>
+  disabledControls?: DisabledControl[]
+  streamUrl?: string // WebSocket URL for spoke data
+}
+
+interface DisabledControl {
+  controlId: string
+  reason: string
+}
+```
+
+### ControlConstraint
+
+```typescript
+interface ControlConstraint {
+  controlId: string
+  condition: {
+    type: 'disabled_when' | 'read_only_when' | 'restricted_when'
+    dependsOn: string // Control ID this depends on
+    operator: string // "==", "!=", "<", ">", etc.
+    value: any // Value to compare against
+  }
+  effect: {
+    disabled?: boolean
+    readOnly?: boolean
+    allowedValues?: any[] // Restricted set when condition is met
+    reason?: string // Human-readable explanation
+  }
+}
+```
+
+### ArpaTarget
+
+```typescript
+interface ArpaTarget {
+  id: number // Target ID (1-99 typically)
+  status: 'tracking' | 'lost' | 'acquiring'
+  position: {
+    bearing: number // Degrees true from own vessel
+    distance: number // Meters from own vessel
+    latitude?: number // Calculated lat (if heading available)
+    longitude?: number // Calculated lon (if heading available)
+  }
+  motion: {
+    course: number // Computed COG (degrees true)
+    speed: number // Computed SOG (m/s)
+  }
+  danger: {
+    cpa: number // Closest Point of Approach (meters)
+    tcpa: number // Time to CPA (seconds, negative = past)
+  }
+  acquisition: 'manual' | 'auto'
+  firstSeen: string // ISO 8601 timestamp
+  lastSeen: string // ISO 8601 timestamp
+}
+```
+
+### TargetListResponse
+
+```typescript
+interface TargetListResponse {
+  radarId: string
+  timestamp: string // ISO 8601
+  targets: ArpaTarget[]
+}
+```
+
+### TargetStreamMessage
+
+```typescript
+type TargetStreamMessage =
+  | { type: 'target_update'; target: ArpaTarget }
+  | { type: 'target_acquired'; target: ArpaTarget }
+  | {
+      type: 'target_lost'
+      targetId: number
+      reason: 'no_return' | 'manual_cancel'
+      lastPosition: { bearing: number; distance: number }
+    }
+```
+
+### ArpaSettings
+
+```typescript
+interface ArpaSettings {
+  targetLostTimeout: number // Seconds before marking target lost (default: 45)
+  cpaAlertThreshold: number // CPA meters for alert state (default: 500)
+  tcpaAlertThreshold: number // TCPA seconds within which to check CPA (default: 600)
+}
+```
+
+## Providers
+
+The Radar API supports registration of multiple radar provider plugins. All radars from all providers are aggregated under the unified API.
+
+### Listing Available Radar Providers
+
+```typescript
+HTTP GET "/signalk/v2/api/vessels/self/radars/_providers"
+```
+
+_Response:_
+
+```json
+{
+  "mayara-radar": {
+    "name": "Mayara Radar Plugin"
+  },
+  "navico-radar": {
+    "name": "Navico Radar Provider"
+  }
+}
+```
+
+## Creating a Radar Provider Plugin
+
+To create a radar provider plugin, implement the `RadarProvider` interface:
+
+```typescript
+interface RadarProvider {
+  name: string
+  methods: RadarProviderMethods
+}
+
+interface RadarProviderMethods {
+  // Required - radar discovery
+  getRadars(): Promise<string[]>
+  getCapabilities(radarId: string): Promise<CapabilityManifest | null>
+  getState(radarId: string): Promise<RadarState | null>
+
+  // Required - control
+  setControl(radarId: string, controlId: string, value: any): Promise<boolean>
+  setControls(radarId: string, controls: Record<string, any>): Promise<boolean>
+
+  // Optional - streaming (for integrated providers)
+  handleStreamConnection?(radarId: string, ws: WebSocket): void
+
+  // Optional - ARPA targets
+  getTargets?(radarId: string): Promise<TargetListResponse | null>
+  acquireTarget?(
+    radarId: string,
+    bearing: number,
+    distance: number
+  ): Promise<{ success: boolean; targetId?: number }>
+  cancelTarget?(radarId: string, targetId: number): Promise<boolean>
+  handleTargetStreamConnection?(radarId: string, ws: WebSocket): void
+}
+```
+
+Register with the server:
+
+```typescript
+app.radarApi.register(plugin.id, {
+  name: 'My Radar Plugin',
+  methods: {
+    getRadars: async () => ['radar-1'],
+    getCapabilities: async (id) => ({
+      id,
+      make: 'MyBrand',
+      model: 'Model-X',
+      characteristics: {
+        /* ... */
+      },
+      controls: [
+        /* ... */
+      ]
+    }),
+    getState: async (id) => ({
+      id,
+      timestamp: new Date().toISOString(),
+      status: 'transmit',
+      controls: { power: 'transmit', gain: { mode: 'auto', value: 50 } }
+    }),
+    setControl: async (id, controlId, value) => {
+      // Send command to radar hardware
+      return true
+    },
+    setControls: async (id, controls) => {
+      // Send multiple commands
+      return true
+    }
+  }
+})
+```
+
+For WASM plugins, use the `radarProvider` capability and implement the corresponding FFI exports.
+
+## Accessing the Radar API from Plugins
+
+Plugins that want to **consume** radar data (rather than provide it) can access the Radar API programmatically using the `getRadarApi()` method on the server app object.
+
+This provides typed, in-process access to the Radar API without going through HTTP:
+
+```typescript
+plugin.start = async (settings) => {
+  // Check if Radar API is available
+  if (app.getRadarApi) {
+    try {
+      const radarApi = await app.getRadarApi()
+
+      // List all available radars
+      const radars = await radarApi.getRadars()
+      app.debug(`Found ${radars.length} radars`)
+
+      // Get info for a specific radar
+      for (const radar of radars) {
+        const info = await radarApi.getRadarInfo(radar.id)
+        if (info) {
+          app.debug(
+            `Radar ${info.name}: status=${info.status}, range=${info.range}m`
+          )
+        }
+      }
+    } catch (err) {
+      app.debug('Radar API not available:', err.message)
+    }
+  }
+}
+```
+
+This pattern follows the same approach as the History API's `getHistoryApi()` method. The property is optional to support older servers that don't have radar API support.
+
+## Naming Conventions
+
+Following consistent naming conventions ensures that clients can work with any radar provider without custom mapping code. When multiple providers use the same control IDs, client UIs "just work" across brands.
+
+### Why This Matters
+
+The Radar API uses **semantic control IDs** that are vendor-neutral. Each vendor's proprietary control names should be mapped to standardized IDs:
+
+```
+Vendor-Specific Name     →    Semantic API ID
+─────────────────────────────────────────────
+Furuno "RezBoost"        →    beamSharpening
+Navico "Beam Sharpening" →    beamSharpening
+Furuno "Target Analyzer" →    dopplerMode
+Navico "VelocityTrack"   →    dopplerMode
+```
+
+### Quick Reference
+
+| Element             | Convention     | Example                              |
+| ------------------- | -------------- | ------------------------------------ |
+| Control IDs         | lowerCamelCase | `beamSharpening`, `dopplerMode`      |
+| Property names      | lowerCamelCase | `mode`, `value`, `enabled`           |
+| String enum values  | lowercase      | `"auto"`, `"manual"`, `"standby"`    |
+| Numeric enum values | integers       | `0`, `1`, `2`, `3`                   |
+| Display names       | Title Case     | `"Beam Sharpening"`                  |
+| Units               | lowercase      | `"meters"`, `"degrees"`, `"percent"` |
+
+### Control ID Naming
+
+Use **lowerCamelCase** for all control identifiers:
+
+```
+✓ beamSharpening
+✓ dopplerMode
+✓ interferenceRejection
+✓ noTransmitZones
+
+✗ beam_sharpening      (no underscores)
+✗ BeamSharpening       (no PascalCase)
+✗ BEAM_SHARPENING      (no SCREAMING_CASE)
+```
+
+Name controls by what they **do**, not what the vendor calls them:
+
+```
+✓ beamSharpening     (describes function)
+✗ rezBoost           (vendor-specific name)
+
+✓ dopplerMode        (describes technology)
+✗ targetAnalyzer     (Furuno marketing name)
+✗ velocityTrack      (Navico marketing name)
+```
+
+### Standard Control IDs
+
+Providers should use these standard IDs when their radar supports the equivalent functionality:
+
+**Base Controls (All Radars)**
+
+| ID      | Type     | Description                                        |
+| ------- | -------- | -------------------------------------------------- |
+| `power` | enum     | Operational state: off, standby, transmit, warming |
+| `range` | number   | Detection range in meters                          |
+| `gain`  | compound | Signal amplification: {mode, value}                |
+| `sea`   | compound | Sea clutter suppression: {mode, value}             |
+| `rain`  | compound | Rain clutter suppression: {mode, value}            |
+
+**Read-Only Info**
+
+| ID                | Type   | Description              |
+| ----------------- | ------ | ------------------------ |
+| `serialNumber`    | string | Hardware serial number   |
+| `firmwareVersion` | string | Firmware version string  |
+| `operatingHours`  | number | Total hours of operation |
+
+**Signal Processing**
+
+| ID                    | Type     | Common Vendor Names                            |
+| --------------------- | -------- | ---------------------------------------------- |
+| `beamSharpening`      | enum     | Furuno: RezBoost, Navico: Beam Sharpening      |
+| `dopplerMode`         | compound | Furuno: Target Analyzer, Navico: VelocityTrack |
+| `dopplerSpeed`        | number   | Navico: Doppler Speed                          |
+| `birdMode`            | enum     | Furuno: Bird Mode                              |
+| `noiseReduction`      | boolean  | Noise Reduction                                |
+| `mainBangSuppression` | number   | MBS                                            |
+
+**Interference Filtering**
+
+| ID                           | Type         | Description                            |
+| ---------------------------- | ------------ | -------------------------------------- |
+| `interferenceRejection`      | boolean/enum | Filters interference from other radars |
+| `localInterferenceRejection` | enum         | Navico: Local IR                       |
+| `sidelobeSuppression`        | compound     | Navico: SLS                            |
+
+**Target Processing**
+
+| ID                 | Type    | Description                          |
+| ------------------ | ------- | ------------------------------------ |
+| `targetSeparation` | enum    | Distinguishes closely-spaced targets |
+| `targetExpansion`  | enum    | Makes small targets more visible     |
+| `targetBoost`      | enum    | Amplifies weak targets               |
+| `autoAcquire`      | boolean | Automatic ARPA target acquisition    |
+
+**Operating Modes**
+
+| ID           | Type | Description                                          |
+| ------------ | ---- | ---------------------------------------------------- |
+| `presetMode` | enum | Pre-configured mode (harbor/offshore/weather/custom) |
+| `scanSpeed`  | enum | Antenna rotation speed                               |
+| `txChannel`  | enum | TX frequency channel selection                       |
+
+**Receiver Controls**
+
+| ID          | Type     | Description                    |
+| ----------- | -------- | ------------------------------ |
+| `tune`      | compound | Receiver tuning: {mode, value} |
+| `colorGain` | compound | Color intensity: {mode, value} |
+
+**Installation Settings**
+
+| ID                 | Type     | Description                             |
+| ------------------ | -------- | --------------------------------------- |
+| `bearingAlignment` | number   | Heading offset correction (degrees)     |
+| `antennaHeight`    | number   | Antenna height above waterline (meters) |
+| `noTransmitZones`  | compound | Sectors where radar won't transmit      |
+
+### Compound Control Patterns
+
+**Mode + Value Pattern** (for controls with auto/manual):
+
+```json
+{
+  "gain": {
+    "mode": "auto",
+    "value": 50
+  }
+}
+```
+
+**Enabled + Mode Pattern** (for toggleable features with sub-modes):
+
+```json
+{
+  "dopplerMode": {
+    "enabled": true,
+    "mode": "approaching"
+  }
+}
+```
+
+**Array Pattern** (for multi-item controls):
+
+```json
+{
+  "noTransmitZones": {
+    "zones": [
+      { "enabled": true, "start": 90, "end": 180 },
+      { "enabled": false, "start": 0, "end": 0 }
+    ]
+  }
+}
+```
+
+### Adding a New Control
+
+Before creating a new control ID:
+
+1. **Check if a semantic ID already exists** - Don't create `echoBoost` if `targetBoost` covers the same functionality
+2. **Use semantic naming** - Name by function, not vendor marketing
+3. **Document the vendor mapping** - Help other developers understand the equivalence
+4. **Follow the patterns** - Use established compound control structures
+
+## Caching
+
+Radar API responses include `Cache-Control: no-cache` headers. Clients should not cache radar data as it can change at any time:
+
+- **Model identification**: Some radars (e.g., Furuno) identify their model via TCP connection, which happens after initial discovery
+- **Status changes**: Radar power state, transmit status can change
+- **Control values**: Gain, sea clutter, range, etc. can be modified by the user or other clients
+
+Clients that need to minimize API calls should implement their own caching strategy with appropriate invalidation logic.

--- a/packages/server-api/src/features.ts
+++ b/packages/server-api/src/features.ts
@@ -73,5 +73,6 @@ export type SignalKApiId =
   | 'autopilot'
   | 'anchor'
   | 'logbook'
+  | 'radar'
   | 'historyplayback' //https://signalk.org/specification/1.7.0/doc/streaming_api.html#history-playback
   | 'historysnapshot' //https://signalk.org/specification/1.7.0/doc/rest_api.html#history-snapshot-retrieval

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -11,6 +11,7 @@ export * from './mmsi/mmsi'
 export * from './propertyvalues'
 export * from './brand'
 export * from './weatherapi'
+export * as radar from './radarapi'
 export * from './streambundle'
 export * from './subscriptionmanager'
 /** @category History API */

--- a/packages/server-api/src/radarapi.ts
+++ b/packages/server-api/src/radarapi.ts
@@ -1,0 +1,824 @@
+/**
+ * Radar API Types
+ *
+ * Types and interfaces for the Signal K Radar API at
+ * /signalk/v2/api/vessels/self/radars
+ */
+
+// ============================================================================
+// Radar Status Types
+// ============================================================================
+
+/** @category Radar API */
+export type RadarStatus = 'off' | 'standby' | 'transmit' | 'warming'
+
+// ============================================================================
+// Radar Control Types
+// ============================================================================
+
+/** @category Radar API */
+export interface RadarControlValue {
+  auto: boolean
+  value: number
+}
+
+/** @category Radar API */
+export interface RadarControls {
+  gain: RadarControlValue
+  sea?: RadarControlValue
+  rain?: { value: number }
+  interferenceRejection?: { value: number }
+  targetExpansion?: { value: number }
+  targetBoost?: { value: number }
+  // Extensible for radar-specific controls
+  [key: string]: RadarControlValue | { value: number } | undefined
+}
+
+/** @category Radar API */
+export interface LegendEntry {
+  color: string
+  label: string
+  minValue?: number
+  maxValue?: number
+}
+
+// ============================================================================
+// Capability and State Types
+// ============================================================================
+
+/**
+ * Optional features a radar provider may support.
+ *
+ * These indicate what API features are implemented by the provider,
+ * NOT hardware capabilities (those are in characteristics).
+ *
+ * @category Radar API
+ */
+export type SupportedFeature = 'arpa' | 'guardZones' | 'trails' | 'dualRange'
+
+/**
+ * Hardware characteristics of a radar.
+ *
+ * @category Radar API
+ */
+export interface RadarCharacteristics {
+  /** Maximum detection range in meters */
+  maxRange: number
+  /** Minimum detection range in meters */
+  minRange: number
+  /** Supported discrete range values in meters */
+  supportedRanges: number[]
+  /** Number of spokes per full rotation */
+  spokesPerRevolution: number
+  /** Maximum spoke length in samples */
+  maxSpokeLength: number
+  /** Whether the radar supports Doppler/motion detection */
+  hasDoppler: boolean
+  /** Whether the radar supports dual-range mode */
+  hasDualRange: boolean
+  /** Maximum range for dual-range mode (if supported) */
+  maxDualRange?: number
+  /** Number of no-transmit zones supported */
+  noTransmitZoneCount: number
+}
+
+/**
+ * Control definition describing a radar control.
+ *
+ * @category Radar API
+ */
+export interface ControlDefinitionV5 {
+  /** Semantic control ID (e.g., "gain", "beamSharpening") */
+  id: string
+  /** Human-readable name */
+  name: string
+  /** Description for tooltips */
+  description: string
+  /** Category: base controls all radars have, extended are model-specific */
+  category: 'base' | 'extended'
+  /** Control value type */
+  type: 'boolean' | 'number' | 'enum' | 'compound'
+
+  /** For type: "number" - value range constraints */
+  range?: {
+    min: number
+    max: number
+    step?: number
+    unit?: string
+  }
+
+  /** For type: "enum" - allowed values */
+  values?: Array<{
+    value: string | number
+    label: string
+    description?: string
+  }>
+
+  /** For type: "compound" - property definitions */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  properties?: Record<string, any>
+
+  /** Supported modes (auto/manual) */
+  modes?: ('auto' | 'manual')[]
+  /** Default mode */
+  defaultMode?: 'auto' | 'manual'
+
+  /** Whether this control is read-only */
+  readOnly?: boolean
+  /** Default value */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default?: any
+}
+
+/**
+ * Control constraint describing dependencies between controls.
+ *
+ * @category Radar API
+ */
+export interface ControlConstraint {
+  /** Control ID this constraint applies to */
+  controlId: string
+
+  /** Condition that triggers the constraint */
+  condition: {
+    type: 'disabled_when' | 'read_only_when' | 'restricted_when'
+    dependsOn: string
+    operator: '==' | '!=' | '>' | '<' | '>=' | '<='
+    value: string | number | boolean
+  }
+
+  /** Effect when condition is true */
+  effect: {
+    disabled?: boolean
+    readOnly?: boolean
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    allowedValues?: any[]
+    reason?: string
+  }
+}
+
+/**
+ * Capability manifest describing what a radar can do.
+ * This is cacheable - capabilities rarely change at runtime.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "id": "1",
+ *   "make": "Furuno",
+ *   "model": "DRS4D-NXT",
+ *   "characteristics": {
+ *     "maxRange": 88896,
+ *     "minRange": 116,
+ *     "supportedRanges": [116, 231, 463, ...],
+ *     "hasDoppler": true
+ *   },
+ *   "controls": [
+ *     {"id": "power", "type": "enum", ...},
+ *     {"id": "gain", "type": "compound", ...}
+ *   ]
+ * }
+ * ```
+ */
+export interface CapabilityManifest {
+  /** Radar ID */
+  id: string
+  /** Manufacturer name */
+  make: string
+  /** Model name */
+  model: string
+
+  /** Model family (optional) */
+  modelFamily?: string
+  /** Serial number (optional) */
+  serialNumber?: string
+  /** Firmware version (optional) */
+  firmwareVersion?: string
+
+  /** Hardware characteristics */
+  characteristics: RadarCharacteristics
+
+  /** Available controls with their schemas */
+  controls: ControlDefinitionV5[]
+
+  /** Control dependencies/constraints */
+  constraints?: ControlConstraint[]
+
+  /**
+   * Optional features this provider implements.
+   *
+   * Indicates which optional API features are available:
+   * - 'arpa': ARPA target tracking (GET /targets, POST /targets, etc.)
+   * - 'guardZones': Guard zone alerting (GET /guardZones, etc.)
+   * - 'trails': Target trails/history (GET /trails)
+   * - 'dualRange': Dual-range simultaneous display
+   *
+   * Note: This declares API capabilities, not hardware. A radar may have
+   * hardware Doppler support (characteristics.hasDoppler) but the provider
+   * might not implement the trails API endpoint.
+   */
+  supportedFeatures?: SupportedFeature[]
+}
+
+/**
+ * Current radar state.
+ * Contains status and all current control values.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "id": "1",
+ *   "timestamp": "2025-01-15T10:30:00Z",
+ *   "status": "transmit",
+ *   "controls": {
+ *     "power": "transmit",
+ *     "range": 5556,
+ *     "gain": {"mode": "auto", "value": 65}
+ *   }
+ * }
+ * ```
+ */
+export interface RadarState {
+  /** Radar ID */
+  id: string
+  /** ISO 8601 timestamp of when state was captured */
+  timestamp: string
+  /** Current operational status */
+  status: RadarStatus
+
+  /** Current control values keyed by control ID */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  controls: Record<string, any>
+
+  /** Controls that are currently disabled and why */
+  disabledControls?: Array<{
+    controlId: string
+    reason: string
+  }>
+}
+
+// ============================================================================
+// ARPA Target Types
+// ============================================================================
+
+/**
+ * ARPA target status.
+ *
+ * @category Radar API
+ */
+export type ArpaTargetStatus = 'tracking' | 'lost' | 'acquiring'
+
+/**
+ * ARPA target acquisition method.
+ *
+ * @category Radar API
+ */
+export type ArpaAcquisitionMethod = 'manual' | 'auto'
+
+/**
+ * ARPA target position data.
+ *
+ * @category Radar API
+ */
+export interface ArpaTargetPosition {
+  /** Bearing from own ship in degrees (0-360, true north) */
+  bearing: number
+  /** Distance from own ship in meters */
+  distance: number
+  /** Latitude (if GPS available) */
+  latitude?: number
+  /** Longitude (if GPS available) */
+  longitude?: number
+}
+
+/**
+ * ARPA target motion data.
+ *
+ * @category Radar API
+ */
+export interface ArpaTargetMotion {
+  /** Course over ground in degrees (0-360, true north) */
+  course: number
+  /** Speed over ground in meters per second */
+  speed: number
+}
+
+/**
+ * ARPA target danger assessment.
+ *
+ * @category Radar API
+ */
+export interface ArpaTargetDanger {
+  /** Closest Point of Approach in meters */
+  cpa: number
+  /** Time to CPA in seconds (negative if target is receding) */
+  tcpa: number
+}
+
+/**
+ * ARPA tracked target.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "id": 1,
+ *   "status": "tracking",
+ *   "position": {
+ *     "bearing": 45.2,
+ *     "distance": 1852,
+ *     "latitude": 52.1234,
+ *     "longitude": 4.5678
+ *   },
+ *   "motion": {
+ *     "course": 180.5,
+ *     "speed": 5.14
+ *   },
+ *   "danger": {
+ *     "cpa": 150,
+ *     "tcpa": 300
+ *   },
+ *   "acquisition": "manual",
+ *   "firstSeen": "2025-01-15T10:28:00Z",
+ *   "lastSeen": "2025-01-15T10:30:00Z"
+ * }
+ * ```
+ */
+export interface ArpaTarget {
+  /** Unique target identifier (1-99 typically) */
+  id: number
+  /** Current tracking status */
+  status: ArpaTargetStatus
+  /** Target position relative to own ship */
+  position: ArpaTargetPosition
+  /** Target motion (course and speed) */
+  motion: ArpaTargetMotion
+  /** Danger assessment (CPA/TCPA) */
+  danger: ArpaTargetDanger
+  /** How this target was acquired */
+  acquisition: ArpaAcquisitionMethod
+  /** ISO 8601 timestamp when target was first acquired */
+  firstSeen: string
+  /** ISO 8601 timestamp of most recent radar return */
+  lastSeen: string
+}
+
+/**
+ * Response from GET /radars/{id}/targets.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "radarId": "radar-0",
+ *   "timestamp": "2025-01-15T10:30:00Z",
+ *   "targets": [
+ *     { "id": 1, "status": "tracking", ... },
+ *     { "id": 2, "status": "lost", ... }
+ *   ]
+ * }
+ * ```
+ */
+export interface TargetListResponse {
+  /** Radar ID */
+  radarId: string
+  /** ISO 8601 timestamp */
+  timestamp: string
+  /** List of tracked targets */
+  targets: ArpaTarget[]
+}
+
+/**
+ * WebSocket message for target streaming.
+ *
+ * @category Radar API
+ */
+export interface TargetStreamMessage {
+  /** Message type */
+  type: 'target_update' | 'target_lost' | 'target_acquired'
+  /** ISO 8601 timestamp */
+  timestamp: string
+  /** Updated/lost/acquired target */
+  target: ArpaTarget
+}
+
+/**
+ * ARPA settings for a radar.
+ *
+ * @category Radar API
+ */
+export interface ArpaSettings {
+  /** Whether ARPA is enabled */
+  enabled: boolean
+  /** Maximum number of targets to track (typically 10-100) */
+  maxTargets: number
+  /** CPA threshold for danger alert in meters */
+  cpaThreshold: number
+  /** TCPA threshold for danger alert in seconds */
+  tcpaThreshold: number
+  /** Seconds before marking a target as lost */
+  lostTargetTimeout: number
+  /** Auto-acquisition sensitivity (0=off, 1-3=low/med/high) */
+  autoAcquisition: number
+}
+
+// ============================================================================
+// Radar Info (Response Object)
+// ============================================================================
+
+/**
+ * Radar information returned by GET /radars/{id}
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "id": "radar-0",
+ *   "name": "Furuno DRS4D-NXT",
+ *   "brand": "Furuno",
+ *   "status": "transmit",
+ *   "spokesPerRevolution": 2048,
+ *   "maxSpokeLen": 1024,
+ *   "range": 2000,
+ *   "controls": {
+ *     "gain": { "auto": false, "value": 50 },
+ *     "sea": { "auto": true, "value": 30 }
+ *   },
+ *   "streamUrl": "ws://192.168.1.100:3001/v1/api/stream/radar-0"
+ * }
+ * ```
+ */
+export interface RadarInfo {
+  /** Unique identifier for this radar */
+  id: string
+  /** Display name */
+  name: string
+  /** Radar brand/manufacturer */
+  brand?: string
+  /** Current operational status */
+  status: RadarStatus
+  /** Number of spokes per full rotation */
+  spokesPerRevolution: number
+  /** Maximum spoke length in samples */
+  maxSpokeLen: number
+  /** Current range in meters */
+  range: number
+  /** Current control settings */
+  controls: RadarControls
+  /** Color legend for radar display */
+  legend?: LegendEntry[]
+  /**
+   * WebSocket URL for radar spoke streaming.
+   *
+   * - If **absent**: Clients use the built-in stream endpoint:
+   *   `ws://server/signalk/v2/api/vessels/self/radars/{id}/stream`
+   *   or `ws://server/signalk/v2/api/streams/radars/{id}`
+   *   (WASM plugins emit spokes via `sk_radar_emit_spokes()` FFI binding)
+   *
+   * - If **present**: Clients connect directly to external URL (backward compat)
+   *   @example "ws://192.168.1.100:3001/stream" (external mayara-server)
+   */
+  streamUrl?: string
+}
+
+// ============================================================================
+// Radar Provider Interface (for plugins)
+// ============================================================================
+
+/**
+ * Provider interface for plugins that provide radar data.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```javascript
+ * app.registerRadarProvider({
+ *   name: 'Furuno Radar Plugin',
+ *   methods: {
+ *     getRadars: async () => ['radar-0'],
+ *     getRadarInfo: async (id) => ({
+ *       id: 'radar-0',
+ *       name: 'Furuno DRS4D-NXT',
+ *       status: 'transmit',
+ *       spokesPerRevolution: 2048,
+ *       maxSpokeLen: 1024,
+ *       range: 2000,
+ *       controls: { gain: { auto: false, value: 50 } },
+ *       streamUrl: 'ws://192.168.1.100:3001/stream'
+ *     }),
+ *     setPower: async (id, state) => { ... },
+ *     setRange: async (id, range) => { ... },
+ *     setGain: async (id, gain) => { ... }
+ *   }
+ * })
+ * ```
+ */
+export interface RadarProvider {
+  /** Display name for this radar provider */
+  name: string
+  /** Provider methods */
+  methods: RadarProviderMethods
+}
+
+/** @category Radar API */
+export interface RadarProviderMethods {
+  /** Plugin ID (set automatically on registration) */
+  pluginId?: string
+
+  /**
+   * Get list of radar IDs this provider manages.
+   * @returns Array of radar IDs
+   */
+  getRadars: () => Promise<string[]>
+
+  /**
+   * Get detailed info for a specific radar.
+   * @param radarId The radar ID
+   * @returns Radar info or null if not found
+   */
+  getRadarInfo: (radarId: string) => Promise<RadarInfo | null>
+
+  /**
+   * Set radar power state.
+   * @param radarId The radar ID
+   * @param state Target power state
+   * @returns true on success
+   */
+  setPower?: (radarId: string, state: RadarStatus) => Promise<boolean>
+
+  /**
+   * Set radar range in meters.
+   * @param radarId The radar ID
+   * @param range Range in meters
+   * @returns true on success
+   */
+  setRange?: (radarId: string, range: number) => Promise<boolean>
+
+  /**
+   * Set radar gain.
+   * @param radarId The radar ID
+   * @param gain Gain settings
+   * @returns true on success
+   */
+  setGain?: (
+    radarId: string,
+    gain: { auto: boolean; value?: number }
+  ) => Promise<boolean>
+
+  /**
+   * Set radar sea clutter.
+   * @param radarId The radar ID
+   * @param sea Sea clutter settings
+   * @returns true on success
+   */
+  setSea?: (
+    radarId: string,
+    sea: { auto: boolean; value?: number }
+  ) => Promise<boolean>
+
+  /**
+   * Set radar rain clutter.
+   * @param radarId The radar ID
+   * @param rain Rain clutter settings
+   * @returns true on success
+   */
+  setRain?: (
+    radarId: string,
+    rain: { auto: boolean; value?: number }
+  ) => Promise<boolean>
+
+  /**
+   * Set multiple radar controls at once.
+   * @param radarId The radar ID
+   * @param controls Partial controls to update
+   * @returns true on success
+   */
+  setControls?: (
+    radarId: string,
+    controls: Partial<RadarControls>
+  ) => Promise<boolean>
+
+  /**
+   * Handle WebSocket stream connection (optional).
+   * Only needed if provider doesn't expose external streamUrl.
+   * @param radarId The radar ID
+   * @param ws WebSocket connection to send spoke data to
+   */
+  handleStreamConnection?: (radarId: string, ws: WebSocket) => void
+
+  // ============================================
+  // Capability and State Methods
+  // ============================================
+
+  /**
+   * Get capability manifest for a radar.
+   * Returns detailed capabilities including supported controls, ranges, features.
+   * @param radarId The radar ID
+   * @returns CapabilityManifest or null if not found
+   */
+  getCapabilities?: (radarId: string) => Promise<CapabilityManifest | null>
+
+  /**
+   * Get current radar state.
+   * Returns status and all current control values.
+   * @param radarId The radar ID
+   * @returns RadarState or null if not found
+   */
+  getState?: (radarId: string) => Promise<RadarState | null>
+
+  /**
+   * Get a single control value.
+   * @param radarId The radar ID
+   * @param controlId The semantic control ID (e.g., "gain", "beamSharpening")
+   * @returns Control value or null if not found
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getControl?: (radarId: string, controlId: string) => Promise<any | null>
+
+  /**
+   * Set a single control value.
+   * @param radarId The radar ID
+   * @param controlId The semantic control ID (e.g., "gain", "beamSharpening")
+   * @param value The value to set
+   * @returns Result with success flag and optional error
+   */
+  setControl?: (
+    radarId: string,
+    controlId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value: any
+  ) => Promise<{ success: boolean; error?: string }>
+
+  // ============================================
+  // ARPA Target Methods
+  // ============================================
+
+  /**
+   * Get all tracked ARPA targets.
+   * @param radarId The radar ID
+   * @returns Target list response or null if not supported
+   */
+  getTargets?: (radarId: string) => Promise<TargetListResponse | null>
+
+  /**
+   * Manually acquire a target at the specified position.
+   * @param radarId The radar ID
+   * @param bearing Bearing in degrees (0-360, true north)
+   * @param distance Distance in meters
+   * @returns Result with success flag and optional target ID
+   */
+  acquireTarget?: (
+    radarId: string,
+    bearing: number,
+    distance: number
+  ) => Promise<{ success: boolean; targetId?: number; error?: string }>
+
+  /**
+   * Cancel tracking of a target.
+   * @param radarId The radar ID
+   * @param targetId The target ID to cancel
+   * @returns true on success
+   */
+  cancelTarget?: (radarId: string, targetId: number) => Promise<boolean>
+
+  /**
+   * Handle WebSocket target stream connection.
+   * Streams target updates in real-time.
+   * @param radarId The radar ID
+   * @param ws WebSocket connection to send target updates to
+   */
+  handleTargetStreamConnection?: (radarId: string, ws: WebSocket) => void
+
+  /**
+   * Get ARPA settings.
+   * @param radarId The radar ID
+   * @returns ARPA settings or null if not supported
+   */
+  getArpaSettings?: (radarId: string) => Promise<ArpaSettings | null>
+
+  /**
+   * Update ARPA settings.
+   * @param radarId The radar ID
+   * @param settings Partial settings to update
+   * @returns Result with success flag and optional error
+   */
+  setArpaSettings?: (
+    radarId: string,
+    settings: Partial<ArpaSettings>
+  ) => Promise<{ success: boolean; error?: string }>
+}
+
+// ============================================================================
+// Radar API Interface
+// ============================================================================
+
+/**
+ * Radar API methods available on the server.
+ *
+ * @category Radar API
+ */
+export interface RadarApi {
+  /** Register a radar provider plugin */
+  register: (pluginId: string, provider: RadarProvider) => void
+  /** Unregister a radar provider plugin */
+  unRegister: (pluginId: string) => void
+  /** Get list of all radars from all providers */
+  getRadars: () => Promise<RadarInfo[]>
+  /** Get info for a specific radar */
+  getRadarInfo: (radarId: string) => Promise<RadarInfo | null>
+}
+
+/**
+ * Registry interface exposed to plugins via ServerAPI.
+ *
+ * @category Radar API
+ */
+export interface RadarProviderRegistry {
+  /**
+   * Register a radar provider plugin.
+   * See Radar Provider Plugins documentation for details.
+   *
+   * @category Radar API
+   */
+  registerRadarProvider: (provider: RadarProvider) => void
+  /**
+   * Access the Radar API to get radar info and manage radars.
+   *
+   * @category Radar API
+   */
+  radarApi: RadarApi
+}
+
+/**
+ * Interface for accessing the Radar API from plugins.
+ *
+ * This provides typed, in-process programmatic access to the Radar API,
+ * similar to {@link history!WithHistoryApi | WithHistoryApi} for the History API.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```javascript
+ * // Check if Radar API is available
+ * if (app.getRadarApi) {
+ *   const radarApi = await app.getRadarApi();
+ *   const radars = await radarApi.getRadars();
+ *   app.debug(`Found ${radars.length} radars`);
+ * }
+ * ```
+ */
+export type WithRadarApi = {
+  /**
+   * Returns a promise for the active Radar API implementation, or rejects if unavailable.
+   * The property is optional to support older servers that do not have radar API support.
+   *
+   * @returns Promise that resolves to a {@link RadarApi} instance if available, or rejects with an error if not.
+   */
+  getRadarApi?: () => Promise<RadarApi>
+}
+
+/**
+ * List of registered radar providers (for /_providers endpoint)
+ *
+ * @hidden visible through API
+ * @category Radar API
+ */
+export interface RadarProviders {
+  [id: string]: {
+    name: string
+    isDefault: boolean
+  }
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Type guard to validate a RadarProvider object.
+ *
+ * @category Radar API
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isRadarProvider = (obj: any): obj is RadarProvider => {
+  const typedObj = obj
+  return (
+    ((typedObj !== null && typeof typedObj === 'object') ||
+      typeof typedObj === 'function') &&
+    typeof typedObj['name'] === 'string' &&
+    ((typedObj['methods'] !== null &&
+      typeof typedObj['methods'] === 'object') ||
+      typeof typedObj['methods'] === 'function') &&
+    (typeof typedObj['methods']['pluginId'] === 'undefined' ||
+      typeof typedObj['methods']['pluginId'] === 'string') &&
+    typeof typedObj['methods']['getRadars'] === 'function' &&
+    typeof typedObj['methods']['getRadarInfo'] === 'function'
+  )
+}

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -8,6 +8,7 @@ import {
   Delta,
   WithResourcesApi
 } from '.'
+import { RadarProviderRegistry, WithRadarApi } from './radarapi'
 import { CourseApi } from './course'
 import { HistoryApiRegistry, WithHistoryApi } from './history'
 import { StreamBundle } from './streambundle'
@@ -35,6 +36,8 @@ export interface ServerAPI
     WithResourcesApi,
     AutopilotProviderRegistry,
     WeatherProviderRegistry,
+    RadarProviderRegistry,
+    WithRadarApi,
     WithHistoryApi,
     HistoryApiRegistry,
     WithFeatures,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,8 +6,10 @@ import { FeaturesApi } from './discovery'
 import { ResourcesApi } from './resources'
 import { WeatherApi } from './weather'
 import { AutopilotApi } from './autopilot'
+import { RadarApi } from './radar'
 import { HistoryApiHttpRegistry } from './history'
 import { SignalKApiId, WithFeatures } from '@signalk/server-api'
+import { binaryStreamManager, initializeBinaryStreams } from './streams'
 
 export interface ApiResponse {
   state: 'FAILED' | 'COMPLETED' | 'PENDING'
@@ -54,6 +56,13 @@ export const startApis = (
     WithFeatures
 ) => {
   const apiList: Array<SignalKApiId> = []
+
+  // Initialize binary stream manager for WASM plugin streaming
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).binaryStreamManager = binaryStreamManager
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  initializeBinaryStreams(app as any)
+
   const resourcesApi = new ResourcesApi(app)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(app as any).resourcesApi = resourcesApi
@@ -74,6 +83,11 @@ export const startApis = (
   ;(app as any).autopilotApi = autopilotApi
   apiList.push('autopilot')
 
+  const radarApi = new RadarApi(app)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).radarApi = radarApi
+  apiList.push('radar')
+
   const featuresApi = new FeaturesApi(app)
 
   const historyApiHttpRegistry = new HistoryApiHttpRegistry(app)
@@ -87,6 +101,7 @@ export const startApis = (
     weatherApi.start(),
     featuresApi.start(),
     autopilotApi.start(),
+    radarApi.start(),
     historyApiHttpRegistry.start()
   ])
   return apiList

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -1,0 +1,1085 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createDebug } from '../../debug'
+const debug = createDebug('signalk-server:api:radar')
+
+import { IRouter, Request, Response } from 'express'
+import { WithSecurityStrategy } from '../../security'
+
+import { Responses } from '../'
+import { SignalKMessageHub } from '../../app'
+
+import { radar } from '@signalk/server-api'
+
+const RADAR_API_PATH = `/signalk/v2/api/vessels/self/radars`
+
+interface RadarApplication
+  extends WithSecurityStrategy, SignalKMessageHub, IRouter {}
+
+export class RadarApi {
+  private radarProviders: Map<string, radar.RadarProvider> = new Map()
+  private defaultProviderId?: string
+
+  constructor(private app: RadarApplication) {}
+
+  async start() {
+    this.initApiEndpoints()
+    return Promise.resolve()
+  }
+
+  // ***** Plugin Interface methods *****
+
+  /**
+   * Register plugin as radar provider.
+   */
+  register(pluginId: string, provider: radar.RadarProvider) {
+    debug(`** Registering radar provider... ${pluginId}`)
+
+    if (!pluginId || !provider) {
+      throw new Error(`Error registering radar provider ${pluginId}!`)
+    }
+    if (!radar.isRadarProvider(provider)) {
+      throw new Error(
+        `${pluginId} is missing RadarProvider properties/methods!`
+      )
+    } else {
+      if (!this.radarProviders.has(pluginId)) {
+        this.radarProviders.set(pluginId, provider)
+      }
+      if (this.radarProviders.size === 1) {
+        this.defaultProviderId = pluginId
+      }
+    }
+    debug(`No. of RadarProviders registered =`, this.radarProviders.size)
+  }
+
+  /**
+   * Unregister plugin as radar provider.
+   */
+  unRegister(pluginId: string) {
+    if (!pluginId) {
+      return
+    }
+    debug(`** Request to un-register radar provider... ${pluginId}`)
+
+    if (!this.radarProviders.has(pluginId)) {
+      debug(`** NOT FOUND... ${pluginId}... cannot un-register!`)
+      return
+    }
+
+    debug(`** Un-registering radar provider... ${pluginId}`)
+    this.radarProviders.delete(pluginId)
+    if (pluginId === this.defaultProviderId) {
+      this.defaultProviderId = undefined
+    }
+    // update defaultProviderId if required
+    if (this.radarProviders.size !== 0 && !this.defaultProviderId) {
+      this.defaultProviderId = this.radarProviders.keys().next().value
+    }
+    debug(
+      `Remaining number of Radar Providers registered =`,
+      this.radarProviders.size,
+      'defaultProvider =',
+      this.defaultProviderId
+    )
+  }
+
+  // ***** Server API methods *****
+
+  /**
+   * Get list of all radars from all providers.
+   */
+  async getRadars(): Promise<radar.RadarInfo[]> {
+    const radars: radar.RadarInfo[] = []
+    for (const [pluginId, provider] of this.radarProviders) {
+      try {
+        const radarIds = await provider.methods.getRadars()
+        for (const radarId of radarIds) {
+          const info = await provider.methods.getRadarInfo(radarId)
+          if (info) {
+            radars.push(info)
+          }
+        }
+      } catch (err: any) {
+        debug(`Error getting radars from ${pluginId}: ${err.message}`)
+      }
+    }
+    return radars
+  }
+
+  /**
+   * Get info for a specific radar by ID.
+   */
+  async getRadarInfo(radarId: string): Promise<radar.RadarInfo | null> {
+    // Search all providers for this radar
+    for (const [pluginId, provider] of this.radarProviders) {
+      try {
+        const radarIds = await provider.methods.getRadars()
+        if (radarIds.includes(radarId)) {
+          return await provider.methods.getRadarInfo(radarId)
+        }
+      } catch (err: any) {
+        debug(`Error checking radar ${radarId} in ${pluginId}: ${err.message}`)
+      }
+    }
+    return null
+  }
+
+  // ***** Private methods *****
+
+  private updateAllowed(request: Request): boolean {
+    return this.app.securityStrategy.shouldAllowPut(
+      request,
+      'vessels.self',
+      null,
+      'radar'
+    )
+  }
+
+  /**
+   * Find the provider that owns a specific radar.
+   */
+  private async findProviderForRadar(
+    radarId: string
+  ): Promise<radar.RadarProviderMethods | null> {
+    for (const [pluginId, provider] of this.radarProviders) {
+      try {
+        const radarIds = await provider.methods.getRadars()
+        if (radarIds.includes(radarId)) {
+          return provider.methods
+        }
+      } catch (err: any) {
+        debug(`Error checking radar ${radarId} in ${pluginId}: ${err.message}`)
+      }
+    }
+    return null
+  }
+
+  private initApiEndpoints() {
+    debug(`** Initialise ${RADAR_API_PATH} endpoints. **`)
+
+    // Disable caching for all radar API endpoints
+    // Radar data can change at any time (model identification, status, controls)
+    this.app.use(`${RADAR_API_PATH}`, (_req: Request, res: Response, next) => {
+      res.setHeader('Cache-Control', 'no-cache')
+      next()
+    })
+
+    // GET /radars - List all radars
+    this.app.get(`${RADAR_API_PATH}`, async (req: Request, res: Response) => {
+      debug(`** ${req.method} ${req.path}`)
+      try {
+        const radars = await this.getRadars()
+        res.status(200).json(radars)
+      } catch (err: any) {
+        res.status(500).json({
+          statusCode: 500,
+          state: 'FAILED',
+          message: err.message
+        })
+      }
+    })
+
+    // GET /radars/_providers - List registered providers
+    this.app.get(
+      `${RADAR_API_PATH}/_providers`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const r: radar.RadarProviders = {}
+          this.radarProviders.forEach((v: radar.RadarProvider, k: string) => {
+            r[k] = {
+              name: v.name,
+              isDefault: k === this.defaultProviderId
+            }
+          })
+          res.status(200).json(r)
+        } catch (err: any) {
+          res.status(400).json({
+            statusCode: 400,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/_providers/_default - Get default provider
+    this.app.get(
+      `${RADAR_API_PATH}/_providers/_default`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          res.status(200).json({
+            id: this.defaultProviderId
+          })
+        } catch (err: any) {
+          res.status(400).json({
+            statusCode: 400,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // POST /radars/_providers/_default/:id - Set default provider
+    this.app.post(
+      `${RADAR_API_PATH}/_providers/_default/:id`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          if (!req.params.id) {
+            throw new Error('Provider id not supplied!')
+          }
+          if (this.radarProviders.has(req.params.id)) {
+            this.defaultProviderId = req.params.id
+            res.status(200).json({
+              statusCode: 200,
+              state: 'COMPLETED',
+              message: `Default provider set to ${req.params.id}.`
+            })
+          } else {
+            throw new Error(`Provider ${req.params.id} not found!`)
+          }
+        } catch (err: any) {
+          res.status(400).json({
+            statusCode: 400,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/:id - Get specific radar info
+    this.app.get(
+      `${RADAR_API_PATH}/:id`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const radarInfo = await this.getRadarInfo(req.params.id)
+          if (radarInfo) {
+            res.status(200).json(radarInfo)
+          } else {
+            res.status(404).json(Responses.notFound)
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id - Update radar controls
+    this.app.put(
+      `${RADAR_API_PATH}/:id`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setControls) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setControls'
+            })
+            return
+          }
+          const controls: Partial<radar.RadarControls> =
+            req.body.value ?? req.body
+          const success = await provider.setControls(req.params.id, controls)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to update radar controls'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/power - Set radar power state
+    this.app.put(
+      `${RADAR_API_PATH}/:id/power`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setPower) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setPower'
+            })
+            return
+          }
+          const state: radar.RadarStatus = req.body.value
+          if (!['off', 'standby', 'transmit', 'warming'].includes(state)) {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message:
+                'Invalid power state. Must be: off, standby, transmit, or warming'
+            })
+            return
+          }
+          const success = await provider.setPower(req.params.id, state)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to set radar power state'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/range - Set radar range
+    this.app.put(
+      `${RADAR_API_PATH}/:id/range`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setRange) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setRange'
+            })
+            return
+          }
+          const range: number = req.body.value
+          if (typeof range !== 'number' || range <= 0) {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Invalid range value. Must be a positive number (meters)'
+            })
+            return
+          }
+          const success = await provider.setRange(req.params.id, range)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to set radar range'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/gain - Set radar gain
+    this.app.put(
+      `${RADAR_API_PATH}/:id/gain`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setGain) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setGain'
+            })
+            return
+          }
+          const gain: { auto: boolean; value?: number } =
+            typeof req.body.value === 'object' ? req.body.value : req.body
+          if (typeof gain.auto !== 'boolean') {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Invalid gain value. Must have "auto" boolean property'
+            })
+            return
+          }
+          const success = await provider.setGain(req.params.id, gain)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to set radar gain'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/sea - Set radar sea clutter
+    this.app.put(
+      `${RADAR_API_PATH}/:id/sea`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setSea) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setSea'
+            })
+            return
+          }
+          const sea: { auto: boolean; value?: number } =
+            typeof req.body.value === 'object' ? req.body.value : req.body
+          if (typeof sea.auto !== 'boolean') {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Invalid sea value. Must have "auto" boolean property'
+            })
+            return
+          }
+          const success = await provider.setSea(req.params.id, sea)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to set radar sea clutter'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/rain - Set radar rain clutter
+    this.app.put(
+      `${RADAR_API_PATH}/:id/rain`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json(Responses.notFound)
+            return
+          }
+          if (!provider.setRain) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setRain'
+            })
+            return
+          }
+          const rain: { auto: boolean; value?: number } =
+            typeof req.body.value === 'object' ? req.body.value : req.body
+          if (typeof rain.auto !== 'boolean') {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Invalid rain value. Must have "auto" boolean property'
+            })
+            return
+          }
+          const success = await provider.setRain(req.params.id, rain)
+          if (success) {
+            res.status(200).json(Responses.ok)
+          } else {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Failed to set radar rain clutter'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // ============================================
+    // Capability and State Endpoints
+    // ============================================
+
+    // GET /radars/:id/capabilities - Get radar capability manifest (cacheable)
+    this.app.get(
+      `${RADAR_API_PATH}/:id/capabilities`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getCapabilities) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support getCapabilities'
+            })
+            return
+          }
+          const capabilities = await provider.getCapabilities(req.params.id)
+          if (capabilities) {
+            res.status(200).json(capabilities)
+          } else {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/:id/state - Get current radar state
+    this.app.get(
+      `${RADAR_API_PATH}/:id/state`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getState) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support getState'
+            })
+            return
+          }
+          const state = await provider.getState(req.params.id)
+          if (state) {
+            res.status(200).json(state)
+          } else {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/:id/controls - List all controls with current values
+    this.app.get(
+      `${RADAR_API_PATH}/:id/controls`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getState) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support getState'
+            })
+            return
+          }
+          const state = await provider.getState(req.params.id)
+          if (state && state.controls) {
+            res.status(200).json(state.controls)
+          } else {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/:id/controls/:controlId - Get single control value
+    this.app.get(
+      `${RADAR_API_PATH}/:id/controls/:controlId`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getControl) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support getControl'
+            })
+            return
+          }
+          const value = await provider.getControl(
+            req.params.id,
+            req.params.controlId
+          )
+          if (value !== null && value !== undefined) {
+            res.status(200).json({ value })
+          } else {
+            res.status(404).json({
+              error: 'Control not found',
+              controlId: req.params.controlId
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/controls/:controlId - Set single control value
+    this.app.put(
+      `${RADAR_API_PATH}/:id/controls/:controlId`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.setControl) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support setControl'
+            })
+            return
+          }
+          const value = req.body.value !== undefined ? req.body.value : req.body
+          const result = await provider.setControl(
+            req.params.id,
+            req.params.controlId,
+            value
+          )
+          if (result.success) {
+            res.status(200).json({ success: true })
+          } else {
+            res.status(400).json({
+              success: false,
+              error: result.error || 'Failed to set control',
+              controlId: req.params.controlId
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // Note: WebSocket stream endpoint (/radars/:id/stream) would require
+    // additional WebSocket handling infrastructure. For now, providers
+    // should expose their own streamUrl for direct client connection.
+
+    // ============================================
+    // ARPA Target Endpoints
+    // ============================================
+
+    // GET /radars/:id/targets - Get all tracked ARPA targets
+    this.app.get(
+      `${RADAR_API_PATH}/:id/targets`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getTargets) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support ARPA targets'
+            })
+            return
+          }
+          const targets = await provider.getTargets(req.params.id)
+          if (targets) {
+            res.status(200).json(targets)
+          } else {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // POST /radars/:id/targets - Manually acquire a target
+    this.app.post(
+      `${RADAR_API_PATH}/:id/targets`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.acquireTarget) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support target acquisition'
+            })
+            return
+          }
+          const { bearing, distance } = req.body
+          if (typeof bearing !== 'number' || typeof distance !== 'number') {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message:
+                'Invalid request. Must provide bearing (degrees) and distance (meters)'
+            })
+            return
+          }
+          if (bearing < 0 || bearing >= 360) {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Bearing must be between 0 and 360 degrees'
+            })
+            return
+          }
+          if (distance <= 0) {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Distance must be a positive number (meters)'
+            })
+            return
+          }
+          const result = await provider.acquireTarget(
+            req.params.id,
+            bearing,
+            distance
+          )
+          if (result.success) {
+            res.status(201).json({
+              success: true,
+              targetId: result.targetId
+            })
+          } else {
+            res.status(400).json({
+              success: false,
+              error: result.error || 'Failed to acquire target'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // DELETE /radars/:id/targets/:targetId - Cancel tracking of a target
+    this.app.delete(
+      `${RADAR_API_PATH}/:id/targets/:targetId`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.cancelTarget) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support target cancellation'
+            })
+            return
+          }
+          const targetId = parseInt(req.params.targetId, 10)
+          if (isNaN(targetId)) {
+            res.status(400).json({
+              statusCode: 400,
+              state: 'FAILED',
+              message: 'Invalid target ID. Must be a number'
+            })
+            return
+          }
+          const success = await provider.cancelTarget(req.params.id, targetId)
+          if (success) {
+            res.status(200).json({ success: true })
+          } else {
+            res.status(404).json({
+              success: false,
+              error: 'Target not found or already cancelled'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // GET /radars/:id/arpa/settings - Get ARPA settings
+    this.app.get(
+      `${RADAR_API_PATH}/:id/arpa/settings`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.getArpaSettings) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support ARPA settings'
+            })
+            return
+          }
+          const settings = await provider.getArpaSettings(req.params.id)
+          if (settings) {
+            res.status(200).json(settings)
+          } else {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // PUT /radars/:id/arpa/settings - Update ARPA settings
+    this.app.put(
+      `${RADAR_API_PATH}/:id/arpa/settings`,
+      async (req: Request, res: Response) => {
+        debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        try {
+          const provider = await this.findProviderForRadar(req.params.id)
+          if (!provider) {
+            res.status(404).json({
+              error: 'Radar not found',
+              id: req.params.id
+            })
+            return
+          }
+          if (!provider.setArpaSettings) {
+            res.status(501).json({
+              statusCode: 501,
+              state: 'FAILED',
+              message: 'Provider does not support ARPA settings'
+            })
+            return
+          }
+          const settings: Partial<radar.ArpaSettings> =
+            req.body.value !== undefined ? req.body.value : req.body
+          const result = await provider.setArpaSettings(req.params.id, settings)
+          if (result.success) {
+            res.status(200).json({ success: true })
+          } else {
+            res.status(400).json({
+              success: false,
+              error: result.error || 'Failed to update ARPA settings'
+            })
+          }
+        } catch (err: any) {
+          res.status(500).json({
+            statusCode: 500,
+            state: 'FAILED',
+            message: err.message
+          })
+        }
+      }
+    )
+
+    // Note: WebSocket target stream endpoint (/radars/:id/targets/stream)
+    // would require additional WebSocket handling infrastructure.
+    // For real-time target updates, clients should subscribe to the
+    // main radar stream which includes target data.
+  }
+}

--- a/src/api/radar/openApi.json
+++ b/src/api/radar/openApi.json
@@ -1,0 +1,313 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Signal K Radar API",
+    "version": "2.0.0",
+    "description": "API for managing marine radar devices"
+  },
+  "paths": {
+    "/signalk/v2/api/vessels/self/radars": {
+      "get": {
+        "tags": ["radar"],
+        "summary": "List all radars",
+        "description": "Returns a list of all radars from all registered providers",
+        "responses": {
+          "200": {
+            "description": "List of radars",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RadarInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/_providers": {
+      "get": {
+        "tags": ["radar"],
+        "summary": "List radar providers",
+        "description": "Returns a list of registered radar provider plugins",
+        "responses": {
+          "200": {
+            "description": "List of providers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "type": "string" },
+                      "isDefault": { "type": "boolean" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/_providers/_default": {
+      "get": {
+        "tags": ["radar"],
+        "summary": "Get default provider",
+        "responses": {
+          "200": {
+            "description": "Default provider ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/_providers/_default/{id}": {
+      "post": {
+        "tags": ["radar"],
+        "summary": "Set default provider",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Default provider updated" },
+          "403": { "description": "Unauthorized" },
+          "400": { "description": "Provider not found" }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/{id}": {
+      "get": {
+        "tags": ["radar"],
+        "summary": "Get radar info",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Radar information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RadarInfo" }
+              }
+            }
+          },
+          "404": { "description": "Radar not found" }
+        }
+      },
+      "put": {
+        "tags": ["radar"],
+        "summary": "Update radar controls",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RadarControls" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Controls updated" },
+          "403": { "description": "Unauthorized" },
+          "404": { "description": "Radar not found" }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/{id}/power": {
+      "put": {
+        "tags": ["radar"],
+        "summary": "Set radar power state",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "enum": ["off", "standby", "transmit", "warming"]
+                  }
+                },
+                "required": ["value"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Power state updated" },
+          "403": { "description": "Unauthorized" },
+          "404": { "description": "Radar not found" }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/{id}/range": {
+      "put": {
+        "tags": ["radar"],
+        "summary": "Set radar range",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "number",
+                    "description": "Range in meters"
+                  }
+                },
+                "required": ["value"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Range updated" },
+          "403": { "description": "Unauthorized" },
+          "404": { "description": "Radar not found" }
+        }
+      }
+    },
+    "/signalk/v2/api/vessels/self/radars/{id}/gain": {
+      "put": {
+        "tags": ["radar"],
+        "summary": "Set radar gain",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "auto": { "type": "boolean" },
+                  "value": { "type": "number" }
+                },
+                "required": ["auto"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Gain updated" },
+          "403": { "description": "Unauthorized" },
+          "404": { "description": "Radar not found" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RadarInfo": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Unique radar identifier" },
+          "name": { "type": "string", "description": "Display name" },
+          "brand": { "type": "string", "description": "Manufacturer/brand" },
+          "status": {
+            "type": "string",
+            "enum": ["off", "standby", "transmit", "warming"],
+            "description": "Current operational status"
+          },
+          "spokesPerRevolution": {
+            "type": "integer",
+            "description": "Number of spokes per full rotation"
+          },
+          "maxSpokeLen": {
+            "type": "integer",
+            "description": "Maximum spoke length in samples"
+          },
+          "range": {
+            "type": "number",
+            "description": "Current range in meters"
+          },
+          "controls": { "$ref": "#/components/schemas/RadarControls" },
+          "streamUrl": {
+            "type": "string",
+            "description": "WebSocket URL for spoke stream. If absent, use /radars/{id}/stream"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status",
+          "spokesPerRevolution",
+          "maxSpokeLen",
+          "range",
+          "controls"
+        ]
+      },
+      "RadarControls": {
+        "type": "object",
+        "properties": {
+          "gain": { "$ref": "#/components/schemas/ControlValue" },
+          "sea": { "$ref": "#/components/schemas/ControlValue" },
+          "rain": {
+            "type": "object",
+            "properties": { "value": { "type": "number" } }
+          }
+        },
+        "required": ["gain"]
+      },
+      "ControlValue": {
+        "type": "object",
+        "properties": {
+          "auto": { "type": "boolean" },
+          "value": { "type": "number" }
+        },
+        "required": ["auto", "value"]
+      }
+    }
+  }
+}

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -1,0 +1,8 @@
+import { OpenApiDescription } from '../swagger'
+import radarApiDoc from './openApi.json'
+
+export const radarApiRecord = {
+  name: 'radar',
+  path: '/signalk/v2/api/vessels/self/radars',
+  apiDoc: radarApiDoc as unknown as OpenApiDescription
+}

--- a/src/api/streams/binary-stream-manager.ts
+++ b/src/api/streams/binary-stream-manager.ts
@@ -1,0 +1,258 @@
+/**
+ * Binary Stream Manager
+ *
+ * Manages WebSocket streaming of high-frequency binary data from WASM plugins.
+ * Handles buffering, client connections, and slow consumer disconnection.
+ */
+
+import Debug from 'debug'
+import type { WebSocket } from 'ws'
+
+const debug = Debug('signalk:streams:binary-stream-manager')
+
+/**
+ * Maximum buffer size per WebSocket before considering client too slow
+ */
+const MAX_WEBSOCKET_BUFFER_SIZE = 256 * 1024 // 256KB
+
+/**
+ * Maximum consecutive drops before disconnecting slow client
+ */
+const MAX_CONSECUTIVE_DROPS = 30 // ~0.5 seconds at 60Hz
+
+/**
+ * Maximum frames buffered per stream (ring buffer)
+ */
+const MAX_BUFFERED_FRAMES = 100
+
+/**
+ * Security principal representing the authenticated user/device
+ */
+export interface StreamPrincipal {
+  identifier: string
+}
+
+/**
+ * Client connected to a binary stream
+ */
+interface StreamClient {
+  streamId: string
+  ws: WebSocket
+  principal: StreamPrincipal
+  consecutiveDropCount: number
+  connectedAt: number
+}
+
+/**
+ * Manages binary data streaming to WebSocket clients
+ */
+export class BinaryStreamManager {
+  private clients: Map<string, Set<StreamClient>> = new Map()
+  private buffers: Map<string, Buffer[]> = new Map()
+
+  /**
+   * Emit binary data to all clients subscribed to a stream
+   * Called by WASM plugins via FFI binding
+   *
+   * @param streamId - Stream identifier (e.g., "radars/radar-0")
+   * @param data - Binary data to send
+   */
+  private emitCount: number = 0
+
+  emitData(streamId: string, data: Buffer): void {
+    this.emitCount++
+    // Log periodically
+    if (this.emitCount % 500 === 0) {
+      const clients = this.clients.get(streamId)
+      debug(
+        'emitData #%d: streamId=%s, dataLen=%d, clients=%d',
+        this.emitCount,
+        streamId,
+        data.length,
+        clients?.size || 0
+      )
+    }
+
+    // Add to ring buffer
+    let buffer = this.buffers.get(streamId)
+    if (!buffer) {
+      buffer = []
+      this.buffers.set(streamId, buffer)
+    }
+
+    buffer.push(data)
+
+    // Maintain ring buffer size
+    if (buffer.length > MAX_BUFFERED_FRAMES) {
+      buffer.shift() // Remove oldest frame
+    }
+
+    // Send to all connected clients
+    const clients = this.clients.get(streamId)
+    if (!clients || clients.size === 0) {
+      return // No clients, buffered for later
+    }
+
+    for (const client of clients) {
+      this.sendToClient(client, data)
+    }
+  }
+
+  /**
+   * Add a WebSocket client to a stream
+   *
+   * @param streamId - Stream identifier
+   * @param ws - WebSocket connection
+   * @param principal - Security principal (authenticated user)
+   */
+  addClient(streamId: string, ws: WebSocket, principal: StreamPrincipal): void {
+    debug('Adding client to stream: %s', streamId)
+
+    const client: StreamClient = {
+      streamId,
+      ws,
+      principal,
+      consecutiveDropCount: 0,
+      connectedAt: Date.now()
+    }
+
+    // Add to clients map
+    let clients = this.clients.get(streamId)
+    if (!clients) {
+      clients = new Set()
+      this.clients.set(streamId, clients)
+    }
+    clients.add(client)
+
+    // Note: We intentionally do NOT send buffered frames to new clients.
+    // For high-frequency streams like radar, sending 100 buffered frames
+    // at once overwhelms the client's WebSocket buffer, triggering
+    // backpressure disconnection. Fresh data will arrive immediately anyway.
+
+    debug(`Stream ${streamId} now has ${clients.size} client(s)`)
+  }
+
+  /**
+   * Remove a WebSocket client from a stream
+   *
+   * @param streamId - Stream identifier
+   * @param ws - WebSocket connection to remove
+   */
+  removeClient(streamId: string, ws: WebSocket): void {
+    const clients = this.clients.get(streamId)
+    if (!clients) {
+      return
+    }
+
+    // Find and remove client
+    for (const client of clients) {
+      if (client.ws === ws) {
+        clients.delete(client)
+        debug(
+          'Removed client from stream: %s, remaining: %d',
+          streamId,
+          clients.size
+        )
+        break
+      }
+    }
+
+    // Clean up empty client sets
+    if (clients.size === 0) {
+      this.clients.delete(streamId)
+      debug(`Stream ${streamId} has no more clients`)
+    }
+  }
+
+  /**
+   * Clean up all clients and buffers for a stream
+   * Called when plugin stops
+   *
+   * @param streamId - Stream identifier
+   */
+  cleanupStream(streamId: string): void {
+    const clients = this.clients.get(streamId)
+    if (clients) {
+      for (const client of clients) {
+        try {
+          client.ws.close(1001, 'Stream ended')
+        } catch (error) {
+          debug(`Error closing client WebSocket: ${error}`)
+        }
+      }
+      this.clients.delete(streamId)
+    }
+
+    this.buffers.delete(streamId)
+    debug(`Cleaned up stream: ${streamId}`)
+  }
+
+  /**
+   * Send binary data to a specific client, disconnecting slow consumers
+   *
+   * @param client - Client to send to
+   * @param data - Binary data
+   */
+  private sendToClient(client: StreamClient, data: Buffer): void {
+    // Check if client buffer is full (slow consumer)
+    if (client.ws.bufferedAmount > MAX_WEBSOCKET_BUFFER_SIZE) {
+      client.consecutiveDropCount++
+
+      if (client.consecutiveDropCount > MAX_CONSECUTIVE_DROPS) {
+        debug(
+          `Disconnecting slow client on stream ${client.streamId} ` +
+            `(dropped ${client.consecutiveDropCount} frames)`
+        )
+        try {
+          client.ws.close(1008, 'Client cannot keep up with data rate')
+        } catch (error) {
+          debug(`Error closing slow client: ${error}`)
+        }
+
+        // Remove from clients set
+        const clients = this.clients.get(client.streamId)
+        if (clients) {
+          clients.delete(client)
+        }
+      }
+
+      // Skip sending this frame
+      return
+    }
+
+    // Reset drop counter on successful send
+    client.consecutiveDropCount = 0
+
+    // Send binary frame
+    try {
+      client.ws.send(data, { binary: true })
+    } catch (error) {
+      debug(`Error sending to client on stream ${client.streamId}: ${error}`)
+    }
+  }
+
+  /**
+   * Get number of buffered frames for a stream (for testing)
+   *
+   * @param streamId - Stream identifier
+   * @returns Number of buffered frames
+   */
+  getBufferSize(streamId: string): number {
+    const buffer = this.buffers.get(streamId)
+    return buffer ? buffer.length : 0
+  }
+
+  /**
+   * Get number of connected clients for a stream (for testing)
+   *
+   * @param streamId - Stream identifier
+   * @returns Number of connected clients
+   */
+  getClientCount(streamId: string): number {
+    const clients = this.clients.get(streamId)
+    return clients ? clients.size : 0
+  }
+}
+
+// Export singleton instance
+export const binaryStreamManager = new BinaryStreamManager()

--- a/src/api/streams/index.ts
+++ b/src/api/streams/index.ts
@@ -1,0 +1,181 @@
+/**
+ * Binary Stream WebSocket Endpoints
+ *
+ * Provides WebSocket endpoints for high-frequency binary data streaming
+ * from WASM plugins (radar spokes, AIS targets, etc.)
+ */
+
+import Debug from 'debug'
+import WebSocket from 'ws'
+import { IncomingMessage } from 'http'
+import { Duplex } from 'stream'
+import { Server as HttpServer } from 'http'
+import { Server as HttpsServer } from 'https'
+import { SecurityStrategy, WithSecurityStrategy } from '../../security'
+import { binaryStreamManager, StreamPrincipal } from './binary-stream-manager'
+
+const debug = Debug('signalk:streams')
+
+/**
+ * Extended security strategy with WebSocket authentication methods.
+ * These methods are implemented by tokensecurity.js and dummysecurity.ts
+ * but not declared in the base SecurityStrategy interface.
+ */
+interface WebSocketSecurityStrategy extends SecurityStrategy {
+  shouldAllowWrite?: (request: IncomingMessage, requestType: string) => boolean
+  authorizeWS?: (request: IncomingMessage) => void
+}
+
+/**
+ * Application with HTTP server for WebSocket upgrades
+ */
+interface WithServer {
+  server: HttpServer | HttpsServer | null
+}
+
+/**
+ * Application interface for binary stream initialization
+ */
+interface StreamApplication
+  extends WithServer, Omit<WithSecurityStrategy, 'securityStrategy'> {
+  securityStrategy: WebSocketSecurityStrategy
+}
+
+/**
+ * Extended request with SignalK principal attached by security middleware
+ */
+interface AuthenticatedRequest extends IncomingMessage {
+  skPrincipal?: StreamPrincipal
+}
+
+/**
+ * Initialize binary stream WebSocket endpoints
+ *
+ * @param app - SignalK application instance
+ */
+export function initializeBinaryStreams(app: StreamApplication): void {
+  debug('initializeBinaryStreams called, app.server exists: %s', !!app.server)
+  if (!app.server) {
+    debug('HTTP server not available, skipping binary stream initialization')
+    return
+  }
+
+  debug('Initializing binary stream WebSocket endpoints')
+
+  // Handle WebSocket upgrade requests for binary streams
+  // Note: This listener is added to app.server which should be an HTTP server
+  debug('Adding upgrade listener to server')
+  app.server.on(
+    'upgrade',
+    (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+      debug(
+        'Upgrade request received: %s, headers.host: %s',
+        request.url,
+        request.headers.host
+      )
+      try {
+        const url = new URL(request.url!, `http://${request.headers.host}`)
+        const pathname = url.pathname
+        debug('Pathname: %s', pathname)
+
+        // Match: /signalk/v2/api/streams/:streamId (support path segments in streamId)
+        const streamMatch = pathname.match(
+          /^\/signalk\/v2\/api\/streams\/(.+)$/
+        )
+
+        // Match: /signalk/v2/api/vessels/self/radars/:id/stream (convenience alias)
+        const radarMatch = pathname.match(
+          /^\/signalk\/v2\/api\/vessels\/self\/radars\/([^\/]+)\/stream$/
+        )
+
+        let streamId: string | null = null
+
+        if (streamMatch) {
+          streamId = decodeURIComponent(streamMatch[1])
+          debug('Matched stream pattern: %s', streamId)
+        } else if (radarMatch) {
+          // Alias: map radar endpoint to radars/{radarId} stream
+          const radarId = radarMatch[1]
+          streamId = `radars/${radarId}`
+          debug('Matched radar stream pattern: %s', streamId)
+        } else {
+          // Not a binary stream endpoint, let other handlers process
+          debug('No match for path, ignoring: %s', pathname)
+          return
+        }
+
+        debug('Processing WebSocket upgrade for stream: %s', streamId)
+
+        // Authenticate the request (if security is enabled)
+        let principal: StreamPrincipal = { identifier: 'unknown' }
+        const authRequest = request as AuthenticatedRequest
+
+        // Check if security is enabled
+        if (
+          app.securityStrategy &&
+          typeof app.securityStrategy.shouldAllowWrite === 'function'
+        ) {
+          try {
+            // Security is enabled, perform authentication
+            if (app.securityStrategy.authorizeWS) {
+              app.securityStrategy.authorizeWS(request)
+              principal = authRequest.skPrincipal || { identifier: 'unknown' }
+            } else {
+              // Fallback: use shouldAllowWrite for basic auth check
+              if (!app.securityStrategy.shouldAllowWrite(request, 'streams')) {
+                throw new Error('Unauthorized')
+              }
+              principal = authRequest.skPrincipal || { identifier: 'unknown' }
+            }
+          } catch (error) {
+            debug(`Authentication failed for stream ${streamId}: ${error}`)
+            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+            socket.destroy()
+            return
+          }
+        } else {
+          // Security is disabled, allow connection without authentication
+          debug(
+            `Security disabled, allowing unauthenticated connection to stream: ${streamId}`
+          )
+          principal = { identifier: 'unauthenticated' }
+        }
+
+        // Create WebSocket connection
+        debug('Creating WebSocket server for stream: %s', streamId)
+        const wss = new WebSocket.Server({ noServer: true })
+        wss.handleUpgrade(request, socket, head, (ws) => {
+          debug('WebSocket connected to stream: %s', streamId)
+
+          // Register client with stream manager
+          binaryStreamManager.addClient(streamId!, ws, principal)
+
+          ws.on('close', () => {
+            debug(`WebSocket disconnected from stream: ${streamId}`)
+            binaryStreamManager.removeClient(streamId!, ws)
+          })
+
+          ws.on('error', (err: Error) => {
+            debug(`WebSocket error for stream ${streamId}: ${err}`)
+            binaryStreamManager.removeClient(streamId!, ws)
+          })
+
+          // Binary streams are one-way (server → client), ignore client messages
+          ws.on('message', () => {
+            debug(`Ignoring message from client on binary stream ${streamId}`)
+          })
+        })
+      } catch (error) {
+        debug(`Error handling WebSocket upgrade: ${error}`)
+        console.error('[signalk:streams] WebSocket upgrade error:', error)
+        socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n')
+        socket.destroy()
+      }
+    }
+  )
+
+  debug('Binary stream WebSocket endpoints initialized')
+}
+
+// Export stream manager for use by FFI bindings
+export { binaryStreamManager }

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -11,6 +11,7 @@ import { discoveryApiRecord } from './discovery/openApi'
 import { weatherApiRecord } from './weather/openApi'
 import { appsApiRecord } from './apps/openApi'
 import { historyApiRecord } from './history/openApi'
+import { radarApiRecord } from './radar/openApi'
 import { PluginId, PluginManager } from '../interfaces/plugins'
 import { Brand } from '@signalk/server-api'
 
@@ -35,7 +36,8 @@ const apiDocs = [
   resourcesApiRecord,
   weatherApiRecord,
   securityApiRecord,
-  historyApiRecord
+  historyApiRecord,
+  radarApiRecord
 ].reduce<ApiRecords>((acc, apiRecord: OpenApiRecord) => {
   acc[apiRecord.name] = apiRecord
   return acc


### PR DESCRIPTION
- Add comprehensive REST API for radar control and monitoring
- Implement dynamic feature discovery for radar capabilities
- Add binary stream manager for radar video/scan data
- Register Radar API in OpenAPI documentation
- Add programmatic radar access via WithRadarApi interface

Actually by @dirkwa, I just split this commit off from the body of work originally in #2158 