### PR TITLE
fix: guard document.title access in setVesselInfo for vitest compatibility  - R19

### DIFF
--- a/packages/server-admin-ui-react19/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui-react19/src/store/slices/appSlice.ts
@@ -181,7 +181,7 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
   },
 
   setVesselInfo: (vesselInfo) => {
-    if (vesselInfo.name) {
+    if (vesselInfo.name && typeof document !== 'undefined') {
       document.title = vesselInfo.name
     }
     set({ vesselInfo })


### PR DESCRIPTION
The `setVesselInfo` store action in the R19 admin UI sets `document.title` when a vessel name is available. This works fine in the browser but throws a `ReferenceError` when running under vitest's default Node environment, where `document` doesn't exist.

This has been broken since the store action was written, but never surfaced because vitest wasn't part of the main `npm test` workflow until recently — the R19 store tests were only run in isolation. Now that we're looking at the full vitest output across the project, this showed up as the only actual test failure (the other 23 "failed" test files are all import/config issues with vitest picking up compiled dist files alongside source).

One-line fix: `typeof document !== 'undefined'` guard before the assignment.