### PR TITLE
fix(admin-ui): prevent table header from overlapping context dropdown

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.js
@@ -416,6 +416,10 @@ class DataBrowser extends Component {
                     isSearchable={true}
                     isClearable={true}
                     noOptionsMessage={() => 'No contexts available'}
+                    menuPortalTarget={document.body}
+                    styles={{
+                      menuPortal: (base) => ({ ...base, zIndex: 9999 })
+                    }}
                   />
                 </Col>
                 <Col xs="6" md="2">


### PR DESCRIPTION
The sticky table header introduced in #2236 has a z-index that causes it to render on top of the context dropdown menu.

This fix portals the react-select menu to document.body with an elevated z-index, ensuring the dropdown always appears above the table header.