### PR TITLE
fix: remove duplicate bundledDependencies config

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,9 +142,6 @@
     "signalk-n2kais-to-nmea0183": "^2.0.0",
     "signalk-to-nmea2000": "^2.16.0"
   },
-  "bundledDependencies": [
-    "@signalk/server-api"
-  ],
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^1.45.1",
     "@eslint/js": "^9.24.0",
@@ -186,9 +183,5 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.29.1"
   },
-  "funding": "https://opencollective.com/signalk",
-  "bundleDependencies": [
-    "@signalk/server-api",
-    "@signalk/server-admin-ui"
-  ]
+  "funding": "https://opencollective.com/signalk"
 }

--- a/test/wasm-plugins.ts
+++ b/test/wasm-plugins.ts
@@ -15,7 +15,7 @@ import { expect } from 'chai'
 import fs from 'fs'
 import path from 'path'
 import { freeport } from './ts-servertestutilities'
-import { startServerP } from './servertestutilities'
+import { startServerP, serverTestConfigDirectory } from './servertestutilities'
 
 interface PluginInfo {
   id: string
@@ -40,8 +40,8 @@ interface ServerInstance {
   }
 }
 
-const wasmTestConfigDirectory = () =>
-  path.join(__dirname, 'wasm-plugin-test-config')
+// Use the same config directory as startServerP to ensure plugins are discovered
+const testConfigDirectory = serverTestConfigDirectory
 
 const examplePluginDir = path.join(
   __dirname,
@@ -83,12 +83,10 @@ describe('WASM Plugins', function () {
         return
       }
 
-      // Set up the test environment
-      process.env.SIGNALK_NODE_CONFIG_DIR = wasmTestConfigDirectory()
-
       // Create symlink to the example plugin in test config node_modules
+      // Note: startServerP sets SIGNALK_NODE_CONFIG_DIR to serverTestConfigDirectory()
       const pluginDest = path.join(
-        wasmTestConfigDirectory(),
+        testConfigDirectory(),
         'node_modules',
         '@signalk',
         'example-hello-assemblyscript'
@@ -96,7 +94,7 @@ describe('WASM Plugins', function () {
 
       // Create @signalk directory if needed
       const signalkDir = path.join(
-        wasmTestConfigDirectory(),
+        testConfigDirectory(),
         'node_modules',
         '@signalk'
       )
@@ -119,7 +117,7 @@ describe('WASM Plugins', function () {
       }
       // Clean up symlink
       const pluginDest = path.join(
-        wasmTestConfigDirectory(),
+        testConfigDirectory(),
         'node_modules',
         '@signalk',
         'example-hello-assemblyscript'


### PR DESCRIPTION
## Summary

Remove both `bundledDependencies` and `bundleDependencies` fields to fix npm workspace compatibility.

## Problem

The package.json had both spellings with inconsistent values:

- `bundledDependencies`: `["@signalk/server-api"]`
- `bundleDependencies`: `["@signalk/server-api", "@signalk/server-admin-ui"]`

This conflicts with npm's workspace support ([npm/cli#3466](https://github.com/npm/cli/issues/3466)) and causes dependencies to be missing from global installs, breaking Docker builds.

## Verification

This fix cannot be fully tested locally because the workspace packages (`@signalk/server-api`, etc.) need to be published to npm first. Please verify by:

1. Wait for CI to build the Docker image
2. Test with: `docker run -d -p 3000:3000 ghcr.io/signalk/signalk-server:<sha>`
3. Confirm the server starts without missing dependency errors