### PR TITLE
fix: appstore install/remove progress not shown in UI

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -201,7 +201,7 @@ module.exports = function (app) {
     }
   }
 
-  function getAllModuleInfo(plugins, webapps, serverVersion, distTagsMap) {
+  function getAllModuleInfo(plugins, webapps, serverVersion, distTagsMap = {}) {
     const all = emptyAppStoreInfo()
 
     if (


### PR DESCRIPTION
When installing or removing a plugin via the appstore, the UI never showed the "Installing" / "Removing" progress bar or status text.

The root cause is that `sendAppStoreChangedEvent()` calls `getAllModuleInfo(plugins, webapps, serverVersion)` without passing the `distTagsMap` argument. Inside `getModulesInfo()`, the code does `distTagsMap[name]` which throws a TypeError because `distTagsMap` is `undefined`. This crashes the entire event pipeline, so the `APP_STORE_CHANGED` event never reaches the UI via websocket.

The fix is simply to default the parameter to an empty object `{}`. The dist-tags lookup then safely returns `undefined` per key (which is already handled by the existing `if (tags)` guard), and the install/remove status events flow through to the UI as intended.