### PR TITLE
fix: replace @homebridge/ciao with bonjour-service to fix mDNS name conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   ],
   "dependencies": {
     "@assemblyscript/loader": "^0.28.9",
-    "@homebridge/ciao": "^1.3.4",
     "@signalk/course-provider": "^1.0.0",
     "@signalk/n2k-signalk": ">=4.1.0-beta",
     "@signalk/nmea0183-signalk": "^3.0.0",
@@ -84,6 +83,7 @@
     "as-fetch": "^2.1.4",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
+    "bonjour-service": "^1.3.0",
     "body-parser": "^1.20.3",
     "busboy": "^1.6.0",
     "chalk": "^3.0.0",
@@ -106,6 +106,7 @@
     "geolib": "3.2.2",
     "helmet": "^8.1.0",
     "inquirer": "^7.0.0",
+    "jose": "^6.1.0",
     "json-patch": "^0.7.0",
     "jsonwebtoken": "^9.0.0",
     "listr": "^0.14.1",
@@ -116,6 +117,7 @@
     "morgan": "^1.5.0",
     "ms": "^2.1.2",
     "ncp": "^2.0.0",
+    "openid-client": "^6.1.0",
     "primus": "^7.0.0",
     "selfsigned": "^2.4.1",
     "semver": "^7.5.4",
@@ -124,9 +126,7 @@
     "swagger-ui-express": "^4.5.0",
     "unzipper": "^0.12.3",
     "uuid": "^8.1.0",
-    "ws": "^8.17.0",
-    "jose": "^6.1.0",
-    "openid-client": "^6.1.0"
+    "ws": "^8.17.0"
   },
   "optionalDependencies": {
     "@mxtommy/kip": "^4.0.0",

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -19,7 +19,7 @@
 const _ = require('lodash')
 import { createDebug } from './debug'
 const debug = createDebug('signalk-server:mdns')
-const ciao = require('@homebridge/ciao')
+const { Bonjour } = require('bonjour-service')
 const ports = require('./ports')
 
 module.exports = function mdnsResponder(app) {
@@ -30,8 +30,8 @@ module.exports = function mdnsResponder(app) {
     return
   }
 
-  // Create a single responder instance for all services
-  const responder = ciao.getResponder()
+  // Create Bonjour instance
+  const bonjour = new Bonjour()
 
   // Build TXT record, stripping null/empty values
   let txtRecord = {
@@ -46,16 +46,29 @@ module.exports = function mdnsResponder(app) {
   }
   txtRecord = _.pickBy(txtRecord, _.identity)
 
-  // Collect services to advertise
-  const services = []
+  // Configure hostname if different from OS hostname
+  const host = app.config.getExternalHostname()
+  const osHostname = require('os').hostname()
+  const hostOption = host !== osHostname ? host : undefined
+
+  const serviceName = config.vesselName || config.name || 'SignalK'
+  const publishedServices = []
 
   // Primary HTTP/HTTPS service
-  services.push({
-    name: config.vesselName || config.name || 'SignalK',
-    type: app.config.settings.ssl ? 'signalk-https' : 'signalk-http',
-    port: ports.getExternalPort(app),
-    txt: txtRecord
-  })
+  const primaryType = app.config.settings.ssl ? 'signalk-https' : 'signalk-http'
+  const primaryPort = ports.getExternalPort(app)
+
+  debug(`Starting mDNS ad: _${primaryType}._tcp ${host}:${primaryPort}`)
+  publishedServices.push(
+    bonjour.publish({
+      name: serviceName,
+      type: primaryType,
+      port: primaryPort,
+      txt: txtRecord,
+      host: hostOption,
+      probe: false // Disable probing - we own this service name
+    })
+  )
 
   // Additional services from interfaces
   for (const key in app.interfaces) {
@@ -66,14 +79,22 @@ module.exports = function mdnsResponder(app) {
       const mdnsConfig = app.interfaces[key].mdns
 
       if (mdnsConfig.type === 'tcp' && mdnsConfig.name.charAt(0) === '_') {
-        // Remove leading underscore - ciao adds it automatically
+        // Remove leading underscore - bonjour-service adds it automatically
         const serviceType = mdnsConfig.name.substring(1)
-        services.push({
-          name: config.vesselName || config.name || 'SignalK',
-          type: serviceType,
-          port: mdnsConfig.port,
-          txt: txtRecord
-        })
+
+        debug(
+          `Starting mDNS ad: _${serviceType}._tcp ${host}:${mdnsConfig.port}`
+        )
+        publishedServices.push(
+          bonjour.publish({
+            name: serviceName,
+            type: serviceType,
+            port: mdnsConfig.port,
+            txt: txtRecord,
+            host: hostOption,
+            probe: false // Disable probing - we own this service name
+          })
+        )
       } else {
         debug('Not advertising mDNS service for interface: ' + key)
         debug(
@@ -83,100 +104,18 @@ module.exports = function mdnsResponder(app) {
     }
   }
 
-  // Configure hostname if different from OS hostname
-  const host = app.config.getExternalHostname()
-  const osHostname = require('os').hostname()
-  const serviceOptions = host !== osHostname ? { hostname: host } : {}
-
-  debug('mDNS service options:', serviceOptions)
-
-  const activeServices = []
-  let stopping = false
-  let advertisingPromise = null
-
-  // Start advertising all services
-  const startAdvertising = async () => {
-    for (const svc of services) {
-      // Check if we're stopping before starting each service
-      if (stopping) {
-        debug('Stopping flag set, skipping remaining services')
-        break
-      }
-
-      debug('Starting mDNS ad: _' + svc.type + '._tcp ' + host + ':' + svc.port)
-
-      try {
-        const service = responder.createService({
-          name: svc.name,
-          type: svc.type,
-          port: svc.port,
-          txt: svc.txt,
-          ...serviceOptions
-        })
-
-        service.on('name-change', (newName) => {
-          debug(`Service name changed to: ${newName}`)
-        })
-
-        activeServices.push(service)
-
-        // Don't await if we're stopping
-        if (!stopping) {
-          await service.advertise()
-          debug(`Successfully advertising _${svc.type}._tcp`)
-        }
-      } catch (err) {
-        // Ignore errors if we're stopping
-        if (!stopping) {
-          console.error(`Failed to advertise _${svc.type}._tcp:`, err)
-        }
-      }
-    }
-  }
-
-  // Start advertising (track the promise so we can wait for it on stop)
-  advertisingPromise = startAdvertising().catch((err) => {
-    if (!stopping) {
-      console.error('mDNS advertising failed:', err)
-    }
-  })
+  debug(`Published ${publishedServices.length} mDNS services`)
 
   return {
-    stop: async function () {
+    stop: function () {
       debug('Stopping mDNS advertisements...')
-
-      // Set stopping flag to prevent new operations
-      stopping = true
-
-      // Wait for advertising to complete or fail (with a timeout)
-      if (advertisingPromise) {
-        try {
-          await Promise.race([
-            advertisingPromise,
-            new Promise((resolve) => setTimeout(resolve, 1000))
-          ])
-        } catch (err) {
-          debug('Error waiting for advertising to complete:', err)
-        }
-      }
-
-      // Stop all services
-      for (const service of activeServices) {
-        try {
-          await service.end()
-        } catch (err) {
-          debug('Error stopping service:', err)
-        }
-      }
-
-      // Shutdown the responder (sends goodbye packets)
-      try {
-        await responder.shutdown()
-      } catch (err) {
-        debug('Error shutting down responder:', err)
-      }
-
-      debug('mDNS advertisements stopped')
+      return new Promise((resolve) => {
+        bonjour.unpublishAll(() => {
+          bonjour.destroy()
+          debug('mDNS advertisements stopped')
+          resolve()
+        })
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace @homebridge/ciao with bonjour-service for mDNS advertisement
- Fix service names being incorrectly suffixed with (2), (3), etc.

## Problem

The ciao library has a bug in its `checkLocalConflicts()` function that incorrectly treats hostname sharing between local services as a conflict. When Signal K registers multiple services (signalk-http, signalk-ws, signalk-tcp) with the same name, ciao detects a "hostname conflict" and renames them to "MyBoat (2)", "MyBoat (3)", etc.

This violates RFC 6762 which allows multiple services on the same device to share a hostname - only FQDNs need to be unique. The issue is documented in homebridge/ciao#20 (reported by @sbender9) and remains unfixed.

## Solution

Switch to `bonjour-service` which only checks FQDN conflicts during probing, not hostname conflicts between local services. Probing is disabled since we own these service names.

## Testing

- Build passes
- 364 tests pass
- Manual verification: all mDNS services publish with the same name, no numbering