### PR TITLE
feat: detect and display deprecated plugins/webapps in admin UI - R19

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -56,13 +56,31 @@ export default function Sidebar({ location }: SidebarProps) {
 
   const items = useMemo((): NavItemData[] => {
     const appUpdates = appStore.updates.length
-    let updatesBadge: BadgeData | null = null
+    const appDeprecated = appStore.deprecated?.length || 0
+    let appstoreBadge: BadgeData | null = null
     let serverUpdateBadge: BadgeData | null = null
     let accessRequestsBadge: BadgeData | null = null
     let expiredDevicesBadge: BadgeData | null = null
 
-    if (appUpdates > 0) {
-      updatesBadge = {
+    if (appStore.storeAvailable === false) {
+      appstoreBadge = {
+        variant: 'danger',
+        text: 'OFFLINE'
+      }
+    } else if (appUpdates > 0 && appDeprecated > 0) {
+      appstoreBadge = {
+        variant: 'warning',
+        text: `${appUpdates}\u2191 ${appDeprecated}\u2717`,
+        color: 'warning'
+      }
+    } else if (appDeprecated > 0) {
+      appstoreBadge = {
+        variant: 'danger',
+        text: `${appDeprecated}`,
+        color: 'danger'
+      }
+    } else if (appUpdates > 0) {
+      appstoreBadge = {
         variant: 'success',
         text: `${appUpdates}`,
         color: 'success'
@@ -82,13 +100,6 @@ export default function Sidebar({ location }: SidebarProps) {
         variant: 'danger',
         text: `${expiredDeviceCount}`,
         color: 'danger'
-      }
-    }
-
-    if (appStore.storeAvailable === false) {
-      updatesBadge = {
-        variant: 'danger',
-        text: 'OFFLINE'
       }
     }
 
@@ -127,7 +138,7 @@ export default function Sidebar({ location }: SidebarProps) {
           name: 'Appstore',
           url: '/appstore',
           icon: 'icon-basket',
-          badge: updatesBadge
+          badge: appstoreBadge
         },
         {
           name: 'Server',

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -95,7 +95,8 @@ const initialAppState: AppSliceState = {
     updates: [],
     installed: [],
     available: [],
-    installing: []
+    installing: [],
+    deprecated: []
   },
   loginStatus: {},
   serverSpecification: {},
@@ -139,7 +140,8 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
       installing: [...appStore.installing].sort(nameCollator),
       available: [...appStore.available].sort(nameCollator),
       installed: [...appStore.installed].sort(nameCollator),
-      updates: [...appStore.updates].sort(nameCollator)
+      updates: [...appStore.updates].sort(nameCollator),
+      deprecated: [...(appStore.deprecated || [])].sort(nameCollator)
     }
     set({ appStore: sorted })
   },

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -14,6 +14,7 @@ export interface AppStoreState {
   installed: AppInfo[]
   available: AppInfo[]
   installing: InstallingApp[]
+  deprecated: AppInfo[]
   storeAvailable?: boolean
   canUpdateServer?: boolean
   serverUpdate?: string
@@ -25,6 +26,8 @@ export interface AppInfo {
   version?: string
   description?: string
   author?: string
+  deprecatedMessage?: string
+  isOrphan?: boolean
   [key: string]: unknown
 }
 

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
   useOptimistic,
   useTransition,
   ChangeEvent,
@@ -10,6 +11,8 @@ import {
   FormEvent
 } from 'react'
 import { useParams } from 'react-router-dom'
+import { useAppStore } from '../../store'
+import Badge from 'react-bootstrap/Badge'
 import PluginConfigurationForm from './../ServerConfig/PluginConfigurationForm'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -70,6 +73,17 @@ export default function PluginConfigurationList() {
   const [wasmEnabled, setWasmEnabled] = useState(true)
 
   const [isFiltering, startFilterTransition] = useTransition()
+
+  const appStore = useAppStore()
+  const deprecatedMap = useMemo(() => {
+    const map = new Map<string, string>()
+    ;(appStore.deprecated || []).forEach((app) => {
+      if (app.deprecatedMessage) {
+        map.set(app.name, app.deprecatedMessage)
+      }
+    })
+    return map
+  }, [appStore.deprecated])
 
   const tableContainerRef = useRef<HTMLDivElement>(null)
   const configCardRef = useRef<HTMLDivElement>(null)
@@ -421,6 +435,15 @@ export default function PluginConfigurationList() {
                             </strong>
                           ) : (
                             plugin.name
+                          )}
+                          {deprecatedMap.has(plugin.packageName) && (
+                            <Badge
+                              bg="danger"
+                              className="ms-2"
+                              title={deprecatedMap.get(plugin.packageName)}
+                            >
+                              Deprecated
+                            </Badge>
                           )}
                         </td>
                         <td>

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import Badge from 'react-bootstrap/Badge'
 import Card from 'react-bootstrap/Card'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTableCells } from '@fortawesome/free-solid-svg-icons/faTableCells'
@@ -19,6 +20,7 @@ interface WebAppInfo {
 
 interface WebappProps {
   webAppInfo: WebAppInfo
+  deprecatedMessage?: string
   children?: ReactNode
 }
 
@@ -28,7 +30,11 @@ export function urlToWebapp(webAppInfo: WebAppInfo): string {
     : `/${webAppInfo.name}/`
 }
 
-export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
+export default function Webapp({
+  webAppInfo,
+  deprecatedMessage,
+  ...attributes
+}: WebappProps) {
   const padding = { card: 'p-3', icon: 'p-3', lead: 'mt-2' }
 
   const card = {
@@ -77,7 +83,14 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
       <Card>
         <Card.Body className={card.style} {...attributes}>
           {blockIcon(webAppInfo?.signalk?.appIcon || null)}
-          <div className={lead.classes}>{header}</div>
+          <div className={lead.classes}>
+            {header}
+            {deprecatedMessage && (
+              <Badge bg="danger" className="ms-2" title={deprecatedMessage}>
+                Deprecated
+              </Badge>
+            )}
+          </div>
           <div className="text-muted font-xs">{webAppInfo.description}</div>
         </Card.Body>
       </Card>

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense, createElement, ComponentType } from 'react'
-import { useWebapps, useAddons } from '../../store'
+import { useWebapps, useAddons, useAppStore } from '../../store'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
 import { ADDON_PANEL, toLazyDynamicComponent } from './dynamicutilities'
@@ -27,6 +27,17 @@ interface AddonPanelProps {
 export default function Webapps() {
   const webapps = useWebapps() as WebAppInfo[]
   const addons = useAddons() as AddonModule[]
+  const appStore = useAppStore()
+
+  const deprecatedMap = useMemo(() => {
+    const map = new Map<string, string>()
+    ;(appStore.deprecated || []).forEach((app) => {
+      if (app.deprecatedMessage) {
+        map.set(app.name, app.deprecatedMessage)
+      }
+    })
+    return map
+  }, [appStore.deprecated])
 
   const addonComponents = useMemo(
     () =>
@@ -53,7 +64,11 @@ export default function Webapps() {
               .map((webAppInfo) => {
                 return (
                   <Col xs="12" md="12" lg="6" xl="4" key={webAppInfo.name}>
-                    <Webapp key={webAppInfo.name} webAppInfo={webAppInfo} />
+                    <Webapp
+                      key={webAppInfo.name}
+                      webAppInfo={webAppInfo}
+                      deprecatedMessage={deprecatedMap.get(webAppInfo.name)}
+                    />
                   </Col>
                 )
               })}

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -27,6 +27,7 @@ interface AppInfo {
   prereleaseVersion?: string
   updated?: string
   categories: string[]
+  deprecatedMessage?: string
   [key: string]: unknown
 }
 
@@ -36,6 +37,7 @@ interface AppStore {
   installed: AppInfo[]
   installing: InstallingApp[]
   updates: AppInfo[]
+  deprecated: AppInfo[]
   categories?: string[]
 }
 
@@ -55,6 +57,8 @@ const selectedViewToFilter = (
     return (app) => updateAvailable(app, appStore)
   } else if (selectedView === 'Installing') {
     return (app) => !!app.installing
+  } else if (selectedView === 'Deprecated') {
+    return (app) => !!app.deprecatedMessage
   }
   return () => true
 }
@@ -191,6 +195,17 @@ const Apps: React.FC = () => {
                   </span>
                 )}
               </Button>
+              {appStore.deprecated?.length > 0 && (
+                <Button
+                  variant={view === 'Deprecated' ? 'secondary' : 'light'}
+                  onClick={() => setSelectedView('Deprecated')}
+                >
+                  Deprecated
+                  <span className="badge__deprecated">
+                    {appStore.deprecated.length}
+                  </span>
+                </Button>
+              )}
               {appStore.installing.length > 0 && (
                 <>
                   <Button

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -45,6 +45,7 @@ interface AppData {
   isPlugin?: boolean
   id?: string
   npmUrl?: string
+  deprecatedMessage?: string
   [key: string]: unknown
 }
 
@@ -215,6 +216,22 @@ export default function ActionCellRenderer({
       <div className="progress__wrapper">
         <div className="progress__status p-1">{status}</div>
         {progress}
+      </div>
+    )
+  } else if (app.deprecatedMessage && app.installed) {
+    content = (
+      <div className="d-flex flex-column align-items-end">
+        <span className="badge text-bg-danger mb-2">Deprecated</span>
+        <Button variant="danger" size="sm" onClick={handleRemoveClick}>
+          <FontAwesomeIcon className="me-2" icon={faTrashCan} />
+          Remove
+        </Button>
+        <small
+          className="text-muted mt-1 text-end"
+          style={{ maxWidth: 200, fontSize: '0.75rem' }}
+        >
+          {app.deprecatedMessage}
+        </small>
       </div>
     )
   } else {

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -69,6 +69,16 @@
           padding: 3px;
           vertical-align: middle;
         }
+
+        span.badge__deprecated {
+          color: #fff !important;
+          font-size: 10px;
+          border-radius: 3px;
+          background-color: #dc3545 !important;
+          margin-left: 5px;
+          padding: 3px;
+          vertical-align: middle;
+        }
       }
     }
 

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -26,7 +26,8 @@ const {
   fetchDistTagsForPackages,
   getLatestServerVersion,
   getAuthor,
-  getKeywords
+  getKeywords,
+  checkDeprecations
 } = require('../modules')
 const { SERVERROUTESPREFIX } = require('../constants')
 const { getCategories, getAvailableCategories } = require('../categories')
@@ -104,7 +105,9 @@ module.exports = function (app) {
             .then(([plugins, webapps]) => {
               if (
                 !plugins.find(packageNameIs(name)) &&
-                !webapps.find(packageNameIs(name))
+                !webapps.find(packageNameIs(name)) &&
+                !getPlugin(name) &&
+                !getWebApp(name)
               ) {
                 res.status(404)
                 res.json('No such webapp or plugin available:' + name)
@@ -161,23 +164,28 @@ module.exports = function (app) {
         }
       )
 
-      app.get(`${SERVERROUTESPREFIX}/appstore/available/`, (req, res) => {
-        const installedNames = getInstalledPackageNames()
-
-        Promise.all([
-          findPluginsAndWebapps(),
-          getLatestServerVersion(app.config.version).catch(() => '0.0.0'),
-          fetchDistTagsForPackages(installedNames).catch(() => ({}))
-        ])
-          .then(([[plugins, webapps], serverVersion, distTagsMap]) =>
-            getAllModuleInfo(plugins, webapps, serverVersion, distTagsMap)
+      app.get(`${SERVERROUTESPREFIX}/appstore/available/`, async (req, res) => {
+        try {
+          const installedNames = getInstalledPackageNames()
+          const [plugins, webapps] = await findPluginsAndWebapps()
+          const serverVersion = await getLatestServerVersion(
+            app.config.version
+          ).catch(() => '0.0.0')
+          const distTagsMap = await fetchDistTagsForPackages(
+            installedNames
+          ).catch(() => ({}))
+          const result = await getAllModuleInfo(
+            plugins,
+            webapps,
+            serverVersion,
+            distTagsMap
           )
-          .then((result) => res.json(result))
-          .catch((error) => {
-            console.log(error.message)
-            debug(error.stack)
-            res.json(emptyAppStoreInfo(false))
-          })
+          res.json(result)
+        } catch (error) {
+          console.log(error.message)
+          debug(error.stack)
+          res.json(emptyAppStoreInfo(false))
+        }
       })
     },
     stop: () => undefined
@@ -234,13 +242,19 @@ module.exports = function (app) {
       installed: [],
       updates: [],
       installing: [],
+      deprecated: [],
       categories: getAvailableCategories(),
       storeAvailable: storeAvailable,
       isInDocker: process.env.IS_IN_DOCKER === 'true'
     }
   }
 
-  function getAllModuleInfo(plugins, webapps, serverVersion, distTagsMap = {}) {
+  async function getAllModuleInfo(
+    plugins,
+    webapps,
+    serverVersion,
+    distTagsMap = {}
+  ) {
     const all = emptyAppStoreInfo()
 
     if (
@@ -282,6 +296,61 @@ module.exports = function (app) {
     getModulesInfo(plugins, getPlugin, all, distTagsMap)
     getModulesInfo(webapps, getWebApp, all, distTagsMap)
 
+    // Add locally installed plugins not in npm search results (orphans)
+    if (app.plugins) {
+      const installedPluginNames = new Set(all.installed.map((p) => p.name))
+      app.plugins.forEach((plugin) => {
+        if (!installedPluginNames.has(plugin.packageName)) {
+          const orphanInfo = {
+            name: plugin.packageName,
+            version: plugin.version,
+            description: plugin.description || '',
+            author: '',
+            categories: [],
+            keywords: ['signalk-node-server-plugin'],
+            npmUrl: null,
+            isPlugin: true,
+            isWebapp: false,
+            isEmbeddableWebapp: false,
+            id: plugin.id,
+            installedVersion: plugin.version,
+            isOrphan: true
+          }
+          addOrphanInstallState(orphanInfo, all)
+        }
+      })
+    }
+
+    // Add locally installed webapps not in npm search results (orphans)
+    const addOrphanWebapps = (webappList, isEmbeddable = false) => {
+      if (!webappList) return
+      const installedNames = new Set(all.installed.map((p) => p.name))
+      webappList.forEach((webapp) => {
+        if (!installedNames.has(webapp.name)) {
+          const orphanInfo = {
+            name: webapp.name,
+            version: webapp.version,
+            description: webapp.description || '',
+            author: '',
+            categories: [],
+            keywords: isEmbeddable
+              ? ['signalk-embeddable-webapp']
+              : ['signalk-webapp'],
+            npmUrl: null,
+            isPlugin: false,
+            isWebapp: !isEmbeddable,
+            isEmbeddableWebapp: isEmbeddable,
+            installedVersion: webapp.version,
+            isOrphan: true
+          }
+          addOrphanInstallState(orphanInfo, all)
+        }
+      })
+    }
+    addOrphanWebapps(app.webapps, false)
+    addOrphanWebapps(app.addons, false)
+    addOrphanWebapps(app.embeddablewebapps, true)
+
     if (process.env.PLUGINS_WITH_UPDATE_DISABLED) {
       const disabled = process.env.PLUGINS_WITH_UPDATE_DISABLED.split(',')
       all.updates.forEach((info) => {
@@ -291,7 +360,45 @@ module.exports = function (app) {
       })
     }
 
+    // Check npm deprecation status for all installed packages
+    if (all.installed.length > 0) {
+      try {
+        const installedNames = all.installed.map((p) => p.name)
+        const deprecationStatus = await checkDeprecations(installedNames)
+        all.installed.forEach((plugin) => {
+          const deprecatedMsg = deprecationStatus[plugin.name]
+          if (deprecatedMsg) {
+            plugin.deprecatedMessage = deprecatedMsg
+            all.deprecated.push(plugin)
+          }
+        })
+      } catch (err) {
+        debug('Failed to check deprecation status:', err)
+      }
+    }
+
     return all
+  }
+
+  function addOrphanInstallState(orphanInfo, result) {
+    const name = orphanInfo.name
+    if (moduleInstallQueue.find((p) => p.name === name)) {
+      orphanInfo.isWaiting = true
+      addIfNotDuplicate(result.installing, orphanInfo)
+    } else if (modulesInstalledSinceStartup[name]) {
+      if (moduleInstalling && moduleInstalling.name === name) {
+        if (moduleInstalling.isRemove) {
+          orphanInfo.isRemoving = true
+        } else {
+          orphanInfo.isInstalling = true
+        }
+      } else if (modulesInstalledSinceStartup[name].code !== 0) {
+        orphanInfo.installFailed = true
+      }
+      orphanInfo.isRemove = modulesInstalledSinceStartup[name].isRemove
+      addIfNotDuplicate(result.installing, orphanInfo)
+    }
+    addIfNotDuplicate(result.installed, orphanInfo)
   }
 
   function getModulesInfo(modules, existing, result, distTagsMap) {
@@ -403,20 +510,21 @@ module.exports = function (app) {
     return npm || null
   }
 
-  function sendAppStoreChangedEvent() {
-    findPluginsAndWebapps().then(([plugins, webapps]) => {
-      getLatestServerVersion(app.config.version)
-        .then((serverVersion) =>
-          getAllModuleInfo(plugins, webapps, serverVersion)
-        )
-        .then((result) => {
-          app.emit('serverevent', {
-            type: 'APP_STORE_CHANGED',
-            from: 'signalk-server',
-            data: result
-          })
-        })
-    })
+  async function sendAppStoreChangedEvent() {
+    try {
+      const [plugins, webapps] = await findPluginsAndWebapps()
+      const serverVersion = await getLatestServerVersion(
+        app.config.version
+      ).catch(() => '0.0.0')
+      const result = await getAllModuleInfo(plugins, webapps, serverVersion)
+      app.emit('serverevent', {
+        type: 'APP_STORE_CHANGED',
+        from: 'signalk-server',
+        data: result
+      })
+    } catch (err) {
+      debug('Failed to send app store changed event:', err)
+    }
   }
 
   function installSKModule(module, version) {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -584,6 +584,64 @@ export async function importOrRequire(moduleDir: string) {
   }
 }
 
+const deprecationCache: Record<
+  string,
+  { time: number; deprecated: string | false }
+> = {}
+const DEPRECATION_CACHE_TTL = 60 * 60 * 1000
+
+async function checkPackageDeprecation(
+  packageName: string
+): Promise<string | false> {
+  const cached = deprecationCache[packageName]
+  if (cached && Date.now() - cached.time < DEPRECATION_CACHE_TTL) {
+    return cached.deprecated
+  }
+
+  try {
+    const res = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}`
+    )
+    if (!res.ok) return false
+
+    const data = (await res.json()) as {
+      'dist-tags'?: { latest?: string }
+      versions?: Record<string, { deprecated?: string }>
+    }
+    const latestVersion = data['dist-tags']?.latest
+    const deprecated =
+      (latestVersion && data.versions?.[latestVersion]?.deprecated) || false
+
+    deprecationCache[packageName] = { time: Date.now(), deprecated }
+    return deprecated
+  } catch (err) {
+    npmDebug(`Failed to check deprecation for ${packageName}: ${err}`)
+    return false
+  }
+}
+
+async function checkDeprecations(
+  packageNames: string[]
+): Promise<Record<string, string | false>> {
+  const CONCURRENCY = 5
+  const results: Record<string, string | false> = {}
+
+  for (let i = 0; i < packageNames.length; i += CONCURRENCY) {
+    const batch = packageNames.slice(i, i + CONCURRENCY)
+    const batchResults = await Promise.all(
+      batch.map(async (name) => ({
+        name,
+        deprecated: await checkPackageDeprecation(name)
+      }))
+    )
+    batchResults.forEach(({ name, deprecated }) => {
+      results[name] = deprecated
+    })
+  }
+
+  return results
+}
+
 module.exports = {
   modulesWithKeyword,
   installModule,
@@ -598,5 +656,7 @@ module.exports = {
   restoreModules,
   importOrRequire,
   runNpm,
-  getPluginDataSize
+  getPluginDataSize,
+  checkDeprecations,
+  checkPackageDeprecation
 }


### PR DESCRIPTION
Supersedes #2274 — rebased and rewritten for current master.

## Summary

- Query npm registry for deprecation status of installed packages (1-hour cache, concurrency-limited batch lookups)
- Detect orphan plugins/webapps (installed locally but absent from npm search) and surface them in the appstore data
- Orphan install/remove state tracking so progress animations work correctly
- Allow removing orphan plugins that aren't in npm search results (was returning 404)

### UI (React 19 admin UI — Zustand + react-bootstrap)

- **Deprecated tab** in Appstore with remove-only action and deprecation message
- **Combined sidebar badge** (e.g. "3↑ 1✗" for updates + deprecated)
- **Deprecated badge** on Plugin Configuration and Webapps pages

## Tested

- Install `@signalk/zones` (deprecated), verify Deprecated tab appears
- Remove from Deprecated tab, verify progress animation and "Removed" status
- Verify combined sidebar badge shows deprecation count
- Verify deprecated badge on Plugin Configuration page
- Server + R19 UI build and lint clean