### PR TITLE
fix(ui): remove noisy success alerts from connection operations

### DIFF
--- a/packages/server-admin-ui-react19/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -185,10 +185,10 @@ const ProvidersConfiguration: React.FC = () => {
       setSelectedProvider(null)
       setSelectedIndex(-1)
       navigate('/serverConfiguration/connections/-')
+    } else {
+      const text = await response.text()
+      alert(text)
     }
-
-    const text = await response.text()
-    alert(text)
   }, [selectedProvider, selectedIndex, discoveredProviders, navigate])
 
   const handleCancel = useCallback(() => {
@@ -208,18 +208,20 @@ const ProvidersConfiguration: React.FC = () => {
         credentials: 'include'
       }
     )
-    const text = await response.text()
-
-    setProviders((prev) => {
-      const newProviders = [...prev]
-      if (selectedIndex >= 0) {
-        newProviders.splice(selectedIndex, 1)
-      }
-      return newProviders
-    })
-    setSelectedProvider(null)
-    setSelectedIndex(-1)
-    alert(text)
+    if (response.ok) {
+      setProviders((prev) => {
+        const newProviders = [...prev]
+        if (selectedIndex >= 0) {
+          newProviders.splice(selectedIndex, 1)
+        }
+        return newProviders
+      })
+      setSelectedProvider(null)
+      setSelectedIndex(-1)
+    } else {
+      const text = await response.text()
+      alert(text)
+    }
   }, [selectedProvider, selectedIndex])
 
   const providerClicked = useCallback((provider: Provider, index: number) => {

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -134,38 +134,35 @@ class ProvidersConfiguration extends Component {
       },
       body: JSON.stringify(this.state.selectedProvider),
       credentials: 'include'
-    })
-      .then((response) => {
-        if (response.ok) {
-          var provider = JSON.parse(JSON.stringify(this.state.selectedProvider))
-          delete provider.isNew
-          delete provider.wasDiscovered
-          delete this.state.selectedProvider.isNew
-          if (isNew) {
-            this.state.providers.push(provider)
-          } else {
-            this.state.providers[this.state.selectedIndex] = provider
-          }
-          if (wasDiscovered) {
-            this.props.discoveredProviders.splice(this.state.selectedIndex, 1)
-          }
-          this.setState(
-            {
-              providers: this.state.providers,
-              //discoveredProviders: this.state.discoveredProviders,
-              selectedProvider: null,
-              selectedIndex: -1
-            },
-            () => {
-              this.props.history.push('/serverConfiguration/connections/-')
-            }
-          )
+    }).then((response) => {
+      if (response.ok) {
+        var provider = JSON.parse(JSON.stringify(this.state.selectedProvider))
+        delete provider.isNew
+        delete provider.wasDiscovered
+        delete this.state.selectedProvider.isNew
+        if (isNew) {
+          this.state.providers.push(provider)
+        } else {
+          this.state.providers[this.state.selectedIndex] = provider
         }
-        return response.text()
-      })
-      .then((text) => {
-        alert(text)
-      })
+        if (wasDiscovered) {
+          this.props.discoveredProviders.splice(this.state.selectedIndex, 1)
+        }
+        this.setState(
+          {
+            providers: this.state.providers,
+            //discoveredProviders: this.state.discoveredProviders,
+            selectedProvider: null,
+            selectedIndex: -1
+          },
+          () => {
+            this.props.history.push('/serverConfiguration/connections/-')
+          }
+        )
+      } else {
+        response.text().then((text) => alert(text))
+      }
+    })
   }
 
   handleCancel() {
@@ -182,17 +179,18 @@ class ProvidersConfiguration extends Component {
         },
         credentials: 'include'
       }
-    )
-      .then((response) => response.text())
-      .then((response) => {
+    ).then((response) => {
+      if (response.ok) {
         this.state.providers.splice(this.state.selectedIndex, 1)
         this.setState({
           providers: this.state.providers,
           selectedProvider: null,
           selectedIndex: -1
         })
-        alert(response)
-      })
+      } else {
+        response.text().then((text) => alert(text))
+      }
+    })
   }
 
   providerClicked(provider, index) {


### PR DESCRIPTION
## Summary

- Remove browser `alert()` dialogs that pop up after every connection add, update, or delete
- Error alerts are preserved so validation failures and save errors are still shown

## Details

After PR #2332 landed live-restart of connection pipelines, the "Connection added" / "Connection deleted" / "Connection updated" alerts became pure noise — the UI already updates its state and navigates away on success, so the user can see the operation worked without a blocking dialog.

Both admin UIs are updated:

- `packages/server-admin-ui/` (legacy React 16)
- `packages/server-admin-ui-react19/` (React 19)

The backend response messages in `src/interfaces/providers.js` are unchanged — they're still useful for API consumers and tested in `test/providers.js`.

## Verified

- Manual test: add, update, delete connections — no alert on success, alert on error (e.g. empty ID)