### PR TITLE
fix: include server-api tests in npm test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,6 @@ jobs:
       - run: sfw npm install
       - run: npm run build:all
 
-      - name: server-api
-        working-directory: ./packages/server-api
-        run: |
-          npm run test
-
       - name: resources-provider-plugin
         working-directory: ./packages/resources-provider-plugin
         run: |

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "ci-lint": "eslint && prettier --check .",
     "update-latest-release": "git checkout master && git branch -D latest-release || git checkout -b latest-release && git push -f origin/latest-release",
     "start": "node bin/signalk-server",
-    "test-only": "NODE_ENV=test mocha 'test/**/*.[jt]s' 'dist/**/*.test.js'",
+    "test-only": "NODE_ENV=test mocha 'test/**/*.[jt]s'",
     "test:admin-ui": "npm run test -w @signalk/server-admin-ui-react19",
-    "test": "npm run build && npm run test-only && npm run ci-lint && npm run test:admin-ui",
+    "test:server-api": "npm run test -w @signalk/server-api",
+    "test": "npm run build && npm run test-only && npm run ci-lint && npm run test:admin-ui && npm run test:server-api",
     "heroku-postbuild": "npm run build:all",
     "master-changed-files": "git diff --name-status $(git tag | tail -1)..master"
   },


### PR DESCRIPTION

While working on the codebase I noticed that the `@signalk/server-api` package tests (MMSI parsing, deltas, property values) never run as part of `npm test`. They only ran in CI via a separate explicit step — meaning a developer could break server-api locally and not notice until the CI pipeline caught it.

**Changes:**

- Add `test:server-api` to the root test script, following the same workspace pattern already used for `test:admin-ui`
- Remove the dead `'dist/**/*.test.js'` glob from `test-only` — it resolved relative to root `/dist/` which has no test files, so it matched nothing
- Remove the now-redundant explicit `server-api` step from CI since `npm test` covers it

After this change, `npm test` runs everything: 368 mocha + 87 vitest (admin-ui) + 13 server-api.
