### PR TITLE
feature: drop arm/v7 container image support

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -55,7 +55,7 @@ jobs:
             os: alpine
             node: 22.x
             node_safe: 22
-            platform: linux/arm64,linux/arm/v7
+            platform: linux/arm64
           - vm: ubuntu-24.04-arm
             arch: arm
             os: alpine

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -52,7 +52,7 @@ jobs:
           - vm: ubuntu-24.04-arm
             arch: arm
             node: 22.x
-            platform: linux/arm64,linux/arm/v7
+            platform: linux/arm64
           - vm: ubuntu-24.04-arm
             arch: arm
             node: 24.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           - vm: ubuntu-24.04-arm
             arch: arm
             node: 22.x
-            platform: linux/arm64,linux/arm/v7
+            platform: linux/arm64
           - vm: ubuntu-24.04-arm
             arch: arm
             node: 24.x


### PR DESCRIPTION
Stop building container images for arm/v7
as nodesource has dropped support for it.