### PR TITLE
fix: R19 hamburger menu not working on mobile (iOS)

### DIFF
--- a/packages/server-admin-ui-react19/scss/_custom.scss
+++ b/packages/server-admin-ui-react19/scss/_custom.scss
@@ -4,6 +4,7 @@
 .app-header .navbar-toggler {
   border: none;
   outline: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
 
   &:focus {
     box-shadow: none;

--- a/packages/server-admin-ui-react19/scss/core/_layout.scss
+++ b/packages/server-admin-ui-react19/scss/core/_layout.scss
@@ -16,6 +16,7 @@ app-root {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .app-header {
@@ -79,6 +80,7 @@ app-root {
     z-index: $zindex-sticky - 1;
     width: $sidebar-width;
     height: calc(100vh - #{$navbar-height});
+    height: calc(100dvh - #{$navbar-height});
     // margin-top: - $navbar-height;
 
     // .sidebar-nav {
@@ -104,6 +106,7 @@ app-root {
     position: fixed;
     z-index: $zindex-sticky - 1;
     height: calc(100vh - #{$navbar-height});
+    height: calc(100dvh - #{$navbar-height});
   }
 }
 
@@ -189,6 +192,10 @@ app-root {
         100vh - #{$aside-menu-nav-padding-y * 2 + $font-size-base} -
           #{$navbar-height}
       );
+      height: calc(
+        100dvh - #{$aside-menu-nav-padding-y * 2 + $font-size-base} -
+          #{$navbar-height}
+      );
     }
   }
 
@@ -215,6 +222,10 @@ app-root {
     .tab-content {
       height: calc(
         100vh - #{$aside-menu-nav-padding-y * 2 + $font-size-base} -
+          #{$navbar-height}
+      );
+      height: calc(
+        100dvh - #{$aside-menu-nav-padding-y * 2 + $font-size-base} -
           #{$navbar-height}
       );
     }
@@ -370,12 +381,14 @@ app-root {
     z-index: $zindex-sticky - 1;
     width: $mobile-sidebar-width;
     height: calc(100vh - #{$navbar-height});
+    height: calc(100dvh - #{$navbar-height});
     margin-left: -$mobile-sidebar-width;
 
     .sidebar-nav,
     .nav {
       width: $mobile-sidebar-width;
       min-height: calc(100vh - #{$navbar-height});
+      min-height: calc(100dvh - #{$navbar-height});
     }
 
     .sidebar-minimizer {

--- a/packages/server-admin-ui-react19/src/components/Header/Header.tsx
+++ b/packages/server-admin-ui-react19/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, MouseEvent } from 'react'
+import { useState, useEffect, useCallback, type MouseEvent } from 'react'
 import Alert from 'react-bootstrap/Alert'
 import Dropdown from 'react-bootstrap/Dropdown'
 import Nav from 'react-bootstrap/Nav'
@@ -44,7 +44,12 @@ export default function Header() {
     setDropdownOpen(!dropdownOpen)
   }
 
-  const sidebarToggle = (e: MouseEvent) => {
+  const mobileSidebarToggle = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    document.body.classList.toggle('sidebar-mobile-show')
+  }
+
+  const sidebarToggle = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     document.body.classList.toggle('sidebar-hidden')
   }
@@ -79,10 +84,23 @@ export default function Header() {
           detected – some updates were skipped. Check your connection.
         </Alert>
       )}
-      <Navbar.Brand href="#" />
-      <Navbar.Toggle className="me-auto" onClick={sidebarToggle}>
+      <button
+        type="button"
+        className="navbar-toggler d-lg-none"
+        onClick={mobileSidebarToggle}
+        aria-label="Toggle sidebar"
+      >
         <span className="navbar-toggler-icon" />
-      </Navbar.Toggle>
+      </button>
+      <Navbar.Brand href="#" />
+      <button
+        type="button"
+        className="navbar-toggler d-none d-lg-block me-auto"
+        onClick={sidebarToggle}
+        aria-label="Toggle sidebar"
+      >
+        <span className="navbar-toggler-icon" />
+      </button>
       <Nav className="ms-auto">
         {/* Desktop: show items directly */}
         {loginStatus.status === 'loggedIn' &&


### PR DESCRIPTION
 ## Summary

The R19 migration (commit dc5cf06) merged the mobile and desktop sidebar toggle buttons into a single `Navbar.Toggle` that only toggles `sidebar-hidden`. The mobile CSS expects `sidebar-mobile-show` on `document.body` to slide the sidebar in — so the hamburger button had no visible effect on mobile viewports.

- Restore the two-button pattern from the old admin UI: a mobile toggle (`sidebar-mobile-show`, visible below `lg` breakpoint) and a desktop toggle (`sidebar-hidden`, visible at `lg`+)
- Use plain `<button>` elements instead of `Navbar.Toggle` to avoid react-bootstrap's collapse behavior interfering with our custom click handlers
- Add `100dvh` fallbacks for iOS Safari's dynamic viewport height (address bar)
- Add `-webkit-tap-highlight-color` for touch feedback on iOS

## Tested

- Desktop: hamburger toggles sidebar open/closed as before
- Mobile viewport (dev tools or real device): hamburger slides sidebar in/out
- iOS Safari: tap hamburger opens sidebar, tap again closes it
- Navigate while sidebar is open → sidebar closes automatically (popstate handler)