### PR TITLE
fix(server-api): Allow calling history api with from/to without duration

### DIFF
--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -76,7 +76,7 @@ export type TimeRangeQueryParams =
     }
   | {
       // from - to
-      duration: never
+      duration?: never
       from: string
       to: string
     }
@@ -184,7 +184,7 @@ export type TimeRangeParams =
     }
   | {
       // from - to
-      duration: never
+      duration?: never
       from: Temporal.Instant
       to: Temporal.Instant
     }


### PR DESCRIPTION
if `from` and `to` are provided, the current types cannot be satisfied because `duration: never` is a required property.

For example, given this usage:

```ts
  const history = await app.getHistoryApi?.();

  if (!history) {
    app.debug("History API provider not available");
    return;
  }

  return history.getValues({
    from: Temporal.Instant.from(from.toISOString()),
    to: Temporal.Instant.from(to.toISOString()),
    pathSpecs: [{ path: "navigation.position" as Path, aggregate: "first" }],
    resolution: 1,
  });
```

TypeScript gives this error:

```
src/sources/history.ts:56:21 - error TS2345: Argument of type '{ from: Temporal.Instant; to: Temporal.Instant; pathSpecs: { path: Path; aggregate: "first"; }[]; resolution: number; }' is not assignable to parameter of type 'ValuesRequest'.
  Type '{ from: Temporal.Instant; to: Temporal.Instant; pathSpecs: { path: Path; aggregate: "first"; }[]; resolution: number; }' is not assignable to type '{ duration: never; from: Instant; to: Instant; } & { context?: Context | undefined; resolution?: number | undefined; pathSpecs: PathSpec[]; }'.
    Property 'duration' is missing in type '{ from: Temporal.Instant; to: Temporal.Instant; pathSpecs: { path: Path; aggregate: "first"; }[]; resolution: number; }' but required in type '{ duration: never; from: Instant; to: Instant; }'.

 56   history.getValues({
                        ~
 57     from: Temporal.Instant.from(from.toISOString()),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
 60     resolution: 1,
    ~~~~~~~~~~~~~~~~~~
 61   });
    ~~~

  ../../node_modules/@signalk/server-api/dist/history.d.ts:114:5
    114     duration: never;
            ~~~~~~~~
    'duration' is declared here.
```