### PR TITLE
feat(ui): add server default preset functionality in unit preferences…

### DIFF
--- a/packages/server-admin-ui-react19/src/store/index.ts
+++ b/packages/server-admin-ui-react19/src/store/index.ts
@@ -125,6 +125,10 @@ export function useActivePreset() {
   return useStore((s) => s.activePreset)
 }
 
+export function useServerDefaultPreset() {
+  return useStore((s) => s.serverDefaultPreset)
+}
+
 export function usePresets() {
   return useStore((s) => s.presets)
 }


### PR DESCRIPTION
… ## Summary of Changes

### Feature: Admin Can Set Server Default Preset

**Purpose**: Allow admins to set the server-wide default preset that new users will get when they first log in.

---

### R16 (`packages/server-admin-ui/src/views/ServerConfig/UnitPreferencesSettings.js`)

**Changes:**
1. Added `fetchServerDefaultPreset()` and `setServerDefaultPreset()` helper functions to GET/PUT `/signalk/v1/unitpreferences/config`
2. Added state: `serverDefaultPreset`, `updateServerDefault`
3. Modified `componentDidMount()` to fetch the server default
4. Modified `handleUpdateServerDefaultChange()` to immediately save when checkbox is checked
5. Modified `handlePresetChange()` to also PUT server default if checkbox is checked
6. Added checkbox UI + "Current server default: X" label (admin-only)

---

### R19 Store (`packages/server-admin-ui-react19/src/store/slices/unitPreferencesSlice.ts`)

**Changes:**
1. Added `serverDefaultPreset: string` to state
2. Added `fetchServerDefaultPresetFromServer()` helper function
3. Added `setServerDefaultPreset()` action to PUT to config endpoint
4. Modified `fetchUnitPreferences()` to also fetch server default

---

### R19 Component (`packages/server-admin-ui-react19/src/views/ServerConfig/UnitPreferencesSettings.tsx`)

**Changes:**
1. Added `updateServerDefault` local state
2. Added checkbox onChange that immediately saves when checked
3. Modified `handlePresetChange()` to also call `setServerDefaultPreset()` if checkbox checked
4. Modified `useEffect` to refetch when `loginStatus` changes (fixes user switching without page refresh)
5. Added checkbox UI + "Current server default: X" label (admin-only)

---

### R19 Store Exports (`packages/server-admin-ui-react19/src/store/index.ts`)

**Changes:**
1. Added `useServerDefaultPreset()` hook export

---
