### PR TITLE
refactor: switch from mdns-js to dnssd2 in discovery.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "jsonwebtoken": "^9.0.0",
     "listr": "^0.14.1",
     "lodash": "^4.17.21",
-    "mdns-js": "^1.0.3",
     "minimist": "^1.2.8",
     "moment": "^2.10.6",
     "morgan": "^1.5.0",

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -18,7 +18,7 @@ import { createDebug } from './debug'
 const debug = createDebug('signalk-server:discovery')
 const canboatjs = require('@canboat/canboatjs')
 const dgram = require('dgram')
-const mdns = require('mdns-js')
+const dnssd = require('dnssd2')
 const { networkInterfaces } = require('os')
 
 module.exports.runDiscovery = function (app) {
@@ -196,28 +196,23 @@ module.exports.runDiscovery = function (app) {
 
   function discoverSignalkWs(wsType) {
     try {
-      mdns.excludeInterface('0.0.0.0')
-      var browser = mdns.createBrowser(mdns.tcp('signalk-' + wsType))
+      const browser = new dnssd.Browser(dnssd.tcp('signalk-' + wsType))
 
-      browser.on('ready', function onReady() {
-        try {
-          debug('looking for SignalK ' + wsType)
-          browser.discover()
-        } catch (err) {
-          debug('discoverSignalkWs:', err)
-        }
-      })
-
-      browser.on('update', function onUpdate(data) {
+      browser.on('serviceUp', (service) => {
         try {
           if (
-            !isLocalIP(data.addresses[0]) &&
-            Array.isArray(data.type) &&
-            data.type[0].name === 'signalk-' + wsType &&
-            !findWSProvider(data.addresses[0], wsType, data.host, data.port)
+            service.addresses &&
+            service.addresses.length > 0 &&
+            !isLocalIP(service.addresses[0]) &&
+            !findWSProvider(
+              service.addresses[0],
+              wsType,
+              service.host,
+              service.port
+            )
           ) {
-            debug('discoverSignalkWs found data[' + wsType + ']:', data)
-            const providerId = wsType + '-' + data.host + ':' + data.port
+            debug('discoverSignalkWs found service[' + wsType + ']:', service)
+            const providerId = wsType + '-' + service.host + ':' + service.port
             app.emit('discovered', {
               id: providerId,
               enabled: false,
@@ -228,8 +223,8 @@ module.exports.runDiscovery = function (app) {
                     type: 'SignalK',
                     subOptions: {
                       type: wsType,
-                      host: data.host,
-                      port: data.port,
+                      host: service.host,
+                      port: service.port,
                       providerId: providerId
                     },
                     providerId: providerId
@@ -242,6 +237,13 @@ module.exports.runDiscovery = function (app) {
           debug('discoverSignalkWs:', err)
         }
       })
+
+      browser.on('error', (err) => {
+        debug('discoverSignalkWs browser error:', err)
+      })
+
+      debug('looking for SignalK ' + wsType)
+      browser.start()
 
       setTimeout(() => {
         try {

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -25,16 +25,6 @@ const ports = require('./ports')
 module.exports = function mdnsResponder(app) {
   const config = app.config
 
-  let mdns = dnssd
-
-  try {
-    mdns = require('mdns')
-    debug('using  mdns')
-  } catch (ex) {
-    debug(ex)
-    debug('mdns not found, using dnssd2')
-  }
-
   if (typeof config.settings.mdns !== 'undefined' && !config.settings.mdns) {
     debug('Mdns disabled by configuration')
     return
@@ -57,7 +47,7 @@ module.exports = function mdnsResponder(app) {
 
   const types = []
   types.push({
-    type: app.config.settings.ssl ? mdns.tcp('https') : mdns.tcp('http'),
+    type: app.config.settings.ssl ? dnssd.tcp('https') : dnssd.tcp('http'),
     port: ports.getExternalPort(app)
   })
 
@@ -73,7 +63,7 @@ module.exports = function mdnsResponder(app) {
         service.name.charAt(0) === '_'
       ) {
         types.push({
-          type: mdns[service.type](service.name),
+          type: dnssd[service.type](service.name),
           port: service.port
         })
       } else {
@@ -110,7 +100,7 @@ module.exports = function mdnsResponder(app) {
         ':' +
         type.port
     )
-    const ad = new mdns.Advertisement(type.type, type.port, options)
+    const ad = new dnssd.Advertisement(type.type, type.port, options)
     ad.on('error', (err) => {
       console.log(type.type.name)
       console.error(err)


### PR DESCRIPTION
Replace mdns-js with dnssd2 in discovery.js and remove the mdns fallback from mdns.js, unifying mDNS library usage to dnssd2 only. Pure js solution. 

Server Logs: `signalk-server:mdns`
```
Feb 02 18:56:55 2026-02-02T18:56:55.507Z signalk-server:mdns { txtRecord: { txtvers: '1', swname: 'signalk-server', swvers: '2.20.3', roles: 'master, main', self: 'urn:mrn:imo:mmsi:2300xxxxx', vname: 'MyBoat', vmmsi: '2300xxxxx' }, txt: { txtvers: '1', swname: 'signalk-server', swvers: '2.20.3', roles: 'master, main', self: 'urn:mrn:imo:mmsi:2300xxxxx', vname: 'MyBoat', vmmsi: '2300xxxxx' } }
Feb 02 18:56:55 2026-02-02T18:56:55.509Z signalk-server:mdns Starting mDNS ad: _http._tcp intel-linux:3000
Feb 02 18:56:55 2026-02-02T18:56:55.510Z signalk-server:mdns Starting mDNS ad: _nmea-0183._tcp intel-linux:10110
Feb 02 18:56:55 2026-02-02T18:56:55.510Z signalk-server:mdns Starting mDNS ad: _signalk-http._tcp intel-linux:3000
Feb 02 18:56:55 2026-02-02T18:56:55.511Z signalk-server:mdns Starting mDNS ad: _signalk-tcp._tcp intel-linux:8375
Feb 02 18:56:55 2026-02-02T18:56:55.511Z signalk-server:mdns Starting mDNS ad: _signalk-ws._tcp intel-linux:3000
```
Discovery from modified SK
<img width="914" height="189" alt="image" src="https://github.com/user-attachments/assets/4e67e18a-86b4-49df-9d50-9a9fc9cd1f8c" />
