### PR TITLE
Fix server-api test glob to include src/ root test files

### DIFF
--- a/packages/server-api/package.json
+++ b/packages/server-api/package.json
@@ -12,7 +12,7 @@
     "prettier": "prettier --write .",
     "lint": "eslint --fix",
     "format": "npm run prettier && npm run lint",
-    "test": "mocha src/**/*.test.ts"
+    "test": "mocha 'src/**/*.test.ts' 'src/*.test.ts'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `@signalk/server-api` test script uses `mocha src/**/*.test.ts` unquoted. Bash expands this before mocha sees it, and with `globstar` off (the default), `**` is treated as `*` — so only `src/mmsi/mmsi.test.ts` is found. Two test files in `src/` root (`propertyvalues.test.ts` with 3 tests, `deltas.test.ts` with compile-time type checks) are silently skipped.

Fix: quote the globs so mocha handles expansion via node-glob (which treats `**` correctly), and add an explicit `src/*.test.ts` for the root case.

Test count: 13 → 16 passing.