### PR TITLE
fix: move baconjs from peerDependencies to dependencies in server-api

### DIFF
--- a/packages/server-api/package.json
+++ b/packages/server-api/package.json
@@ -21,13 +21,11 @@
   "author": "teppo.kurki@iki.fi",
   "license": "Apache-2.0",
   "dependencies": {
-    "@js-temporal/polyfill": "^0.5.1"
+    "@js-temporal/polyfill": "^0.5.1",
+    "baconjs": "^1.0.1"
   },
   "devDependencies": {
     "ts-auto-guard": "^5.0.1"
-  },
-  "peerDependencies": {
-    "baconjs": "^1.0.1"
   },
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Moves `baconjs` from `peerDependencies` to `dependencies` in `@signalk/server-api`
- `server-api` directly imports `baconjs` in `propertyvalues.ts` and `streambundle.ts`, so it should declare it as a proper dependency
- Fixes plugins installed in `~/.signalk/` failing with `Cannot find module 'baconjs'` because npm does not auto-install peer dependencies into nested `node_modules` trees