### PR TITLE
Revert back to using mdns and dnsd

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "as-fetch": "^2.1.4",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
-    "bonjour-service": "^1.3.0",
     "body-parser": "^1.20.3",
     "busboy": "^1.6.0",
     "chalk": "^3.0.0",
@@ -94,6 +93,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.5.2",
     "debug": "^4.3.3",
+    "dnssd2": "1.0.0",
     "errorhandler": "^1.3.0",
     "esm-resolve": "^1.0.11",
     "express": "^4.21.2",
@@ -136,6 +136,7 @@
     "@signalk/signalk-to-nmea0183": "^1.0.0",
     "@signalk/udp-nmea-plugin": "^2.0.0",
     "@signalk/vesselpositions": "^1.0.0",
+    "mdns": "^2.5.1",
     "serialport": "^11.0.0",
     "signalk-n2kais-to-nmea0183": "^2.0.0",
     "signalk-to-nmea2000": "^2.16.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,71 +551,58 @@ class Server {
     return this
   }
 
-  stop(cb?: () => void) {
-    return new Promise((resolve, reject) => {
-      if (!this.app.started) {
-        resolve(this)
-      } else {
-        // Stop all interfaces (some may be async)
-        const stopInterfaces = async () => {
-          const stopPromises = Object.values(this.app.interfaces).map(
-            (intf: any) => {
-              if (
-                intf !== null &&
-                typeof intf === 'object' &&
-                typeof intf.stop === 'function'
-              ) {
-                const result = intf.stop()
-                // Handle both sync and async stops
-                return result instanceof Promise ? result : Promise.resolve()
-              }
-              return Promise.resolve()
-            }
-          )
-          await Promise.all(stopPromises)
+  async stop(cb?: () => void) {
+    if (!this.app.started) {
+      return this
+    }
+
+    try {
+      _.each(this.app.interfaces, (intf: any) => {
+        if (
+          intf !== null &&
+          typeof intf === 'object' &&
+          typeof intf.stop === 'function'
+        ) {
+          intf.stop()
         }
+      })
 
-        stopInterfaces()
-          .catch((err) => debug('Error stopping interfaces:', err))
-          .then(() => {
+      this.app.intervals.forEach((interval) => {
+        clearInterval(interval)
+      })
+
+      this.app.providers.forEach((providerHolder) => {
+        providerHolder.pipeElements[0].end()
+      })
+
+      debug('Closing server...')
+
+      const that = this
+      return new Promise((resolve, reject) => {
+        this.app.server.close(() => {
+          debug('Server closed')
+          if (that.app.redirectServer) {
             try {
-              this.app.intervals.forEach((interval) => {
-                clearInterval(interval)
-              })
-
-              this.app.providers.forEach((providerHolder) => {
-                providerHolder.pipeElements[0].end()
-              })
-
-              debug('Closing server...')
-
-              const that = this
-              this.app.server.close(() => {
-                debug('Server closed')
-                if (that.app.redirectServer) {
-                  try {
-                    that.app.redirectServer.close(() => {
-                      debug('Redirect server closed')
-                      delete that.app.redirectServer
-                      that.app.started = false
-                      cb && cb()
-                      resolve(that)
-                    })
-                  } catch (err) {
-                    reject(err)
-                  }
-                } else {
-                  that.app.started = false
-                  cb && cb()
-                  resolve(that)
-                }
+              that.app.redirectServer.close(() => {
+                debug('Redirect server closed')
+                delete that.app.redirectServer
+                that.app.started = false
+                cb && cb()
+                resolve(that)
               })
             } catch (err) {
               reject(err)
             }
-          })
-      }
-    })
+          } else {
+            that.app.started = false
+            cb && cb()
+            resolve(that)
+          }
+        })
+      })
+    } catch (err) {
+      throw err
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface SignalKServer extends ServerAPI {
 
 export class Interface {
   start?: () => void
-  stop?: () => void | Promise<void>
+  stop?: () => void
   mdns?: MdnsAdvertisement
 }
 


### PR DESCRIPTION
Revert back to using mdns and dnsd after issues
with ciao and bonjour-service.

Fixes #2294

Revert "fix: replace @homebridge/ciao with bonjour-service to fix mDNS name conflicts (#2275)"

This reverts commit 8cc1f48328cb5cb5699e19bb24cc67f9ab6ef7d4.

Revert " fix: replace native mdns with @homebridge/ciao to eliminate Avahi warnings (#2234)"

This reverts commit 03f1d2830009dea76d8407ff6778dd18ad9fd1d8.