### PR TITLE
fix: /signalk/v2/api/history in History API provider

### DIFF
--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -64,7 +64,7 @@ export class HistoryApiHttpRegistry {
   }
 
   start() {
-    this.app.get('/signalk/v2/history/values', (req, res) =>
+    this.app.get('/signalk/v2/api/history/values', (req, res) =>
       respondWith(
         this.provider,
         () => {
@@ -75,7 +75,7 @@ export class HistoryApiHttpRegistry {
       )
     )
 
-    this.app.get('/signalk/v2/history/contexts', (req, res) =>
+    this.app.get('/signalk/v2/api/history/contexts', (req, res) =>
       respondWith(
         this.provider,
         () => {
@@ -91,7 +91,7 @@ export class HistoryApiHttpRegistry {
       )
     )
 
-    this.app.get('/signalk/v2/history/paths', (req, res) =>
+    this.app.get('/signalk/v2/api/history/paths', (req, res) =>
       respondWith(
         this.provider,
         () => {


### PR DESCRIPTION
Place the history api implementation under /signalk/v2/api where  it should be per other apis and the OpenApi spec.