### PR TITLE
fix(admin-ui): DataBrowser mobile layout with stacked card view

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
@@ -23,10 +23,18 @@ function DataRow({
   if (!data) {
     return (
       <div className={`virtual-table-row ${index % 2 ? 'striped' : ''}`}>
-        <div className="virtual-table-cell path-cell">Loading...</div>
-        <div className="virtual-table-cell value-cell"></div>
-        <div className="virtual-table-cell timestamp-cell"></div>
-        <div className="virtual-table-cell source-cell"></div>
+        <div className="virtual-table-cell path-cell" data-label="Path">
+          Loading...
+        </div>
+        <div className="virtual-table-cell value-cell" data-label="Value"></div>
+        <div
+          className="virtual-table-cell timestamp-cell"
+          data-label="Time"
+        ></div>
+        <div
+          className="virtual-table-cell source-cell"
+          data-label="Source"
+        ></div>
       </div>
     )
   }
@@ -36,7 +44,7 @@ function DataRow({
   return (
     <div className={`virtual-table-row ${index % 2 ? 'striped' : ''}`}>
       {/* Path Cell */}
-      <div className="virtual-table-cell path-cell">
+      <div className="virtual-table-cell path-cell" data-label="Path">
         <CopyToClipboardWithFade text={data.path}>
           <span>
             {data.path} <i className="far fa-copy"></i>
@@ -45,7 +53,7 @@ function DataRow({
       </div>
 
       {/* Value Cell */}
-      <div className="virtual-table-cell value-cell">
+      <div className="virtual-table-cell value-cell" data-label="Value">
         <ValueRenderer data={data} meta={meta} units={units} raw={raw} />
       </div>
 
@@ -53,7 +61,7 @@ function DataRow({
       <TimestampCell timestamp={data.timestamp} isPaused={isPaused} />
 
       {/* Source Cell */}
-      <div className="virtual-table-cell source-cell">
+      <div className="virtual-table-cell source-cell" data-label="Source">
         <input
           type="checkbox"
           onChange={() => onToggleSource(data.$source)}
@@ -66,9 +74,9 @@ function DataRow({
         />
         <CopyToClipboardWithFade text={data.$source}>
           {data.$source} <i className="far fa-copy"></i>
-        </CopyToClipboardWithFade>{' '}
-        {data.pgn || ''}
-        {data.sentence || ''}
+        </CopyToClipboardWithFade>
+        {data.pgn && <span>&nbsp;{data.pgn}</span>}
+        {data.sentence && <span>&nbsp;{data.sentence}</span>}
       </div>
     </div>
   )

--- a/packages/server-admin-ui/src/views/DataBrowser/TimestampCell.js
+++ b/packages/server-admin-ui/src/views/DataBrowser/TimestampCell.js
@@ -45,7 +45,11 @@ function TimestampCell({ timestamp, isPaused, className }) {
   }`
 
   return (
-    <div className={cellClass} key={isAnimating ? animationKey : 'static'}>
+    <div
+      className={cellClass}
+      key={isAnimating ? animationKey : 'static'}
+      data-label="Time"
+    >
       {timestamp}
     </div>
   )

--- a/packages/server-admin-ui/src/views/DataBrowser/VirtualTable.css
+++ b/packages/server-admin-ui/src/views/DataBrowser/VirtualTable.css
@@ -142,38 +142,107 @@
   }
 }
 
+/* Narrow screens: stack cells vertically with per-row labels */
 @media (max-width: 768px) {
-  .virtual-table-row,
   .virtual-table-header {
+    display: none;
+  }
+
+  .virtual-table-row {
+    display: block;
+    padding: 0.5rem;
+    border-bottom: 2px solid #c8ced3;
+  }
+
+  .virtual-table-row.striped {
+    background-color: rgba(0, 0, 0, 0.02);
+  }
+
+  .virtual-table-cell {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    width: 100%;
+    border-right: none;
+    padding: 0.25rem 0;
+    overflow: visible;
+    min-width: 0;
+  }
+
+  .virtual-table-cell::before {
+    content: attr(data-label);
+    font-weight: 600;
+    flex-shrink: 0;
+    width: 60px;
+    color: #6c757d;
     font-size: 0.75rem;
   }
 
-  .virtual-table-cell,
-  .virtual-table-header-cell {
-    padding: 0.3rem 0.15rem;
+  .virtual-table-cell.path-cell {
+    display: block;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid #e9ecef;
+    margin-bottom: 0.25rem;
+    word-break: break-all;
   }
 
-  .virtual-table-header,
-  .virtual-table-row {
-    grid-template-columns:
-      minmax(100px, 1.5fr) minmax(80px, 2fr) minmax(60px, 0.8fr)
-      minmax(90px, 1.2fr);
+  .virtual-table-cell.path-cell::before {
+    display: none;
   }
 
-  .virtual-table-cell pre {
+  .virtual-table-cell.value-cell {
+    min-width: 0;
+  }
+
+  .virtual-table-cell.value-cell > * {
+    flex: 1;
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  .virtual-table-cell.timestamp-cell {
+    white-space: normal;
+  }
+
+  .virtual-table-cell.timestamp-updated {
+    position: static;
+  }
+
+  .virtual-table-cell.timestamp-updated::before {
+    content: attr(data-label);
+    position: static;
+    width: 60px;
+    background-color: transparent;
+    animation: none;
+  }
+
+  .virtual-table-row:has(.timestamp-updated) {
+    border-left: 3px solid #28a745;
+    animation: borderFade 15s ease-out forwards;
+  }
+
+  @keyframes borderFade {
+    0% {
+      border-left-color: #28a745;
+    }
+    100% {
+      border-left-color: transparent;
+    }
+  }
+
+  .virtual-table-cell.source-cell {
+    flex-wrap: wrap;
+  }
+
+  .virtual-table-cell.source-cell > * {
+    word-break: break-all;
+  }
+
+  .virtual-table-info {
     font-size: 0.7rem;
-  }
-}
-
-@media (max-width: 576px) {
-  .virtual-table-row,
-  .virtual-table-header {
-    font-size: 0.7rem;
-  }
-
-  .virtual-table-cell,
-  .virtual-table-header-cell {
-    padding: 0.25rem 0.1rem;
+    padding: 0.4rem;
   }
 }
 


### PR DESCRIPTION
Title: fix(admin-ui): DataBrowser mobile layout with stacked card view

Description:

On narrow screens (<768px), the DataBrowser table columns overlap because the CSS grid minimum column widths exceed the viewport width.

This PR switches to a stacked card layout on narrow screens where each data row displays vertically with labeled fields (Path as header, then Value/Time/Source stacked below). Virtualization is disabled on narrow screens since row heights become variable.

After:
<img width="478" height="1064" alt="image" src="https://github.com/user-attachments/assets/2ee701e2-461c-4c99-ba43-e9d8cfa2a93f" />


Addresses #2281