### PR TITLE
feat: embed TypeDoc documentation within admin UI

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -310,12 +310,8 @@ const mapStateToProps = (state) => {
 
   result.items.push({
     name: 'Documentation',
-    url: `${window.location.protocol}//${window.location.host}/documentation`,
-    icon: 'icon-book-open',
-    props: {
-      target: '_blank',
-      rel: 'noopener noreferrer'
-    }
+    url: '/documentation',
+    icon: 'icon-book-open'
   })
 
   result.items.push({

--- a/packages/server-admin-ui/src/containers/Full/Full.js
+++ b/packages/server-admin-ui/src/containers/Full/Full.js
@@ -10,6 +10,7 @@ import Footer from '../../components/Footer/Footer'
 
 import Dashboard from '../../views/Dashboard/Dashboard'
 import Embedded from '../../views/Webapps/Embedded'
+import EmbeddedDocs from '../../views/Webapps/EmbeddedDocs'
 import Webapps from '../../views/Webapps/Webapps'
 import DataBrowser from '../../views/DataBrowser/DataBrowser'
 import Playground from '../../views/Playground'
@@ -118,6 +119,11 @@ class Full extends Component {
                 <Route
                   path="/security/access/requests"
                   component={loginOrOriginal(AccessRequests)}
+                />
+                <Route
+                  path="/documentation"
+                  name="Documentation"
+                  component={EmbeddedDocs}
                 />
                 <Route path="/login" component={Login} />
                 <Route path="/register" component={Register} />

--- a/packages/server-admin-ui/src/views/Webapps/EmbeddedDocs.js
+++ b/packages/server-admin-ui/src/views/Webapps/EmbeddedDocs.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+const EmbeddedDocs = () => {
+  const docsUrl = `${window.location.protocol}//${window.location.host}/documentation/`
+
+  return (
+    <iframe
+      src={docsUrl}
+      style={{
+        width: '100%',
+        height: 'calc(100vh - 55px)',
+        border: 'none'
+      }}
+      title="Signal K Documentation"
+    />
+  )
+}
+
+export default EmbeddedDocs


### PR DESCRIPTION
## Summary

- Display TypeDoc API documentation in an iframe within the admin UI instead of opening in a new browser tab
- Users can browse documentation while maintaining access to the admin navbar and sidebar navigation
- Original `/documentation/` endpoint remains accessible for direct access

## Changes

| File | Change |
|------|--------|
| `EmbeddedDocs.js` | New component with responsive iframe (`calc(100vh - 55px)`) |
| `Full.js` | Add `/documentation` route before login route |
| `Sidebar.js` | Change Documentation link from external (`target: '_blank'`) to internal route |

## Validation Evidence

Comprehensive browser automation testing was performed with 14 screenshots captured:

### Baseline (Before Changes)
- **T001**: Admin UI dashboard loads correctly
- **T002**: Documentation link opens in new tab (old behavior)

### Core Feature Validation
- **T006**: Embedded docs display with navbar and sidebar visible ✓
- **T007**: Admin navigation (Dashboard, logo click) works from docs view ✓
- **T008**: TypeDoc internal navigation works within iframe ✓
- **T009**: Browser back/forward navigation works ✓

### Direct URL & Compatibility
- **T010**: Direct URL `admin/#/documentation` loads correctly ✓
- **T011**: Original `/documentation/` URL still works standalone ✓

### Responsive & Edge Cases
- **T012**: Responsive at 800x600 and mobile (375x667) ✓
- **T013**: Wide content (API docs) displays with proper scrolling ✓

### Build Verification
- **T014**: `npm run build` completes with no errors ✓

## Test Checklist

- [x] Click "Documentation" in sidebar → docs display within admin UI
- [x] Admin navbar remains visible when viewing docs
- [x] TypeDoc navigation links work within iframe
- [x] Click another sidebar item → navigates away normally
- [x] Browser back button → returns to previous page
- [x] Direct URL `admin/#/documentation` → loads correctly
- [x] Window resize → iframe resizes appropriately
- [x] Original URL `/documentation/` → still works

## Screenshots

*Screenshots were captured during automated testing. Key validations:*

1. **Embedded view**: TypeDoc content displays within admin UI frame with full navbar/sidebar
<img width="2288" height="1384" alt="T006-embedded-docs" src="https://github.com/user-attachments/assets/f66d8649-1e62-46a8-bd0b-d66194499c3c" />

2. **Responsive**: Layout adapts correctly from mobile (375px) to desktop (1280px)
<img width="1600" height="1200" alt="T012-responsive-800x600" src="https://github.com/user-attachments/assets/76c022fa-35e2-4a89-8e29-7b62047288e2" />

<img width="1000" height="1334" alt="T012-responsive-mobile" src="https://github.com/user-attachments/assets/ab6ad2a0-1956-40e4-aa50-0c0c5dfca556" />


3. **Navigation**: All internal TypeDoc links stay within iframe, admin navigation unaffected
<img width="2288" height="1384" alt="T009-back-navigation" src="https://github.com/user-attachments/assets/d095aec1-5edf-4f4a-93ef-a464beec8d0d" />

---

🤖 Generated with [Claude Code](https://claude.ai/code)