### PR TITLE
feat: add showcase banner to React 19 admin UI header

### DIFF
--- a/packages/server-admin-ui-react19/src/components/Header/Header.tsx
+++ b/packages/server-admin-ui-react19/src/components/Header/Header.tsx
@@ -102,7 +102,7 @@ export default function Header() {
         <span className="navbar-toggler-icon" />
       </button>
       <span className="text-warning flex-grow-1 text-center fw-semibold">
-        React 19 UI showcase — do not use for production yet
+        Admin UI React 19 version for testing
       </span>
       <Nav className="ms-auto">
         {/* Desktop: show items directly */}


### PR DESCRIPTION
Adds a visible warning text in the header navbar of the React 19 admin UI: "React 19 UI showcase — do not use for production yet"

The text is centered in the header bar between the sidebar toggle and the login/restart buttons, styled as a Bootstrap warning color. It's always visible — no dismiss button — so users immediately know this UI is a preview and not the production interface.

Single line change in `Header.tsx`, no new dependencies.


<img width="910" height="59" alt="image" src="https://github.com/user-attachments/assets/e6ff5045-d26a-490c-9f3d-c4f92c6fa5c8" />
