### PR TITLE
refactor: remove enableWasmLogging from settings.json

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -76,7 +76,6 @@ export interface Config {
     keepMostRecentLogsOnly?: boolean
     logCountToKeep?: number
     enablePluginLogging?: boolean
-    enableWasmLogging?: boolean
     loggingDirectory?: string
     sourcePriorities?: any
     trustProxy?: boolean | string | number

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -145,21 +145,6 @@ interface ModuleInfo {
   name: string
 }
 
-// Helper function to update WASM debug logging
-function updateWasmDebugLogging(enabled: boolean, app: App) {
-  const wasmDebugPattern = 'signalk:wasm:*'
-
-  if (enabled) {
-    // Add WASM debug using the logging module's API
-    debug('Enabling WASM debug logging')
-    app.logging.addDebug(wasmDebugPattern)
-  } else {
-    // Remove WASM debug using the logging module's API
-    debug('Disabling WASM debug logging')
-    app.logging.removeDebug(wasmDebugPattern)
-  }
-}
-
 module.exports = function (
   app: App,
   saveSecurityConfig: SecurityConfigSaver,
@@ -191,12 +176,6 @@ module.exports = function (
 
   let securityWasEnabled = false
   const restoreSessions = new Map<string, string>()
-
-  // Initialize WASM logging on startup based on config
-  if (app.config.settings.enableWasmLogging !== false) {
-    // Default to enabled if not explicitly disabled
-    updateWasmDebugLogging(true, app)
-  }
 
   const logopath = path.resolve(app.config.configPath, 'logo.svg')
   if (fs.existsSync(logopath)) {
@@ -645,10 +624,7 @@ module.exports = function (
         enablePluginLogging:
           isUndefined(app.config.settings.enablePluginLogging) ||
           app.config.settings.enablePluginLogging,
-        trustProxy: app.config.settings.trustProxy || false,
-        enableWasmLogging:
-          isUndefined(app.config.settings.enableWasmLogging) ||
-          app.config.settings.enableWasmLogging
+        trustProxy: app.config.settings.trustProxy || false
       },
       loggingDirectory: app.config.settings.loggingDirectory,
       pruneContextsMinutes: app.config.settings.pruneContextsMinutes || 60,
@@ -778,12 +754,6 @@ module.exports = function (
 
     if (!isUndefined(settings.options.trustProxy)) {
       app.config.settings.trustProxy = settings.options.trustProxy
-    }
-
-    if (!isUndefined(settings.options.enableWasmLogging)) {
-      app.config.settings.enableWasmLogging = settings.options.enableWasmLogging
-      // Update WASM debug logging dynamically
-      updateWasmDebugLogging(settings.options.enableWasmLogging ?? true, app)
     }
 
     if (!isUndefined(settings.port)) {


### PR DESCRIPTION
## Summary

Removes the `enableWasmLogging` setting from settings.json configuration.
WASM debug logging now uses the standard debug file mechanism.

## Motivation

This was a development leftover from WASM feature implementation. The setting
was inconsistent with how all other debug logging is configured:
- Other debug: configured via `{configPath}/debug` file
- WASM logging: was configured in `settings.json`

## Changes

- Remove `enableWasmLogging` from Config type
- Remove initialization and API handling in serverroutes.ts

## How to enable WASM logging

Add `signalk:wasm:*` to the debug file in your config directory.