### PR TITLE
fix: DataBrowser meta toggle stops data updates and multiple UX issues - R19

### DIFF
--- a/packages/server-admin-ui-react19/src/views/DataBrowser/GranularSubscriptionManager.ts
+++ b/packages/server-admin-ui-react19/src/views/DataBrowser/GranularSubscriptionManager.ts
@@ -238,11 +238,14 @@ class GranularSubscriptionManager {
   /**
    * Extract unique paths from path$SourceKeys
    * path$SourceKey format: "navigation.position$sourceId" -> extract "navigation.position"
+   * When context is "all", keys are prefixed: "context\0path$source" -> strip context prefix first
    */
   private _extractUniquePaths(path$SourceKeys: Set<string>): string[] {
     const paths = new Set<string>()
     for (const pk of path$SourceKeys) {
-      const path = getPathFromKey(pk)
+      const nullIdx = pk.indexOf('\0')
+      const key = nullIdx >= 0 ? pk.slice(nullIdx + 1) : pk
+      const path = getPathFromKey(key)
       if (path) {
         paths.add(path)
       }

--- a/packages/server-admin-ui-react19/src/views/DataBrowser/VirtualTable.css
+++ b/packages/server-admin-ui-react19/src/views/DataBrowser/VirtualTable.css
@@ -60,11 +60,7 @@
 
 .virtual-table-row[data-raw-row='true'] {
   content-visibility: auto;
-  contain-intrinsic-block-size: 80px;
-}
-
-.virtual-table-row[data-raw-row='true']:nth-child(-n + 20) {
-  content-visibility: visible;
+  contain-intrinsic-block-size: 150px;
 }
 
 .virtual-table-row:hover {
@@ -122,7 +118,7 @@
   bottom: 0;
   width: 3px;
   background-color: var(--bs-success, #00cd79);
-  animation: highlightFade 15s ease-out;
+  animation: highlightFade 15s ease-out forwards;
 }
 
 @keyframes highlightFade {
@@ -317,7 +313,7 @@
   opacity: 1;
 }
 
-/* Meta table specific styles */
-.virtual-table-meta .virtual-table-row {
-  min-height: 60px;
+.virtual-table-meta-row {
+  content-visibility: auto;
+  contain-intrinsic-block-size: 200px;
 }


### PR DESCRIPTION
## Summary

- Fix meta toggle killing live data updates permanently — VirtualizedDataTable's unmount cleanup called `unsubscribeAll()` on the shared subscription manager; removed that and added re-subscribe logic in DataBrowser when switching back from meta view
- Fix filtered search (e.g. typing "pos") not receiving value updates or freshness animation — DataBrowser subscribed to `signalkData` via `useShallow`, causing full re-renders on every delta; replaced with targeted `dataVersion` + `contextKeys` subscriptions and `useMemo` for path lists
- Fix "all" context duplicates in meta view — `uniquePathsForMeta` didn't dedup multi-source paths; added dedup via `ctx\0path` key
- Fix GranularSubscriptionManager not stripping `context\0` prefix from "all" context keys, causing subscription messages with invalid paths
- Fix race condition on initial load — `startDiscovery()` could fire before the hello message set `skSelf`, so `handleMessage` dropped all announcements; now gates on `skSelf`
- Fix freshness indicator green bar reappearing after 15s fade — CSS animation lacked `forwards` fill-mode
- Fix meta table scroll flicker — replaced spacer-based virtualization (inaccurate with variable-height rows) with `content-visibility: auto` for native browser off-screen skipping
- Fix raw data truncation and scroll-to-bottom redraw — same `content-visibility: auto` approach for raw rows
- Add collapsible meta rows with summary line (click to expand/collapse)
- Fix duplicate HTML form field IDs when multiple meta rows rendered in "all" context — scope IDs with context+path prefix