### PR TITLE
feat: add ema and sma to History API

### DIFF
--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -1,6 +1,19 @@
 import { Context, Path, Timestamp } from '.'
 import { Temporal } from '@js-temporal/polyfill'
 
+/**
+ * Method for aggregating historical data points within a time bucket.
+ *
+ * - `average`: Mean of all values in the bucket
+ * - `min`: Minimum value
+ * - `max`: Maximum value
+ * - `first`: First value chronologically
+ * - `last`: Last value chronologically
+ * - `mid`: Midpoint between min and max: (min + max) / 2
+ * - `middle_index`: Value at the middle index position
+ * - `sma`: Simple Moving Average with number of samples specified in the parameter array (e.g., sma:5 for 5-sample SMA)
+ * - `ema`: Exponential Moving Average with alpha specified in the parameter array (e.g., ema:0.2 for alpha=0.2 EMA)
+ */
 export type AggregateMethod =
   | 'average'
   | 'min'
@@ -9,6 +22,8 @@ export type AggregateMethod =
   | 'last'
   | 'mid'
   | 'middle_index'
+  | 'sma'
+  | 'ema'
 
 export type ValueList = {
   path: Path
@@ -116,6 +131,9 @@ export interface HistoryApi {
   /**
    * Retrieves historical values for the specified query parameters.
    *
+   * For aggregation methods that require parameters (sma, ema), implementations should use sensible defaults
+   * if the parameter array is empty in the PathSpec. For example: sma could default to 5 samples, ema could default to 0.2 alpha.
+   *
    * @param query - The {@link ValuesRequest} containing context, time range, resolution, and path specifications.
    * @returns A promise that resolves to a {@link ValuesResponse} containing the requested historical data.
    */
@@ -196,6 +214,7 @@ export type TimeRangeParams =
 export interface PathSpec {
   path: Path
   aggregate: AggregateMethod
+  parameter: string[]
 }
 
 export type ValuesRequest = TimeRangeParams & {

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -169,10 +169,17 @@ const splitPathExpression = (pathExpression: string): PathSpec => {
   if (parts[0] === 'navigation.position') {
     aggregateMethod = 'first' as AggregateMethod
   }
-  return {
+
+  // Extract all parameters from parts[2] onwards
+  const parameters: string[] = parts.slice(2).filter((p) => p.length > 0)
+
+  const pathSpec: PathSpec = {
     path: parts[0] as Path,
-    aggregate: aggregateMethod
+    aggregate: aggregateMethod,
+    parameter: parameters
   }
+
+  return pathSpec
 }
 
 const parseTimeRangeParams = (query: Record<string, unknown>) => {

--- a/src/api/history/openApi.json
+++ b/src/api/history/openApi.json
@@ -75,8 +75,8 @@
           {
             "name": "paths",
             "in": "query",
-            "description": "Comma separated ist of Signal K paths whose data should be retrieved, optional aggregation methods for each path as postfix separated by a colon. Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index'",
-            "example": "navigation.speedOverGround,navigation.speedThroughWater:max",
+            "description": "Comma separated list of Signal K paths whose data should be retrieved, optional aggregation methods for each path as postfix separated by a colon. Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index' | 'sma' | 'ema'. The 'sma' (simple moving average) and 'ema' (exponential moving average) methods accept an optional numeric parameter separated by colon: for sma it is the number of samples, for ema it is the alpha value (0-1). If not provided, implementations should use sensible defaults.",
+            "example": "navigation.speedOverGround:sma:5,navigation.speedThroughWater:max",
             "schema": {
               "type": "string"
             },


### PR DESCRIPTION
Add explicit support for Simple Moving
Average and Exponential Moving Average
to History API.