### PR TITLE
fix: use global flag in subscription path and context matching regex

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -274,7 +274,7 @@ function handleSubscribeRow(
 }
 
 function pathMatcher(path: string = '*') {
-  const pattern = path.replace('.', '\\.').replace('*', '.*')
+  const pattern = path.replace(/\./g, '\\.').replace(/\*/g, '.*')
   const matcher = new RegExp('^' + pattern + '$')
   return (aPath: string) => matcher.test(aPath)
 }
@@ -289,8 +289,8 @@ function contextMatcher(
   if (subscribeCommand.context) {
     if (isString(subscribeCommand.context)) {
       const pattern = subscribeCommand.context
-        .replace('.', '\\.')
-        .replace('*', '.*')
+        .replace(/\./g, '\\.')
+        .replace(/\*/g, '.*')
       const matcher = new RegExp('^' + pattern + '$')
       return (normalizedDeltaData: WithContext) =>
         matcher.test(normalizedDeltaData.context) ||


### PR DESCRIPTION
## Summary

- Subscription wildcard matching uses `String.replace()` which only replaces the first occurrence when called with a string argument. For multi-segment paths like `navigation.course.*`, only the first dot is escaped — subsequent dots remain as regex wildcards (`.` = any character), causing `navigation.course.*` to incorrectly match `navigation.courseOverGround`.
- Fix both `pathMatcher()` and `contextMatcher()` to use regex literals with the global flag (`/\./g`, `/\*/g`), consistent with the correct implementation already in `wasm-subscriptions.ts`.
