### PR TITLE
Increase HTTP rate limit defaults to fix 429 errors with webapps

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -70,8 +70,8 @@ type HttpRateLimitOverrides = {
 }
 
 const DEFAULT_HTTP_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000 // 10 minutes
-const DEFAULT_HTTP_RATE_LIMIT_API_MAX = 100
-const DEFAULT_HTTP_RATE_LIMIT_LOGIN_STATUS_MAX = 10
+const DEFAULT_HTTP_RATE_LIMIT_API_MAX = 1000
+const DEFAULT_HTTP_RATE_LIMIT_LOGIN_STATUS_MAX = 1000
 
 function getHttpRateLimitOverridesFromEnv(): HttpRateLimitOverrides {
   const raw = process.env.HTTP_RATE_LIMITS

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -404,7 +404,7 @@ module.exports = function (app, config) {
         : []
 
     let loginWindowMs = 10 * 60 * 1000
-    let loginMax = 10
+    let loginMax = 100
     for (const part of parsedParts) {
       const eqIndex = part.indexOf('=')
       if (eqIndex === -1) {


### PR DESCRIPTION
The previous defaults were too restrictive for normal webapp usage, causing freeboard-sk and kip to hit rate limits during regular operation, especially on the loginStatus endpoint.

New defaults (per 10-minute window):
- loginStatusMax: 10 → 1000 (polled frequently by webapps)
- apiMax: 100 → 1000
- loginMax: 10 → 100

Fixes #2247
Addresses https://discord.com/channels/1170433917761892493/1459633684515655703
