### PR TITLE
chore: remove mDNS announcement for WASM interface

### DIFF
--- a/src/interfaces/wasm.ts
+++ b/src/interfaces/wasm.ts
@@ -8,18 +8,11 @@
 
 import Debug from 'debug'
 import { initializeWasm, shutdownAllWasmPlugins } from '../wasm'
-import { getExternalPort } from '../ports'
 
 const debug = Debug('signalk:interfaces:wasm')
 
 module.exports = (app: any) => {
   const api: any = {}
-
-  api.mdns = {
-    name: '_signalk-wasm',
-    type: 'tcp',
-    port: getExternalPort(app)
-  }
 
   api.start = () => {
     debug('Starting WASM interface')


### PR DESCRIPTION
The _signalk-wasm._tcp mDNS service advertisement was added during development but is not needed.
Remove it as requested by maintainers.