### PR TITLE
fix: await async file write in setup to prevent ENOENT on fresh install

### DIFF
--- a/bin/signalk-server-setup
+++ b/bin/signalk-server-setup
@@ -224,7 +224,7 @@ function promptForVesselName(configDirectory, updateExisting) {
                 deltaEditor.removeSelfValue('uuid')
               }
               deltaEditor.setSelfValue('name', vesselName)
-              deltaEditor.save(defaultsLocation)
+              return deltaEditor.save(defaultsLocation)
             }
           },
           {
@@ -269,6 +269,9 @@ function promptForVesselName(configDirectory, updateExisting) {
                 settingsLocation,
                 configDirectory
               ].forEach((file) => {
+                if (!fs.existsSync(file)) {
+                  return
+                }
                 let stat = fs.statSync(file)
                 let mode =
                   file === startupLocation || stat.isDirectory() ? '755' : '644'


### PR DESCRIPTION
## Summary

Fresh install via `npm i -g signalk-server` followed by `signalk-server-setup` fails on v2.20.3 with:
```

Error: ENOENT: no such file or directory, stat '/home/home/.signalk/baseDeltas.json'

```

The setup script calls `deltaEditor.save()` without returning the promise. The `listr` task runner only awaits promises that are explicitly returned, so it moves on to the file ownership task immediately.

This was a latent bug that became visible after #2227 changed `save()` from a single `fs.promises.writeFile()` to a two-step atomic write (write `.tmp`, then rename). The rename hasn't completed when the next task calls `fs.statSync()`.

## Changes

- Return the promise from `deltaEditor.save()` so listr awaits completion
- Add `fs.existsSync()` guard in the ownership task for robustness
