### PR TITLE
test: add dependency version sync test for React 19 admin UI

### DIFF
--- a/packages/server-admin-ui-react19/src/dependency-sync.test.ts
+++ b/packages/server-admin-ui-react19/src/dependency-sync.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { satisfies } from 'semver'
+
+describe('dependency version sync', () => {
+  it('installed versions satisfy @signalk/server-admin-ui-dependencies peerDependencies', () => {
+    const depsPackageJson = JSON.parse(
+      readFileSync(
+        join(__dirname, '../../server-admin-ui-dependencies/package.json'),
+        'utf-8'
+      )
+    )
+
+    const peerDeps: Record<string, string> =
+      depsPackageJson.peerDependencies ?? {}
+
+    const mismatches: string[] = []
+
+    for (const [name, range] of Object.entries(peerDeps)) {
+      let installedVersion: string
+      try {
+        const pkgJson = JSON.parse(
+          readFileSync(
+            require.resolve(`${name}/package.json`, {
+              paths: [join(__dirname, '..')]
+            }),
+            'utf-8'
+          )
+        )
+        installedVersion = pkgJson.version
+      } catch {
+        mismatches.push(`${name}: not installed (expected ${range})`)
+        continue
+      }
+
+      if (!satisfies(installedVersion, range)) {
+        mismatches.push(
+          `${name}: installed ${installedVersion} does not satisfy ${range}`
+        )
+      }
+    }
+
+    expect(
+      mismatches,
+      'Version mismatches with @signalk/server-admin-ui-dependencies'
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

I looked into removing the overlapping dependencies from the React 19 admin UI's `package.json` that are already declared as peerDependencies in `@signalk/server-admin-ui-dependencies`, as Teppo suggested.

**It turns out they can't be removed** while both admin UIs coexist in the monorepo. The legacy admin UI uses older major versions of all the shared packages (Bootstrap 4, react-select 3, reactstrap 5, React 16), and npm hoists those to the root `node_modules/`. When I removed the newer versions from the React 19 package's `devDependencies`, npm stopped installing them locally — and the `validate-peer-dependencies` check in `vite.config.js` correctly failed, finding Bootstrap 4.6.2 instead of `^5.3.3`, etc.

This applies to all 6 overlapping packages, not just React. The explicit declarations in the React 19 package are what force npm to install the correct newer versions in its local `node_modules/` instead of falling back to the hoisted legacy versions.

**What this PR does instead**: adds a vitest that asserts the actually-installed versions of shared UI libraries satisfy the peerDependency ranges from `@signalk/server-admin-ui-dependencies`. If someone updates a version in one place but not the other, the test fails with a clear message naming the mismatched package, expected range, and actual version. This catches drift early in CI.

## Test plan

-  `npm run build:all` passes
-  `npm test --workspace=packages/server-admin-ui-react19` — 87 tests pass (including the new sync test)
-  Verified the test correctly detects mismatches by temporarily changing a version