### PR TITLE
fix: drop ignored NMEA sentences instead of emptying them

### DIFF
--- a/packages/server-admin-ui-react19/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/BasicProvider.tsx
@@ -704,7 +704,7 @@ function IgnoredSentences({
     <TextInput
       title="Ignored Sentences"
       name="options.ignoredSentences"
-      helpText="NMEA0183 sentences to throw away from the input data. Example: RMC,ROT"
+      helpText="NMEA0183 sentences to throw away from the input data. Requires a server restart to take effect. Example: RMC,ROT"
       value={displayValue as string}
       onChange={handleChange}
     />

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -564,7 +564,7 @@ class IgnoredSentences extends Component {
       <TextInput
         title="Ignored Sentences"
         name="options.ignoredSentences"
-        helpText="NMEA0183 sentences to throw away from the input data. Example: RMC,ROT"
+        helpText="NMEA0183 sentences to throw away from the input data. Requires a server restart to take effect. Example: RMC,ROT"
         value={this.state.value}
         onChange={this.onChange}
       />

--- a/packages/streams/replacer.js
+++ b/packages/streams/replacer.js
@@ -28,7 +28,10 @@ function Replacer(options) {
 }
 
 Replacer.prototype._transform = function (chunk, encoding, done) {
-  this.doPush(chunk.toString().replace(this.regexp, this.template))
+  const result = chunk.toString().replace(this.regexp, this.template)
+  if (result.length > 0) {
+    this.doPush(result)
+  }
   done()
 }
 


### PR DESCRIPTION
The Replacer stream transform replaced filtered sentences with empty strings but still pushed them downstream. The parser then emitted these empty strings as nmea0183 events. Now sentences matching an ignore pattern are dropped entirely.

Also add a restart hint to the Ignored Sentences help text in both admin UIs, since the filtering pipeline is only built at server startup.