### PR TITLE
feat: detect and display deprecated plugins/webapps in admin UI

### DIFF
--- a/packages/server-admin-ui-react19/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui-react19/src/components/Sidebar/Sidebar.tsx
@@ -44,12 +44,30 @@ export default function Sidebar({ location }: SidebarProps) {
 
   const items = useMemo((): NavItemData[] => {
     const appUpdates = appStore.updates.length
-    let updatesBadge: BadgeData | null = null
+    const appDeprecated = appStore.deprecated?.length || 0
+    let appstoreBadge: BadgeData | null = null
     let serverUpdateBadge: BadgeData | null = null
     let accessRequestsBadge: BadgeData | null = null
 
-    if (appUpdates > 0) {
-      updatesBadge = {
+    if (appStore.storeAvailable === false) {
+      appstoreBadge = {
+        variant: 'danger',
+        text: 'OFFLINE'
+      }
+    } else if (appUpdates > 0 && appDeprecated > 0) {
+      appstoreBadge = {
+        variant: 'warning',
+        text: `${appUpdates}\u2191 ${appDeprecated}\u2717`,
+        color: 'warning'
+      }
+    } else if (appDeprecated > 0) {
+      appstoreBadge = {
+        variant: 'danger',
+        text: `${appDeprecated}`,
+        color: 'danger'
+      }
+    } else if (appUpdates > 0) {
+      appstoreBadge = {
         variant: 'success',
         text: `${appUpdates}`,
         color: 'success'
@@ -61,13 +79,6 @@ export default function Sidebar({ location }: SidebarProps) {
         variant: 'danger',
         text: `${accessRequests.length}`,
         color: 'danger'
-      }
-    }
-
-    if (appStore.storeAvailable === false) {
-      updatesBadge = {
-        variant: 'danger',
-        text: 'OFFLINE'
       }
     }
 
@@ -106,7 +117,7 @@ export default function Sidebar({ location }: SidebarProps) {
           name: 'Appstore',
           url: '/appstore',
           icon: 'icon-basket',
-          badge: updatesBadge
+          badge: appstoreBadge
         },
         {
           name: 'Server',

--- a/packages/server-admin-ui-react19/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui-react19/src/store/slices/appSlice.ts
@@ -100,7 +100,8 @@ const initialAppState: AppSliceState = {
     updates: [],
     installed: [],
     available: [],
-    installing: []
+    installing: [],
+    deprecated: []
   },
   loginStatus: {},
   serverSpecification: {},
@@ -142,7 +143,8 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
       installing: [...appStore.installing].sort(nameCollator),
       available: [...appStore.available].sort(nameCollator),
       installed: [...appStore.installed].sort(nameCollator),
-      updates: [...appStore.updates].sort(nameCollator)
+      updates: [...appStore.updates].sort(nameCollator),
+      deprecated: [...(appStore.deprecated || [])].sort(nameCollator)
     }
     set({ appStore: sorted })
   },

--- a/packages/server-admin-ui-react19/src/store/types.ts
+++ b/packages/server-admin-ui-react19/src/store/types.ts
@@ -14,6 +14,7 @@ export interface AppStoreState {
   installed: AppInfo[]
   available: AppInfo[]
   installing: InstallingApp[]
+  deprecated: AppInfo[]
   storeAvailable?: boolean
   canUpdateServer?: boolean
   serverUpdate?: string
@@ -25,6 +26,8 @@ export interface AppInfo {
   version?: string
   description?: string
   author?: string
+  deprecatedMessage?: string
+  isOrphan?: boolean
   [key: string]: unknown
 }
 

--- a/packages/server-admin-ui-react19/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui-react19/src/views/Configuration/Configuration.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
   useOptimistic,
   useTransition,
   ChangeEvent,
@@ -10,6 +11,8 @@ import {
   FormEvent
 } from 'react'
 import { useParams } from 'react-router-dom'
+import { useAppStore } from '../../store'
+import Badge from 'react-bootstrap/Badge'
 import PluginConfigurationForm from './../ServerConfig/PluginConfigurationForm'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -71,6 +74,17 @@ export default function PluginConfigurationList() {
   const [wasmEnabled, setWasmEnabled] = useState(true)
 
   const [isFiltering, startFilterTransition] = useTransition()
+
+  const appStore = useAppStore()
+  const deprecatedMap = useMemo(() => {
+    const map = new Map<string, string>()
+    ;(appStore.deprecated || []).forEach((app) => {
+      if (app.deprecatedMessage) {
+        map.set(app.name, app.deprecatedMessage)
+      }
+    })
+    return map
+  }, [appStore.deprecated])
 
   const tableContainerRef = useRef<HTMLDivElement>(null)
 
@@ -405,6 +419,15 @@ export default function PluginConfigurationList() {
                     >
                       <td>
                         <strong>{plugin.name}</strong>
+                        {deprecatedMap.has(plugin.packageName) && (
+                          <Badge
+                            bg="danger"
+                            className="ms-2"
+                            title={deprecatedMap.get(plugin.packageName)}
+                          >
+                            Deprecated
+                          </Badge>
+                        )}
                       </td>
                       <td>
                         <div className="d-flex align-items-center justify-content-between">

--- a/packages/server-admin-ui-react19/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui-react19/src/views/Webapps/Webapp.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import Badge from 'react-bootstrap/Badge'
 import Card from 'react-bootstrap/Card'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTableCells } from '@fortawesome/free-solid-svg-icons/faTableCells'
@@ -19,6 +20,7 @@ interface WebAppInfo {
 
 interface WebappProps {
   webAppInfo: WebAppInfo
+  deprecatedMessage?: string
   children?: ReactNode
 }
 
@@ -28,7 +30,11 @@ export function urlToWebapp(webAppInfo: WebAppInfo): string {
     : `/${webAppInfo.name}`
 }
 
-export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
+export default function Webapp({
+  webAppInfo,
+  deprecatedMessage,
+  ...attributes
+}: WebappProps) {
   const padding = { card: 'p-3', icon: 'p-3', lead: 'mt-2' }
 
   const card = {
@@ -77,7 +83,14 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
       <Card>
         <Card.Body className={card.style} {...attributes}>
           {blockIcon(webAppInfo?.signalk?.appIcon || null)}
-          <div className={lead.classes}>{header}</div>
+          <div className={lead.classes}>
+            {header}
+            {deprecatedMessage && (
+              <Badge bg="danger" className="ms-2" title={deprecatedMessage}>
+                Deprecated
+              </Badge>
+            )}
+          </div>
           <div className="text-muted font-xs">{webAppInfo.description}</div>
         </Card.Body>
       </Card>

--- a/packages/server-admin-ui-react19/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui-react19/src/views/Webapps/Webapps.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense, createElement, ComponentType } from 'react'
-import { useWebapps, useAddons } from '../../store'
+import { useWebapps, useAddons, useAppStore } from '../../store'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
 import { ADDON_PANEL, toLazyDynamicComponent } from './dynamicutilities'
@@ -27,6 +27,17 @@ interface AddonPanelProps {
 export default function Webapps() {
   const webapps = useWebapps() as WebAppInfo[]
   const addons = useAddons() as AddonModule[]
+  const appStore = useAppStore()
+
+  const deprecatedMap = useMemo(() => {
+    const map = new Map<string, string>()
+    ;(appStore.deprecated || []).forEach((app) => {
+      if (app.deprecatedMessage) {
+        map.set(app.name, app.deprecatedMessage)
+      }
+    })
+    return map
+  }, [appStore.deprecated])
 
   const addonComponents = useMemo(
     () =>
@@ -53,7 +64,11 @@ export default function Webapps() {
               .map((webAppInfo) => {
                 return (
                   <Col xs="12" md="12" lg="6" xl="4" key={webAppInfo.name}>
-                    <Webapp key={webAppInfo.name} webAppInfo={webAppInfo} />
+                    <Webapp
+                      key={webAppInfo.name}
+                      webAppInfo={webAppInfo}
+                      deprecatedMessage={deprecatedMap.get(webAppInfo.name)}
+                    />
                   </Col>
                 )
               })}

--- a/packages/server-admin-ui-react19/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui-react19/src/views/appstore/Apps/Apps.tsx
@@ -27,6 +27,7 @@ interface AppInfo {
   prereleaseVersion?: string
   updated?: string
   categories: string[]
+  deprecatedMessage?: string
   [key: string]: unknown
 }
 
@@ -36,6 +37,7 @@ interface AppStore {
   installed: AppInfo[]
   installing: InstallingApp[]
   updates: AppInfo[]
+  deprecated: AppInfo[]
   categories?: string[]
 }
 
@@ -55,6 +57,8 @@ const selectedViewToFilter = (
     return (app) => updateAvailable(app, appStore)
   } else if (selectedView === 'Installing') {
     return (app) => !!app.installing
+  } else if (selectedView === 'Deprecated') {
+    return (app) => !!app.deprecatedMessage
   }
   return () => true
 }
@@ -189,6 +193,17 @@ const Apps: React.FC = () => {
                   </span>
                 )}
               </Button>
+              {appStore.deprecated?.length > 0 && (
+                <Button
+                  variant={view === 'Deprecated' ? 'secondary' : 'light'}
+                  onClick={() => setSelectedView('Deprecated')}
+                >
+                  Deprecated
+                  <span className="badge__deprecated">
+                    {appStore.deprecated.length}
+                  </span>
+                </Button>
+              )}
               {appStore.installing.length > 0 && (
                 <>
                   <Button

--- a/packages/server-admin-ui-react19/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui-react19/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -30,6 +30,7 @@ interface AppData {
   isPlugin?: boolean
   id?: string
   npmUrl?: string
+  deprecatedMessage?: string
   [key: string]: unknown
 }
 
@@ -131,6 +132,22 @@ export default function ActionCellRenderer({
       <div className="progress__wrapper">
         <div className="progress__status p-1">{status}</div>
         {progress}
+      </div>
+    )
+  } else if (app.deprecatedMessage && app.installed) {
+    content = (
+      <div className="d-flex flex-column align-items-end">
+        <span className="badge text-bg-danger mb-2">Deprecated</span>
+        <Button variant="danger" size="sm" onClick={handleRemoveClick}>
+          <FontAwesomeIcon className="me-2" icon={faTrashCan} />
+          Remove
+        </Button>
+        <small
+          className="text-muted mt-1 text-end"
+          style={{ maxWidth: 200, fontSize: '0.75rem' }}
+        >
+          {app.deprecatedMessage}
+        </small>
       </div>
     )
   } else {

--- a/packages/server-admin-ui-react19/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui-react19/src/views/appstore/appStore.scss
@@ -69,6 +69,16 @@
           padding: 3px;
           vertical-align: middle;
         }
+
+        span.badge__deprecated {
+          color: #fff !important;
+          font-size: 10px;
+          border-radius: 3px;
+          background-color: #dc3545 !important;
+          margin-left: 5px;
+          padding: 3px;
+          vertical-align: middle;
+        }
       }
     }
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -458,6 +458,64 @@ export async function importOrRequire(moduleDir: string) {
   }
 }
 
+const deprecationCache: Record<
+  string,
+  { time: number; deprecated: string | false }
+> = {}
+const DEPRECATION_CACHE_TTL = 60 * 60 * 1000
+
+async function checkPackageDeprecation(
+  packageName: string
+): Promise<string | false> {
+  const cached = deprecationCache[packageName]
+  if (cached && Date.now() - cached.time < DEPRECATION_CACHE_TTL) {
+    return cached.deprecated
+  }
+
+  try {
+    const res = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}`
+    )
+    if (!res.ok) return false
+
+    const data = (await res.json()) as {
+      'dist-tags'?: { latest?: string }
+      versions?: Record<string, { deprecated?: string }>
+    }
+    const latestVersion = data['dist-tags']?.latest
+    const deprecated =
+      (latestVersion && data.versions?.[latestVersion]?.deprecated) || false
+
+    deprecationCache[packageName] = { time: Date.now(), deprecated }
+    return deprecated
+  } catch (err) {
+    npmDebug(`Failed to check deprecation for ${packageName}: ${err}`)
+    return false
+  }
+}
+
+async function checkDeprecations(
+  packageNames: string[]
+): Promise<Record<string, string | false>> {
+  const CONCURRENCY = 5
+  const results: Record<string, string | false> = {}
+
+  for (let i = 0; i < packageNames.length; i += CONCURRENCY) {
+    const batch = packageNames.slice(i, i + CONCURRENCY)
+    const batchResults = await Promise.all(
+      batch.map(async (name) => ({
+        name,
+        deprecated: await checkPackageDeprecation(name)
+      }))
+    )
+    batchResults.forEach(({ name, deprecated }) => {
+      results[name] = deprecated
+    })
+  }
+
+  return results
+}
+
 module.exports = {
   modulesWithKeyword,
   installModule,
@@ -471,5 +529,7 @@ module.exports = {
   getKeywords,
   restoreModules,
   importOrRequire,
-  runNpm
+  runNpm,
+  checkDeprecations,
+  checkPackageDeprecation
 }


### PR DESCRIPTION
Supersedes #2274 — rebased and rewritten for current master.

## Summary

- Query npm registry for deprecation status of installed packages (1-hour cache, concurrency-limited batch lookups)
- Detect orphan plugins/webapps (installed locally but absent from npm search) and surface them in the appstore data
- Orphan install/remove state tracking so progress animations work correctly
- Allow removing orphan plugins that aren't in npm search results (was returning 404)

### UI (React 19 admin UI — Zustand + react-bootstrap)

- **Deprecated tab** in Appstore with remove-only action and deprecation message
- **Combined sidebar badge** (e.g. "3↑ 1✗" for updates + deprecated)
- **Deprecated badge** on Plugin Configuration and Webapps pages

## Tested

- Install `@signalk/zones` (deprecated), verify Deprecated tab appears
- Remove from Deprecated tab, verify progress animation and "Removed" status
- Verify combined sidebar badge shows deprecation count
- Verify deprecated badge on Plugin Configuration page
- Server + R19 UI build and lint clean