### PR TITLE
feat: WASM serverEvents capability with generic event mechanism       

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,5 @@ public
 **/.__mf__temp
 # AssemblyScript build outputs
 packages/assemblyscript-plugin-sdk/build
+# Rust build outputs
+**/target

--- a/examples/wasm-plugins/example-event-handler-rust/.gitignore
+++ b/examples/wasm-plugins/example-event-handler-rust/.gitignore
@@ -1,0 +1,21 @@
+# Rust build artifacts
+target/
+Cargo.lock
+
+# Editor/IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Built WASM (will be built fresh)
+*.wasm
+
+# npm
+node_modules/
+package-lock.json

--- a/examples/wasm-plugins/example-event-handler-rust/.npmignore
+++ b/examples/wasm-plugins/example-event-handler-rust/.npmignore
@@ -1,0 +1,26 @@
+# Rust build artifacts
+target/
+Cargo.lock
+
+# Editor/IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Development files
+*.rs.bk
+.rustfmt.toml
+rustfmt.toml
+.cargo/
+
+# Keep only the essential files:
+# - package.json
+# - plugin.wasm
+# - README.md
+# - src/ (optional, for reference)

--- a/examples/wasm-plugins/example-event-handler-rust/Cargo.toml
+++ b/examples/wasm-plugins/example-event-handler-rust/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "event-handler-rust"
+version = "0.1.0"
+edition = "2021"
+description = "Event Handler WASM plugin for Signal K - Rust implementation demonstrating server events"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# JSON serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[profile.release]
+# Optimize for size
+opt-level = "s"
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/examples/wasm-plugins/example-event-handler-rust/README.md
+++ b/examples/wasm-plugins/example-event-handler-rust/README.md
@@ -1,0 +1,27 @@
+# Event Handler WASM Plugin (Rust)
+
+Demonstrates server event handling for WASM plugins.
+
+## What it does
+
+- Subscribes to `SERVERSTATISTICS` events
+- Monitors delta rate and emits `PLUGIN_HIGH_DELTA_RATE` alert when threshold exceeded
+- Clears alert when rate returns to normal
+
+## Configuration
+
+| Option               | Type    | Default | Description                  |
+| -------------------- | ------- | ------- | ---------------------------- |
+| `deltaRateThreshold` | number  | 100     | Alert threshold (deltas/sec) |
+| `enableDebug`        | boolean | false   | Log all events               |
+
+## Building
+
+```bash
+cargo build --release --target wasm32-wasip1
+npm run postbuild
+```
+
+## License
+
+Apache-2.0

--- a/examples/wasm-plugins/example-event-handler-rust/README.md
+++ b/examples/wasm-plugins/example-event-handler-rust/README.md
@@ -1,19 +1,38 @@
-# Event Handler WASM Plugin (Rust)
+# NMEA Converter WASM Plugin (Rust)
 
-Demonstrates server event handling for WASM plugins.
+Demonstrates the generic event mechanism by converting NMEA 0183 sentences to NMEA 2000 PGN JSON format.
 
 ## What it does
 
-- Subscribes to `SERVERSTATISTICS` events
-- Monitors delta rate and emits `PLUGIN_HIGH_DELTA_RATE` alert when threshold exceeded
-- Clears alert when rate returns to normal
+- Subscribes to `nmea0183` and `nmea0183out` events
+- Parses NMEA 0183 sentences (RMC, GGA)
+- Emits `nmea2000JsonOut` events with PGN data for interop with other plugins
+
+## Supported Conversions
+
+| NMEA 0183 | NMEA 2000 PGN | Description             |
+| --------- | ------------- | ----------------------- |
+| RMC       | 129025        | Position, Rapid Update  |
+| RMC       | 129026        | COG & SOG, Rapid Update |
+| GGA       | 129025        | Position, Rapid Update  |
 
 ## Configuration
 
-| Option               | Type    | Default | Description                  |
-| -------------------- | ------- | ------- | ---------------------------- |
-| `deltaRateThreshold` | number  | 100     | Alert threshold (deltas/sec) |
-| `enableDebug`        | boolean | false   | Log all events               |
+| Option        | Type    | Default               | Description                |
+| ------------- | ------- | --------------------- | -------------------------- |
+| `enableDebug` | boolean | false                 | Log all NMEA events        |
+| `sourceId`    | string  | "wasm-nmea-converter" | Source ID for emitted PGNs |
+
+## Event Flow
+
+```
+[Hardware/Provider] --nmea0183--> [This Plugin] --nmea2000JsonOut--> [N2K Output]
+```
+
+The plugin demonstrates how WASM plugins can:
+
+1. Subscribe to generic events (not just server events)
+2. Emit generic events for interop with the Signal K data pipeline
 
 ## Building
 

