### PR TITLE
fix(ui): prevent duplicate description on boolean plugin config fields

### DIFF
--- a/packages/server-admin-ui-react19/src/views/ServerConfig/PluginConfigurationForm.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/PluginConfigurationForm.tsx
@@ -207,7 +207,7 @@ const FieldTemplate = (props: FieldTemplateProps) => {
           {required && <span className="required">*</span>}
         </label>
       )}
-      {description && !isObject && (
+      {description && !isObject && !isCheckbox && (
         <p id={`${id}__description`} className={CSS_CLASSES.FIELD_DESCRIPTION}>
           {description}
         </p>

--- a/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.js
@@ -141,7 +141,7 @@ const FieldTemplate = (props) => {
           {required && <span className="required">*</span>}
         </label>
       )}
-      {description && !isObject && (
+      {description && !isObject && !isCheckbox && (
         <p id={`${id}__description`} className={CSS_CLASSES.FIELD_DESCRIPTION}>
           {description}
         </p>


### PR DESCRIPTION

## Summary

Boolean (checkbox) plugin configuration fields display their description text twice — once rendered by our custom `FieldTemplate` and once by the RJSF `CheckboxWidget` inside `{children}`.

The `FieldTemplate` already correctly skips rendering the `<label>` for checkbox fields (`!isCheckbox`), but the same guard was missing from the `{description}` rendering condition. Other field types don't exhibit this because their widgets don't independently render the description.

### Fix

Add `!isCheckbox` to the description condition in both admin UIs:

```jsx
// Before:
{description && !isObject && (

// After:
{description && !isObject && !isCheckbox && (
```

### Affected files

- `packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.js` (React 16)
- `packages/server-admin-ui-react19/src/views/ServerConfig/PluginConfigurationForm.tsx` (React 19)

### Tested

- Autopilot plugin `enableV2API` checkbox: description appears once
- Toggling the checkbox on/off works correctly
- Non-boolean fields unaffected

Addresses #2377