### PR TITLE
fix(ui): replace unit preferences pill buttons with dropdown select R19

### DIFF
--- a/packages/server-admin-ui-react19/src/views/ServerConfig/UnitPreferencesSettings.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/UnitPreferencesSettings.tsx
@@ -285,37 +285,43 @@ const UnitPreferencesSettings: React.FC = () => {
                   </optgroup>
                 )}
               </Form.Select>
-              {isAdmin && (
-                <>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept=".json"
-                    onChange={handleFileUpload}
-                    style={{ display: 'none' }}
-                  />
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={uploadStatus === 'uploading'}
-                  >
-                    <FontAwesomeIcon icon={faUpload} />{' '}
-                    {uploadStatus === 'uploading' ? 'Uploading...' : 'Upload'}
-                  </Button>
-                  {activeCustomPreset && (
-                    <Button
-                      variant="outline-danger"
-                      size="sm"
-                      onClick={() => handleDeletePreset(activePreset)}
-                      title={`Delete ${activeCustomPreset.label}`}
-                    >
-                      <FontAwesomeIcon icon={faTrash} />
-                    </Button>
-                  )}
-                </>
+              {isAdmin && activeCustomPreset && (
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  onClick={() => handleDeletePreset(activePreset)}
+                  title={`Delete ${activeCustomPreset.label}`}
+                >
+                  <FontAwesomeIcon icon={faTrash} />
+                </Button>
               )}
             </div>
+            {isAdmin && (
+              <div style={{ marginTop: '10px' }}>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  onChange={handleFileUpload}
+                  style={{ display: 'none' }}
+                />
+                <Form.Text
+                  className="text-muted"
+                  style={{ marginRight: '8px' }}
+                >
+                  Add custom preset
+                </Form.Text>
+                <Button
+                  variant="outline-primary"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadStatus === 'uploading'}
+                >
+                  <FontAwesomeIcon icon={faUpload} />{' '}
+                  {uploadStatus === 'uploading' ? 'Uploading...' : 'Upload'}
+                </Button>
+              </div>
+            )}
             {uploadStatus === 'success' && (
               <Alert
                 variant="success"


### PR DESCRIPTION
## Summary

- Replace the colorful pill-button layout in the Unit Preferences settings with a standard `Form.Select` dropdown, consistent with other form controls on the Settings page (e.g. Ship Type in Vessel Base Data)
- Combine the two separate rows (Display Units + Upload Preset) into a single compact row: dropdown + Upload button + Delete button (admin only)
- Built-in and custom presets are grouped via `<optgroup>` labels in the dropdown
- No Save button is needed — preset selection is persisted immediately via the Signal K Application Data store (`/signalk/v1/applicationData/user/`), providing per-user preferences

## Changes

- `packages/server-admin-ui-react19/src/views/ServerConfig/UnitPreferencesSettings.tsx` — UI-only change, no backend or store modifications

## Before / After

**Before:** Multi-colored pill badges spread across a full row + separate Upload Preset row — inconsistent with the rest of the Settings page

**After:** Single-row layout with a standard Bootstrap dropdown select + inline admin buttons — matches existing form patterns

## Tested 

- Changed preset, verified per user

## Image

<img width="1182" height="140" alt="image" src="https://github.com/user-attachments/assets/3a12e767-0b4e-4d05-a743-dcca79aadba7" />
