### PR TITLE
chore: dependabot scans all folders

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,34 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
     open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  # Enable version updates for Docker
-  - package-ecosystem: 'docker'
-    # Look for a `Dockerfile` in the `root` directory
-    directory: '/'
-    # Check for updates once a week
+  - package-ecosystem: "docker"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
 
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"


### PR DESCRIPTION
Hey, looking for ways to contribute although I am more of a embedded guy.

One finding I had is, that
a) there are a lot of dependabot PRs
b) the npm packages in packages dont get updated?

This PR is meant to group minor version PRs from dependabot, as there should be no problems there.
I try to go through major updates and update the code accordingly in future PRs

In general: what is a way to help you keeping the packages up to date?