### PR TITLE
chore: pin @mxtommy/kip@^3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "ws": "^8.17.0"
   },
   "optionalDependencies": {
-    "@mxtommy/kip": "^4.0.0",
+    "@mxtommy/kip": "4.4.0",
     "@signalk/freeboard-sk": "^2.0.0-beta.3",
     "@signalk/instrumentpanel": "0.x",
     "@signalk/set-system-time": "^1.5.0",


### PR DESCRIPTION
Pin Kip to keep the install size in check and
avoid issues with Duckdb dependency.

https://github.com/mxtommy/Kip/issues/980
https://github.com/mxtommy/Kip/issues/979