### PR TITLE
fix: update previousPoint when active route geometry changes

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -210,6 +210,20 @@ export class CourseApi {
                       !!this.courseInfo.activeRoute.reverse
                     )
                   }
+                  if (this.courseInfo.previousPoint?.type === RoutePoint) {
+                    const prevIndex =
+                      (this.courseInfo.activeRoute.pointIndex as number) - 1
+                    if (prevIndex >= 0) {
+                      this.courseInfo.previousPoint = {
+                        type: RoutePoint,
+                        position: this.getRoutePoint(
+                          rte,
+                          prevIndex,
+                          !!this.courseInfo.activeRoute.reverse
+                        )
+                      }
+                    }
+                  }
                   this.emitCourseInfo()
                 }
               }


### PR DESCRIPTION
## Summary

- When navigating an active route at pointIndex > 0, modifying the route's geometry (e.g. moving a waypoint) now correctly updates `navigation.course.previousPoint` in addition to `nextPoint`
- Previously only `nextPoint` was refreshed from the updated route coordinates, leaving `previousPoint` stale — causing incorrect crossTrackError calculations and the data browser showing a dotted line to the old position

Addresses #2326

## Test plan

-  New test: activates a route, advances past point 0, modifies the previous point's coordinates via the resources API, verifies `previousPoint.position` reflects the new coordinates
-  All existing course tests pass
-  Full test suite passes (372 tests)
-  Manually verified against running server: modified route point 0 from `[177.38, -17.77]` to `[170.00, -10.00]` and confirmed `previousPoint` updated correctly