### PR TITLE
chore: docker builds - add wait time to housekeeping processes

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -102,10 +102,14 @@ jobs:
       packages: write
 
     steps:
+      - name: Wait for GHCR indexing
+        run: sleep 60
       - name: Remove Docker Image from GHCR
+        continue-on-error: true
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           packages: signalk-server-base
           delete-untagged: true
-          delete-tags: amd-24.04-24.x,amd-24.04-22.x,arm-24.04-24.x,arm-24.04-22.x
+          delete-tags: |
+            amd-*,arm-*
           token: ${{ secrets.GHCR_PAT }} # Need to have delete permission

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -139,7 +139,10 @@ jobs:
     permissions:
       packages: write
     steps:
+      - name: Wait for GHCR indexing
+        run: sleep 60
       - name: Remove Temporary & Untagged Docker Images from GHCR
+        continue-on-error: true
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           packages: signalk-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,10 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Remove Docker Image from GHCR
+      - name: Wait for GHCR indexing
+        run: sleep 60
+      - name: Remove Temporary & Untagged Docker Images from GHCR
+        continue-on-error: true
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           packages: signalk-server


### PR DESCRIPTION
Time to time, indexes take longer to appear in GHCR’s package API. Wait time allow this to happen.
Fix applied following build processes
- base docker images
- dev docker images
- release docker images