### PR TITLE
refactor: improve type safety in OIDC module

### DIFF
--- a/src/oidc/oidc-admin.ts
+++ b/src/oidc/oidc-admin.ts
@@ -22,12 +22,12 @@ import { getDiscoveryDocument } from './discovery'
 const SERVERROUTESPREFIX = '/skServer'
 
 /**
- * Security configuration structure (subset needed for OIDC admin)
+ * Security configuration structure (subset needed for OIDC admin).
+ * Allows additional properties since the full security config has many fields.
  */
 export interface SecurityConfigForOIDC {
   oidc?: PartialOIDCConfig
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
+  [key: string]: unknown
 }
 
 /**

--- a/src/oidc/user-info.ts
+++ b/src/oidc/user-info.ts
@@ -24,7 +24,8 @@ import { OIDCError, OIDCUserInfo } from './types'
  */
 export function decodeIdToken(idToken: string): Record<string, unknown> {
   const parts = idToken.split('.')
-  if (parts.length !== 3) {
+  const payloadPart = parts[1]
+  if (parts.length !== 3 || !payloadPart) {
     throw new OIDCError(
       'Invalid ID token format - expected 3 parts',
       'INVALID_TOKEN'
@@ -32,7 +33,7 @@ export function decodeIdToken(idToken: string): Record<string, unknown> {
   }
 
   try {
-    const payload = Buffer.from(parts[1], 'base64url').toString('utf8')
+    const payload = Buffer.from(payloadPart, 'base64url').toString('utf8')
     return JSON.parse(payload)
   } catch (err) {
     throw new OIDCError(


### PR DESCRIPTION
## Improve type safety in OIDC module

### Summary

- Replace `[key: string]: any` with `[key: string]: unknown` in `SecurityConfigForOIDC` interface
- Fix potential undefined access in `decodeIdToken` function

### Details

**Stricter index signature typing** (`oidc-admin.ts`)

Changed the index signature from `any` to `unknown`, which enforces proper type checking when accessing dynamic properties. This eliminates the need for the `eslint-disable` comment and aligns with TypeScript strict mode best practices.

**Safer array access** (`user-info.ts`)

The `decodeIdToken` function now explicitly checks that the payload part exists before using it. While the length check already ensures 3 parts, TypeScript's strict mode requires this additional guard since array index access can return `undefined`. This makes the code more robust and satisfies strict null checks.