### PR TITLE
fix: restore express.static trailing-slash redirect for webapp routes

### DIFF
--- a/packages/server-admin-ui-react19/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui-react19/src/views/Webapps/Webapp.tsx
@@ -25,7 +25,7 @@ interface WebappProps {
 export function urlToWebapp(webAppInfo: WebAppInfo): string {
   return webAppInfo.keywords?.includes('signalk-embeddable-webapp')
     ? `/admin/#/e/${toSafeModuleId(webAppInfo.name)}`
-    : `/${webAppInfo.name}`
+    : `/${webAppInfo.name}/`
 }
 
 export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.js
@@ -19,7 +19,7 @@ const propTypes = {
 export function urlToWebapp(webAppInfo) {
   return webAppInfo.keywords.includes('signalk-embeddable-webapp')
     ? `/admin/#/e/${toSafeModuleId(webAppInfo.name)}`
-    : `/${webAppInfo.name}`
+    : `/${webAppInfo.name}/`
 }
 
 class Webapp extends Component {

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -271,6 +271,10 @@ module.exports = function (
   }
 
   app.get('/admin/', (req: Request, res: Response) => {
+    if (!req.originalUrl.endsWith('/')) {
+      res.redirect(301, req.originalUrl + '/')
+      return
+    }
     serveIndexWithAddonScripts(path.join(adminUiPath, 'index.html'), res)
   })
 
@@ -285,6 +289,10 @@ module.exports = function (
   app.get(
     '/@signalk/server-admin-ui-react19/',
     (req: Request, res: Response) => {
+      if (!req.originalUrl.endsWith('/')) {
+        res.redirect(301, req.originalUrl + '/')
+        return
+      }
       serveIndexWithAddonScripts(path.join(react19UiPath, 'index.html'), res)
     }
   )
@@ -1114,7 +1122,7 @@ module.exports = function (
           name: webapp.name,
           version: webapp.version,
           description: webapp.description,
-          location: `/${webapp.name}`,
+          location: `/${webapp.name}/`,
           license: webapp.license,
           author: getAuthor(webapp)
         }


### PR DESCRIPTION
## Problem

PR #2342 added an explicit GET route for `/@signalk/server-admin-ui-react19/` to inject addon scripts into `index.html`. However, Express compiles route patterns like `/path/` with an optional trailing slash (`\/?`), so the handler also matches `/@signalk/server-admin-ui-react19` (without slash). Since this route is registered before `webapps.js` mounts `express.static`, it intercepts the request and serves `index.html` at the slash-less URL — causing the browser to resolve relative asset paths against the wrong base, resulting in 404s for all static assets.

## Fix

- Add an explicit 301 redirect in the `/admin/` and `/@signalk/server-admin-ui-react19/` GET handlers when the trailing slash is missing, restoring the behaviour `express.static` would have provided
- No redundant routes or `express.static` mounts needed — `webapps.js` already handles static file serving
- Update the `apps/list` API endpoint to return webapp locations with trailing slashes
- Update `urlToWebapp()` in both admin UIs to generate trailing-slash URLs, eliminating the redirect hop when clicking a webapp

## Tested
- Manual tests on AMD64 and ARM64 with and without installing new webapps and embedded R16 webapps in R19