### PR TITLE
docs: remove unsupported signalk-category-hidden keyword

### DIFF
--- a/docs/develop/plugins/publishing.md
+++ b/docs/develop/plugins/publishing.md
@@ -23,7 +23,6 @@ Additionally you can have your plugin appear within one or more AppStore categor
 - `signalk-category-cloud`
 - `signalk-category-weather`
 - `signalk-category-deprecated`
-- `signalk-category-hidden` (won't show on the App Store)
 
 To have your plugin start automatically after being installed, without requiring any configuration via the **Plugin Config** screen add the following key to the `package.json` file:
 


### PR DESCRIPTION
## Summary

Remove the `signalk-category-hidden` keyword from the plugin publishing documentation.

As discussed in #2268, this keyword was never implemented in the AppStore filtering logic — plugins using it still appear in the store. Rather than implementing it (consensus is that hiding published plugins is a rare need with existing workarounds), this simply removes the misleading documentation.

Addresses #2268