--- a/examples/wasm-plugins/example-event-handler-rust/package.json
+++ b/examples/wasm-plugins/example-event-handler-rust/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@signalk/example-event-handler-rust",
+  "version": "0.1.0",
+  "description": "Event Handler WASM plugin for Signal K - Rust implementation demonstrating server events",
+  "main": "plugin.wasm",
+  "scripts": {
+    "build": "cargo build --release --target wasm32-wasip1",
+    "postbuild": "cp target/wasm32-wasip1/release/event_handler_rust.wasm plugin.wasm",
+    "clean": "cargo clean && rm -f plugin.wasm",
+    "check": "cargo check --target wasm32-wasip1"
+  },
+  "keywords": [
+    "signalk-wasm-plugin",
+    "signalk-category-utilities",
+    "wasm",
+    "rust",
+    "events"
+  ],
+  "author": "Signal K",
+  "license": "Apache-2.0",
+  "signalk-plugin-enabled-by-default": false,
+  "wasmManifest": "plugin.wasm",
+  "wasmCapabilities": {
+    "network": false,
+    "storage": "vfs-only",
+    "dataRead": true,
+    "dataWrite": false,
+    "serverEvents": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SignalK/signalk-server"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/wasm-plugins/example-event-handler-rust/src/lib.rs
+++ b/examples/wasm-plugins/example-event-handler-rust/src/lib.rs
@@ -1,0 +1,368 @@
+//! Event Handler WASM Plugin for Signal K
+//!
+//! Monitors server statistics and emits alerts when thresholds are exceeded.
+
+use std::cell::RefCell;
+use serde::{Deserialize, Serialize};
+
+#[link(wasm_import_module = "env")]
+extern "C" {
+    fn sk_debug(ptr: *const u8, len: usize);
+    fn sk_set_status(ptr: *const u8, len: usize);
+    fn sk_set_error(ptr: *const u8, len: usize);
+    fn sk_subscribe_events(event_types_ptr: *const u8, event_types_len: usize) -> i32;
+    fn sk_emit_event(
+        type_ptr: *const u8,
+        type_len: usize,
+        data_ptr: *const u8,
+        data_len: usize,
+    ) -> i32;
+    fn sk_get_allowed_event_types(buf_ptr: *mut u8, buf_max_len: usize) -> i32;
+}
+
+fn debug(msg: &str) {
+    unsafe { sk_debug(msg.as_ptr(), msg.len()); }
+}
+
+fn set_status(msg: &str) {
+    unsafe { sk_set_status(msg.as_ptr(), msg.len()); }
+}
+
+fn set_error(msg: &str) {
+    unsafe { sk_set_error(msg.as_ptr(), msg.len()); }
+}
+
+fn subscribe_events(event_types: &[&str]) -> bool {
+    let json = serde_json::to_string(event_types).unwrap_or_else(|_| "[]".to_string());
+    unsafe { sk_subscribe_events(json.as_ptr(), json.len()) == 1 }
+}
+
+fn emit_event(event_type: &str, data: &impl Serialize) -> bool {
+    let data_json = serde_json::to_string(data).unwrap_or_else(|_| "{}".to_string());
+    unsafe {
+        sk_emit_event(
+            event_type.as_ptr(),
+            event_type.len(),
+            data_json.as_ptr(),
+            data_json.len(),
+        ) == 1
+    }
+}
+
+#[allow(dead_code)]
+fn get_allowed_event_types() -> Vec<String> {
+    let mut buf = vec![0u8; 1024];
+    let len = unsafe { sk_get_allowed_event_types(buf.as_mut_ptr(), buf.len()) };
+    if len > 0 {
+        buf.truncate(len as usize);
+        let json = String::from_utf8_lossy(&buf);
+        serde_json::from_str(&json).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+thread_local! {
+    static STATE: RefCell<PluginState> = RefCell::new(PluginState::default());
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct PluginConfig {
+    /// Delta rate threshold to trigger HIGH_DELTA_RATE alert (deltas/second)
+    #[serde(default = "default_delta_rate_threshold")]
+    delta_rate_threshold: f64,
+
+    /// Enable debug logging of all received events
+    #[serde(default)]
+    enable_debug: bool,
+}
+
+fn default_delta_rate_threshold() -> f64 { 100.0 }
+
+#[derive(Debug, Default)]
+struct PluginState {
+    config: PluginConfig,
+    is_running: bool,
+
+    // Statistics tracking
+    events_received: u64,
+    last_delta_rate: f64,
+    high_rate_alert_active: bool,
+
+    ws_clients: u32,
+    uptime_seconds: f64,
+}
+
+#[no_mangle]
+pub extern "C" fn allocate(size: usize) -> *mut u8 {
+    let mut buf = Vec::with_capacity(size);
+    let ptr = buf.as_mut_ptr();
+    std::mem::forget(buf);
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn deallocate(ptr: *mut u8, size: usize) {
+    unsafe {
+        let _ = Vec::from_raw_parts(ptr, 0, size);
+    }
+}
+
+static PLUGIN_ID: &str = "event-handler-rust";
+static PLUGIN_NAME: &str = "Event Handler (Rust)";
+static PLUGIN_SCHEMA: &str = r#"{
+    "type": "object",
+    "title": "Event Handler Configuration",
+    "properties": {
+        "deltaRateThreshold": {
+            "type": "number",
+            "title": "Delta Rate Threshold",
+            "description": "Emit PLUGIN_HIGH_DELTA_RATE alert when server exceeds this rate (deltas/second)",
+            "default": 100,
+            "minimum": 10,
+            "maximum": 10000
+        },
+        "enableDebug": {
+            "type": "boolean",
+            "title": "Enable Debug Logging",
+            "description": "Log all received events (verbose)",
+            "default": false
+        }
+    }
+}"#;
+
+#[no_mangle]
+pub extern "C" fn plugin_id(out_ptr: *mut u8, out_max_len: usize) -> i32 {
+    write_string(PLUGIN_ID, out_ptr, out_max_len)
+}
+
+#[no_mangle]
+pub extern "C" fn plugin_name(out_ptr: *mut u8, out_max_len: usize) -> i32 {
+    write_string(PLUGIN_NAME, out_ptr, out_max_len)
+}
+
+#[no_mangle]
+pub extern "C" fn plugin_schema(out_ptr: *mut u8, out_max_len: usize) -> i32 {
+    write_string(PLUGIN_SCHEMA, out_ptr, out_max_len)
+}
+
+#[no_mangle]
+pub extern "C" fn plugin_start(config_ptr: *const u8, config_len: usize) -> i32 {
+    let config_json = unsafe {
+        let slice = std::slice::from_raw_parts(config_ptr, config_len);
+        String::from_utf8_lossy(slice).to_string()
+    };
+
+    let parsed_config: PluginConfig = match serde_json::from_str(&config_json) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&format!("Failed to parse config: {}", e));
+            return 1;
+        }
+    };
+
+    STATE.with(|state| {
+        let mut s = state.borrow_mut();
+        s.config = parsed_config.clone();
+        s.is_running = true;
+        s.events_received = 0;
+        s.high_rate_alert_active = false;
+    });
+
+    debug(&format!(
+        "Event Handler starting with threshold: {} deltas/sec",
+        parsed_config.delta_rate_threshold
+    ));
+
+    if subscribe_events(&["SERVERSTATISTICS", "VESSEL_INFO"]) {
+        debug("Subscribed to SERVERSTATISTICS and VESSEL_INFO events");
+    } else {
+        set_error("Failed to subscribe to server events");
+        return 1;
+    }
+
+    set_status("Monitoring server events");
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn plugin_stop() -> i32 {
+    STATE.with(|state| {
+        let mut s = state.borrow_mut();
+        s.is_running = false;
+
+        debug(&format!(
+            "Event Handler stopping. Total events received: {}",
+            s.events_received
+        ));
+    });
+
+    set_status("Stopped");
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn event_handler(event_ptr: *const u8, event_len: usize) {
+    let event_json = unsafe {
+        let slice = std::slice::from_raw_parts(event_ptr, event_len);
+        String::from_utf8_lossy(slice).to_string()
+    };
+
+    let event: ServerEvent = match serde_json::from_str(&event_json) {
+        Ok(e) => e,
+        Err(e) => {
+            debug(&format!("Failed to parse event: {}", e));
+            return;
+        }
+    };
+
+    STATE.with(|state| {
+        let mut s = state.borrow_mut();
+        s.events_received += 1;
+
+        if s.config.enable_debug {
+            debug(&format!(
+                "Event received: type={}, from={:?}",
+                event.event_type, event.from
+            ));
+        }
+
+        match event.event_type.as_str() {
+            "SERVERSTATISTICS" => handle_server_statistics(&mut s, &event),
+            "VESSEL_INFO" => handle_vessel_info(&s, &event),
+            _ => {
+                if s.config.enable_debug {
+                    debug(&format!("Unhandled event type: {}", event.event_type));
+                }
+            }
+        }
+    });
+}
+
+#[derive(Debug, Deserialize)]
+struct ServerEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[allow(dead_code)]
+    from: Option<String>,
+    data: serde_json::Value,
+    #[allow(dead_code)]
+    timestamp: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ServerStatistics {
+    delta_rate: Option<f64>,
+    ws_clients: Option<u32>,
+    uptime: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HighDeltaRateAlert {
+    current_rate: f64,
+    threshold: f64,
+    ws_clients: u32,
+    uptime_seconds: f64,
+    message: String,
+}
+
+fn handle_server_statistics(state: &mut PluginState, event: &ServerEvent) {
+    let stats: ServerStatistics = match serde_json::from_value(event.data.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            debug(&format!("Failed to parse SERVERSTATISTICS: {}", e));
+            return;
+        }
+    };
+
+    // Update state with latest values
+    if let Some(rate) = stats.delta_rate {
+        state.last_delta_rate = rate;
+    }
+    if let Some(clients) = stats.ws_clients {
+        state.ws_clients = clients;
+    }
+    if let Some(uptime) = stats.uptime {
+        state.uptime_seconds = uptime;
+    }
+
+    // Check if delta rate exceeds threshold
+    let rate = state.last_delta_rate;
+    let threshold = state.config.delta_rate_threshold;
+
+    if rate > threshold && !state.high_rate_alert_active {
+        // Delta rate crossed threshold - emit alert
+        state.high_rate_alert_active = true;
+
+        let alert = HighDeltaRateAlert {
+            current_rate: rate,
+            threshold,
+            ws_clients: state.ws_clients,
+            uptime_seconds: state.uptime_seconds,
+            message: format!(
+                "Delta rate ({:.1}/s) exceeded threshold ({:.1}/s)",
+                rate, threshold
+            ),
+        };
+
+        if emit_event("HIGH_DELTA_RATE", &alert) {
+            debug(&format!(
+                "Emitted PLUGIN_HIGH_DELTA_RATE alert: {:.1} > {:.1}",
+                rate, threshold
+            ));
+            set_status(&format!("Alert: High delta rate ({:.1}/s)", rate));
+        }
+    } else if rate <= threshold && state.high_rate_alert_active {
+        // Delta rate dropped below threshold - clear alert
+        state.high_rate_alert_active = false;
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct AlertCleared {
+            current_rate: f64,
+            threshold: f64,
+            message: String,
+        }
+
+        let cleared = AlertCleared {
+            current_rate: rate,
+            threshold,
+            message: format!(
+                "Delta rate ({:.1}/s) returned to normal (threshold: {:.1}/s)",
+                rate, threshold
+            ),
+        };
+
+        if emit_event("HIGH_DELTA_RATE_CLEARED", &cleared) {
+            debug("Emitted PLUGIN_HIGH_DELTA_RATE_CLEARED");
+            set_status("Monitoring server events");
+        }
+    }
+
+    if state.events_received % 12 == 0 {
+        set_status(&format!(
+            "Delta rate: {:.1}/s, WS clients: {}, Uptime: {:.0}s",
+            rate, state.ws_clients, state.uptime_seconds
+        ));
+    }
+}
+
+fn handle_vessel_info(state: &PluginState, event: &ServerEvent) {
+    if state.config.enable_debug {
+        debug(&format!("Vessel info changed: {:?}", event.data));
+    }
+}
+
+fn write_string(s: &str, ptr: *mut u8, max_len: usize) -> i32 {
+    let bytes = s.as_bytes();
+    let len = bytes.len().min(max_len);
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len);
+    }
+
+    len as i32
+}

--- a/src/wasm/bindings/env-imports.ts
+++ b/src/wasm/bindings/env-imports.ts
@@ -12,6 +12,11 @@ import { WasmCapabilities } from '../types'
 import { createResourceProviderBinding } from './resource-provider'
 import { createWeatherProviderBinding } from './weather-provider'
 import {
+  getEventManager,
+  PLUGIN_EVENT_PREFIX,
+  ServerEvent
+} from '../wasm-events'
+import {
   createRadarProviderBinding,
   createRadarEmitSpokesBinding
 } from './radar-provider'
@@ -1036,6 +1041,157 @@ export function createEnvImports(
     sk_tcp_close: (socketId: number): void => {
       if (!capabilities.rawSockets) return
       tcpSocketManager.close(socketId)
+    },
+
+    // ==========================================================================
+    // Server Events API
+    // Allows WASM plugins to receive server events and emit custom events
+    // Requires serverEvents capability
+    // ==========================================================================
+
+    /**
+     * Subscribe to server events
+     *
+     * @param eventTypesPtr - Pointer to JSON array of event types (e.g., '["SERVERSTATISTICS", "VESSEL_INFO"]')
+     *                        Empty array '[]' subscribes to all allowed events
+     * @param eventTypesLen - Length of event types JSON string
+     * @returns 1 on success, 0 on failure (capability not granted or invalid JSON)
+     *
+     * Note: The actual event delivery happens via the event_handler export.
+     * Plugin must export: event_handler(eventJson: string) -> void
+     */
+    sk_subscribe_events: (
+      eventTypesPtr: number,
+      eventTypesLen: number
+    ): number => {
+      if (!capabilities.serverEvents) {
+        debug(`[${pluginId}] serverEvents capability not granted`)
+        return 0
+      }
+
+      try {
+        const eventTypesJson = readUtf8String(eventTypesPtr, eventTypesLen)
+        const eventTypes: string[] = JSON.parse(eventTypesJson)
+
+        if (!Array.isArray(eventTypes)) {
+          debug(
+            `[${pluginId}] sk_subscribe_events: expected array, got ${typeof eventTypes}`
+          )
+          return 0
+        }
+
+        debug(
+          `[${pluginId}] Subscribing to events: ${eventTypes.length === 0 ? 'all allowed' : eventTypes.join(', ')}`
+        )
+
+        const eventManager = getEventManager()
+        eventManager.register(pluginId, eventTypes, (event: ServerEvent) => {
+          debug(
+            `[${pluginId}] Event received but handler not yet configured: ${event.type}`
+          )
+        })
+
+        return 1
+      } catch (error) {
+        debug(`[${pluginId}] sk_subscribe_events error: ${error}`)
+        return 0
+      }
+    },
+
+    /**
+     * Emit a custom event from the plugin
+     *
+     * @param typePtr - Pointer to event type string (will be prefixed with 'PLUGIN_' if not already)
+     * @param typeLen - Length of event type string
+     * @param dataPtr - Pointer to event data JSON string
+     * @param dataLen - Length of event data JSON string
+     * @returns 1 on success, 0 on failure
+     *
+     * Security: Event type will always be prefixed with 'PLUGIN_' to prevent
+     * plugins from impersonating server events. The 'from' field is automatically
+     * set to the plugin ID.
+     */
+    sk_emit_event: (
+      typePtr: number,
+      typeLen: number,
+      dataPtr: number,
+      dataLen: number
+    ): number => {
+      if (!capabilities.serverEvents) {
+        debug(`[${pluginId}] serverEvents capability not granted`)
+        return 0
+      }
+
+      try {
+        let eventType = readUtf8String(typePtr, typeLen)
+        const dataJson = readUtf8String(dataPtr, dataLen)
+
+        let data: unknown
+        try {
+          data = JSON.parse(dataJson)
+        } catch {
+          debug(`[${pluginId}] sk_emit_event: invalid JSON data`)
+          return 0
+        }
+
+        if (!eventType.startsWith(PLUGIN_EVENT_PREFIX)) {
+          eventType = PLUGIN_EVENT_PREFIX + eventType
+        }
+
+        debug(`[${pluginId}] Emitting event: ${eventType}`)
+
+        const event: ServerEvent = {
+          type: eventType,
+          from: pluginId,
+          data,
+          timestamp: Date.now()
+        }
+
+        if (app && app.emit) {
+          app.emit(eventType, event)
+          debug(`[${pluginId}] Event emitted to server bus: ${eventType}`)
+        }
+
+        const eventManager = getEventManager()
+        eventManager.routeEvent(event)
+
+        return 1
+      } catch (error) {
+        debug(`[${pluginId}] sk_emit_event error: ${error}`)
+        return 0
+      }
+    },
+
+    /**
+     * Get list of allowed event types that WASM plugins can subscribe to
+     *
+     * @param bufPtr - Buffer to write JSON array of allowed event types
+     * @param bufMaxLen - Maximum buffer size
+     * @returns Number of bytes written, or 0 if buffer too small / error
+     */
+    sk_get_allowed_event_types: (bufPtr: number, bufMaxLen: number): number => {
+      try {
+        const eventManager = getEventManager()
+        const allowedTypes = eventManager.getAllowedEventTypes()
+        const jsonStr = JSON.stringify(allowedTypes)
+        const jsonBytes = Buffer.from(jsonStr, 'utf8')
+
+        if (jsonBytes.length > bufMaxLen) {
+          debug(`[${pluginId}] sk_get_allowed_event_types: buffer too small`)
+          return 0
+        }
+
+        if (memoryRef.current) {
+          const memView = new Uint8Array(memoryRef.current.buffer)
+          memView.set(jsonBytes, bufPtr)
+          return jsonBytes.length
+        }
+
+        return 0
+      } catch (error) {
+        debug(`[${pluginId}] sk_get_allowed_event_types error: ${error}`)
+        return 0
+      }
     }
   }
 

--- a/src/wasm/bindings/radar-provider.ts
+++ b/src/wasm/bindings/radar-provider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * WASM Radar Provider Support
  *
@@ -7,7 +6,13 @@
  */
 
 import Debug from 'debug'
-import { WasmRadarProvider, WasmPluginInstance } from '../types'
+import {
+  WasmRadarProvider,
+  WasmPluginInstance,
+  WasmCapabilities,
+  SignalKApp,
+  WasmRawExports
+} from '../types'
 
 const debug = Debug('signalk:wasm:radar-provider')
 
@@ -28,10 +33,10 @@ export async function callWasmRadarHandler(
 ): Promise<string | null> {
   try {
     const asLoader = pluginInstance.asLoader
-    // Use the wrapped exports which have proper WASI initialization
-    // Fall back to raw instance exports if wrapped exports don't have the handler
-    const _wrappedExports = pluginInstance.exports as any
-    const rawExports = pluginInstance.instance?.exports as any
+    // Use raw instance exports for calling handlers
+    const rawExports = pluginInstance.instance?.exports as
+      | (WasmRawExports & WebAssembly.Exports)
+      | undefined
 
     // Debug: list available exports when handler is not found
     if (rawExports) {
@@ -50,6 +55,9 @@ export async function callWasmRadarHandler(
       // Need to handle Asyncify for handlers that call fetchSync
       const requestPtr = asLoader.exports.__newString(requestJson)
 
+      // Get the handler function with proper typing
+      const handlerFn = asLoader.exports[handlerName] as (ptr: number) => number
+
       // Set up Asyncify resume handling
       let resumePromiseResolve: ((result: string | null) => void) | null = null
       const resumePromise = new Promise<string | null>((resolve) => {
@@ -57,12 +65,12 @@ export async function callWasmRadarHandler(
       })
 
       // Store the result pointer from the handler call
-      let handlerResultPtr: any = null
+      let handlerResultPtr: number = 0
 
       if (pluginInstance.setAsyncifyResume) {
         pluginInstance.setAsyncifyResume(() => {
           debug(`Re-calling ${handlerName} to resume from rewind state`)
-          const resumeResultPtr = asLoader.exports[handlerName](requestPtr)
+          const resumeResultPtr = handlerFn(requestPtr)
           const result = asLoader.exports.__getString(resumeResultPtr)
           if (resumePromiseResolve) {
             resumePromiseResolve(result)
@@ -72,7 +80,7 @@ export async function callWasmRadarHandler(
       }
 
       // Call the handler
-      handlerResultPtr = asLoader.exports[handlerName](requestPtr)
+      handlerResultPtr = handlerFn(requestPtr)
 
       // Check if we're in Asyncify unwind state
       if (typeof asLoader.exports.asyncify_get_state === 'function') {
@@ -183,7 +191,10 @@ export function updateRadarProviderInstance(
  * @param pluginId The plugin ID
  * @param app The Signal K app (optional, if provided will also unregister from RadarApi)
  */
-export function cleanupRadarProviders(pluginId: string, app?: any): void {
+export function cleanupRadarProviders(
+  pluginId: string,
+  app?: SignalKApp
+): void {
   if (wasmRadarProviders.has(pluginId)) {
     debug(`Removing radar provider registration: ${pluginId}`)
     wasmRadarProviders.delete(pluginId)
@@ -214,8 +225,8 @@ export function cleanupRadarProviders(pluginId: string, app?: any): void {
  */
 export function createRadarProviderBinding(
   pluginId: string,
-  capabilities: { radarProvider?: boolean },
-  app: any,
+  capabilities: Pick<WasmCapabilities, 'radarProvider'>,
+  app: SignalKApp | undefined,
   readUtf8String: (ptr: number, len: number) => string
 ): (namePtr: number, nameLen: number) => number {
   return (namePtr: number, nameLen: number): number => {
@@ -281,7 +292,7 @@ export function createRadarProviderBinding(
            * Get radar info for a specific radar
            * @param radarId The radar ID
            */
-          getRadarInfo: async (radarId: string): Promise<any | null> => {
+          getRadarInfo: async (radarId: string): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -490,7 +501,7 @@ export function createRadarProviderBinding(
            */
           setControls: async (
             radarId: string,
-            controls: any
+            controls: Record<string, unknown>
           ): Promise<boolean> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
@@ -522,7 +533,7 @@ export function createRadarProviderBinding(
            * Get capability manifest for a radar
            * @param radarId The radar ID
            */
-          getCapabilities: async (radarId: string): Promise<any | null> => {
+          getCapabilities: async (radarId: string): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -560,7 +571,7 @@ export function createRadarProviderBinding(
            * Get current state
            * @param radarId The radar ID
            */
-          getState: async (radarId: string): Promise<any | null> => {
+          getState: async (radarId: string): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -600,7 +611,7 @@ export function createRadarProviderBinding(
           getControl: async (
             radarId: string,
             controlId: string
-          ): Promise<any | null> => {
+          ): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -643,7 +654,7 @@ export function createRadarProviderBinding(
           setControl: async (
             radarId: string,
             controlId: string,
-            value: any
+            value: unknown
           ): Promise<{ success: boolean; error?: string }> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
@@ -679,7 +690,7 @@ export function createRadarProviderBinding(
            * Get all tracked ARPA targets
            * @param radarId The radar ID
            */
-          getTargets: async (radarId: string): Promise<any | null> => {
+          getTargets: async (radarId: string): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -793,7 +804,7 @@ export function createRadarProviderBinding(
            * Get ARPA settings
            * @param radarId The radar ID
            */
-          getArpaSettings: async (radarId: string): Promise<any | null> => {
+          getArpaSettings: async (radarId: string): Promise<unknown> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
               debug(`[${pluginId}] Radar provider instance not ready`)
@@ -834,7 +845,7 @@ export function createRadarProviderBinding(
            */
           setArpaSettings: async (
             radarId: string,
-            settings: any
+            settings: Record<string, unknown>
           ): Promise<{ success: boolean; error?: string }> => {
             const provider = wasmRadarProviders.get(pluginId)
             if (!provider || !provider.pluginInstance) {
@@ -894,7 +905,7 @@ export function createRadarProviderBinding(
 export function createRadarEmitSpokesBinding(
   pluginId: string,
   capabilities: { radarProvider?: boolean },
-  app: any,
+  app: SignalKApp | undefined,
   readUtf8String: (ptr: number, len: number) => string,
   readBinaryData: (ptr: number, len: number) => Buffer
 ): (

--- a/src/wasm/loader/index.ts
+++ b/src/wasm/loader/index.ts
@@ -22,7 +22,6 @@ import { initializeLifecycleFunctions } from './plugin-registry'
 initializeLifecycleFunctions(
   startWasmPlugin,
   updateWasmPluginConfig,
-  unloadWasmPlugin,
   stopWasmPlugin
 )
 

--- a/src/wasm/loader/plugin-registry.ts
+++ b/src/wasm/loader/plugin-registry.ts
@@ -46,6 +46,7 @@ interface WasmPackageJson {
     weatherProvider?: boolean
     radarProvider?: boolean
     rawSockets?: boolean
+    serverEvents?: boolean
   }
   signalk?: Record<string, unknown>
 }
@@ -223,7 +224,8 @@ export async function registerWasmPlugin(
       resourceProvider: packageJson.wasmCapabilities?.resourceProvider || false,
       weatherProvider: packageJson.wasmCapabilities?.weatherProvider || false,
       radarProvider: packageJson.wasmCapabilities?.radarProvider || false,
-      rawSockets: packageJson.wasmCapabilities?.rawSockets || false
+      rawSockets: packageJson.wasmCapabilities?.rawSockets || false,
+      serverEvents: packageJson.wasmCapabilities?.serverEvents || false
     }
 
     // Load WASM module temporarily to extract schema and display name

--- a/src/wasm/loader/plugin-routes.ts
+++ b/src/wasm/loader/plugin-routes.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-require-imports */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * WASM Plugin HTTP Route Handlers
  *
@@ -8,19 +5,17 @@
  * Includes custom endpoint routing, log streaming, and basic REST API endpoints.
  */
 
+import * as fs from 'fs'
 import * as path from 'path'
 import * as express from 'express'
-import { Request, Response } from 'express'
+import type { Request, Response } from 'express'
 import { spawn } from 'child_process'
 import * as readline from 'readline'
 import Debug from 'debug'
 import { WasmPlugin } from './types'
+import { SignalKApp, WasmRawExports } from '../types'
 import { getWasmRuntime } from '../wasm-runtime'
-import {
-  getPluginStoragePaths,
-  readPluginConfig,
-  writePluginConfig
-} from '../wasm-storage'
+import { getPluginStoragePaths, readPluginConfig } from '../wasm-storage'
 import { SERVERROUTESPREFIX } from '../../constants'
 
 const debug = Debug('signalk:wasm:loader')
@@ -58,7 +53,6 @@ export async function handleLogViewerRequest(
 
     const logLines: string[] = []
     let hasError = false
-    let errorOutput = ''
 
     // Stream lines using readline
     const rl = readline.createInterface({
@@ -72,8 +66,8 @@ export async function handleLogViewerRequest(
       }
     })
 
-    p.stderr.on('data', (data) => {
-      errorOutput += data.toString()
+    p.stderr.on('data', () => {
+      // Errors are logged when journalctl exits with non-zero code
     })
 
     p.on('error', (err) => {
@@ -172,8 +166,9 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
     typeof plugin.instance.asLoader.exports.http_endpoints === 'function'
   const hasRustEndpoints =
     plugin.instance.instance &&
-    typeof (plugin.instance.instance.exports as any).http_endpoints ===
-      'function'
+    typeof (
+      plugin.instance.instance.exports as WasmRawExports & WebAssembly.Exports
+    ).http_endpoints === 'function'
 
   if (!hasAsEndpoints && !hasRustEndpoints) {
     debug(`No custom HTTP endpoints for ${plugin.id}`)
@@ -197,7 +192,8 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
       )
     } else {
       // Rust: http_endpoints(out_ptr, out_max_len) -> written_len
-      const rawExports = plugin.instance.instance.exports as any
+      const rawExports = plugin.instance.instance.exports as WasmRawExports &
+        WebAssembly.Exports
       if (
         typeof rawExports.allocate === 'function' &&
         typeof rawExports.http_endpoints === 'function'
@@ -373,7 +369,8 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
             debug(
               `Using raw exports for handler ${handler} (Rust buffer-based)`
             )
-            const rawExports = plugin.instance!.instance.exports as any
+            const rawExports = plugin.instance!.instance
+              .exports as WasmRawExports & WebAssembly.Exports
             const handlerFunc = rawExports[handler]
 
             if (typeof handlerFunc !== 'function') {
@@ -482,23 +479,23 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
  * Set up REST API routes for a WASM plugin
  */
 export function setupWasmPluginRoutes(
-  app: any,
+  app: SignalKApp,
   plugin: WasmPlugin,
   configPath: string,
   updateWasmPluginConfig: (
-    app: any,
+    app: SignalKApp,
     pluginId: string,
-    configuration: any,
+    configuration: unknown,
     configPath: string
   ) => Promise<void>,
-  startWasmPlugin: (app: any, pluginId: string) => Promise<void>,
-  unloadWasmPlugin: (app: any, pluginId: string) => Promise<void>,
+  startWasmPlugin: (app: SignalKApp, pluginId: string) => Promise<void>,
   stopWasmPlugin: (pluginId: string) => Promise<void>
 ): void {
   const router = express.Router()
 
   // GET /plugins/:id - Get plugin info
   router.get('/', (req: Request, res: Response) => {
+    void req // Required by Express signature
     res.json({
       enabled: plugin.enabled,
       enabledByDefault: false,
@@ -557,13 +554,14 @@ export function setupWasmPluginRoutes(
             debug(`Plugin was disabled at startup, loading WASM binary now...`)
 
             // Read package.json to get WASM path
-            const packageJson = require(
-              path.join(
-                plugin.packageLocation,
-                plugin.packageName,
-                'package.json'
-              )
+            const packageJsonPath = path.join(
+              plugin.packageLocation,
+              plugin.packageName,
+              'package.json'
             )
+            const packageJson = JSON.parse(
+              fs.readFileSync(packageJsonPath, 'utf-8')
+            ) as { wasmManifest: string }
             const wasmPath = path.join(
               plugin.packageLocation,
               plugin.packageName,
@@ -632,6 +630,7 @@ export function setupWasmPluginRoutes(
 
   // GET /plugins/:id/config - Get plugin configuration
   router.get('/config', (req: Request, res: Response) => {
+    void req // Required by Express signature
     const storagePaths = getPluginStoragePaths(
       configPath,
       plugin.id,
@@ -648,7 +647,9 @@ export function setupWasmPluginRoutes(
   })
 
   // Register the router for this plugin
-  app.use(backwardsCompat(`/plugins/${plugin.id}`), router)
+  if (app.use) {
+    app.use(backwardsCompat(`/plugins/${plugin.id}`), router)
+  }
 
   // Store router in plugin object for later removal
   plugin.router = router

--- a/src/wasm/loader/types.ts
+++ b/src/wasm/loader/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * WASM Plugin Type Definitions
  *
@@ -45,12 +44,13 @@ export interface WasmPlugin {
   status: 'stopped' | 'starting' | 'running' | 'error' | 'crashed'
   statusMessage?: string
   errorMessage?: string
-  schema?: any
-  configuration?: any
+  schema?: Record<string, unknown>
+  configuration?: Record<string, unknown>
   crashCount: number
   lastCrash?: Date
   restartBackoff: number // milliseconds
   description?: string
   state?: string
   format?: WasmFormat // Binary format: wasi-p1 or component-model
+  stop?: () => Promise<void>
 }

--- a/src/wasm/types.ts
+++ b/src/wasm/types.ts
@@ -25,6 +25,7 @@ export interface WasmCapabilities {
   weatherProvider?: boolean // Can register as a weather provider
   radarProvider?: boolean // Can register as a radar provider
   rawSockets?: boolean // Can open UDP/TCP sockets for radar, NMEA, etc.
+  serverEvents?: boolean // Can receive and emit server events
 }
 
 /**
@@ -195,6 +196,9 @@ export interface WasmRawExports {
   // Delta handler
   delta_handler?: (ptr: number, len: number) => void
 
+  // Event handler
+  event_handler?: (ptr: number, len: number) => void
+
   // Index signature for dynamic handler access
   [key: string]: unknown
 }
@@ -256,6 +260,9 @@ export interface WasmPluginExports {
   // Optional: Delta handler - receives Signal K deltas as JSON strings
   // Enables plugins to react to navigation data changes, course updates, etc.
   delta_handler?: (deltaJson: string) => void
+  // Optional: Receives server events as JSON strings
+  // Enables plugins to react to server state changes (connections, statistics, etc.)
+  event_handler?: (eventJson: string) => void
 }
 
 /**

--- a/src/wasm/wasm-events.test.ts
+++ b/src/wasm/wasm-events.test.ts
@@ -1,0 +1,134 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/**
+ * Unit tests for WasmEventManager
+ */
+
+import { expect } from 'chai'
+import { WasmEventManager, ServerEvent } from './wasm-events'
+
+describe('WasmEventManager', () => {
+  let manager: WasmEventManager
+
+  beforeEach(() => {
+    manager = new WasmEventManager()
+  })
+
+  describe('isAllowed', () => {
+    it('allows server events', () => {
+      expect(manager.isAllowed('SERVERSTATISTICS')).to.be.true
+      expect(manager.isAllowed('VESSEL_INFO')).to.be.true
+      expect(manager.isAllowed('DEBUG_SETTINGS')).to.be.true
+      expect(manager.isAllowed('SERVERMESSAGE')).to.be.true
+      expect(manager.isAllowed('PROVIDERSTATUS')).to.be.true
+      expect(manager.isAllowed('SOURCEPRIORITIES')).to.be.true
+    })
+
+    it('allows generic NMEA events', () => {
+      expect(manager.isAllowed('nmea0183')).to.be.true
+      expect(manager.isAllowed('nmea0183out')).to.be.true
+      expect(manager.isAllowed('nmea2000JsonOut')).to.be.true
+      expect(manager.isAllowed('nmea2000out')).to.be.true
+      expect(manager.isAllowed('nmea2000OutAvailable')).to.be.true
+    })
+
+    it('allows canboatjs events', () => {
+      expect(manager.isAllowed('canboatjs:error')).to.be.true
+      expect(manager.isAllowed('canboatjs:warning')).to.be.true
+      expect(manager.isAllowed('canboatjs:unparsed:data')).to.be.true
+    })
+
+    it('allows PLUGIN_ prefixed events', () => {
+      expect(manager.isAllowed('PLUGIN_CUSTOM')).to.be.true
+      expect(manager.isAllowed('PLUGIN_MY_EVENT')).to.be.true
+    })
+
+    it('rejects unknown event types', () => {
+      expect(manager.isAllowed('UNKNOWN')).to.be.false
+      expect(manager.isAllowed('randomEvent')).to.be.false
+    })
+  })
+
+  describe('isServerEvent / isGenericEvent', () => {
+    it('correctly identifies server events', () => {
+      expect(manager.isServerEvent('SERVERSTATISTICS')).to.be.true
+      expect(manager.isServerEvent('VESSEL_INFO')).to.be.true
+      expect(manager.isServerEvent('nmea0183')).to.be.false
+      expect(manager.isServerEvent('nmea2000JsonOut')).to.be.false
+    })
+
+    it('correctly identifies generic events', () => {
+      expect(manager.isGenericEvent('nmea0183')).to.be.true
+      expect(manager.isGenericEvent('nmea0183out')).to.be.true
+      expect(manager.isGenericEvent('nmea2000JsonOut')).to.be.true
+      expect(manager.isGenericEvent('canboatjs:error')).to.be.true
+      expect(manager.isGenericEvent('SERVERSTATISTICS')).to.be.false
+      expect(manager.isGenericEvent('VESSEL_INFO')).to.be.false
+    })
+  })
+
+  describe('getAllowedEventTypes', () => {
+    it('returns all allowed event types', () => {
+      const types = manager.getAllowedEventTypes()
+      expect(types).to.include('SERVERSTATISTICS')
+      expect(types).to.include('nmea0183')
+      expect(types).to.include('nmea2000JsonOut')
+    })
+  })
+
+  describe('getAllowedServerEvents', () => {
+    it('returns only server events', () => {
+      const types = manager.getAllowedServerEvents()
+      expect(types).to.include('SERVERSTATISTICS')
+      expect(types).to.include('VESSEL_INFO')
+      expect(types).to.not.include('nmea0183')
+      expect(types).to.not.include('nmea2000JsonOut')
+    })
+  })
+
+  describe('getAllowedGenericEvents', () => {
+    it('returns only generic events', () => {
+      const types = manager.getAllowedGenericEvents()
+      expect(types).to.include('nmea0183')
+      expect(types).to.include('nmea2000JsonOut')
+      expect(types).to.not.include('SERVERSTATISTICS')
+      expect(types).to.not.include('VESSEL_INFO')
+    })
+  })
+
+  describe('routeEvent', () => {
+    it('routes events to subscribed plugins', () => {
+      const received: ServerEvent[] = []
+      manager.register('test-plugin', ['nmea0183'], (event) => {
+        received.push(event)
+      })
+
+      const event: ServerEvent = {
+        type: 'nmea0183',
+        data: '$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A',
+        timestamp: Date.now()
+      }
+
+      manager.routeEvent(event)
+
+      expect(received).to.have.length(1)
+      expect(received[0].type).to.equal('nmea0183')
+    })
+
+    it('does not route disallowed events', () => {
+      const received: ServerEvent[] = []
+      manager.register('test-plugin', [], (event) => {
+        received.push(event)
+      })
+
+      const event: ServerEvent = {
+        type: 'UNKNOWN_EVENT',
+        data: {},
+        timestamp: Date.now()
+      }
+
+      manager.routeEvent(event)
+
+      expect(received).to.have.length(0)
+    })
+  })
+})

--- a/src/wasm/wasm-events.ts
+++ b/src/wasm/wasm-events.ts
@@ -1,0 +1,229 @@
+/**
+ * WASM Plugin Server Event Management
+ *
+ * PropertyValues events are excluded because they contain function references.
+ */
+
+import Debug from 'debug'
+
+const debug = Debug('signalk:wasm:events')
+
+export interface ServerEvent {
+  type: string
+  from?: string
+  data: unknown
+  timestamp: number
+}
+
+export type EventCallback = (event: ServerEvent) => void
+
+export interface EventSubscription {
+  pluginId: string
+  eventTypes: string[]
+  callback: EventCallback
+}
+
+const WASM_ALLOWED_EVENT_TYPES = new Set([
+  'SERVERSTATISTICS',
+  'VESSEL_INFO',
+  'DEBUG_SETTINGS',
+  'SERVERMESSAGE',
+  'PROVIDERSTATUS',
+  'SOURCEPRIORITIES'
+])
+
+export const PLUGIN_EVENT_PREFIX = 'PLUGIN_'
+
+export class WasmEventManager {
+  private subscriptions: Map<string, EventSubscription[]> = new Map()
+  private buffers: Map<string, ServerEvent[]> = new Map()
+  private buffering: Set<string> = new Set()
+
+  isAllowed(eventType: string): boolean {
+    return (
+      WASM_ALLOWED_EVENT_TYPES.has(eventType) ||
+      eventType.startsWith(PLUGIN_EVENT_PREFIX)
+    )
+  }
+
+  getAllowedEventTypes(): string[] {
+    return Array.from(WASM_ALLOWED_EVENT_TYPES)
+  }
+
+  register(
+    pluginId: string,
+    eventTypes: string[],
+    callback: EventCallback
+  ): void {
+    if (!this.subscriptions.has(pluginId)) {
+      this.subscriptions.set(pluginId, [])
+    }
+
+    const allowedTypes =
+      eventTypes.length === 0
+        ? this.getAllowedEventTypes()
+        : eventTypes.filter((t) => this.isAllowed(t))
+
+    this.subscriptions.get(pluginId)!.push({
+      pluginId,
+      eventTypes: allowedTypes,
+      callback
+    })
+    debug(
+      `Registered event subscription for ${pluginId}: ${allowedTypes.join(', ') || 'all'}`
+    )
+  }
+
+  unregister(pluginId: string): void {
+    const count = this.subscriptions.get(pluginId)?.length || 0
+    this.subscriptions.delete(pluginId)
+    debug(`Unregistered ${count} event subscriptions for ${pluginId}`)
+  }
+
+  getSubscriptions(pluginId: string): EventSubscription[] {
+    return this.subscriptions.get(pluginId) || []
+  }
+
+  routeEvent(event: ServerEvent): void {
+    if (this.subscriptions.size === 0) {
+      debug(`No subscriptions, skipping event ${event.type}`)
+      return
+    }
+
+    if (!this.isAllowed(event.type)) {
+      debug(`Event type ${event.type} not allowed for WASM plugins`)
+      return
+    }
+
+    debug(`Routing event ${event.type} to ${this.subscriptions.size} plugin(s)`)
+
+    const eventWithTimestamp: ServerEvent = {
+      ...event,
+      timestamp: event.timestamp || Date.now()
+    }
+
+    for (const [pluginId, subs] of this.subscriptions) {
+      if (this.buffering.has(pluginId)) {
+        this.bufferEvent(pluginId, eventWithTimestamp)
+        continue
+      }
+
+      for (const sub of subs) {
+        if (
+          sub.eventTypes.length === 0 ||
+          sub.eventTypes.includes(event.type)
+        ) {
+          try {
+            sub.callback(eventWithTimestamp)
+          } catch (error) {
+            debug(`Error in event callback for ${pluginId}:`, error)
+          }
+          break
+        }
+      }
+    }
+  }
+
+  startBuffering(pluginId: string): void {
+    debug(`Started buffering events for ${pluginId}`)
+    this.buffering.add(pluginId)
+    this.buffers.set(pluginId, [])
+  }
+
+  stopBuffering(pluginId: string): ServerEvent[] {
+    debug(`Stopped buffering events for ${pluginId}`)
+    this.buffering.delete(pluginId)
+
+    const buffered = this.buffers.get(pluginId) || []
+    this.buffers.delete(pluginId)
+
+    debug(`Returning ${buffered.length} buffered events for ${pluginId}`)
+    return buffered
+  }
+
+  private bufferEvent(pluginId: string, event: ServerEvent): void {
+    if (!this.buffers.has(pluginId)) {
+      this.buffers.set(pluginId, [])
+    }
+
+    const buffer = this.buffers.get(pluginId)!
+    buffer.push(event)
+
+    const MAX_BUFFER_SIZE = 100
+    if (buffer.length > MAX_BUFFER_SIZE) {
+      buffer.shift()
+      debug(`Event buffer overflow for ${pluginId}, dropped oldest event`)
+    }
+  }
+
+  replayBuffered(pluginId: string, callback: EventCallback): void {
+    const buffered = this.buffers.get(pluginId) || []
+    debug(`Replaying ${buffered.length} buffered events to ${pluginId}`)
+
+    for (const event of buffered) {
+      try {
+        callback(event)
+      } catch (error) {
+        debug(`Error replaying event to ${pluginId}:`, error)
+      }
+    }
+
+    this.buffers.delete(pluginId)
+  }
+
+  getStats(): {
+    totalSubscriptions: number
+    activePlugins: number
+    bufferingPlugins: number
+    bufferedEvents: number
+  } {
+    let totalSubscriptions = 0
+    for (const subs of this.subscriptions.values()) {
+      totalSubscriptions += subs.length
+    }
+
+    let bufferedEvents = 0
+    for (const buffer of this.buffers.values()) {
+      bufferedEvents += buffer.length
+    }
+
+    return {
+      totalSubscriptions,
+      activePlugins: this.subscriptions.size,
+      bufferingPlugins: this.buffering.size,
+      bufferedEvents
+    }
+  }
+
+  clear(): void {
+    this.subscriptions.clear()
+    this.buffers.clear()
+    this.buffering.clear()
+    debug('Cleared all event subscriptions and buffers')
+  }
+}
+
+let eventManager: WasmEventManager | null = null
+
+export function getEventManager(): WasmEventManager {
+  if (!eventManager) {
+    eventManager = new WasmEventManager()
+  }
+  return eventManager
+}
+
+export function initializeEventManager(): WasmEventManager {
+  if (eventManager) {
+    debug('Event manager already initialized')
+    return eventManager
+  }
+
+  eventManager = new WasmEventManager()
+  debug('Event manager initialized')
+  return eventManager
+}
+
+export function resetEventManager(): void {
+  debug('Resetting event manager singleton')
+  eventManager = null
+}

--- a/src/wasm/wasm-events.ts
+++ b/src/wasm/wasm-events.ts
@@ -23,13 +23,38 @@ export interface EventSubscription {
   callback: EventCallback
 }
 
-const WASM_ALLOWED_EVENT_TYPES = new Set([
+/**
+ * Server events (uppercase) - delivered via serverevent wrapper
+ */
+const WASM_ALLOWED_SERVER_EVENTS = new Set([
   'SERVERSTATISTICS',
   'VESSEL_INFO',
   'DEBUG_SETTINGS',
   'SERVERMESSAGE',
   'PROVIDERSTATUS',
   'SOURCEPRIORITIES'
+])
+
+/**
+ * Generic events (lowercase) - NMEA data streams and parser events
+ */
+const WASM_ALLOWED_GENERIC_EVENTS = new Set([
+  'nmea0183', // Raw NMEA 0183 sentences from hardware
+  'nmea0183out', // Derived NMEA 0183 from plugins
+  'nmea2000JsonOut', // NMEA 2000 JSON PGN data
+  'nmea2000out', // Raw NMEA 2000 data
+  'nmea2000OutAvailable', // Signal that N2K output is ready
+  'canboatjs:error', // Parser error events
+  'canboatjs:warning', // Parser warning events
+  'canboatjs:unparsed:data' // Unparsed data from canboatjs
+])
+
+/**
+ * Combined set of all allowed event types for WASM plugins
+ */
+const WASM_ALLOWED_EVENT_TYPES = new Set([
+  ...WASM_ALLOWED_SERVER_EVENTS,
+  ...WASM_ALLOWED_GENERIC_EVENTS
 ])
 
 export const PLUGIN_EVENT_PREFIX = 'PLUGIN_'
@@ -48,6 +73,22 @@ export class WasmEventManager {
 
   getAllowedEventTypes(): string[] {
     return Array.from(WASM_ALLOWED_EVENT_TYPES)
+  }
+
+  getAllowedServerEvents(): string[] {
+    return Array.from(WASM_ALLOWED_SERVER_EVENTS)
+  }
+
+  getAllowedGenericEvents(): string[] {
+    return Array.from(WASM_ALLOWED_GENERIC_EVENTS)
+  }
+
+  isServerEvent(eventType: string): boolean {
+    return WASM_ALLOWED_SERVER_EVENTS.has(eventType)
+  }
+
+  isGenericEvent(eventType: string): boolean {
+    return WASM_ALLOWED_GENERIC_EVENTS.has(eventType)
   }
 
   register(

--- a/src/wasm/wasm-serverapi.ts
+++ b/src/wasm/wasm-serverapi.ts
@@ -49,7 +49,7 @@ export function createServerAPIBridge(
       /**
        * Handle delta message from plugin
        *
-       * @param pluginIdParam - Plugin identifier
+       * @param callerPluginId - Plugin identifier
        * @param deltaJson - Delta message as JSON string
        * @param version - Signal K version: 1 = v1 (default), 2 = v2
        *
@@ -57,29 +57,32 @@ export function createServerAPIBridge(
        * Use v2 for Course API paths and other v2-specific data.
        */
       handleMessage: (
-        pluginIdParam: string,
+        callerPluginId: string,
         deltaJson: string,
         version: number = 1
       ) => {
         if (!capabilities.dataWrite) {
-          throw new Error(`Plugin ${pluginId} lacks dataWrite capability`)
+          throw new Error(`Plugin ${callerPluginId} lacks dataWrite capability`)
         }
 
         try {
           const delta = JSON.parse(deltaJson)
           const skVersion = version === 2 ? SKVersion.v2 : SKVersion.v1
-          debug(`Plugin ${pluginId} emitting delta (${skVersion}):`, delta)
+          debug(
+            `Plugin ${callerPluginId} emitting delta (${skVersion}):`,
+            delta
+          )
 
           // Forward to server's handleMessage with version
           if (app.handleMessage) {
-            app.handleMessage(pluginId, delta, skVersion)
+            app.handleMessage(callerPluginId, delta, skVersion)
           } else {
             debug('Warning: app.handleMessage not available')
           }
         } catch (error) {
           const errorMsg =
             error instanceof Error ? error.message : String(error)
-          debug(`Error handling delta from ${pluginId}: ${errorMsg}`)
+          debug(`Error handling delta from ${callerPluginId}: ${errorMsg}`)
           throw error
         }
       }

--- a/src/wasm/wasm-subscriptions.ts
+++ b/src/wasm/wasm-subscriptions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * WASM Plugin Delta Subscription Management
  *
@@ -15,17 +14,17 @@ const debug = Debug('signalk:wasm:subscriptions')
 export interface DeltaSubscription {
   pluginId: string
   pattern: string // Path pattern like "navigation.*" or "*"
-  callback: (delta: any) => void
+  callback: (delta: Delta) => void
 }
 
 export interface Delta {
   context: string
   updates: Array<{
-    source: any
+    source: Record<string, unknown>
     timestamp: string
     values: Array<{
       path: string
-      value: any
+      value: unknown
     }>
   }>
 }
@@ -46,7 +45,7 @@ export class WasmSubscriptionManager {
   register(
     pluginId: string,
     pattern: string,
-    callback: (delta: any) => void
+    callback: (delta: Delta) => void
   ): void {
     if (!this.subscriptions.has(pluginId)) {
       this.subscriptions.set(pluginId, [])


### PR DESCRIPTION
                                                                                       
  ## Description:                                                                               
                                                                                             
  Completes the serverEvents capability for WASM plugins, enabling them to receive both      
  server events and NMEA data stream events, and emit events back to the Signal K pipeline.  
                                                                                             
  ## Changes                                                                                    
                                                                                             
  ### Generic event mechanism:                                                                   
  - Add nmea0183, nmea0183out, nmea2000JsonOut, nmea2000out, nmea2000OutAvailable,           
  canboatjs:* to allowed event types                                                         
  - Subscribe plugins to generic events via app.on() in lifecycle                            
  - Allow sk_emit_event to emit standard event names (no PLUGIN_ prefix for generic events)  
  - Fix serverEvents capability not being loaded from package.json                           
                                                                                             
  ### TypeScript strict mode:                                                                    
  - Enable noUnusedLocals, noUnusedParameters, noImplicitReturns, etc.                       
  - No eslint-disable workarounds, no _prefix hiding                                         
                                                                                             
  ### Documentation:                                                                             
  - Add serverEvents section to capabilities.md with event types table and usage examples    
                                                                                             
  ## Testing                                                                                    
                                                                                             
  - 382 tests pass                                                                           
  - Example plugin demonstrates nmea0183 → nmea2000JsonOut conversion (RMC/GGA → PGN         
  129025/129026)                                                                             
  - Verified event delivery with sample NMEA data