### PR TITLE
feat: multi-GNSS antenna position configuration

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -22,7 +22,8 @@ import {
   useSourcePriorities,
   usePriorityOverrides,
   usePriorityGroups,
-  useActiveConflictCount
+  useActiveConflictCount,
+  useUnconfiguredGnssSources
 } from '../../store'
 import classNames from 'classnames'
 import { isOverrideDormantUnderGroups } from '../../utils/sourceGroups'
@@ -156,6 +157,8 @@ export default function Sidebar({ location }: SidebarProps) {
     (d) => d.tokenExpiry && d.tokenExpiry * 1000 < nowMs
   ).length
 
+  const unconfiguredGnssCount = useUnconfiguredGnssSources().length
+
   const items = useMemo((): NavItemData[] => {
     const appUpdates = appStore.updates.length
     let updatesBadge: BadgeData | null = null
@@ -263,7 +266,14 @@ export default function Sidebar({ location }: SidebarProps) {
                 }
               : null
         },
-        { name: 'Unit Preferences', url: '/data/units' },
+        {
+          name: 'Preferences',
+          url: '/data/preferences',
+          badge:
+            unconfiguredGnssCount > 0
+              ? { variant: 'warning', text: `${unconfiguredGnssCount}` }
+              : null
+        },
         { name: 'Fiddler', url: '/data/fiddler' }
       )
     }
@@ -281,7 +291,7 @@ export default function Sidebar({ location }: SidebarProps) {
       },
       ((): NavItemData => {
         const dataBadgeCount = isAdmin
-          ? prioritiesAttentionCount + conflictCount
+          ? prioritiesAttentionCount + conflictCount + unconfiguredGnssCount
           : 0
         return {
           name: 'Data',
@@ -421,7 +431,8 @@ export default function Sidebar({ location }: SidebarProps) {
     plugins,
     conflictCount,
     unconfiguredPriorityCount,
-    overridesWithMissingSourcesCount
+    overridesWithMissingSourcesCount,
+    unconfiguredGnssCount
   ])
 
   const [openDropdowns, setOpenDropdowns] = useState<Set<string>>(

--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -76,8 +76,8 @@ const Configuration = lazyWithRetry(
 const Settings = lazyWithRetry(
   () => import('../../views/ServerConfig/Settings')
 )
-const UnitPreferencesSettings = lazyWithRetry(
-  () => import('../../views/ServerConfig/UnitPreferencesSettings')
+const PreferencesPage = lazyWithRetry(
+  () => import('../../views/ServerConfig/PreferencesPage')
 )
 const BackupRestore = lazyWithRetry(
   () => import('../../views/ServerConfig/BackupRestore')
@@ -323,10 +323,8 @@ export default function Full() {
                   element={<ProtectedRoute component={SourcePriorityPage} />}
                 />
                 <Route
-                  path="/data/units"
-                  element={
-                    <ProtectedRoute component={UnitPreferencesSettings} />
-                  }
+                  path="/data/preferences"
+                  element={<ProtectedRoute component={PreferencesPage} />}
                 />
                 <Route
                   path="/data/fiddler"
@@ -344,6 +342,10 @@ export default function Full() {
                 <Route
                   path="/databrowser"
                   element={<Navigate to="/data/browser" replace />}
+                />
+                <Route
+                  path="/data/units"
+                  element={<Navigate to="/data/preferences" replace />}
                 />
                 <Route
                   path="/serverConfiguration/datafiddler"

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -121,6 +121,8 @@ export async function fetchAllData(): Promise<void> {
     fetchAndSet('/n2kDeviceStatus', state.setN2kDeviceStatus),
     fetchAndSet('/livePreferredSources', state.setLivePreferredSources),
     fetchAndSet('/multiSourcePaths', state.setMultiSourcePaths),
-    fetchAndSet('/reconciledGroups', state.setReconciledGroups)
+    fetchAndSet('/reconciledGroups', state.setReconciledGroups),
+    fetchAndSet('/gnssSensors', state.setGnssSensors),
+    fetchAndSet('/positionSources', state.setPositionSources)
   ])
 }

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -122,7 +122,11 @@ export async function fetchAllData(): Promise<void> {
     fetchAndSet('/livePreferredSources', state.setLivePreferredSources),
     fetchAndSet('/multiSourcePaths', state.setMultiSourcePaths),
     fetchAndSet('/reconciledGroups', state.setReconciledGroups),
-    fetchAndSet('/gnssSensors', state.setGnssSensors),
+    fetchAndSet(
+      '/signalk/v2/api/vessels/self/sensors/gnss',
+      state.setGnssSensors,
+      ''
+    ),
     fetchAndSet('/positionSources', state.setPositionSources)
   ])
 }

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -1,4 +1,8 @@
 import { useStore } from './store'
+import {
+  GNSS_API_PATH,
+  sanitizeGnssConfig
+} from './store/slices/gnssPositionSlice'
 
 declare global {
   interface Window {
@@ -123,8 +127,8 @@ export async function fetchAllData(): Promise<void> {
     fetchAndSet('/multiSourcePaths', state.setMultiSourcePaths),
     fetchAndSet('/reconciledGroups', state.setReconciledGroups),
     fetchAndSet(
-      '/signalk/v2/api/vessels/self/sensors/gnss',
-      state.setGnssSensors,
+      GNSS_API_PATH,
+      (data: unknown) => state.setGnssSensors(sanitizeGnssConfig(data)),
       ''
     ),
     fetchAndSet('/positionSources', state.setPositionSources)

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -352,6 +352,24 @@ export class WebSocketService {
             (data ?? {}) as Parameters<SignalKStore['setN2kDeviceStatus']>[0]
           )
         break
+      case 'POSITION_SOURCES':
+        useStore
+          .getState()
+          .setPositionSources(
+            Array.isArray(data)
+              ? data.filter((item): item is string => typeof item === 'string')
+              : []
+          )
+        break
+      case 'GNSS_SENSORS':
+        useStore
+          .getState()
+          .setGnssSensors(
+            Array.isArray(data)
+              ? (data as Parameters<SignalKStore['setGnssSensors']>[0])
+              : []
+          )
+        break
       case 'RESTORESTATUS':
         this.zustandSetState({ restoreStatus: data } as Partial<SignalKStore>)
         break

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -1,5 +1,5 @@
 import { useStore, type SignalKStore } from '../store'
-import { EMPTY_GNSS_CONFIG } from '../store/slices/gnssPositionSlice'
+import { sanitizeGnssConfig } from '../store/slices/gnssPositionSlice'
 import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
@@ -363,19 +363,7 @@ export class WebSocketService {
           )
         break
       case 'GNSS_SENSORS': {
-        const payload = data as
-          Parameters<SignalKStore['setGnssSensors']>[0] | undefined
-        const validCorrection =
-          payload?.correction === 'off' ||
-          payload?.correction === 'replace' ||
-          payload?.correction === 'both'
-        useStore
-          .getState()
-          .setGnssSensors(
-            payload && validCorrection && Array.isArray(payload.sensors)
-              ? payload
-              : EMPTY_GNSS_CONFIG
-          )
+        useStore.getState().setGnssSensors(sanitizeGnssConfig(data))
         break
       }
       case 'RESTORESTATUS':

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -1,4 +1,5 @@
 import { useStore, type SignalKStore } from '../store'
+import { EMPTY_GNSS_CONFIG } from '../store/slices/gnssPositionSlice'
 import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
@@ -361,15 +362,22 @@ export class WebSocketService {
               : []
           )
         break
-      case 'GNSS_SENSORS':
+      case 'GNSS_SENSORS': {
+        const payload = data as
+          Parameters<SignalKStore['setGnssSensors']>[0] | undefined
+        const validCorrection =
+          payload?.correction === 'off' ||
+          payload?.correction === 'replace' ||
+          payload?.correction === 'both'
         useStore
           .getState()
           .setGnssSensors(
-            Array.isArray(data)
-              ? (data as Parameters<SignalKStore['setGnssSensors']>[0])
-              : []
+            payload && validCorrection && Array.isArray(payload.sensors)
+              ? payload
+              : EMPTY_GNSS_CONFIG
           )
         break
+      }
       case 'RESTORESTATUS':
         this.zustandSetState({ restoreStatus: data } as Partial<SignalKStore>)
         break

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -15,6 +15,10 @@ import {
   type UnitPreferencesSlice
 } from './slices/unitPreferencesSlice'
 import {
+  createGnssPositionSlice,
+  type GnssPositionSlice
+} from './slices/gnssPositionSlice'
+import {
   conflictKey,
   detectInstanceConflicts,
   extractN2kDevices
@@ -29,12 +33,14 @@ export type {
 export type { DataSlice, PathData, MetaData } from './slices/dataSlice'
 export type { PrioritiesSlice } from './slices/prioritiesSlice'
 export type { UnitPreferencesSlice } from './slices/unitPreferencesSlice'
+export type { GnssPositionSlice } from './slices/gnssPositionSlice'
 
 export type SignalKStore = AppSlice &
   WsSlice &
   DataSlice &
   PrioritiesSlice &
-  UnitPreferencesSlice
+  UnitPreferencesSlice &
+  GnssPositionSlice
 
 export const useStore = create<SignalKStore>()(
   subscribeWithSelector((...args) => ({
@@ -42,7 +48,8 @@ export const useStore = create<SignalKStore>()(
     ...createWsSlice(...args),
     ...createDataSlice(...args),
     ...createPrioritiesSlice(...args),
-    ...createUnitPreferencesSlice(...args)
+    ...createUnitPreferencesSlice(...args),
+    ...createGnssPositionSlice(...args)
   }))
 )
 
@@ -374,6 +381,30 @@ export function usePreferredSourceByPath(): Map<string, string> {
     }
     return map
   }, [serialized])
+}
+
+export function useGnssSensorsData() {
+  return useStore((s) => s.gnssSensorsData)
+}
+
+export function usePositionSources() {
+  return useStore((s) => s.positionSources)
+}
+
+// Detected navigation.position sources that have no sensor row yet.
+// The shared definition of "configured" — a row exists for the source,
+// regardless of whether its offsets are filled in (the corrector skips
+// rows with null offsets) — used by both the Preferences page rows and
+// the sidebar warning badge so the two cannot drift.
+export function useUnconfiguredGnssSources(): string[] {
+  const gnssSensorsData = useGnssSensorsData()
+  const positionSources = usePositionSources()
+  return useMemo(() => {
+    const configuredRefs = new Set(
+      gnssSensorsData.sensors.filter((s) => s.$source).map((s) => s.$source)
+    )
+    return positionSources.filter((ref) => !configuredRefs.has(ref))
+  }, [gnssSensorsData, positionSources])
 }
 
 export * from './types'

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -403,7 +403,12 @@ export function useUnconfiguredGnssSources(): string[] {
     const configuredRefs = new Set(
       gnssSensorsData.sensors.filter((s) => s.$source).map((s) => s.$source)
     )
-    return positionSources.filter((ref) => !configuredRefs.has(ref))
+    // *.ccrp sources are the corrector's own output in 'both' mode —
+    // offering them as configurable antennas would invite correcting
+    // already-corrected data.
+    return positionSources.filter(
+      (ref) => !configuredRefs.has(ref) && !ref.endsWith('.ccrp')
+    )
   }, [gnssSensorsData, positionSources])
 }
 

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useStore } from '../index'
 import type { GnssSensorConfig } from '../types'
-import type { GnssConfigPayload } from './gnssPositionSlice'
+import {
+  EMPTY_GNSS_CONFIG,
+  sanitizeGnssConfig,
+  type GnssConfigPayload
+} from './gnssPositionSlice'
 
 function row(sensorId: string, $source: string): GnssSensorConfig {
   return { sensorId, $source, fromBow: null, fromCenter: null }
@@ -57,6 +61,20 @@ describe('gnssPositionSlice', () => {
       const data = useStore.getState().gnssSensorsData
       expect(data.sensors).toEqual([])
       expect(data.saveState.dirty).toBe(false)
+    })
+
+    it('stores the server correction status when present', () => {
+      useStore.getState().setGnssSensors({
+        correction: 'replace',
+        sensors: [],
+        status: { mode: 'replace', active: false, blocked: 'no-heading' }
+      })
+
+      expect(useStore.getState().gnssSensorsData.status).toEqual({
+        mode: 'replace',
+        active: false,
+        blocked: 'no-heading'
+      })
     })
   })
 
@@ -217,6 +235,75 @@ describe('gnssPositionSlice', () => {
       useStore.getState().removeGnssSensor(5)
 
       expect(useStore.getState().gnssSensorsData.sensors).toHaveLength(1)
+    })
+  })
+
+  describe('sanitizeGnssConfig', () => {
+    it('passes a well-formed payload through, keeping status', () => {
+      const payload = {
+        correction: 'replace',
+        sensors: [row('gnss1', 'n2k.0.5')],
+        status: { mode: 'replace' as const, active: true }
+      }
+      expect(sanitizeGnssConfig(payload)).toEqual(payload)
+    })
+
+    it('falls back to the empty default on a bad correction mode', () => {
+      expect(sanitizeGnssConfig({ correction: 'nonsense', sensors: [] })).toBe(
+        EMPTY_GNSS_CONFIG
+      )
+    })
+
+    it('falls back when sensors is not an array', () => {
+      expect(sanitizeGnssConfig({ correction: 'off', sensors: 'oops' })).toBe(
+        EMPTY_GNSS_CONFIG
+      )
+    })
+
+    it('falls back when a sensor element is malformed', () => {
+      expect(
+        sanitizeGnssConfig({
+          correction: 'off',
+          sensors: [{ sensorId: 'gnss1' }] // missing $source/offsets
+        })
+      ).toBe(EMPTY_GNSS_CONFIG)
+    })
+
+    it('drops a malformed status while keeping a valid payload', () => {
+      const result = sanitizeGnssConfig({
+        correction: 'replace',
+        sensors: [],
+        status: { mode: 'bogus', active: 'yes' }
+      })
+      expect(result.correction).toBe('replace')
+      expect(result.status).toBeUndefined()
+    })
+
+    it('drops a status with an invalid blocked value', () => {
+      const result = sanitizeGnssConfig({
+        correction: 'replace',
+        sensors: [],
+        status: { mode: 'replace', active: false, blocked: 'nope' }
+      })
+      expect(result.status).toBeUndefined()
+    })
+
+    it('keeps a status with a valid blocked value', () => {
+      const result = sanitizeGnssConfig({
+        correction: 'replace',
+        sensors: [],
+        status: { mode: 'replace', active: false, blocked: 'no-length' }
+      })
+      expect(result.status).toEqual({
+        mode: 'replace',
+        active: false,
+        blocked: 'no-length'
+      })
+    })
+
+    it('falls back on null/undefined input', () => {
+      expect(sanitizeGnssConfig(undefined)).toBe(EMPTY_GNSS_CONFIG)
+      expect(sanitizeGnssConfig(null)).toBe(EMPTY_GNSS_CONFIG)
     })
   })
 })

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useStore } from '../index'
 import type { GnssSensorConfig } from '../types'
+import type { GnssConfigPayload } from './gnssPositionSlice'
 
 function row(sensorId: string, $source: string): GnssSensorConfig {
   return { sensorId, $source, fromBow: null, fromCenter: null }
+}
+
+function cfg(sensors: GnssSensorConfig[]): GnssConfigPayload {
+  return { correction: 'off', sensors }
 }
 
 describe('gnssPositionSlice', () => {
   beforeEach(() => {
     useStore.setState({
       gnssSensorsData: {
+        correction: 'off',
         sensors: [],
         saveState: {
           dirty: false,
@@ -24,17 +30,17 @@ describe('gnssPositionSlice', () => {
     it('applies server rows and resets dirty when there are no local edits', () => {
       const sensors = [row('gnss1', 'n2k.0.5')]
 
-      useStore.getState().setGnssSensors(sensors)
+      useStore.getState().setGnssSensors(cfg(sensors))
 
       expect(useStore.getState().gnssSensorsData.sensors).toEqual(sensors)
       expect(useStore.getState().gnssSensorsData.saveState.dirty).toBe(false)
     })
 
     it('does not clobber unsaved local edits on a live server update', () => {
-      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+      useStore.getState().setGnssSensors(cfg([row('gnss1', 'n2k.0.5')]))
       useStore.getState().updateGnssSensor(0, { fromBow: 2 })
 
-      useStore.getState().setGnssSensors([row('other', 'gp.GP')])
+      useStore.getState().setGnssSensors(cfg([row('other', 'gp.GP')]))
 
       const data = useStore.getState().gnssSensorsData
       expect(data.sensors[0].sensorId).toBe('gnss1')
@@ -43,13 +49,37 @@ describe('gnssPositionSlice', () => {
     })
 
     it('overwrites unsaved local edits when forced', () => {
-      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+      useStore.getState().setGnssSensors(cfg([row('gnss1', 'n2k.0.5')]))
       useStore.getState().updateGnssSensor(0, { fromBow: 2 })
 
-      useStore.getState().setGnssSensors([], true)
+      useStore.getState().setGnssSensors(cfg([]), true)
 
       const data = useStore.getState().gnssSensorsData
       expect(data.sensors).toEqual([])
+      expect(data.saveState.dirty).toBe(false)
+    })
+  })
+
+  describe('setGnssCorrection', () => {
+    it('sets the mode and marks dirty', () => {
+      useStore.getState().setGnssCorrection('replace')
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.correction).toBe('replace')
+      expect(data.saveState.dirty).toBe(true)
+    })
+
+    it('is a no-op when the mode is unchanged', () => {
+      useStore.getState().setGnssCorrection('off')
+
+      expect(useStore.getState().gnssSensorsData.saveState.dirty).toBe(false)
+    })
+
+    it('applies a server-sent mode via setGnssSensors', () => {
+      useStore.getState().setGnssSensors({ correction: 'both', sensors: [] })
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.correction).toBe('both')
       expect(data.saveState.dirty).toBe(false)
     })
   })
@@ -58,7 +88,7 @@ describe('gnssPositionSlice', () => {
     beforeEach(() => {
       useStore
         .getState()
-        .setGnssSensors([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')])
+        .setGnssSensors(cfg([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')]))
     })
 
     it('applies a valid edit, marks dirty and returns true', () => {
@@ -119,11 +149,60 @@ describe('gnssPositionSlice', () => {
     })
   })
 
+  describe('save lifecycle', () => {
+    it('setGnssSaving marks in-flight and clears a previous failure', () => {
+      useStore.getState().setGnssSaveFailed('boom')
+
+      useStore.getState().setGnssSaving()
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.saveState.isSaving).toBe(true)
+      expect(data.saveState.saveFailed).toBe(false)
+      expect(data.saveError).toBeUndefined()
+    })
+
+    it('setGnssSaved clears dirty, in-flight and error state', () => {
+      useStore.getState().setGnssCorrection('replace')
+      useStore.getState().setGnssSaving()
+
+      useStore.getState().setGnssSaved()
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.saveState.dirty).toBe(false)
+      expect(data.saveState.isSaving).toBe(false)
+      expect(data.saveState.saveFailed).toBe(false)
+      expect(data.saveError).toBeUndefined()
+    })
+
+    it('setGnssSaveFailed records the message and stops in-flight', () => {
+      useStore.getState().setGnssSaving()
+
+      useStore.getState().setGnssSaveFailed('duplicate id')
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.saveState.isSaving).toBe(false)
+      expect(data.saveState.saveFailed).toBe(true)
+      expect(data.saveError).toBe('duplicate id')
+    })
+
+    it('clearGnssSaveFailed resets the failure without touching dirty', () => {
+      useStore.getState().setGnssCorrection('replace')
+      useStore.getState().setGnssSaveFailed('duplicate id')
+
+      useStore.getState().clearGnssSaveFailed()
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.saveState.saveFailed).toBe(false)
+      expect(data.saveError).toBeUndefined()
+      expect(data.saveState.dirty).toBe(true)
+    })
+  })
+
   describe('removeGnssSensor', () => {
     it('removes exactly the indexed row and marks dirty', () => {
       useStore
         .getState()
-        .setGnssSensors([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')])
+        .setGnssSensors(cfg([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')]))
 
       useStore.getState().removeGnssSensor(0)
 
@@ -133,7 +212,7 @@ describe('gnssPositionSlice', () => {
     })
 
     it('ignores an out-of-range index', () => {
-      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+      useStore.getState().setGnssSensors(cfg([row('gnss1', 'n2k.0.5')]))
 
       useStore.getState().removeGnssSensor(5)
 

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useStore } from '../index'
+import type { GnssSensorConfig } from '../types'
+
+function row(sensorId: string, $source: string): GnssSensorConfig {
+  return { sensorId, $source, fromBow: null, fromCenter: null }
+}
+
+describe('gnssPositionSlice', () => {
+  beforeEach(() => {
+    useStore.setState({
+      gnssSensorsData: {
+        sensors: [],
+        saveState: {
+          dirty: false,
+          timeoutsOk: true
+        }
+      },
+      positionSources: []
+    })
+  })
+
+  describe('setGnssSensors', () => {
+    it('applies server rows and resets dirty when there are no local edits', () => {
+      const sensors = [row('gnss1', 'n2k.0.5')]
+
+      useStore.getState().setGnssSensors(sensors)
+
+      expect(useStore.getState().gnssSensorsData.sensors).toEqual(sensors)
+      expect(useStore.getState().gnssSensorsData.saveState.dirty).toBe(false)
+    })
+
+    it('does not clobber unsaved local edits on a live server update', () => {
+      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+      useStore.getState().updateGnssSensor(0, { fromBow: 2 })
+
+      useStore.getState().setGnssSensors([row('other', 'gp.GP')])
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.sensors[0].sensorId).toBe('gnss1')
+      expect(data.sensors[0].fromBow).toBe(2)
+      expect(data.saveState.dirty).toBe(true)
+    })
+
+    it('overwrites unsaved local edits when forced', () => {
+      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+      useStore.getState().updateGnssSensor(0, { fromBow: 2 })
+
+      useStore.getState().setGnssSensors([], true)
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.sensors).toEqual([])
+      expect(data.saveState.dirty).toBe(false)
+    })
+  })
+
+  describe('updateGnssSensor', () => {
+    beforeEach(() => {
+      useStore
+        .getState()
+        .setGnssSensors([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')])
+    })
+
+    it('applies a valid edit, marks dirty and returns true', () => {
+      const applied = useStore.getState().updateGnssSensor(0, { fromBow: 3.5 })
+
+      expect(applied).toBe(true)
+      const data = useStore.getState().gnssSensorsData
+      expect(data.sensors[0].fromBow).toBe(3.5)
+      expect(data.saveState.dirty).toBe(true)
+    })
+
+    it('rejects a duplicate sensorId and returns false', () => {
+      const applied = useStore
+        .getState()
+        .updateGnssSensor(1, { sensorId: 'gnss1' })
+
+      expect(applied).toBe(false)
+      expect(useStore.getState().gnssSensorsData.sensors[1].sensorId).toBe(
+        'gnss2'
+      )
+    })
+
+    it('rejects a duplicate $source and returns false', () => {
+      const applied = useStore
+        .getState()
+        .updateGnssSensor(1, { $source: 'n2k.0.5' })
+
+      expect(applied).toBe(false)
+      expect(useStore.getState().gnssSensorsData.sensors[1].$source).toBe(
+        'gp.GP'
+      )
+    })
+
+    it('rejects an out-of-range index and returns false', () => {
+      expect(useStore.getState().updateGnssSensor(-1, { fromBow: 1 })).toBe(
+        false
+      )
+      expect(useStore.getState().updateGnssSensor(2, { fromBow: 1 })).toBe(
+        false
+      )
+    })
+  })
+
+  describe('addGnssSensor', () => {
+    it('generates the next free gnss<n> id', () => {
+      useStore.getState().addGnssSensor('n2k.0.5')
+      useStore.getState().addGnssSensor('gp.GP')
+
+      const sensors = useStore.getState().gnssSensorsData.sensors
+      expect(sensors.map((s) => s.sensorId)).toEqual(['gnss1', 'gnss2'])
+    })
+
+    it('rejects a duplicate $source', () => {
+      useStore.getState().addGnssSensor('n2k.0.5')
+      useStore.getState().addGnssSensor('n2k.0.5')
+
+      expect(useStore.getState().gnssSensorsData.sensors).toHaveLength(1)
+    })
+  })
+
+  describe('removeGnssSensor', () => {
+    it('removes exactly the indexed row and marks dirty', () => {
+      useStore
+        .getState()
+        .setGnssSensors([row('gnss1', 'n2k.0.5'), row('gnss2', 'gp.GP')])
+
+      useStore.getState().removeGnssSensor(0)
+
+      const data = useStore.getState().gnssSensorsData
+      expect(data.sensors.map((s) => s.sensorId)).toEqual(['gnss2'])
+      expect(data.saveState.dirty).toBe(true)
+    })
+
+    it('ignores an out-of-range index', () => {
+      useStore.getState().setGnssSensors([row('gnss1', 'n2k.0.5')])
+
+      useStore.getState().removeGnssSensor(5)
+
+      expect(useStore.getState().gnssSensorsData.sensors).toHaveLength(1)
+    })
+  })
+})

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
@@ -1,5 +1,21 @@
 import type { StateCreator } from 'zustand'
-import type { GnssSensorConfig, GnssSensorsData } from '../types'
+import type {
+  GnssCorrectionMode,
+  GnssSensorConfig,
+  GnssSensorsData
+} from '../types'
+
+export interface GnssConfigPayload {
+  correction: GnssCorrectionMode
+  sensors: GnssSensorConfig[]
+}
+
+// Canonical empty server state, shared with every consumer that needs a
+// fallback so the default cannot drift.
+export const EMPTY_GNSS_CONFIG: GnssConfigPayload = {
+  correction: 'off',
+  sensors: []
+}
 
 export interface GnssPositionSliceState {
   gnssSensorsData: GnssSensorsData
@@ -7,11 +23,13 @@ export interface GnssPositionSliceState {
 }
 
 export interface GnssPositionSliceActions {
-  /** Replace the sensor rows with server state. Skipped while local
-   * edits are unsaved (dirty) so a live GNSS_SENSORS event from another
-   * session cannot clobber in-progress work; pass force to override
-   * (e.g. after a reset that just deleted the config server-side). */
-  setGnssSensors: (sensors: GnssSensorConfig[], force?: boolean) => void
+  /** Replace the correction mode + sensor rows with server state.
+   * Skipped while local edits are unsaved (dirty) so a live
+   * GNSS_SENSORS event from another session cannot clobber in-progress
+   * work; pass force to override (e.g. after a reset that just deleted
+   * the config server-side). */
+  setGnssSensors: (config: GnssConfigPayload, force?: boolean) => void
+  setGnssCorrection: (correction: GnssCorrectionMode) => void
   setPositionSources: (sources: string[]) => void
   /** Returns false when the edit was rejected (out-of-range index or a
    * duplicate sensorId/$source) so callers can surface the reason
@@ -41,6 +59,7 @@ function nextSensorId(sensors: GnssSensorConfig[]): string {
 
 const initialGnssPositionState: GnssPositionSliceState = {
   gnssSensorsData: {
+    correction: 'off',
     sensors: [],
     saveState: {
       dirty: false,
@@ -58,16 +77,30 @@ export const createGnssPositionSlice: StateCreator<
 > = (set) => ({
   ...initialGnssPositionState,
 
-  setGnssSensors: (sensors, force = false) => {
+  setGnssSensors: (config, force = false) => {
     set((state) => {
       if (!force && state.gnssSensorsData.saveState.dirty) return state
       return {
         gnssSensorsData: {
-          sensors,
+          correction: config.correction,
+          sensors: config.sensors,
           saveState: {
             dirty: false,
             timeoutsOk: true
           }
+        }
+      }
+    })
+  },
+
+  setGnssCorrection: (correction) => {
+    set((state) => {
+      if (state.gnssSensorsData.correction === correction) return state
+      return {
+        gnssSensorsData: {
+          ...state.gnssSensorsData,
+          correction,
+          saveState: { ...state.gnssSensorsData.saveState, dirty: true }
         }
       }
     })
@@ -158,7 +191,8 @@ export const createGnssPositionSlice: StateCreator<
           ...state.gnssSensorsData.saveState,
           isSaving: true,
           saveFailed: false
-        }
+        },
+        saveError: undefined
       }
     }))
   },

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
@@ -1,0 +1,207 @@
+import type { StateCreator } from 'zustand'
+import type { GnssSensorConfig, GnssSensorsData } from '../types'
+
+export interface GnssPositionSliceState {
+  gnssSensorsData: GnssSensorsData
+  positionSources: string[]
+}
+
+export interface GnssPositionSliceActions {
+  /** Replace the sensor rows with server state. Skipped while local
+   * edits are unsaved (dirty) so a live GNSS_SENSORS event from another
+   * session cannot clobber in-progress work; pass force to override
+   * (e.g. after a reset that just deleted the config server-side). */
+  setGnssSensors: (sensors: GnssSensorConfig[], force?: boolean) => void
+  setPositionSources: (sources: string[]) => void
+  /** Returns false when the edit was rejected (out-of-range index or a
+   * duplicate sensorId/$source) so callers can surface the reason
+   * instead of letting the input silently snap back. */
+  updateGnssSensor: (
+    index: number,
+    updates: Partial<GnssSensorConfig>
+  ) => boolean
+  addGnssSensor: ($source: string) => void
+  removeGnssSensor: (index: number) => void
+  setGnssSaving: () => void
+  setGnssSaved: () => void
+  setGnssSaveFailed: (message?: string) => void
+  clearGnssSaveFailed: () => void
+}
+
+export type GnssPositionSlice = GnssPositionSliceState &
+  GnssPositionSliceActions
+
+function nextSensorId(sensors: GnssSensorConfig[]): string {
+  const existing = new Set(sensors.map((s) => s.sensorId))
+  for (let i = 1; ; i++) {
+    const id = `gnss${i}`
+    if (!existing.has(id)) return id
+  }
+}
+
+const initialGnssPositionState: GnssPositionSliceState = {
+  gnssSensorsData: {
+    sensors: [],
+    saveState: {
+      dirty: false,
+      timeoutsOk: true
+    }
+  },
+  positionSources: []
+}
+
+export const createGnssPositionSlice: StateCreator<
+  GnssPositionSlice,
+  [],
+  [],
+  GnssPositionSlice
+> = (set) => ({
+  ...initialGnssPositionState,
+
+  setGnssSensors: (sensors, force = false) => {
+    set((state) => {
+      if (!force && state.gnssSensorsData.saveState.dirty) return state
+      return {
+        gnssSensorsData: {
+          sensors,
+          saveState: {
+            dirty: false,
+            timeoutsOk: true
+          }
+        }
+      }
+    })
+  },
+
+  setPositionSources: (positionSources) => {
+    set({ positionSources })
+  },
+
+  updateGnssSensor: (index, updates) => {
+    let applied = false
+    set((state) => {
+      const current = state.gnssSensorsData.sensors
+      if (index < 0 || index >= current.length) return state
+      if (
+        updates.$source !== undefined &&
+        current.some((s, i) => i !== index && s.$source === updates.$source)
+      ) {
+        return state
+      }
+      if (
+        updates.sensorId !== undefined &&
+        current.some((s, i) => i !== index && s.sensorId === updates.sensorId)
+      ) {
+        return state
+      }
+      applied = true
+      const sensors = [...current]
+      sensors[index] = { ...sensors[index], ...updates }
+      return {
+        gnssSensorsData: {
+          ...state.gnssSensorsData,
+          sensors,
+          saveState: { ...state.gnssSensorsData.saveState, dirty: true }
+        }
+      }
+    })
+    return applied
+  },
+
+  addGnssSensor: ($source) => {
+    set((state) => {
+      if (
+        $source &&
+        state.gnssSensorsData.sensors.some((s) => s.$source === $source)
+      ) {
+        return state
+      }
+      const sensors = [
+        ...state.gnssSensorsData.sensors,
+        {
+          sensorId: nextSensorId(state.gnssSensorsData.sensors),
+          $source,
+          fromBow: null,
+          fromCenter: null
+        }
+      ]
+      return {
+        gnssSensorsData: {
+          ...state.gnssSensorsData,
+          sensors,
+          saveState: { ...state.gnssSensorsData.saveState, dirty: true }
+        }
+      }
+    })
+  },
+
+  removeGnssSensor: (index) => {
+    set((state) => {
+      const current = state.gnssSensorsData.sensors
+      if (index < 0 || index >= current.length) return state
+      const sensors = current.filter((_, i) => i !== index)
+      return {
+        gnssSensorsData: {
+          ...state.gnssSensorsData,
+          sensors,
+          saveState: { ...state.gnssSensorsData.saveState, dirty: true }
+        }
+      }
+    })
+  },
+
+  setGnssSaving: () => {
+    set((state) => ({
+      gnssSensorsData: {
+        ...state.gnssSensorsData,
+        saveState: {
+          ...state.gnssSensorsData.saveState,
+          isSaving: true,
+          saveFailed: false
+        }
+      }
+    }))
+  },
+
+  setGnssSaved: () => {
+    set((state) => ({
+      gnssSensorsData: {
+        ...state.gnssSensorsData,
+        saveState: {
+          ...state.gnssSensorsData.saveState,
+          dirty: false,
+          isSaving: false,
+          saveFailed: false
+        },
+        saveError: undefined
+      }
+    }))
+  },
+
+  setGnssSaveFailed: (message?: string) => {
+    set((state) => ({
+      gnssSensorsData: {
+        ...state.gnssSensorsData,
+        saveState: {
+          ...state.gnssSensorsData.saveState,
+          isSaving: false,
+          saveFailed: true
+        },
+        saveError: message
+      }
+    }))
+  },
+
+  clearGnssSaveFailed: () => {
+    set((state) => ({
+      gnssSensorsData: {
+        ...state.gnssSensorsData,
+        saveState: {
+          ...state.gnssSensorsData.saveState,
+          saveFailed: false
+        },
+        saveError: undefined
+      }
+    }))
+  }
+})

--- a/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/gnssPositionSlice.ts
@@ -1,20 +1,77 @@
 import type { StateCreator } from 'zustand'
 import type {
   GnssCorrectionMode,
+  GnssCorrectionStatus,
   GnssSensorConfig,
   GnssSensorsData
 } from '../types'
 
+// v2 sensors API endpoint for the GNSS config; single source of truth for
+// both the initial REST load (dataFetching) and the settings page.
+export const GNSS_API_PATH = '/signalk/v2/api/vessels/self/sensors/gnss'
+
 export interface GnssConfigPayload {
   correction: GnssCorrectionMode
   sensors: GnssSensorConfig[]
+  status?: GnssCorrectionStatus
 }
 
 // Canonical empty server state, shared with every consumer that needs a
-// fallback so the default cannot drift.
-export const EMPTY_GNSS_CONFIG: GnssConfigPayload = {
+// fallback so the default cannot drift. Frozen so a stray push/assign on a
+// consumer cannot corrupt the shared default for every other caller.
+export const EMPTY_GNSS_CONFIG: Readonly<GnssConfigPayload> = Object.freeze({
   correction: 'off',
-  sensors: []
+  // Freeze the array too: it is shared by reference into every
+  // setGnssSensors(EMPTY_GNSS_CONFIG) call, so a shallow freeze would still
+  // let a stray push/sort corrupt the shared default.
+  sensors: Object.freeze([]) as GnssSensorConfig[]
+})
+
+function isGnssCorrectionMode(v: unknown): v is GnssCorrectionMode {
+  return v === 'off' || v === 'replace' || v === 'both'
+}
+
+function isGnssCorrectionStatus(v: unknown): v is GnssCorrectionStatus {
+  if (typeof v !== 'object' || v === null) return false
+  const s = v as GnssCorrectionStatus
+  return (
+    isGnssCorrectionMode(s.mode) &&
+    typeof s.active === 'boolean' &&
+    (s.blocked === undefined ||
+      s.blocked === 'no-length' ||
+      s.blocked === 'no-heading')
+  )
+}
+
+function isGnssSensorConfig(v: unknown): v is GnssSensorConfig {
+  if (typeof v !== 'object' || v === null) return false
+  const s = v as GnssSensorConfig
+  return (
+    typeof s.sensorId === 'string' &&
+    typeof s.$source === 'string' &&
+    (s.fromBow === null || typeof s.fromBow === 'number') &&
+    (s.fromCenter === null || typeof s.fromCenter === 'number')
+  )
+}
+
+// Coerce an untrusted server payload (REST GET body or a GNSS_SENSORS
+// websocket event) into a valid config, falling back to the empty default
+// on any shape mismatch so both entry points validate the same way.
+export function sanitizeGnssConfig(data: unknown): GnssConfigPayload {
+  const payload = data as Partial<GnssConfigPayload> | undefined
+  if (
+    !payload ||
+    !isGnssCorrectionMode(payload.correction) ||
+    !Array.isArray(payload.sensors) ||
+    !payload.sensors.every(isGnssSensorConfig)
+  ) {
+    return EMPTY_GNSS_CONFIG
+  }
+  return {
+    correction: payload.correction,
+    sensors: payload.sensors,
+    status: isGnssCorrectionStatus(payload.status) ? payload.status : undefined
+  }
 }
 
 export interface GnssPositionSliceState {
@@ -84,6 +141,7 @@ export const createGnssPositionSlice: StateCreator<
         gnssSensorsData: {
           correction: config.correction,
           sensors: config.sensors,
+          status: config.status,
           saveState: {
             dirty: false,
             timeoutsOk: true

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -270,9 +270,20 @@ export interface GnssSensorConfig {
 
 export type GnssCorrectionMode = 'off' | 'replace' | 'both'
 
+// Whether lever-arm correction can currently run, mirroring the server's
+// sensors API GET `status`. `active` is true only when a mode is selected
+// and both vessel length and true heading are available; `blocked` names
+// the missing input otherwise.
+export interface GnssCorrectionStatus {
+  mode: GnssCorrectionMode
+  active: boolean
+  blocked?: 'no-length' | 'no-heading'
+}
+
 export interface GnssSensorsData {
   correction: GnssCorrectionMode
   sensors: GnssSensorConfig[]
+  status?: GnssCorrectionStatus
   saveState: SaveState
   saveError?: string
 }

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -270,8 +270,9 @@ export interface GnssSensorConfig {
 
 export type GnssCorrectionMode = 'off' | 'replace' | 'both'
 
-// Whether lever-arm correction can currently run, mirroring the server's
-// sensors API GET `status`. `active` is true only when a mode is selected
+// Whether vessel reference point correction can currently run, mirroring the
+// server's sensors API GET `status`. `active` is true only when a mode is
+// selected
 // and both vessel length and true heading are available; `blocked` names
 // the missing input otherwise.
 export interface GnssCorrectionStatus {

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -268,7 +268,10 @@ export interface GnssSensorConfig {
   fromCenter: number | null
 }
 
+export type GnssCorrectionMode = 'off' | 'replace' | 'both'
+
 export interface GnssSensorsData {
+  correction: GnssCorrectionMode
   sensors: GnssSensorConfig[]
   saveState: SaveState
   saveError?: string

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -260,3 +260,16 @@ export interface CategoryInfo {
   baseUnit?: string
   [key: string]: unknown
 }
+
+export interface GnssSensorConfig {
+  sensorId: string
+  $source: string
+  fromBow: number | null
+  fromCenter: number | null
+}
+
+export interface GnssSensorsData {
+  sensors: GnssSensorConfig[]
+  saveState: SaveState
+  saveError?: string
+}

--- a/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
@@ -1,0 +1,259 @@
+import React, { useRef, useState, useCallback } from 'react'
+import type { GnssSensorConfig } from '../../store/types'
+
+interface BoatSchematicEditorProps {
+  sensors: GnssSensorConfig[]
+  vesselLength: number
+  vesselBeam: number
+  colors: string[]
+  onUpdateSensor: (index: number, updates: Partial<GnssSensorConfig>) => void
+}
+
+const SVG_WIDTH = 200
+const SVG_HEIGHT = 340
+const PADDING = 30
+const DOT_RADIUS = 8
+
+const HULL_LEFT = PADDING
+const HULL_RIGHT = SVG_WIDTH - PADDING
+const HULL_TOP = PADDING
+const HULL_BOTTOM = SVG_HEIGHT - PADDING
+const HULL_CX = SVG_WIDTH / 2
+const HULL_W = HULL_RIGHT - HULL_LEFT
+const HULL_H = HULL_BOTTOM - HULL_TOP
+
+function buildHullPath(): string {
+  const bowTip = `${HULL_CX},${HULL_TOP}`
+  const bowRight = `${HULL_RIGHT},${HULL_TOP + HULL_H * 0.25}`
+  const midRight = `${HULL_RIGHT},${HULL_TOP + HULL_H * 0.5}`
+  const sternRight = `${HULL_RIGHT},${HULL_BOTTOM - 10}`
+  const sternBottom = `${HULL_CX},${HULL_BOTTOM}`
+  const sternLeft = `${HULL_LEFT},${HULL_BOTTOM - 10}`
+  const midLeft = `${HULL_LEFT},${HULL_TOP + HULL_H * 0.5}`
+  const bowLeft = `${HULL_LEFT},${HULL_TOP + HULL_H * 0.25}`
+
+  return [
+    `M ${bowTip}`,
+    `C ${HULL_CX + HULL_W * 0.3},${HULL_TOP} ${HULL_RIGHT},${HULL_TOP + HULL_H * 0.12} ${bowRight}`,
+    `L ${midRight}`,
+    `L ${sternRight}`,
+    `Q ${HULL_RIGHT},${HULL_BOTTOM} ${sternBottom}`,
+    `Q ${HULL_LEFT},${HULL_BOTTOM} ${sternLeft}`,
+    `L ${midLeft}`,
+    `L ${bowLeft}`,
+    `C ${HULL_LEFT},${HULL_TOP + HULL_H * 0.12} ${HULL_CX - HULL_W * 0.3},${HULL_TOP} ${bowTip}`,
+    'Z'
+  ].join(' ')
+}
+
+const HULL_PATH = buildHullPath()
+
+const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
+  sensors,
+  vesselLength,
+  vesselBeam,
+  colors,
+  onUpdateSensor
+}) => {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [dragging, setDragging] = useState<number | null>(null)
+
+  // SK spec: positive fromCenter is port, negative is starboard, but SVG
+  // x grows rightward (starboard) — flip the sign when mapping into SVG.
+  const toSvgCoords = useCallback(
+    (fromBow: number | null, fromCenter: number | null) => {
+      const bow = fromBow ?? 0
+      const center = fromCenter ?? 0
+      const y = HULL_TOP + (bow / vesselLength) * HULL_H
+      const x = HULL_CX - (center / (vesselBeam / 2)) * (HULL_W / 2)
+      return {
+        x: Math.max(HULL_LEFT, Math.min(HULL_RIGHT, x)),
+        y: Math.max(HULL_TOP, Math.min(HULL_BOTTOM, y))
+      }
+    },
+    [vesselLength, vesselBeam]
+  )
+
+  const toBoatCoords = useCallback(
+    (svgX: number, svgY: number) => {
+      const clampedY = Math.max(HULL_TOP, Math.min(HULL_BOTTOM, svgY))
+      const clampedX = Math.max(HULL_LEFT, Math.min(HULL_RIGHT, svgX))
+      const fromBow =
+        Math.round(((clampedY - HULL_TOP) / HULL_H) * vesselLength * 10) / 10
+      const fromCenter =
+        Math.round(
+          -((clampedX - HULL_CX) / (HULL_W / 2)) * (vesselBeam / 2) * 10
+        ) / 10
+      return { fromBow, fromCenter }
+    },
+    [vesselLength, vesselBeam]
+  )
+
+  const getSvgPoint = useCallback((e: React.PointerEvent) => {
+    const svg = svgRef.current
+    if (!svg) return null
+    const pt = svg.createSVGPoint()
+    pt.x = e.clientX
+    pt.y = e.clientY
+    const ctm = svg.getScreenCTM()
+    if (!ctm) return null
+    return pt.matrixTransform(ctm.inverse())
+  }, [])
+
+  const handlePointerDown = useCallback(
+    (index: number) => (e: React.PointerEvent) => {
+      e.preventDefault()
+      ;(e.target as SVGElement).setPointerCapture(e.pointerId)
+      setDragging(index)
+    },
+    []
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (dragging === null) return
+      const svgPt = getSvgPoint(e)
+      if (!svgPt) return
+      const { fromBow, fromCenter } = toBoatCoords(svgPt.x, svgPt.y)
+      onUpdateSensor(dragging, { fromBow, fromCenter })
+    },
+    [dragging, getSvgPoint, toBoatCoords, onUpdateSensor]
+  )
+
+  const handlePointerUp = useCallback(() => {
+    setDragging(null)
+  }, [])
+
+  return (
+    <div className="mt-3 d-flex justify-content-center">
+      <svg
+        ref={svgRef}
+        width={SVG_WIDTH}
+        height={SVG_HEIGHT}
+        viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+        style={{
+          border: '1px solid #dee2e6',
+          borderRadius: 4,
+          cursor: dragging !== null ? 'grabbing' : 'default'
+        }}
+      >
+        <path d={HULL_PATH} fill="#f8f9fa" stroke="#6c757d" strokeWidth={1.5} />
+        <line
+          x1={HULL_CX}
+          y1={HULL_TOP}
+          x2={HULL_CX}
+          y2={HULL_BOTTOM}
+          stroke="#adb5bd"
+          strokeWidth={1}
+          strokeDasharray="4 3"
+        />
+        <line
+          x1={HULL_LEFT}
+          y1={HULL_TOP + HULL_H / 2}
+          x2={HULL_RIGHT}
+          y2={HULL_TOP + HULL_H / 2}
+          stroke="#adb5bd"
+          strokeWidth={1}
+          strokeDasharray="4 3"
+        />
+        <text
+          x={HULL_CX}
+          y={HULL_TOP - 8}
+          textAnchor="middle"
+          fontSize={11}
+          fill="#6c757d"
+        >
+          Bow
+        </text>
+        <text
+          x={HULL_CX}
+          y={HULL_BOTTOM + 16}
+          textAnchor="middle"
+          fontSize={11}
+          fill="#6c757d"
+        >
+          Stern
+        </text>
+        <text
+          x={HULL_LEFT - 4}
+          y={HULL_TOP + HULL_H / 2}
+          textAnchor="end"
+          dominantBaseline="middle"
+          fontSize={10}
+          fill="#6c757d"
+        >
+          Port
+        </text>
+        <text
+          x={HULL_RIGHT + 4}
+          y={HULL_TOP + HULL_H / 2}
+          textAnchor="start"
+          dominantBaseline="middle"
+          fontSize={10}
+          fill="#6c757d"
+        >
+          Stbd
+        </text>
+
+        {sensors.map((sensor, index) => {
+          const { x, y } = toSvgCoords(sensor.fromBow, sensor.fromCenter)
+          const color = colors[index % colors.length]
+          return (
+            <g key={sensor.$source || `sensor-${index}`}>
+              {dragging === index && (
+                <>
+                  <line
+                    x1={x}
+                    y1={HULL_TOP}
+                    x2={x}
+                    y2={HULL_BOTTOM}
+                    stroke={color}
+                    strokeWidth={0.5}
+                    strokeDasharray="3 3"
+                    opacity={0.5}
+                  />
+                  <line
+                    x1={HULL_LEFT}
+                    y1={y}
+                    x2={HULL_RIGHT}
+                    y2={y}
+                    stroke={color}
+                    strokeWidth={0.5}
+                    strokeDasharray="3 3"
+                    opacity={0.5}
+                  />
+                </>
+              )}
+              <circle
+                cx={x}
+                cy={y}
+                r={DOT_RADIUS}
+                fill={color}
+                stroke="#fff"
+                strokeWidth={2}
+                cursor="grab"
+                onPointerDown={handlePointerDown(index)}
+              />
+              <text
+                x={x + DOT_RADIUS + 4}
+                y={y}
+                dominantBaseline="middle"
+                fontSize={10}
+                fill={color}
+                fontWeight="bold"
+                pointerEvents="none"
+              >
+                {sensor.sensorId}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+export default BoatSchematicEditor

--- a/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
@@ -103,7 +103,7 @@ const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
   const handlePointerDown = useCallback(
     (index: number) => (e: React.PointerEvent) => {
       e.preventDefault()
-      ;(e.target as SVGElement).setPointerCapture(e.pointerId)
+      ;(e.currentTarget as SVGElement).setPointerCapture(e.pointerId)
       setDragging(index)
     },
     []
@@ -137,7 +137,10 @@ const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
         style={{
           border: '1px solid #dee2e6',
           borderRadius: 4,
-          cursor: dragging !== null ? 'grabbing' : 'default'
+          cursor: dragging !== null ? 'grabbing' : 'default',
+          // Without this, touch drags fight the browser's scroll/zoom
+          // gestures and the marker sticks on tablets.
+          touchAction: 'none'
         }}
       >
         <path d={HULL_PATH} fill="#f8f9fa" stroke="#6c757d" strokeWidth={1.5} />

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -1,0 +1,559 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import Alert from 'react-bootstrap/Alert'
+import Badge from 'react-bootstrap/Badge'
+import Button from 'react-bootstrap/Button'
+import Card from 'react-bootstrap/Card'
+import Form from 'react-bootstrap/Form'
+import Table from 'react-bootstrap/Table'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash'
+import { faSatelliteDish } from '@fortawesome/free-solid-svg-icons/faSatelliteDish'
+import {
+  useStore,
+  useGnssSensorsData,
+  usePositionSources,
+  useUnconfiguredGnssSources,
+  useSourcesData
+} from '../../store'
+import { useSourceAliases } from '../../hooks/useSourceAliases'
+import type { GnssSensorConfig } from '../../store/types'
+import BoatSchematicEditor from './BoatSchematicEditor'
+
+interface VesselDimensions {
+  length: number | null
+  beam: number | null
+}
+
+const COLORS = ['#0d6efd', '#198754', '#dc3545', '#ffc107', '#0dcaf0']
+const SAVE_ERROR_CLEAR_MS = 8000
+
+const GnssPositionSettings: React.FC = () => {
+  const gnssSensorsData = useGnssSensorsData()
+  const positionSources = usePositionSources()
+  const unconfiguredSources = useUnconfiguredGnssSources()
+  const sourcesData = useSourcesData()
+  const { getDisplayParts } = useSourceAliases()
+
+  const updateGnssSensor = useStore((s) => s.updateGnssSensor)
+  const addGnssSensor = useStore((s) => s.addGnssSensor)
+  const removeGnssSensor = useStore((s) => s.removeGnssSensor)
+  const setGnssSaving = useStore((s) => s.setGnssSaving)
+  const setGnssSaved = useStore((s) => s.setGnssSaved)
+  const setGnssSaveFailed = useStore((s) => s.setGnssSaveFailed)
+  const clearGnssSaveFailed = useStore((s) => s.clearGnssSaveFailed)
+
+  const [vesselDimensions, setVesselDimensions] = useState<VesselDimensions>({
+    length: null,
+    beam: null
+  })
+  const [resetBusy, setResetBusy] = useState(false)
+  const [resetError, setResetError] = useState<string | null>(null)
+  // Stacked save-error timers would let an earlier 8s fire wipe a fresh
+  // validation message; keep the id in a ref so a new failure cancels and
+  // restarts the timer instead of queueing a second one.
+  const saveErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const scheduleSaveErrorClear = useCallback(() => {
+    if (saveErrorTimerRef.current !== null) {
+      clearTimeout(saveErrorTimerRef.current)
+    }
+    saveErrorTimerRef.current = setTimeout(() => {
+      saveErrorTimerRef.current = null
+      clearGnssSaveFailed()
+    }, SAVE_ERROR_CLEAR_MS)
+  }, [clearGnssSaveFailed])
+  useEffect(() => {
+    return () => {
+      if (saveErrorTimerRef.current !== null) {
+        clearTimeout(saveErrorTimerRef.current)
+        saveErrorTimerRef.current = null
+      }
+    }
+  }, [])
+  // Per-input draft strings. Keeping a draft lets the user type transient
+  // values like "-" or "-2." without losing them to Number()->null on every
+  // keystroke; the committed numeric value goes to the store on blur (or
+  // immediately when the input parses to a valid finite number).
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  // Key drafts by the sensor's immutable $source so an in-progress edit
+  // stays attached to the right row across add / remove / reorder.
+  const draftKey = useCallback(
+    ($source: string, field: 'fromBow' | 'fromCenter') => `${$source}.${field}`,
+    []
+  )
+
+  useEffect(() => {
+    fetch(`${window.serverRoutesPrefix}/vessel`, { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data) => {
+        const length = Number(data.length)
+        const beam = Number(data.beam)
+        setVesselDimensions({
+          length: length > 0 ? length : null,
+          beam: beam > 0 ? beam : null
+        })
+      })
+      .catch(() => {})
+  }, [])
+
+  const { sensors, saveState } = gnssSensorsData
+
+  const mergedRows = useMemo(() => {
+    const activeSourceRefs = new Set(positionSources)
+    const rows: {
+      sensor: GnssSensorConfig | null
+      $source: string
+      index: number
+      status: 'configured' | 'unconfigured' | 'offline'
+    }[] = []
+
+    sensors.forEach((sensor, index) => {
+      rows.push({
+        sensor,
+        $source: sensor.$source,
+        index,
+        status: activeSourceRefs.has(sensor.$source) ? 'configured' : 'offline'
+      })
+    })
+
+    unconfiguredSources.forEach((ref) => {
+      rows.push({
+        sensor: null,
+        $source: ref,
+        index: -1,
+        status: 'unconfigured'
+      })
+    })
+
+    return rows
+  }, [sensors, positionSources, unconfiguredSources])
+
+  const handleSave = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault()
+      setGnssSaving()
+      try {
+        const response = await fetch(
+          `${window.serverRoutesPrefix}/gnssSensors`,
+          {
+            method: 'PUT',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(sensors)
+          }
+        )
+        if (response.ok) {
+          // The server clears any legacy sensors.gps.<id>.fromBow/fromCenter
+          // base-delta entries on every save, but FullSignalK retains the
+          // already-emitted values in `signalk.self` until the next
+          // restart. The server signals `restartRequired: true` only when
+          // such entries were actually swept on this save.
+          const body = (await response.json().catch(() => ({}))) as {
+            restartRequired?: boolean
+          }
+          if (body.restartRequired) {
+            useStore.getState().setRestartRequired(true)
+          }
+          setGnssSaved()
+          return
+        }
+        // Backend validators (typebox shape, duplicate ids, physical bounds)
+        // send the rejection reason as plain text — surface it so the user
+        // can correct the specific sensor/value instead of guessing.
+        const message =
+          (await response.text().catch(() => '')) ||
+          `Save failed (HTTP ${response.status})`
+        setGnssSaveFailed(message)
+        scheduleSaveErrorClear()
+      } catch (err) {
+        setGnssSaveFailed((err as Error).message || 'Save failed')
+        scheduleSaveErrorClear()
+      }
+    },
+    [
+      sensors,
+      setGnssSaving,
+      setGnssSaved,
+      setGnssSaveFailed,
+      scheduleSaveErrorClear
+    ]
+  )
+
+  const handleReset = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Reset all GNSS antenna positions?\n\n' +
+        'This removes every configured sensor row. The server stops ' +
+        'applying lever-arm correction to navigation.position and detected ' +
+        'sources will reappear as "unconfigured" rows.'
+    )
+    if (!confirmed) return
+    setResetBusy(true)
+    setResetError(null)
+    try {
+      const res = await fetch(`${window.serverRoutesPrefix}/gnssSensors`, {
+        method: 'DELETE',
+        credentials: 'include'
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      // Same restart-banner trigger as the PUT path: only when legacy
+      // base-delta entries were swept by this DELETE.
+      const body = (await res.json().catch(() => ({}))) as {
+        restartRequired?: boolean
+      }
+      if (body.restartRequired) {
+        useStore.getState().setRestartRequired(true)
+      }
+      // Force past the dirty guard: the server-side config is gone, so
+      // there is nothing left for unsaved local edits to apply to.
+      useStore.getState().setGnssSensors([], true)
+      setDrafts({})
+    } catch (e) {
+      setResetError(`Reset failed: ${(e as Error).message}`)
+    } finally {
+      setResetBusy(false)
+    }
+  }, [])
+
+  // Clear in-flight draft strings keyed by $source. Drafts hold partial
+  // user input like "-" or "-2." so the typed value survives null commits
+  // mid-edit; without this clear, a stale draft would shadow the fresh
+  // store value if the same $source came back into the table.
+  const clearDraftsForSource = useCallback(
+    ($source: string) => {
+      setDrafts((d) => {
+        const next = { ...d }
+        delete next[draftKey($source, 'fromBow')]
+        delete next[draftKey($source, 'fromCenter')]
+        return next
+      })
+    },
+    [draftKey]
+  )
+
+  const handleConfigure = useCallback(
+    ($source: string) => {
+      clearDraftsForSource($source)
+      addGnssSensor($source)
+    },
+    [addGnssSensor, clearDraftsForSource]
+  )
+
+  const handleRemove = useCallback(
+    (index: number, $source: string) => {
+      clearDraftsForSource($source)
+      removeGnssSensor(index)
+    },
+    [removeGnssSensor, clearDraftsForSource]
+  )
+
+  const handleFieldChange = useCallback(
+    (
+      index: number,
+      $source: string,
+      field: keyof GnssSensorConfig,
+      value: string
+    ) => {
+      if (field === 'fromBow' || field === 'fromCenter') {
+        setDrafts((d) => ({ ...d, [draftKey($source, field)]: value }))
+        if (value === '') {
+          updateGnssSensor(index, { [field]: null })
+          return
+        }
+        const num = Number(value)
+        // Only commit fully-parsable finite numbers; partial inputs like
+        // "-", "-2.", or "1e" leave the store value alone so the user can
+        // keep typing without seeing it snap back to null.
+        if (Number.isFinite(num)) {
+          updateGnssSensor(index, { [field]: num })
+        }
+      } else if (!updateGnssSensor(index, { [field]: value })) {
+        // The slice rejects duplicate labels; without feedback the input
+        // just snaps back and the edit looks like it was swallowed.
+        setGnssSaveFailed(`Sensor label "${value}" is already in use`)
+        scheduleSaveErrorClear()
+      }
+    },
+    [updateGnssSensor, draftKey, setGnssSaveFailed, scheduleSaveErrorClear]
+  )
+
+  const handleFieldBlur = useCallback(
+    ($source: string, field: 'fromBow' | 'fromCenter') => {
+      const key = draftKey($source, field)
+      setDrafts((d) => {
+        if (d[key] === undefined) return d
+        const next = { ...d }
+        delete next[key]
+        return next
+      })
+      // If the user left a partial input ("-", "2."), the store still holds
+      // the last good value but the visible draft would have been the
+      // partial — clearing the draft on blur snaps the input back to the
+      // canonical store value.
+    },
+    [draftKey]
+  )
+
+  return (
+    <Card className="mb-4">
+      <Card.Header className="d-flex align-items-center justify-content-between">
+        <span>
+          <FontAwesomeIcon icon={faSatelliteDish} />{' '}
+          <strong>GNSS Antenna Positions</strong>
+        </span>
+        <Button
+          size="sm"
+          variant="outline-danger"
+          onClick={handleReset}
+          disabled={resetBusy}
+          title="Remove all GNSS sensor rows; the server will stop applying lever-arm correction to navigation.position"
+        >
+          {resetBusy ? 'Resetting…' : 'Reset all GNSS sensors'}
+        </Button>
+      </Card.Header>
+      <Card.Body>
+        {resetError && (
+          <Alert
+            variant="danger"
+            onClose={() => setResetError(null)}
+            dismissible
+          >
+            {resetError}
+          </Alert>
+        )}
+        <Alert variant="info" className="mb-3">
+          Configure the physical location of each GNSS antenna on your vessel.
+          Accurate antenna positions improve position data by accounting for the
+          offset between GNSS receiver and vessel reference point. Positive
+          &quot;From Center&quot; values indicate port, negative indicate
+          starboard (per Signal K specification).
+        </Alert>
+
+        {mergedRows.length === 0 ? (
+          <Alert variant="secondary">
+            No GNSS sources detected. GNSS sources will appear here when they
+            start providing position data.
+          </Alert>
+        ) : (
+          <Table responsive hover size="sm">
+            <thead>
+              <tr>
+                <th style={{ width: 12 }}></th>
+                <th>Source</th>
+                <th>Sensor Label</th>
+                <th>From Bow (m)</th>
+                <th>From Center (m)</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mergedRows.map((row) => {
+                const key = row.sensor
+                  ? `cfg-${row.$source}`
+                  : `det-${row.$source}`
+                const color =
+                  row.sensor !== null
+                    ? COLORS[row.index % COLORS.length]
+                    : '#999'
+                const isOffline = row.status === 'offline'
+                const isUnconfigured = row.status === 'unconfigured'
+
+                return (
+                  <tr
+                    key={key}
+                    className={
+                      isUnconfigured
+                        ? 'table-warning'
+                        : isOffline
+                          ? 'text-muted'
+                          : ''
+                    }
+                  >
+                    <td>
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 12,
+                          height: 12,
+                          borderRadius: '50%',
+                          backgroundColor: color
+                        }}
+                      />
+                    </td>
+                    <td>
+                      {(() => {
+                        const parts = getDisplayParts(row.$source, sourcesData)
+                        return (
+                          <>
+                            <div>{parts.primary}</div>
+                            {parts.secondary && (
+                              <small className="text-muted">
+                                {parts.secondary}
+                              </small>
+                            )}
+                          </>
+                        )
+                      })()}
+                    </td>
+                    <td>
+                      {row.sensor ? (
+                        <Form.Control
+                          type="text"
+                          size="sm"
+                          value={row.sensor.sensorId}
+                          onChange={(e) =>
+                            handleFieldChange(
+                              row.index,
+                              row.$source,
+                              'sensorId',
+                              e.target.value
+                            )
+                          }
+                          style={{ width: 100 }}
+                        />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td>
+                      {row.sensor ? (
+                        <Form.Control
+                          type="number"
+                          size="sm"
+                          step="0.1"
+                          min={vesselDimensions.length !== null ? 0 : undefined}
+                          max={vesselDimensions.length ?? undefined}
+                          value={
+                            drafts[draftKey(row.$source, 'fromBow')] ??
+                            (row.sensor.fromBow !== null
+                              ? row.sensor.fromBow
+                              : '')
+                          }
+                          onChange={(e) =>
+                            handleFieldChange(
+                              row.index,
+                              row.$source,
+                              'fromBow',
+                              e.target.value
+                            )
+                          }
+                          onBlur={() => handleFieldBlur(row.$source, 'fromBow')}
+                          style={{ width: 100 }}
+                        />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td>
+                      {row.sensor ? (
+                        <Form.Control
+                          type="number"
+                          size="sm"
+                          step="0.1"
+                          min={
+                            vesselDimensions.beam !== null
+                              ? -vesselDimensions.beam / 2
+                              : undefined
+                          }
+                          max={
+                            vesselDimensions.beam !== null
+                              ? vesselDimensions.beam / 2
+                              : undefined
+                          }
+                          value={
+                            drafts[draftKey(row.$source, 'fromCenter')] ??
+                            (row.sensor.fromCenter !== null
+                              ? row.sensor.fromCenter
+                              : '')
+                          }
+                          onChange={(e) =>
+                            handleFieldChange(
+                              row.index,
+                              row.$source,
+                              'fromCenter',
+                              e.target.value
+                            )
+                          }
+                          onBlur={() =>
+                            handleFieldBlur(row.$source, 'fromCenter')
+                          }
+                          style={{ width: 100 }}
+                        />
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                    <td>
+                      {isUnconfigured ? (
+                        <Badge bg="warning" text="dark">
+                          unconfigured
+                        </Badge>
+                      ) : isOffline ? (
+                        <Badge bg="secondary">offline</Badge>
+                      ) : (
+                        <Badge bg="success">online</Badge>
+                      )}
+                    </td>
+                    <td>
+                      {isUnconfigured ? (
+                        <Button
+                          size="sm"
+                          variant="outline-primary"
+                          onClick={() => handleConfigure(row.$source)}
+                          title="Configure this GNSS source"
+                        >
+                          <FontAwesomeIcon icon={faPlus} /> Configure
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline-danger"
+                          onClick={() => handleRemove(row.index, row.$source)}
+                          title="Remove this sensor configuration"
+                          aria-label={`Remove sensor configuration for ${row.sensor?.sensorId || row.$source}`}
+                        >
+                          <FontAwesomeIcon icon={faTrash} />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </Table>
+        )}
+
+        {sensors.length > 0 &&
+          vesselDimensions.length !== null &&
+          vesselDimensions.beam !== null && (
+            <BoatSchematicEditor
+              sensors={sensors}
+              vesselLength={vesselDimensions.length}
+              vesselBeam={vesselDimensions.beam}
+              colors={COLORS}
+              onUpdateSensor={updateGnssSensor}
+            />
+          )}
+      </Card.Body>
+      <Card.Footer>
+        <Button
+          size="sm"
+          variant="primary"
+          disabled={!saveState.dirty || saveState.isSaving}
+          onClick={handleSave}
+        >
+          <FontAwesomeIcon icon={faFloppyDisk} /> Save
+        </Button>
+        {saveState.saveFailed && (
+          <span className="text-danger ms-2">
+            {gnssSensorsData.saveError ||
+              'Saving GNSS sensor configuration failed!'}
+          </span>
+        )}
+      </Card.Footer>
+    </Card>
+  )
+}
+
+export default GnssPositionSettings

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -380,10 +380,11 @@ const GnssPositionSettings: React.FC = () => {
         <Alert variant="info" className="mb-3">
           Configure the physical location of each GNSS antenna on your vessel.
           Accurate antenna positions improve position data by accounting for the
-          offset between GNSS receiver and vessel reference point (CCRP: Consistent Common Reference Point). Positive
-          &quot;From Center&quot; values indicate port, negative indicate
-          starboard (per Signal K specification). Configure a detected source by
-          editing one of its fields.
+          offset between GNSS receiver and vessel reference point (CCRP:
+          Consistent Common Reference Point). Positive &quot;From Center&quot;
+          values indicate port, negative indicate starboard (per Signal K
+          specification). Configure a detected source by editing one of its
+          fields.
         </Alert>
 
         <Form.Group className="mb-3">
@@ -428,10 +429,11 @@ const GnssPositionSettings: React.FC = () => {
           )}
           {status && status.blocked === 'no-heading' && (
             <Alert variant="warning" className="mt-1 mb-0 py-1 px-2">
-            <small className="d-block mt-1">
-              Correction is enabled but inactive: no true heading is available.
-              It will resume automatically when heading data returns.
-            </small>
+              <small className="d-block mt-1">
+                Correction is enabled but inactive: no true heading is
+                available. It will resume automatically when heading data
+                returns.
+              </small>
             </Alert>
           )}
           {status && status.active && (

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -30,17 +30,17 @@ const CORRECTION_OPTIONS: {
 }[] = [
   {
     value: 'off',
-    label: 'Store positions only',
+    label: 'No correction',
     help: 'Antenna positions are saved but navigation.position data is not modified.'
   },
   {
     value: 'replace',
-    label: 'Correct position data',
+    label: 'In place correction (replace original)',
     help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP). The raw antenna value is replaced; use "Original & corrected" to keep both.'
   },
   {
     value: 'both',
-    label: 'Original & corrected',
+    label: 'Correction as copy (keep original)',
     help: 'The original data is left untouched and the corrected position is additionally published under <sensor label>.ccrp, selectable via source priorities.'
   }
 ]
@@ -414,16 +414,23 @@ const GnssPositionSettings: React.FC = () => {
               snapshot or the live server status, so a length that goes
               missing while the page is open still surfaces. */}
           {(lengthMissing || status?.blocked === 'no-length') && (
-            <small className="d-block text-warning mt-1">
-              Position correction requires the vessel length.{' '}
-              <a href={VESSEL_SETTINGS_HASH}>Set it in Vessel Configuration</a>.
-            </small>
+            <Alert variant="info" className="mt-1 mb-0 py-1 px-2">
+              <small className="d-block mt-1">
+                Position correction requires the vessel length.{' '}
+                <a href={VESSEL_SETTINGS_HASH}>
+                  Set it in Vessel Configuration
+                </a>
+                .
+              </small>
+            </Alert>
           )}
           {status && status.blocked === 'no-heading' && (
-            <small className="d-block text-warning mt-1">
+            <Alert variant="warning" className="mt-1 mb-0 py-1 px-2">
+            <small className="d-block mt-1">
               Correction is enabled but inactive: no true heading is available.
               It will resume automatically when heading data returns.
             </small>
+            </Alert>
           )}
           {status && status.active && (
             <small className="d-block text-success mt-1">

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -17,7 +17,10 @@ import {
 } from '../../store'
 import { useSourceAliases } from '../../hooks/useSourceAliases'
 import type { GnssCorrectionMode, GnssSensorConfig } from '../../store/types'
-import { EMPTY_GNSS_CONFIG } from '../../store/slices/gnssPositionSlice'
+import {
+  EMPTY_GNSS_CONFIG,
+  GNSS_API_PATH
+} from '../../store/slices/gnssPositionSlice'
 import BoatSchematicEditor from './BoatSchematicEditor'
 
 const CORRECTION_OPTIONS: {
@@ -33,7 +36,7 @@ const CORRECTION_OPTIONS: {
   {
     value: 'replace',
     label: 'Correct position data',
-    help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP); the raw antenna value is kept in the delta meta.'
+    help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP). The raw antenna value is replaced; use "Original & corrected" to keep both.'
   },
   {
     value: 'both',
@@ -126,7 +129,16 @@ const GnssPositionSettings: React.FC = () => {
       })
   }, [])
 
-  const { correction, sensors, saveState } = gnssSensorsData
+  const { correction, sensors, saveState, status } = gnssSensorsData
+
+  // Lever-arm correction ('replace'/'both') needs the vessel length to
+  // locate the CCRP; without it the server cannot correct. Disable those
+  // choices and point the user at where length is set.
+  const lengthMissing = vesselDimensions.length === null
+  const VESSEL_SETTINGS_HASH = '#/serverConfiguration/settings'
+  // Save (PUT) and reset (DELETE) mutate the same GNSS config; disable both
+  // while either is in flight so they cannot race on response order.
+  const mutationBusy = saveState.isSaving || resetBusy
 
   const mergedRows = useMemo(() => {
     const activeSourceRefs = new Set(positionSources)
@@ -168,15 +180,12 @@ const GnssPositionSettings: React.FC = () => {
       e.preventDefault()
       setGnssSaving()
       try {
-        const response = await fetch(
-          `${window.serverRoutesPrefix}/gnssSensors`,
-          {
-            method: 'PUT',
-            credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ correction, sensors })
-          }
-        )
+        const response = await fetch(GNSS_API_PATH, {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ correction, sensors })
+        })
         if (response.ok) {
           // The server clears any legacy sensors.gps.<id>.fromBow/fromCenter
           // base-delta entries on every save, but FullSignalK retains the
@@ -226,7 +235,7 @@ const GnssPositionSettings: React.FC = () => {
     setResetBusy(true)
     setResetError(null)
     try {
-      const res = await fetch(`${window.serverRoutesPrefix}/gnssSensors`, {
+      const res = await fetch(GNSS_API_PATH, {
         method: 'DELETE',
         credentials: 'include'
       })
@@ -352,7 +361,7 @@ const GnssPositionSettings: React.FC = () => {
           size="sm"
           variant="outline-danger"
           onClick={handleReset}
-          disabled={resetBusy}
+          disabled={mutationBusy}
           title="Remove all GNSS sensor rows; the server will stop applying lever-arm correction to navigation.position"
         >
           {resetBusy ? 'Resetting…' : 'Reset all GNSS sensors'}
@@ -379,21 +388,48 @@ const GnssPositionSettings: React.FC = () => {
 
         <Form.Group className="mb-3">
           <Form.Label className="fw-bold">Lever-arm correction</Form.Label>
-          {CORRECTION_OPTIONS.map((opt) => (
-            <Form.Check
-              key={opt.value}
-              type="radio"
-              id={`gnss-correction-${opt.value}`}
-              name="gnss-correction"
-              checked={correction === opt.value}
-              onChange={() => setGnssCorrection(opt.value)}
-              label={
-                <>
-                  {opt.label} <small className="text-muted">— {opt.help}</small>
-                </>
-              }
-            />
-          ))}
+          {CORRECTION_OPTIONS.map((opt) => {
+            // 'off' is always available; the correcting modes need length.
+            const requiresLength = opt.value !== 'off'
+            const disabled = requiresLength && lengthMissing
+            return (
+              <Form.Check
+                key={opt.value}
+                type="radio"
+                id={`gnss-correction-${opt.value}`}
+                name="gnss-correction"
+                checked={correction === opt.value}
+                disabled={disabled || mutationBusy}
+                onChange={() => setGnssCorrection(opt.value)}
+                label={
+                  <>
+                    {opt.label}{' '}
+                    <small className="text-muted">— {opt.help}</small>
+                  </>
+                }
+              />
+            )
+          })}
+          {/* Show the length warning from either the mount-time /vessel
+              snapshot or the live server status, so a length that goes
+              missing while the page is open still surfaces. */}
+          {(lengthMissing || status?.blocked === 'no-length') && (
+            <small className="d-block text-warning mt-1">
+              Position correction requires the vessel length.{' '}
+              <a href={VESSEL_SETTINGS_HASH}>Set it in Vessel Configuration</a>.
+            </small>
+          )}
+          {status && status.blocked === 'no-heading' && (
+            <small className="d-block text-warning mt-1">
+              Correction is enabled but inactive: no true heading is available.
+              It will resume automatically when heading data returns.
+            </small>
+          )}
+          {status && status.active && (
+            <small className="d-block text-success mt-1">
+              Correction is active.
+            </small>
+          )}
         </Form.Group>
 
         {mergedRows.length === 0 ? (
@@ -472,6 +508,7 @@ const GnssPositionSettings: React.FC = () => {
                         aria-label={`Sensor label for ${row.$source}`}
                         value={row.sensor ? row.sensor.sensorId : ''}
                         placeholder="label"
+                        disabled={mutationBusy}
                         onFocus={configureOnFocus}
                         onChange={(e) =>
                           row.sensor &&
@@ -499,6 +536,7 @@ const GnssPositionSettings: React.FC = () => {
                             ? row.sensor.fromBow
                             : '')
                         }
+                        disabled={mutationBusy}
                         onFocus={configureOnFocus}
                         onChange={(e) =>
                           row.sensor &&
@@ -535,6 +573,7 @@ const GnssPositionSettings: React.FC = () => {
                             ? row.sensor.fromCenter
                             : '')
                         }
+                        disabled={mutationBusy}
                         onFocus={configureOnFocus}
                         onChange={(e) =>
                           row.sensor &&
@@ -563,6 +602,7 @@ const GnssPositionSettings: React.FC = () => {
                         <Button
                           size="sm"
                           variant="outline-secondary"
+                          disabled={mutationBusy}
                           onClick={() => handleRemove(row.index, row.$source)}
                           title="Clear this sensor's antenna configuration"
                           aria-label={`Clear antenna configuration for ${row.sensor.sensorId || row.$source}`}
@@ -594,7 +634,7 @@ const GnssPositionSettings: React.FC = () => {
         <Button
           size="sm"
           variant="primary"
-          disabled={!saveState.dirty || saveState.isSaving}
+          disabled={!saveState.dirty || mutationBusy}
           onClick={handleSave}
         >
           <FontAwesomeIcon icon={faFloppyDisk} /> Save

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -7,8 +7,6 @@ import Form from 'react-bootstrap/Form'
 import Table from 'react-bootstrap/Table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
-import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
-import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash'
 import { faSatelliteDish } from '@fortawesome/free-solid-svg-icons/faSatelliteDish'
 import {
   useStore,
@@ -18,8 +16,31 @@ import {
   useSourcesData
 } from '../../store'
 import { useSourceAliases } from '../../hooks/useSourceAliases'
-import type { GnssSensorConfig } from '../../store/types'
+import type { GnssCorrectionMode, GnssSensorConfig } from '../../store/types'
+import { EMPTY_GNSS_CONFIG } from '../../store/slices/gnssPositionSlice'
 import BoatSchematicEditor from './BoatSchematicEditor'
+
+const CORRECTION_OPTIONS: {
+  value: GnssCorrectionMode
+  label: string
+  help: string
+}[] = [
+  {
+    value: 'off',
+    label: 'Store positions only',
+    help: 'Antenna positions are saved but navigation.position data is not modified.'
+  },
+  {
+    value: 'replace',
+    label: 'Correct position data',
+    help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP); the raw antenna value is kept in the delta meta.'
+  },
+  {
+    value: 'both',
+    label: 'Original & corrected',
+    help: 'The original data is left untouched and the corrected position is additionally published under <sensor label>.ccrp, selectable via source priorities.'
+  }
+]
 
 interface VesselDimensions {
   length: number | null
@@ -39,6 +60,7 @@ const GnssPositionSettings: React.FC = () => {
   const updateGnssSensor = useStore((s) => s.updateGnssSensor)
   const addGnssSensor = useStore((s) => s.addGnssSensor)
   const removeGnssSensor = useStore((s) => s.removeGnssSensor)
+  const setGnssCorrection = useStore((s) => s.setGnssCorrection)
   const setGnssSaving = useStore((s) => s.setGnssSaving)
   const setGnssSaved = useStore((s) => s.setGnssSaved)
   const setGnssSaveFailed = useStore((s) => s.setGnssSaveFailed)
@@ -85,19 +107,26 @@ const GnssPositionSettings: React.FC = () => {
 
   useEffect(() => {
     fetch(`${window.serverRoutesPrefix}/vessel`, { credentials: 'include' })
-      .then((r) => r.json())
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return (await r.json()) as { length?: unknown; beam?: unknown }
+      })
       .then((data) => {
         const length = Number(data.length)
         const beam = Number(data.beam)
         setVesselDimensions({
-          length: length > 0 ? length : null,
-          beam: beam > 0 ? beam : null
+          length: Number.isFinite(length) && length > 0 ? length : null,
+          beam: Number.isFinite(beam) && beam > 0 ? beam : null
         })
       })
-      .catch(() => {})
+      .catch((err) => {
+        // Dimensions only tighten input bounds and enable the schematic;
+        // the page works without them, so a failure is non-blocking.
+        console.warn('Failed to load vessel dimensions', err)
+      })
   }, [])
 
-  const { sensors, saveState } = gnssSensorsData
+  const { correction, sensors, saveState } = gnssSensorsData
 
   const mergedRows = useMemo(() => {
     const activeSourceRefs = new Set(positionSources)
@@ -105,7 +134,7 @@ const GnssPositionSettings: React.FC = () => {
       sensor: GnssSensorConfig | null
       $source: string
       index: number
-      status: 'configured' | 'unconfigured' | 'offline'
+      online: boolean
     }[] = []
 
     sensors.forEach((sensor, index) => {
@@ -113,20 +142,25 @@ const GnssPositionSettings: React.FC = () => {
         sensor,
         $source: sensor.$source,
         index,
-        status: activeSourceRefs.has(sensor.$source) ? 'configured' : 'offline'
+        online: activeSourceRefs.has(sensor.$source)
       })
     })
 
     unconfiguredSources.forEach((ref) => {
+      // Unconfigured rows come from the live positionSources set, so
+      // they are online by definition.
       rows.push({
         sensor: null,
         $source: ref,
         index: -1,
-        status: 'unconfigured'
+        online: true
       })
     })
 
-    return rows
+    // Stable ordering by source ref: a row keeps its place when it
+    // transitions between unconfigured and configured, so the input the
+    // user just focused does not jump elsewhere in the table.
+    return rows.sort((a, b) => a.$source.localeCompare(b.$source))
   }, [sensors, positionSources, unconfiguredSources])
 
   const handleSave = useCallback(
@@ -140,7 +174,7 @@ const GnssPositionSettings: React.FC = () => {
             method: 'PUT',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(sensors)
+            body: JSON.stringify({ correction, sensors })
           }
         )
         if (response.ok) {
@@ -172,6 +206,7 @@ const GnssPositionSettings: React.FC = () => {
       }
     },
     [
+      correction,
       sensors,
       setGnssSaving,
       setGnssSaved,
@@ -183,9 +218,9 @@ const GnssPositionSettings: React.FC = () => {
   const handleReset = useCallback(async () => {
     const confirmed = window.confirm(
       'Reset all GNSS antenna positions?\n\n' +
-        'This removes every configured sensor row. The server stops ' +
-        'applying lever-arm correction to navigation.position and detected ' +
-        'sources will reappear as "unconfigured" rows.'
+        'This removes every configured sensor row and turns lever-arm ' +
+        'correction off. Detected sources will reappear as ' +
+        '"unconfigured" rows.'
     )
     if (!confirmed) return
     setResetBusy(true)
@@ -206,7 +241,7 @@ const GnssPositionSettings: React.FC = () => {
       }
       // Force past the dirty guard: the server-side config is gone, so
       // there is nothing left for unsaved local edits to apply to.
-      useStore.getState().setGnssSensors([], true)
+      useStore.getState().setGnssSensors(EMPTY_GNSS_CONFIG, true)
       setDrafts({})
     } catch (e) {
       setResetError(`Reset failed: ${(e as Error).message}`)
@@ -272,9 +307,21 @@ const GnssPositionSettings: React.FC = () => {
         // just snaps back and the edit looks like it was swallowed.
         setGnssSaveFailed(`Sensor label "${value}" is already in use`)
         scheduleSaveErrorClear()
+      } else if (saveErrorTimerRef.current !== null) {
+        // A successful edit invalidates a still-visible duplicate-label
+        // error; clear it now instead of waiting for the 8s timer.
+        clearTimeout(saveErrorTimerRef.current)
+        saveErrorTimerRef.current = null
+        clearGnssSaveFailed()
       }
     },
-    [updateGnssSensor, draftKey, setGnssSaveFailed, scheduleSaveErrorClear]
+    [
+      updateGnssSensor,
+      draftKey,
+      setGnssSaveFailed,
+      scheduleSaveErrorClear,
+      clearGnssSaveFailed
+    ]
   )
 
   const handleFieldBlur = useCallback(
@@ -326,8 +373,28 @@ const GnssPositionSettings: React.FC = () => {
           Accurate antenna positions improve position data by accounting for the
           offset between GNSS receiver and vessel reference point. Positive
           &quot;From Center&quot; values indicate port, negative indicate
-          starboard (per Signal K specification).
+          starboard (per Signal K specification). Configure a detected source by
+          editing one of its fields.
         </Alert>
+
+        <Form.Group className="mb-3">
+          <Form.Label className="fw-bold">Lever-arm correction</Form.Label>
+          {CORRECTION_OPTIONS.map((opt) => (
+            <Form.Check
+              key={opt.value}
+              type="radio"
+              id={`gnss-correction-${opt.value}`}
+              name="gnss-correction"
+              checked={correction === opt.value}
+              onChange={() => setGnssCorrection(opt.value)}
+              label={
+                <>
+                  {opt.label} <small className="text-muted">— {opt.help}</small>
+                </>
+              }
+            />
+          ))}
+        </Form.Group>
 
         {mergedRows.length === 0 ? (
           <Alert variant="secondary">
@@ -349,23 +416,25 @@ const GnssPositionSettings: React.FC = () => {
             </thead>
             <tbody>
               {mergedRows.map((row) => {
-                const key = row.sensor
-                  ? `cfg-${row.$source}`
-                  : `det-${row.$source}`
                 const color =
                   row.sensor !== null
                     ? COLORS[row.index % COLORS.length]
                     : '#999'
-                const isOffline = row.status === 'offline'
-                const isUnconfigured = row.status === 'unconfigured'
+                const isUnconfigured = row.sensor === null
+                // Focusing any input of an unconfigured row starts its
+                // configuration: the row gets a sensor entry and the same
+                // input keeps focus, so "click and type" just works.
+                const configureOnFocus = isUnconfigured
+                  ? () => handleConfigure(row.$source)
+                  : undefined
 
                 return (
                   <tr
-                    key={key}
+                    key={row.$source}
                     className={
                       isUnconfigured
                         ? 'table-warning'
-                        : isOffline
+                        : !row.online
                           ? 'text-muted'
                           : ''
                     }
@@ -397,123 +466,108 @@ const GnssPositionSettings: React.FC = () => {
                       })()}
                     </td>
                     <td>
-                      {row.sensor ? (
-                        <Form.Control
-                          type="text"
-                          size="sm"
-                          value={row.sensor.sensorId}
-                          onChange={(e) =>
-                            handleFieldChange(
-                              row.index,
-                              row.$source,
-                              'sensorId',
-                              e.target.value
-                            )
-                          }
-                          style={{ width: 100 }}
-                        />
-                      ) : (
-                        '—'
-                      )}
+                      <Form.Control
+                        type="text"
+                        size="sm"
+                        aria-label={`Sensor label for ${row.$source}`}
+                        value={row.sensor ? row.sensor.sensorId : ''}
+                        placeholder="label"
+                        onFocus={configureOnFocus}
+                        onChange={(e) =>
+                          row.sensor &&
+                          handleFieldChange(
+                            row.index,
+                            row.$source,
+                            'sensorId',
+                            e.target.value
+                          )
+                        }
+                        style={{ width: 100 }}
+                      />
                     </td>
                     <td>
-                      {row.sensor ? (
-                        <Form.Control
-                          type="number"
-                          size="sm"
-                          step="0.1"
-                          min={vesselDimensions.length !== null ? 0 : undefined}
-                          max={vesselDimensions.length ?? undefined}
-                          value={
-                            drafts[draftKey(row.$source, 'fromBow')] ??
-                            (row.sensor.fromBow !== null
-                              ? row.sensor.fromBow
-                              : '')
-                          }
-                          onChange={(e) =>
-                            handleFieldChange(
-                              row.index,
-                              row.$source,
-                              'fromBow',
-                              e.target.value
-                            )
-                          }
-                          onBlur={() => handleFieldBlur(row.$source, 'fromBow')}
-                          style={{ width: 100 }}
-                        />
-                      ) : (
-                        '—'
-                      )}
+                      <Form.Control
+                        type="number"
+                        size="sm"
+                        aria-label={`From bow in meters for ${row.$source}`}
+                        step="0.1"
+                        min={vesselDimensions.length !== null ? 0 : undefined}
+                        max={vesselDimensions.length ?? undefined}
+                        value={
+                          drafts[draftKey(row.$source, 'fromBow')] ??
+                          (row.sensor && row.sensor.fromBow !== null
+                            ? row.sensor.fromBow
+                            : '')
+                        }
+                        onFocus={configureOnFocus}
+                        onChange={(e) =>
+                          row.sensor &&
+                          handleFieldChange(
+                            row.index,
+                            row.$source,
+                            'fromBow',
+                            e.target.value
+                          )
+                        }
+                        onBlur={() => handleFieldBlur(row.$source, 'fromBow')}
+                        style={{ width: 100 }}
+                      />
                     </td>
                     <td>
-                      {row.sensor ? (
-                        <Form.Control
-                          type="number"
-                          size="sm"
-                          step="0.1"
-                          min={
-                            vesselDimensions.beam !== null
-                              ? -vesselDimensions.beam / 2
-                              : undefined
-                          }
-                          max={
-                            vesselDimensions.beam !== null
-                              ? vesselDimensions.beam / 2
-                              : undefined
-                          }
-                          value={
-                            drafts[draftKey(row.$source, 'fromCenter')] ??
-                            (row.sensor.fromCenter !== null
-                              ? row.sensor.fromCenter
-                              : '')
-                          }
-                          onChange={(e) =>
-                            handleFieldChange(
-                              row.index,
-                              row.$source,
-                              'fromCenter',
-                              e.target.value
-                            )
-                          }
-                          onBlur={() =>
-                            handleFieldBlur(row.$source, 'fromCenter')
-                          }
-                          style={{ width: 100 }}
-                        />
-                      ) : (
-                        '—'
-                      )}
+                      <Form.Control
+                        type="number"
+                        size="sm"
+                        aria-label={`From center in meters for ${row.$source}`}
+                        step="0.1"
+                        min={
+                          vesselDimensions.beam !== null
+                            ? -vesselDimensions.beam / 2
+                            : undefined
+                        }
+                        max={
+                          vesselDimensions.beam !== null
+                            ? vesselDimensions.beam / 2
+                            : undefined
+                        }
+                        value={
+                          drafts[draftKey(row.$source, 'fromCenter')] ??
+                          (row.sensor && row.sensor.fromCenter !== null
+                            ? row.sensor.fromCenter
+                            : '')
+                        }
+                        onFocus={configureOnFocus}
+                        onChange={(e) =>
+                          row.sensor &&
+                          handleFieldChange(
+                            row.index,
+                            row.$source,
+                            'fromCenter',
+                            e.target.value
+                          )
+                        }
+                        onBlur={() =>
+                          handleFieldBlur(row.$source, 'fromCenter')
+                        }
+                        style={{ width: 100 }}
+                      />
                     </td>
                     <td>
-                      {isUnconfigured ? (
-                        <Badge bg="warning" text="dark">
-                          unconfigured
-                        </Badge>
-                      ) : isOffline ? (
-                        <Badge bg="secondary">offline</Badge>
-                      ) : (
+                      {row.online ? (
                         <Badge bg="success">online</Badge>
+                      ) : (
+                        <Badge bg="secondary">offline</Badge>
                       )}
                     </td>
                     <td>
-                      {isUnconfigured ? (
+                      {row.sensor && (
                         <Button
                           size="sm"
-                          variant="outline-primary"
-                          onClick={() => handleConfigure(row.$source)}
-                          title="Configure this GNSS source"
-                        >
-                          <FontAwesomeIcon icon={faPlus} /> Configure
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="outline-danger"
+                          variant="outline-secondary"
                           onClick={() => handleRemove(row.index, row.$source)}
-                          title="Remove this sensor configuration"
-                          aria-label={`Remove sensor configuration for ${row.sensor?.sensorId || row.$source}`}
+                          title="Clear this sensor's antenna configuration"
+                          aria-label={`Clear antenna configuration for ${row.sensor.sensorId || row.$source}`}
                         >
-                          <FontAwesomeIcon icon={faTrash} />
+                          Clear
                         </Button>
                       )}
                     </td>

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -36,12 +36,12 @@ const CORRECTION_OPTIONS: {
   {
     value: 'replace',
     label: 'In place correction (replace original)',
-    help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP). The raw antenna value is replaced; use "Original & corrected" to keep both.'
+    help: 'navigation.position from configured antennas is corrected to the vessel reference point (CCRP). The raw antenna value is replaced'
   },
   {
     value: 'both',
     label: 'Correction as copy (keep original)',
-    help: 'The original data is left untouched and the corrected position is additionally published under <sensor label>.ccrp, selectable via source priorities.'
+    help: 'The original data is left untouched and the corrected position is additionally published under <sensor label>.ccrp source, selectable via source priorities.'
   }
 ]
 
@@ -131,9 +131,9 @@ const GnssPositionSettings: React.FC = () => {
 
   const { correction, sensors, saveState, status } = gnssSensorsData
 
-  // Lever-arm correction ('replace'/'both') needs the vessel length to
-  // locate the CCRP; without it the server cannot correct. Disable those
-  // choices and point the user at where length is set.
+  // Vessel reference point correction ('replace'/'both') needs the vessel
+  // length to locate the CCRP; without it the server cannot correct. Disable
+  // those choices and point the user at where length is set.
   const lengthMissing = vesselDimensions.length === null
   const VESSEL_SETTINGS_HASH = '#/serverConfiguration/settings'
   // Save (PUT) and reset (DELETE) mutate the same GNSS config; disable both
@@ -227,8 +227,8 @@ const GnssPositionSettings: React.FC = () => {
   const handleReset = useCallback(async () => {
     const confirmed = window.confirm(
       'Reset all GNSS antenna positions?\n\n' +
-        'This removes every configured sensor row and turns lever-arm ' +
-        'correction off. Detected sources will reappear as ' +
+        'This removes every configured sensor row and turns vessel reference ' +
+        'point correction off. Detected sources will reappear as ' +
         '"unconfigured" rows.'
     )
     if (!confirmed) return
@@ -362,7 +362,7 @@ const GnssPositionSettings: React.FC = () => {
           variant="outline-danger"
           onClick={handleReset}
           disabled={mutationBusy}
-          title="Remove all GNSS sensor rows; the server will stop applying lever-arm correction to navigation.position"
+          title="Remove all GNSS sensor rows; the server will stop applying vessel reference point correction to navigation.position"
         >
           {resetBusy ? 'Resetting…' : 'Reset all GNSS sensors'}
         </Button>
@@ -380,14 +380,16 @@ const GnssPositionSettings: React.FC = () => {
         <Alert variant="info" className="mb-3">
           Configure the physical location of each GNSS antenna on your vessel.
           Accurate antenna positions improve position data by accounting for the
-          offset between GNSS receiver and vessel reference point. Positive
+          offset between GNSS receiver and vessel reference point (CCRP: Consistent Common Reference Point). Positive
           &quot;From Center&quot; values indicate port, negative indicate
           starboard (per Signal K specification). Configure a detected source by
           editing one of its fields.
         </Alert>
 
         <Form.Group className="mb-3">
-          <Form.Label className="fw-bold">Lever-arm correction</Form.Label>
+          <Form.Label className="fw-bold">
+            Vessel reference point (CCRP) correction
+          </Form.Label>
           {CORRECTION_OPTIONS.map((opt) => {
             // 'off' is always available; the correcting modes need length.
             const requiresLength = opt.value !== 'off'

--- a/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import GnssPositionSettings from './GnssPositionSettings'
+import UnitPreferencesSettings from './UnitPreferencesSettings'
+
+const PreferencesPage: React.FC = () => {
+  return (
+    <div className="animated fadeIn">
+      <GnssPositionSettings />
+      <UnitPreferencesSettings />
+    </div>
+  )
+}
+
+export default PreferencesPage

--- a/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.tsx
@@ -18,8 +18,6 @@ interface VesselData {
   length?: string
   beam?: string
   height?: string
-  gpsFromBow?: string
-  gpsFromCenter?: string
 }
 
 const VesselConfiguration: React.FC = () => {
@@ -294,47 +292,6 @@ const VesselConfiguration: React.FC = () => {
                 />
                 <Form.Text muted>
                   The total height of the vessel in meters{' '}
-                </Form.Text>
-              </Col>
-            </Form.Group>
-            <Form.Group as={Row}>
-              <Col md="2">
-                <Form.Label htmlFor="gpsFromBow">
-                  GPS Distance From Bow
-                </Form.Label>
-              </Col>
-              <Col xs="12" md="4">
-                <Form.Control
-                  type="text"
-                  id="gpsFromBow"
-                  name="gpsFromBow"
-                  autoComplete="off"
-                  onChange={handleChange}
-                  value={vesselData.gpsFromBow || ''}
-                />
-                <Form.Text muted>
-                  The distance of the gps receiver from the bow in meters
-                </Form.Text>
-              </Col>
-            </Form.Group>
-            <Form.Group as={Row}>
-              <Col md="2">
-                <Form.Label htmlFor="gpsFromCenter">
-                  GPS Distance From Center
-                </Form.Label>
-              </Col>
-              <Col xs="12" md="4">
-                <Form.Control
-                  type="text"
-                  id="gpsFromCenter"
-                  name="gpsFromCenter"
-                  autoComplete="off"
-                  onChange={handleChange}
-                  value={vesselData.gpsFromCenter || ''}
-                />
-                <Form.Text muted>
-                  The distance from the center of vessel of the gps receiver in
-                  meters
                 </Form.Text>
               </Col>
             </Form.Group>

--- a/packages/server-api/src/deltas.ts
+++ b/packages/server-api/src/deltas.ts
@@ -134,22 +134,6 @@ export interface MetaValue {
     inverseFormula: string
     symbol: string
   }
-  gnssOffsetCorrection?: GnssOffsetCorrection
-}
-
-// Provenance attached to navigation.position deltas the server has
-// corrected for GNSS antenna lever-arm offsets. Preserves the raw
-// measurement and the inputs that produced the corrected value so
-// history consumers can reconstruct the antenna's track. $sensor
-// references the configured sensor row the offsets came from.
-/** @category Server API */
-export interface GnssOffsetCorrection {
-  $sensor: string
-  fromBow: number
-  fromCenter: number
-  lengthOverall: number
-  headingTrue: number
-  rawValue: Position
 }
 
 // Notification attribute types

--- a/packages/server-api/src/deltas.ts
+++ b/packages/server-api/src/deltas.ts
@@ -134,6 +134,22 @@ export interface MetaValue {
     inverseFormula: string
     symbol: string
   }
+  gnssOffsetCorrection?: GnssOffsetCorrection
+}
+
+// Provenance attached to navigation.position deltas the server has
+// corrected for GNSS antenna lever-arm offsets. Preserves the raw
+// measurement and the inputs that produced the corrected value so
+// history consumers can reconstruct the antenna's track. $sensor
+// references the configured sensor row the offsets came from.
+/** @category Server API */
+export interface GnssOffsetCorrection {
+  $sensor: string
+  fromBow: number
+  fromCenter: number
+  lengthOverall: number
+  headingTrue: number
+  rawValue: Position
 }
 
 // Notification attribute types

--- a/packages/server-api/src/features.ts
+++ b/packages/server-api/src/features.ts
@@ -77,3 +77,4 @@ export type SignalKApiId =
   | 'historyplayback' //https://signalk.org/specification/1.7.0/doc/streaming_api.html#history-playback
   | 'historysnapshot' //https://signalk.org/specification/1.7.0/doc/rest_api.html#history-snapshot-retrieval
   | 'notifications'
+  | 'sensors'

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -57,7 +57,7 @@ interface SensorEntry {
 //               configured gnssSensors row are rewritten in place, so
 //               downstream consumers (full data model, streambundle,
 //               WebSocket subscribers, history-recording plugins) see
-//               the position at the Common Coordinate Reference Point
+//               the position at the Consistent Common Reference Point
 //               (CCRP) rather than at the antenna. The raw antenna value
 //               is not retained; use 'both' to keep both positions.
 //   'both'    - the original delta passes through untouched and the

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -89,6 +89,12 @@ export class GnssOffsetCorrector {
         this.rebuildLookup()
         this.warnedNoHeading.clear()
         this.warnedNoLength = false
+      } else if (e?.type === 'POSITION_SOURCES') {
+        // The alias -> canName mapping can resolve after the last
+        // config save (cold boot, late address claim). POSITION_SOURCES
+        // fires when that happens, so re-canonicalising here keeps the
+        // lookup keys aligned with incoming refs.
+        this.rebuildLookup()
       }
     })
     this.app.registerDeltaInputHandler(
@@ -121,7 +127,11 @@ export class GnssOffsetCorrector {
       ) {
         continue
       }
-      next.set(s.$source, {
+      // Key by the canonical form: a row saved while the device's CAN
+      // name was still unresolved holds the alias ref, while incoming
+      // deltas are canonicalised before the lookup in handleUpdate.
+      const canonical = this.app.deltaCache.canonicaliseSourceRef(s.$source)
+      next.set(canonical, {
         sensorId: s.sensorId,
         offset: {
           fromBow: s.fromBow,

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -1,15 +1,4 @@
-import { createDebug } from '../../debug'
-const debug = createDebug('signalk-server:api:gnssOffsetCorrector')
-
-import {
-  Delta,
-  GnssOffsetCorrection,
-  Meta,
-  Path,
-  PathValue,
-  SourceRef,
-  Update
-} from '@signalk/server-api'
+import { Delta, Path, PathValue, SourceRef, Update } from '@signalk/server-api'
 import { IRouter } from 'express'
 import { get as _get } from 'lodash'
 import { SignalKMessageHub, WithConfig } from '../../app'
@@ -32,17 +21,28 @@ const CORRECTOR_ID = 'gnssOffsetCorrector'
 // bound to a *.ccrp ref are never used for correction.
 const CCRP_SOURCE_SUFFIX = '.ccrp'
 const MAX_CORRECTABLE_LATITUDE = 89.999999
+// Raised when a correction mode is active and vessel length is set but no
+// true heading is available, so lever-arm correction cannot run. Cleared
+// when heading returns.
+const HEADING_NOTIFICATION_PATH =
+  'notifications.navigation.gnss.headingUnavailable' as Path
 
 export type GnssCorrectionMode = 'off' | 'replace' | 'both'
+
+// Snapshot of whether lever-arm correction can currently run, for the
+// sensors API GET response and the admin UI. `active` is true only when a
+// correction mode is selected and both required inputs (vessel length and
+// true heading) are available. `blocked` names the missing input so the UI
+// can prompt the user to supply it.
+export interface GnssCorrectionStatus {
+  mode: GnssCorrectionMode
+  active: boolean
+  blocked?: 'no-length' | 'no-heading'
+}
 
 interface SensorEntry {
   sensorId: string
   offset: AntennaOffset
-}
-
-interface CorrectedValue {
-  corrected: Position
-  correction: GnssOffsetCorrection
 }
 
 // Server-side lever-arm correction for GNSS antenna offsets.
@@ -57,9 +57,8 @@ interface CorrectedValue {
 //               downstream consumers (full data model, streambundle,
 //               WebSocket subscribers, history-recording plugins) see
 //               the position at the Common Coordinate Reference Point
-//               (CCRP) rather than at the antenna. The raw antenna
-//               value is preserved in the same update's meta entry
-//               under gnssOffsetCorrection.
+//               (CCRP) rather than at the antenna. The raw antenna value
+//               is not retained; use 'both' to keep both positions.
 //   'both'    - the original delta passes through untouched and the
 //               corrected position is additionally published under
 //               `<sensorId>.ccrp`, so both positions coexist as
@@ -77,8 +76,11 @@ interface CorrectedValue {
 export class GnssOffsetCorrector {
   private lookup: Map<string, SensorEntry> = new Map()
   private mode: GnssCorrectionMode = 'off'
-  private warnedNoHeading: Set<string> = new Set()
   private warnedNoLength = false
+  // True while the headingUnavailable notification is raised. Tracked so
+  // the notification is emitted only on transition (raise/clear), keeping
+  // the per-delta path free of a delta on every position message.
+  private headingNotificationActive = false
 
   constructor(private app: GnssCorrectorApplication) {}
 
@@ -87,8 +89,10 @@ export class GnssOffsetCorrector {
     this.app.on('serverevent', (e: { type?: string }) => {
       if (e?.type === 'GNSS_SENSORS') {
         this.rebuildLookup()
-        this.warnedNoHeading.clear()
         this.warnedNoLength = false
+        // Config changed (mode/sensors); clear any stale heading warning so
+        // the next correction attempt re-evaluates and re-raises if needed.
+        this.clearHeadingNotification()
       } else if (e?.type === 'POSITION_SOURCES') {
         // The alias -> canName mapping can resolve after the last
         // config save (cold boot, late address claim). POSITION_SOURCES
@@ -104,26 +108,41 @@ export class GnssOffsetCorrector {
     )
   }
 
+  // Report whether correction can currently run. When a mode is selected
+  // the missing input (if any) is surfaced so the sensors API and admin UI
+  // can tell the user why correction is inactive.
+  getStatus(): GnssCorrectionStatus {
+    if (this.mode === 'off') {
+      return { mode: 'off', active: false }
+    }
+    if (this.readLengthOverall() === undefined) {
+      return { mode: this.mode, active: false, blocked: 'no-length' }
+    }
+    if (this.readHeadingTrue() === undefined) {
+      return { mode: this.mode, active: false, blocked: 'no-heading' }
+    }
+    return { mode: this.mode, active: true }
+  }
+
   private rebuildLookup(): void {
     this.mode = this.app.config.settings.gnssCorrection ?? 'off'
     const next = new Map<string, SensorEntry>()
     const sensors = this.app.config.settings.gnssSensors ?? []
     for (const s of sensors) {
-      // Skip rows that cannot drive a correctness-preserving correction:
-      //   - empty $source would otherwise hijack every position delta;
-      //   - a half-filled offset (one axis still null) would fabricate
-      //     geometry by coercing the missing axis to zero. Either case
-      //     is user-error state from a partially-edited row, so we
-      //     pass the delta through untouched.
-      // Rows bound to a *.ccrp ref are also skipped: correcting our own
-      // corrected output would recurse.
+      // An empty $source would hijack every position delta; a *.ccrp ref
+      // would make the corrector correct its own output and recurse.
       if (!s.$source) continue
       if (s.$source.endsWith(CCRP_SOURCE_SUFFIX)) continue
+      // gnssSensors is config-backed input: a hand-edited or restored file
+      // can carry a half-filled row (null/undefined axis) or a non-finite
+      // value (NaN/Infinity). Either would fabricate geometry or produce a
+      // NaN position, so skip the row. The typeof checks also narrow away
+      // null/undefined for the offset assignment below.
       if (
-        s.fromBow === null ||
-        s.fromBow === undefined ||
-        s.fromCenter === null ||
-        s.fromCenter === undefined
+        typeof s.fromBow !== 'number' ||
+        !Number.isFinite(s.fromBow) ||
+        typeof s.fromCenter !== 'number' ||
+        !Number.isFinite(s.fromCenter)
       ) {
         continue
       }
@@ -197,37 +216,24 @@ export class GnssOffsetCorrector {
       }
     }
     if (!posPv || !entry) return undefined
-    const computed = this.computeCorrection(update, posPv.value, entry)
-    if (!computed) return undefined
-    const metaEntry: Meta = {
-      path: POSITION_PATH,
-      value: { gnssOffsetCorrection: computed.correction }
-    }
+    const corrected = this.computeCorrection(posPv.value, entry)
+    if (!corrected) return undefined
     if (this.mode === 'both') {
       const ccrpRef = `${entry.sensorId}${CCRP_SOURCE_SUFFIX}` as SourceRef
       return {
         $source: ccrpRef,
         timestamp: update.timestamp,
-        values: [
-          { path: POSITION_PATH, value: computed.corrected } as PathValue
-        ],
-        meta: [metaEntry]
+        values: [{ path: POSITION_PATH, value: corrected } as PathValue]
       } as Update
     }
-    posPv.value = computed.corrected
-    if ('meta' in update && Array.isArray(update.meta)) {
-      update.meta.push(metaEntry)
-    } else {
-      ;(update as Update & { meta: Meta[] }).meta = [metaEntry]
-    }
+    posPv.value = corrected
     return undefined
   }
 
   private computeCorrection(
-    update: Update,
     raw: Position,
     entry: SensorEntry
-  ): CorrectedValue | undefined {
+  ): Position | undefined {
     // Providers are external input: a malformed position (missing or
     // non-finite coordinates) passes through untouched instead of being
     // turned into NaN by the trigonometry.
@@ -242,35 +248,62 @@ export class GnssOffsetCorrector {
     const lengthOverall = this.readLengthOverall()
     if (lengthOverall === undefined) {
       if (!this.warnedNoLength) {
-        debug.enabled &&
-          debug(
-            'skipping correction: design.length.overall not configured; configure under Server > Settings > Vessel Configuration'
-          )
+        // User-actionable misconfiguration (a correction mode is on but the
+        // vessel length it needs is unset), so surface it at warn level
+        // rather than hiding it behind the debug flag. Warned once until the
+        // config changes to avoid flooding the log on the per-delta path.
+        console.warn(
+          'GNSS lever-arm correction skipped: design.length.overall not configured; set it under Server > Settings > Vessel Configuration'
+        )
         this.warnedNoLength = true
       }
       return undefined
     }
     const headingTrue = this.readHeadingTrue()
     if (headingTrue === undefined) {
-      const src = update.$source ?? ('unknown' as SourceRef)
-      if (!this.warnedNoHeading.has(src)) {
-        debug.enabled &&
-          debug('skipping correction for %s: no heading available', src)
-        this.warnedNoHeading.add(src)
-      }
+      // Length is set and a mode is active, so this is a real loss of a
+      // required input: raise a notification (once, on transition) so the
+      // user learns correction has stopped rather than silently getting
+      // uncorrected positions.
+      this.raiseHeadingNotification()
       return undefined
     }
-    return {
-      corrected: correctPosition(raw, entry.offset, lengthOverall, headingTrue),
-      correction: {
-        $sensor: entry.sensorId,
-        fromBow: entry.offset.fromBow,
-        fromCenter: entry.offset.fromCenter,
-        lengthOverall,
-        headingTrue,
-        rawValue: raw
-      }
-    }
+    // Heading is back; retract any outstanding notification.
+    this.clearHeadingNotification()
+    return correctPosition(raw, entry.offset, lengthOverall, headingTrue)
+  }
+
+  private raiseHeadingNotification(): void {
+    if (this.headingNotificationActive) return
+    this.headingNotificationActive = true
+    this.emitHeadingNotification(
+      'warn',
+      'GNSS lever-arm correction inactive: no true heading available'
+    )
+  }
+
+  private clearHeadingNotification(): void {
+    if (!this.headingNotificationActive) return
+    this.headingNotificationActive = false
+    this.emitHeadingNotification(
+      'normal',
+      'GNSS lever-arm correction resumed: true heading available'
+    )
+  }
+
+  private emitHeadingNotification(state: string, message: string): void {
+    this.app.handleMessage(CORRECTOR_ID, {
+      updates: [
+        {
+          values: [
+            {
+              path: HEADING_NOTIFICATION_PATH,
+              value: { state, method: ['visual'], message }
+            }
+          ]
+        }
+      ]
+    })
   }
 
   // Read directly from app.signalk.self the same way put.ts and the
@@ -280,17 +313,29 @@ export class GnssOffsetCorrector {
   private readLengthOverall(): number | undefined {
     const length = _get(this.app.signalk.self, 'design.length.value') as
       { overall?: number } | number | undefined
-    if (typeof length === 'number') return length
-    if (length && typeof length.overall === 'number') return length.overall
-    return undefined
+    const overall = typeof length === 'number' ? length : length?.overall
+    // A non-positive or non-finite length would place the CCRP nowhere
+    // sensible and feed correctPosition garbage; treat it as unavailable.
+    return typeof overall === 'number' &&
+      Number.isFinite(overall) &&
+      overall > 0
+      ? overall
+      : undefined
   }
 
   private readHeadingTrue(): number | undefined {
     const t = _get(this.app.signalk.self, 'navigation.headingTrue.value')
-    if (typeof t === 'number') return t
+    if (typeof t === 'number' && Number.isFinite(t)) return t
     const m = _get(this.app.signalk.self, 'navigation.headingMagnetic.value')
     const v = _get(this.app.signalk.self, 'navigation.magneticVariation.value')
-    if (typeof m === 'number' && typeof v === 'number') return m + v
+    if (
+      typeof m === 'number' &&
+      Number.isFinite(m) &&
+      typeof v === 'number' &&
+      Number.isFinite(v)
+    ) {
+      return m + v
+    }
     return undefined
   }
 }

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -1,0 +1,192 @@
+import { createDebug } from '../../debug'
+const debug = createDebug('signalk-server:api:gnssOffsetCorrector')
+
+import {
+  Delta,
+  GnssOffsetCorrection,
+  Meta,
+  Path,
+  SourceRef,
+  Update
+} from '@signalk/server-api'
+import { IRouter } from 'express'
+import { get as _get } from 'lodash'
+import { SignalKMessageHub, WithConfig } from '../../app'
+import { ConfigApp } from '../../config/config'
+import { WithSecurityStrategy } from '../../security'
+import { correctPosition, AntennaOffset, Position } from './leverArm'
+
+export interface GnssCorrectorApplication
+  extends
+    IRouter,
+    ConfigApp,
+    WithConfig,
+    WithSecurityStrategy,
+    SignalKMessageHub {}
+
+const POSITION_PATH = 'navigation.position'
+const POSITION_META_PATH = POSITION_PATH as Path
+
+interface SensorEntry {
+  sensorId: string
+  offset: AntennaOffset
+}
+
+// Server-side lever-arm correction for GNSS antenna offsets.
+//
+// Rewrites navigation.position deltas whose $source matches a configured
+// gnssSensors row, so downstream consumers (full data model, streambundle,
+// WebSocket subscribers, history-recording plugins) see the position at
+// the Common Coordinate Reference Point (CCRP) rather than at the antenna.
+//
+// CCRP is defined as center-of-vessel on the centerline: body coordinates
+// (length/2, 0) measured from the bow. Derived from design.length.overall
+// (already in Server -> Settings -> Vessel Configuration). When length or
+// heading is unavailable, the delta passes through unmodified.
+//
+// The raw antenna value is preserved in the same update's meta entry under
+// gnssOffsetCorrection so history plugins can reconstruct the antenna's
+// track. app.deltaCache stores the raw per-source value because it ingests
+// before the chain runs - that is intentional and matches the Data Browser
+// expectation that the per-source view shows what each antenna reports.
+export class GnssOffsetCorrector {
+  private lookup: Map<string, SensorEntry> = new Map()
+  private warnedNoHeading: Set<string> = new Set()
+  private warnedNoLength = false
+
+  constructor(private app: GnssCorrectorApplication) {}
+
+  async start(): Promise<void> {
+    this.rebuildLookup()
+    this.app.on('serverevent', (e: { type?: string }) => {
+      if (e?.type === 'GNSS_SENSORS') {
+        this.rebuildLookup()
+        this.warnedNoHeading.clear()
+        this.warnedNoLength = false
+      }
+    })
+    this.app.registerDeltaInputHandler(
+      (delta: Delta, next: (delta: Delta) => void) => {
+        next(this.handle(delta))
+      }
+    )
+  }
+
+  private rebuildLookup(): void {
+    const next = new Map<string, SensorEntry>()
+    const sensors = this.app.config.settings.gnssSensors ?? []
+    for (const s of sensors) {
+      // Skip rows that cannot drive a correctness-preserving correction:
+      //   - empty $source would otherwise hijack every position delta;
+      //   - a half-filled offset (one axis still null) would fabricate
+      //     geometry by coercing the missing axis to zero. Either case
+      //     is user-error state from a partially-edited row, so we
+      //     pass the delta through untouched.
+      if (!s.$source) continue
+      if (s.fromBow === null || s.fromCenter === null) continue
+      next.set(s.$source, {
+        sensorId: s.sensorId,
+        offset: {
+          fromBow: s.fromBow,
+          fromCenter: s.fromCenter
+        }
+      })
+    }
+    this.lookup = next
+  }
+
+  private handle(delta: Delta): Delta {
+    if (this.lookup.size === 0) return delta
+    if (delta.context !== this.app.selfContext) return delta
+    if (!delta.updates) return delta
+    for (const update of delta.updates) {
+      this.handleUpdate(update)
+    }
+    return delta
+  }
+
+  private handleUpdate(update: Update): void {
+    if (!('values' in update) || !update.values) return
+    let posPv: { path: Path; value: Position } | undefined
+    let entry: SensorEntry | undefined
+    for (const pv of update.values) {
+      if (pv.path !== POSITION_PATH) continue
+      if (pv.value === null || typeof pv.value !== 'object') continue
+      const sourceRef = update.$source
+      if (!sourceRef) continue
+      // Configured rows hold the canonical (canName-form) ref offered by
+      // positionSources; N2K deltas that arrive before the device's
+      // address claim is observed are tagged with the numeric-src alias.
+      // Canonicalise before the lookup so those deltas still match.
+      entry = this.lookup.get(
+        this.app.deltaCache.canonicaliseSourceRef(sourceRef)
+      )
+      if (entry) {
+        posPv = pv as { path: Path; value: Position }
+        break
+      }
+    }
+    if (!posPv || !entry) return
+    const lengthOverall = this.readLengthOverall()
+    if (lengthOverall === undefined) {
+      if (!this.warnedNoLength) {
+        debug.enabled &&
+          debug(
+            'skipping correction: design.length.overall not configured; configure under Server > Settings > Vessel Configuration'
+          )
+        this.warnedNoLength = true
+      }
+      return
+    }
+    const headingTrue = this.readHeadingTrue()
+    if (headingTrue === undefined) {
+      const src = update.$source ?? ('unknown' as SourceRef)
+      if (!this.warnedNoHeading.has(src)) {
+        debug.enabled &&
+          debug('skipping correction for %s: no heading available', src)
+        this.warnedNoHeading.add(src)
+      }
+      return
+    }
+    const raw = posPv.value
+    posPv.value = correctPosition(raw, entry.offset, lengthOverall, headingTrue)
+    const correction: GnssOffsetCorrection = {
+      $sensor: entry.sensorId,
+      fromBow: entry.offset.fromBow,
+      fromCenter: entry.offset.fromCenter,
+      lengthOverall,
+      headingTrue,
+      rawValue: raw
+    }
+    const metaEntry: Meta = {
+      path: POSITION_META_PATH,
+      value: { gnssOffsetCorrection: correction }
+    }
+    if ('meta' in update && Array.isArray(update.meta)) {
+      update.meta.push(metaEntry)
+    } else {
+      ;(update as Update & { meta: Meta[] }).meta = [metaEntry]
+    }
+  }
+
+  // Read directly from app.signalk.self the same way put.ts and the
+  // plugin-facing getSelfPath helper do. The plugin `getSelfPath` wrapper
+  // is only assembled inside interfaces/plugins.ts and is not exposed on
+  // the bare app passed into startApis, so we cannot rely on it here.
+  private readLengthOverall(): number | undefined {
+    const length = _get(this.app.signalk.self, 'design.length.value') as
+      { overall?: number } | number | undefined
+    if (typeof length === 'number') return length
+    if (length && typeof length.overall === 'number') return length.overall
+    return undefined
+  }
+
+  private readHeadingTrue(): number | undefined {
+    const t = _get(this.app.signalk.self, 'navigation.headingTrue.value')
+    if (typeof t === 'number') return t
+    const m = _get(this.app.signalk.self, 'navigation.headingMagnetic.value')
+    const v = _get(this.app.signalk.self, 'navigation.magneticVariation.value')
+    if (typeof m === 'number' && typeof v === 'number') return m + v
+    return undefined
+  }
+}

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -6,6 +6,7 @@ import {
   GnssOffsetCorrection,
   Meta,
   Path,
+  PathValue,
   SourceRef,
   Update
 } from '@signalk/server-api'
@@ -24,33 +25,58 @@ export interface GnssCorrectorApplication
     WithSecurityStrategy,
     SignalKMessageHub {}
 
-const POSITION_PATH = 'navigation.position'
-const POSITION_META_PATH = POSITION_PATH as Path
+const POSITION_PATH = 'navigation.position' as Path
+const CORRECTOR_ID = 'gnssOffsetCorrector'
+// $source suffix for corrected positions published alongside the
+// original in 'both' mode. Also serves as the recursion guard: rows
+// bound to a *.ccrp ref are never used for correction.
+const CCRP_SOURCE_SUFFIX = '.ccrp'
+const MAX_CORRECTABLE_LATITUDE = 89.999999
+
+export type GnssCorrectionMode = 'off' | 'replace' | 'both'
 
 interface SensorEntry {
   sensorId: string
   offset: AntennaOffset
 }
 
+interface CorrectedValue {
+  corrected: Position
+  correction: GnssOffsetCorrection
+}
+
 // Server-side lever-arm correction for GNSS antenna offsets.
 //
-// Rewrites navigation.position deltas whose $source matches a configured
-// gnssSensors row, so downstream consumers (full data model, streambundle,
-// WebSocket subscribers, history-recording plugins) see the position at
-// the Common Coordinate Reference Point (CCRP) rather than at the antenna.
+// How configured offsets are applied is governed by
+// settings.gnssCorrection:
+//
+//   'off'     - (default) offsets are stored and documented but
+//               navigation.position data is not touched.
+//   'replace' - navigation.position deltas whose $source matches a
+//               configured gnssSensors row are rewritten in place, so
+//               downstream consumers (full data model, streambundle,
+//               WebSocket subscribers, history-recording plugins) see
+//               the position at the Common Coordinate Reference Point
+//               (CCRP) rather than at the antenna. The raw antenna
+//               value is preserved in the same update's meta entry
+//               under gnssOffsetCorrection.
+//   'both'    - the original delta passes through untouched and the
+//               corrected position is additionally published under
+//               `<sensorId>.ccrp`, so both positions coexist as
+//               separate sources on navigation.position and clients
+//               choose via source priorities.
 //
 // CCRP is defined as center-of-vessel on the centerline: body coordinates
 // (length/2, 0) measured from the bow. Derived from design.length.overall
 // (already in Server -> Settings -> Vessel Configuration). When length or
 // heading is unavailable, the delta passes through unmodified.
 //
-// The raw antenna value is preserved in the same update's meta entry under
-// gnssOffsetCorrection so history plugins can reconstruct the antenna's
-// track. app.deltaCache stores the raw per-source value because it ingests
+// app.deltaCache stores the raw per-source value because it ingests
 // before the chain runs - that is intentional and matches the Data Browser
 // expectation that the per-source view shows what each antenna reports.
 export class GnssOffsetCorrector {
   private lookup: Map<string, SensorEntry> = new Map()
+  private mode: GnssCorrectionMode = 'off'
   private warnedNoHeading: Set<string> = new Set()
   private warnedNoLength = false
 
@@ -73,6 +99,7 @@ export class GnssOffsetCorrector {
   }
 
   private rebuildLookup(): void {
+    this.mode = this.app.config.settings.gnssCorrection ?? 'off'
     const next = new Map<string, SensorEntry>()
     const sensors = this.app.config.settings.gnssSensors ?? []
     for (const s of sensors) {
@@ -82,8 +109,18 @@ export class GnssOffsetCorrector {
       //     geometry by coercing the missing axis to zero. Either case
       //     is user-error state from a partially-edited row, so we
       //     pass the delta through untouched.
+      // Rows bound to a *.ccrp ref are also skipped: correcting our own
+      // corrected output would recurse.
       if (!s.$source) continue
-      if (s.fromBow === null || s.fromCenter === null) continue
+      if (s.$source.endsWith(CCRP_SOURCE_SUFFIX)) continue
+      if (
+        s.fromBow === null ||
+        s.fromBow === undefined ||
+        s.fromCenter === null ||
+        s.fromCenter === undefined
+      ) {
+        continue
+      }
       next.set(s.$source, {
         sensorId: s.sensorId,
         offset: {
@@ -96,17 +133,40 @@ export class GnssOffsetCorrector {
   }
 
   private handle(delta: Delta): Delta {
+    if (this.mode === 'off') return delta
     if (this.lookup.size === 0) return delta
     if (delta.context !== this.app.selfContext) return delta
     if (!delta.updates) return delta
+    let emitted: Update[] | undefined
     for (const update of delta.updates) {
-      this.handleUpdate(update)
+      const emission = this.handleUpdate(update)
+      if (emission) {
+        emitted = emitted ?? []
+        emitted.push(emission)
+      }
+    }
+    if (emitted) {
+      // Publish outside the input-handler call stack: handleMessage runs
+      // the delta chain synchronously, and re-entering it here would let
+      // the corrected delta reach cache/streambundle before the original
+      // finishes its own pass.
+      const companions = emitted
+      setImmediate(() => {
+        this.app.handleMessage(CORRECTOR_ID, {
+          context: delta.context,
+          updates: companions
+        })
+      })
     }
     return delta
   }
 
-  private handleUpdate(update: Update): void {
-    if (!('values' in update) || !update.values) return
+  // In 'replace' mode the update is corrected in place and nothing is
+  // returned. In 'both' mode the update is left untouched and the
+  // corrected position is returned as a new update to publish under
+  // the sensor's *.ccrp source.
+  private handleUpdate(update: Update): Update | undefined {
+    if (!('values' in update) || !update.values) return undefined
     let posPv: { path: Path; value: Position } | undefined
     let entry: SensorEntry | undefined
     for (const pv of update.values) {
@@ -126,7 +186,49 @@ export class GnssOffsetCorrector {
         break
       }
     }
-    if (!posPv || !entry) return
+    if (!posPv || !entry) return undefined
+    const computed = this.computeCorrection(update, posPv.value, entry)
+    if (!computed) return undefined
+    const metaEntry: Meta = {
+      path: POSITION_PATH,
+      value: { gnssOffsetCorrection: computed.correction }
+    }
+    if (this.mode === 'both') {
+      const ccrpRef = `${entry.sensorId}${CCRP_SOURCE_SUFFIX}` as SourceRef
+      return {
+        $source: ccrpRef,
+        timestamp: update.timestamp,
+        values: [
+          { path: POSITION_PATH, value: computed.corrected } as PathValue
+        ],
+        meta: [metaEntry]
+      } as Update
+    }
+    posPv.value = computed.corrected
+    if ('meta' in update && Array.isArray(update.meta)) {
+      update.meta.push(metaEntry)
+    } else {
+      ;(update as Update & { meta: Meta[] }).meta = [metaEntry]
+    }
+    return undefined
+  }
+
+  private computeCorrection(
+    update: Update,
+    raw: Position,
+    entry: SensorEntry
+  ): CorrectedValue | undefined {
+    // Providers are external input: a malformed position (missing or
+    // non-finite coordinates) passes through untouched instead of being
+    // turned into NaN by the trigonometry.
+    if (!Number.isFinite(raw.latitude) || !Number.isFinite(raw.longitude)) {
+      return undefined
+    }
+    // The east/west metres-per-degree scale (cos latitude) vanishes at
+    // the poles; skip correction rather than emit a garbage longitude.
+    if (Math.abs(raw.latitude) > MAX_CORRECTABLE_LATITUDE) {
+      return undefined
+    }
     const lengthOverall = this.readLengthOverall()
     if (lengthOverall === undefined) {
       if (!this.warnedNoLength) {
@@ -136,7 +238,7 @@ export class GnssOffsetCorrector {
           )
         this.warnedNoLength = true
       }
-      return
+      return undefined
     }
     const headingTrue = this.readHeadingTrue()
     if (headingTrue === undefined) {
@@ -146,26 +248,18 @@ export class GnssOffsetCorrector {
           debug('skipping correction for %s: no heading available', src)
         this.warnedNoHeading.add(src)
       }
-      return
+      return undefined
     }
-    const raw = posPv.value
-    posPv.value = correctPosition(raw, entry.offset, lengthOverall, headingTrue)
-    const correction: GnssOffsetCorrection = {
-      $sensor: entry.sensorId,
-      fromBow: entry.offset.fromBow,
-      fromCenter: entry.offset.fromCenter,
-      lengthOverall,
-      headingTrue,
-      rawValue: raw
-    }
-    const metaEntry: Meta = {
-      path: POSITION_META_PATH,
-      value: { gnssOffsetCorrection: correction }
-    }
-    if ('meta' in update && Array.isArray(update.meta)) {
-      update.meta.push(metaEntry)
-    } else {
-      ;(update as Update & { meta: Meta[] }).meta = [metaEntry]
+    return {
+      corrected: correctPosition(raw, entry.offset, lengthOverall, headingTrue),
+      correction: {
+        $sensor: entry.sensorId,
+        fromBow: entry.offset.fromBow,
+        fromCenter: entry.offset.fromCenter,
+        lengthOverall,
+        headingTrue,
+        rawValue: raw
+      }
     }
   }
 

--- a/src/api/gnssOffsetCorrector/index.ts
+++ b/src/api/gnssOffsetCorrector/index.ts
@@ -22,15 +22,15 @@ const CORRECTOR_ID = 'gnssOffsetCorrector'
 const CCRP_SOURCE_SUFFIX = '.ccrp'
 const MAX_CORRECTABLE_LATITUDE = 89.999999
 // Raised when a correction mode is active and vessel length is set but no
-// true heading is available, so lever-arm correction cannot run. Cleared
-// when heading returns.
+// true heading is available, so vessel reference point correction cannot run.
+// Cleared when heading returns.
 const HEADING_NOTIFICATION_PATH =
   'notifications.navigation.gnss.headingUnavailable' as Path
 
 export type GnssCorrectionMode = 'off' | 'replace' | 'both'
 
-// Snapshot of whether lever-arm correction can currently run, for the
-// sensors API GET response and the admin UI. `active` is true only when a
+// Snapshot of whether vessel reference point correction can currently run, for
+// the sensors API GET response and the admin UI. `active` is true only when a
 // correction mode is selected and both required inputs (vessel length and
 // true heading) are available. `blocked` names the missing input so the UI
 // can prompt the user to supply it.
@@ -45,7 +45,8 @@ interface SensorEntry {
   offset: AntennaOffset
 }
 
-// Server-side lever-arm correction for GNSS antenna offsets.
+// Server-side vessel reference point (CCRP) correction for GNSS antenna
+// offsets.
 //
 // How configured offsets are applied is governed by
 // settings.gnssCorrection:
@@ -253,7 +254,7 @@ export class GnssOffsetCorrector {
         // rather than hiding it behind the debug flag. Warned once until the
         // config changes to avoid flooding the log on the per-delta path.
         console.warn(
-          'GNSS lever-arm correction skipped: design.length.overall not configured; set it under Server > Settings > Vessel Configuration'
+          'GNSS vessel reference point (CCRP) correction skipped: design.length.overall not configured; set it under Server > Settings > Vessel Configuration'
         )
         this.warnedNoLength = true
       }
@@ -278,7 +279,7 @@ export class GnssOffsetCorrector {
     this.headingNotificationActive = true
     this.emitHeadingNotification(
       'warn',
-      'GNSS lever-arm correction inactive: no true heading available'
+      'GNSS vessel reference point (CCRP) correction inactive: no true heading available'
     )
   }
 
@@ -287,7 +288,7 @@ export class GnssOffsetCorrector {
     this.headingNotificationActive = false
     this.emitHeadingNotification(
       'normal',
-      'GNSS lever-arm correction resumed: true heading available'
+      'GNSS vessel reference point (CCRP) correction resumed: true heading available'
     )
   }
 

--- a/src/api/gnssOffsetCorrector/leverArm.ts
+++ b/src/api/gnssOffsetCorrector/leverArm.ts
@@ -1,6 +1,6 @@
 /**
  * Vessel reference point (CCRP) correction: translate a GNSS antenna's
- * reported position to the vessel's Common Coordinate Reference Point (CCRP).
+ * reported position to the vessel's Consistent Common Reference Point (CCRP).
  *
  * CCRP is defined as center-of-vessel on the longitudinal centerline,
  * i.e. midships at the centerline. This matches the NMEA 2000 / radar /

--- a/src/api/gnssOffsetCorrector/leverArm.ts
+++ b/src/api/gnssOffsetCorrector/leverArm.ts
@@ -1,6 +1,6 @@
 /**
- * Lever-arm correction: translate a GNSS antenna's reported position to the
- * vessel's Common Coordinate Reference Point (CCRP).
+ * Vessel reference point (CCRP) correction: translate a GNSS antenna's
+ * reported position to the vessel's Common Coordinate Reference Point (CCRP).
  *
  * CCRP is defined as center-of-vessel on the longitudinal centerline,
  * i.e. midships at the centerline. This matches the NMEA 2000 / radar /

--- a/src/api/gnssOffsetCorrector/leverArm.ts
+++ b/src/api/gnssOffsetCorrector/leverArm.ts
@@ -1,0 +1,83 @@
+/**
+ * Lever-arm correction: translate a GNSS antenna's reported position to the
+ * vessel's Common Coordinate Reference Point (CCRP).
+ *
+ * CCRP is defined as center-of-vessel on the longitudinal centerline,
+ * i.e. midships at the centerline. This matches the NMEA 2000 / radar /
+ * AIS industry convention for the vessel reference point.
+ *
+ * Body-frame convention (origin at the bow on the centerline):
+ *   +x toward bow  -> points OUT through the bow; hull lies at negative x
+ *   +y to port     (matches sensors.json "+ve to port, -ve to starboard")
+ *
+ * Body-frame positions:
+ *   Antenna:  x = -fromBow         (fromBow metres aft of the bow)
+ *             y = +fromCenter      (fromCenter metres to port of centerline)
+ *   CCRP:     x = -lengthOverall/2 (midships, aft of the bow)
+ *             y = 0
+ *
+ * Vector from antenna to CCRP in body frame:
+ *   body_x = -(lengthOverall/2) - (-fromBow) = fromBow - lengthOverall/2
+ *               (negative when antenna is forward of midships -> CCRP is aft;
+ *                positive when antenna is aft of midships -> CCRP is forward)
+ *   body_y = 0 - fromCenter = -fromCenter
+ *               (negative when antenna is to port -> CCRP is to starboard;
+ *                positive when antenna is to starboard -> CCRP is to port)
+ *
+ * Body→earth rotation for heading θ (true, clockwise from north, bow
+ * points along +x body):
+ *   At θ=0:  +x body = +north earth, +y body = -east earth (port = west).
+ *   The +y body axis lies 90° counterclockwise from +x body in the
+ *   horizontal earth plane, i.e. azimuth (θ - 90°).
+ *     +x body in earth N/E: ( cos θ,  sin θ)
+ *     +y body in earth N/E: ( sin θ, -cos θ)
+ *   Therefore:
+ *     north = body_x * cos θ + body_y * sin θ
+ *     east  = body_x * sin θ - body_y * cos θ
+ *
+ * (Note: this differs from the standard NED rotation matrix because
+ * +y body is port here, not starboard.)
+ */
+
+export interface AntennaOffset {
+  fromBow: number
+  fromCenter: number
+}
+
+export interface Position {
+  latitude: number
+  longitude: number
+  altitude?: number
+}
+
+const EARTH_RADIUS_M = 6_378_137
+const RAD_TO_DEG = 180 / Math.PI
+const DEG_TO_RAD = Math.PI / 180
+
+export function correctPosition(
+  antenna: Position,
+  offset: AntennaOffset,
+  lengthOverall: number,
+  headingTrueRad: number
+): Position {
+  const bodyX = offset.fromBow - lengthOverall / 2
+  const bodyY = -offset.fromCenter
+  const cosH = Math.cos(headingTrueRad)
+  const sinH = Math.sin(headingTrueRad)
+  const north = bodyX * cosH + bodyY * sinH
+  const east = bodyX * sinH - bodyY * cosH
+  const latRad = antenna.latitude * DEG_TO_RAD
+  const dLat = (north / EARTH_RADIUS_M) * RAD_TO_DEG
+  const dLon = (east / (EARTH_RADIUS_M * Math.cos(latRad))) * RAD_TO_DEG
+  // Wrap longitude into [-180, 180] so a small east/west correction
+  // applied near the antimeridian doesn't emit an out-of-range value
+  // (e.g. 180.0001) that downstream consumers reject. The double mod
+  // handles negative inputs in JavaScript's truncated-mod semantics.
+  const rawLon = antenna.longitude + dLon
+  const longitude = ((((rawLon + 180) % 360) + 360) % 360) - 180
+  return {
+    latitude: antenna.latitude + dLat,
+    longitude,
+    altitude: antenna.altitude
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,7 @@ import {
   GnssOffsetCorrector,
   GnssCorrectorApplication
 } from './gnssOffsetCorrector'
+import { SensorsApi, SensorsApplication } from './sensors'
 import { binaryStreamManager, initializeBinaryStreams } from './streams'
 
 export interface ApiResponse {
@@ -111,6 +112,11 @@ export const startApis = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(app as any).gnssOffsetCorrector = gnssOffsetCorrector
 
+  const sensorsApi = new SensorsApi(app as SensorsApplication)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).sensorsApi = sensorsApi
+  apiList.push('sensors')
+
   Promise.all([
     resourcesApi.start(),
     courseApi.start(),
@@ -120,7 +126,8 @@ export const startApis = (
     radarApi.start(),
     historyApiHttpRegistry.start(),
     notificationApi.start(),
-    gnssOffsetCorrector.start()
+    gnssOffsetCorrector.start(),
+    sensorsApi.start()
   ])
   return apiList
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,10 @@ import { RadarApi } from './radar'
 import { HistoryApiHttpRegistry } from './history'
 import { SignalKApiId, WithFeatures } from '@signalk/server-api'
 import { NotificationApi, NotificationApplication } from './notifications'
+import {
+  GnssOffsetCorrector,
+  GnssCorrectorApplication
+} from './gnssOffsetCorrector'
 import { binaryStreamManager, initializeBinaryStreams } from './streams'
 
 export interface ApiResponse {
@@ -101,6 +105,12 @@ export const startApis = (
   ;(app as any).notificationApi = notificationApi
   apiList.push('notifications')
 
+  const gnssOffsetCorrector = new GnssOffsetCorrector(
+    app as GnssCorrectorApplication
+  )
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).gnssOffsetCorrector = gnssOffsetCorrector
+
   Promise.all([
     resourcesApi.start(),
     courseApi.start(),
@@ -109,7 +119,8 @@ export const startApis = (
     autopilotApi.start(),
     radarApi.start(),
     historyApiHttpRegistry.start(),
-    notificationApi.start()
+    notificationApi.start(),
+    gnssOffsetCorrector.start()
   ])
   return apiList
 }

--- a/src/api/sensors/atomicApply.ts
+++ b/src/api/sensors/atomicApply.ts
@@ -1,0 +1,166 @@
+import { Response } from 'express'
+import { writeBaseDeltasFile, writeSettingsFile } from '../../config/config'
+import { GnssConfigPayload, GnssSensorsPayload } from './schemas'
+import { SensorsApplication } from './index'
+
+// Apply a gnssSensors config change to settings.json and the base-delta
+// store as a single unit: on any write failure the in-memory state is
+// rolled back so disk and memory stay consistent across a restart.
+//
+// `next === undefined` clears the config entirely (DELETE); otherwise
+// `next` is written. `eventData` is forwarded on the GNSS_SENSORS
+// serverevent so listeners (the corrector, WS clients) can react.
+export function applyGnssSensorsAtomic(
+  app: SensorsApplication,
+  next: GnssConfigPayload | undefined,
+  eventData: unknown,
+  res: Response
+): void {
+  const previous: GnssConfigPayload = {
+    correction: app.config.settings.gnssCorrection ?? 'off',
+    sensors: app.config.settings.gnssSensors ?? []
+  }
+  // A synchronous throw would otherwise leave the request hanging; convert
+  // it into a 500.
+  try {
+    runApplyGnssSensorsAtomic(app, previous, next, eventData, res)
+  } catch (err) {
+    console.error('Error applying gnssSensors:', err)
+    if (!res.headersSent) {
+      res.status(500).send('Internal error applying gnssSensors')
+    }
+  }
+}
+
+function runApplyGnssSensorsAtomic(
+  app: SensorsApplication,
+  previous: GnssConfigPayload,
+  next: GnssConfigPayload | undefined,
+  eventData: unknown,
+  res: Response
+): void {
+  const de = app.config.baseDeltaEditor
+  // Sweep any legacy sensors.gps.<sensorId>.fromBow/fromCenter entries
+  // out of the base-delta store on every write. The corrector reads
+  // offsets from settings.gnssSensors directly and no per-sensor
+  // data-model entries are published, so any that exist are stale
+  // leftovers.
+  //
+  // FullSignalK has no per-path tombstone API: removing from the base-delta
+  // store stops the values from being re-emitted at startup, but any
+  // entries already in `app.signalk.self` from a previous run persist
+  // until the next restart. The handler reports that a restart is
+  // required via legacyPathsCleared in the response so the admin UI
+  // can surface the restart banner only when this actually happened.
+  // Swept entries are kept so a failed write can put them back: the
+  // removals live in the same in-memory editor whose baseDeltas.json
+  // write failed (or never ran), and leaving them out would diverge
+  // the editor from what is on disk.
+  const sweptLegacyValues: Array<{ path: string; value: unknown }> = []
+  const legacyPathsCleared = (rows: GnssSensorsPayload): boolean => {
+    for (const s of rows) {
+      for (const path of [
+        `sensors.gps.${s.sensorId}.fromBow`,
+        `sensors.gps.${s.sensorId}.fromCenter`
+      ]) {
+        const value = de.getSelfValue(path)
+        if (value !== undefined) {
+          de.removeSelfValue(path)
+          sweptLegacyValues.push({ path, value })
+        }
+      }
+    }
+    return sweptLegacyValues.length > 0
+  }
+  const hadGnssSensors = Object.prototype.hasOwnProperty.call(
+    app.config.settings,
+    'gnssSensors'
+  )
+  const restorePrevious = () => {
+    for (const { path, value } of sweptLegacyValues) {
+      de.setSelfValue(path, value)
+    }
+    if (!hadGnssSensors) {
+      delete app.config.settings.gnssSensors
+    } else {
+      app.config.settings.gnssSensors = previous.sensors
+    }
+    if (previous.correction === 'off') {
+      delete app.config.settings.gnssCorrection
+    } else {
+      app.config.settings.gnssCorrection = previous.correction
+    }
+  }
+  // Sweep ids from both the outgoing and the incoming rows: a stale
+  // sensors.gps.<id> base-delta entry may predate the first row that
+  // (re)uses that id, so sweeping only `previous` would let it survive
+  // the save that introduces the id.
+  const rowsToSweep = [
+    ...new Map(
+      [...previous.sensors, ...(next?.sensors ?? [])].map((s) => [
+        s.sensorId,
+        s
+      ])
+    ).values()
+  ]
+  let restartRequired = false
+  // The in-memory mutation (base-delta sweep + settings edit) must not be
+  // left half-applied: if it throws before the settings.json write starts,
+  // roll back so memory matches disk, then rethrow for the caller's 500.
+  try {
+    if (next === undefined) {
+      restartRequired = legacyPathsCleared(rowsToSweep)
+      delete app.config.settings.gnssSensors
+      delete app.config.settings.gnssCorrection
+    } else {
+      restartRequired = legacyPathsCleared(rowsToSweep)
+      app.config.settings.gnssSensors = next.sensors
+      if (next.correction === 'off') {
+        delete app.config.settings.gnssCorrection
+      } else {
+        app.config.settings.gnssCorrection = next.correction
+      }
+    }
+  } catch (err) {
+    restorePrevious()
+    throw err
+  }
+  writeSettingsFile(app, app.config.settings, (err: unknown) => {
+    if (err) {
+      restorePrevious()
+      res.status(500).send('Unable to save gnssSensors in settings file')
+      return
+    }
+    // Success and failure are separate arms so that only a rejected
+    // base-deltas write reaches the rollback: a throwing serverevent
+    // listener must not roll back settings.json after both files are
+    // already on disk.
+    writeBaseDeltasFile(app).then(
+      () => {
+        try {
+          app.emit('serverevent', { type: 'GNSS_SENSORS', data: eventData })
+        } catch (err) {
+          console.error('GNSS_SENSORS listener error:', err)
+        }
+        res.json({ result: 'ok', restartRequired })
+      },
+      () => {
+        // settings.json is already on disk with the new payload but the
+        // base-deltas write failed — restore in-memory state first, then
+        // re-write settings.json so disk and memory agree on a restart.
+        restorePrevious()
+        writeSettingsFile(app, app.config.settings, (rollbackErr: unknown) => {
+          if (rollbackErr) {
+            res
+              .status(500)
+              .send(
+                'gnssSensors base-delta write failed and rolling back settings.json also failed; restart server to recover'
+              )
+            return
+          }
+          res.status(500).send('Unable to save gnssSensors base deltas')
+        })
+      }
+    )
+  })
+}

--- a/src/api/sensors/index.ts
+++ b/src/api/sensors/index.ts
@@ -1,0 +1,132 @@
+import { createDebug } from '../../debug'
+const debug = createDebug('signalk-server:api:sensors')
+
+import { IRouter, Request, Response } from 'express'
+import { SignalKMessageHub, WithConfig } from '../../app'
+import { ConfigApp } from '../../config/config'
+import { WithSecurityStrategy } from '../../security'
+import { Responses } from '../'
+import {
+  GnssCorrectionStatus,
+  GnssOffsetCorrector
+} from '../gnssOffsetCorrector'
+import { validateGnssConfigPayload, validateGnssSensorBounds } from './schemas'
+import { applyGnssSensorsAtomic } from './atomicApply'
+import { readDesignLengthOverall } from './vesselDimensions'
+
+const SIGNALK_API_PATH = `/signalk/v2/api`
+const SENSORS_API_PATH = `${SIGNALK_API_PATH}/vessels/self/sensors`
+
+export interface SensorsApplication
+  extends
+    IRouter,
+    ConfigApp,
+    WithConfig,
+    WithSecurityStrategy,
+    SignalKMessageHub {
+  gnssOffsetCorrector?: GnssOffsetCorrector
+}
+
+export class SensorsApi {
+  constructor(private app: SensorsApplication) {}
+
+  async start(): Promise<void> {
+    this.initSensorsRoutes()
+  }
+
+  private updateAllowed(request: Request): boolean {
+    return this.app.securityStrategy.shouldAllowPut(
+      request,
+      'vessels.self',
+      null,
+      'sensors.gnss'
+    )
+  }
+
+  private gnssStatus(): GnssCorrectionStatus {
+    return (
+      this.app.gnssOffsetCorrector?.getStatus() ?? {
+        mode: this.app.config.settings.gnssCorrection ?? 'off',
+        active: false
+      }
+    )
+  }
+
+  // Hull dimensions used to bounds-check offsets. Non-positive values come
+  // from a stale or hand-edited base-delta and would make every offset out
+  // of range; treat them as unavailable so bounds-checking is skipped just
+  // like when the dimension was never set.
+  private hullDimensions(): {
+    lengthOverall: number | undefined
+    beam: number | undefined
+  } {
+    const de = this.app.config.baseDeltaEditor
+    const lengthOverallRaw = readDesignLengthOverall(de)
+    const beamRaw = de.getSelfValue('design.beam')
+    return {
+      lengthOverall:
+        typeof lengthOverallRaw === 'number' && lengthOverallRaw > 0
+          ? lengthOverallRaw
+          : undefined,
+      beam: typeof beamRaw === 'number' && beamRaw > 0 ? beamRaw : undefined
+    }
+  }
+
+  private initSensorsRoutes() {
+    debug(`** Initialise ${SENSORS_API_PATH} path handlers **`)
+
+    this.app.get(`${SENSORS_API_PATH}/gnss`, (req: Request, res: Response) => {
+      debug.enabled && debug(`** ${req.method} ${req.path}`)
+      res.json({
+        correction: this.app.config.settings.gnssCorrection ?? 'off',
+        sensors: this.app.config.settings.gnssSensors ?? [],
+        status: this.gnssStatus()
+      })
+    })
+
+    this.app.put(`${SENSORS_API_PATH}/gnss`, (req: Request, res: Response) => {
+      debug.enabled && debug(`** ${req.method} ${req.path}`)
+      if (!this.updateAllowed(req)) {
+        res.status(403).json(Responses.unauthorised)
+        return
+      }
+      const validation = validateGnssConfigPayload(req.body)
+      if (!validation.ok) {
+        res
+          .status(400)
+          .json({ state: 'FAILED', statusCode: 400, message: validation.error })
+        return
+      }
+      const { lengthOverall, beam } = this.hullDimensions()
+      const boundsError = validateGnssSensorBounds(
+        validation.value.sensors,
+        lengthOverall,
+        beam
+      )
+      if (boundsError) {
+        res
+          .status(400)
+          .json({ state: 'FAILED', statusCode: 400, message: boundsError })
+        return
+      }
+      applyGnssSensorsAtomic(this.app, validation.value, validation.value, res)
+    })
+
+    this.app.delete(
+      `${SENSORS_API_PATH}/gnss`,
+      (req: Request, res: Response) => {
+        debug.enabled && debug(`** ${req.method} ${req.path}`)
+        if (!this.updateAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        applyGnssSensorsAtomic(
+          this.app,
+          undefined,
+          { correction: 'off', sensors: [] },
+          res
+        )
+      }
+    )
+  }
+}

--- a/src/api/sensors/openApi.ts
+++ b/src/api/sensors/openApi.ts
@@ -22,7 +22,7 @@ export const sensorsApiDoc: any = {
     {
       name: 'gnss',
       description:
-        'Configuration of GNSS antenna positions and vessel reference point correction of navigation.position to the vessel Common Coordinate Reference Point (CCRP).'
+        'Configuration of GNSS antenna positions and vessel reference point correction of navigation.position to the vessel Consistent Common Reference Point (CCRP).'
     }
   ],
   components: {

--- a/src/api/sensors/openApi.ts
+++ b/src/api/sensors/openApi.ts
@@ -1,0 +1,230 @@
+import { OpenApiDescription } from '../swagger'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const sensorsApiDoc: any = {
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'Signal K Sensors API',
+    termsOfService: 'http://signalk.org/terms/',
+    license: {
+      name: 'Apache 2.0',
+      url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  externalDocs: {
+    url: 'http://signalk.org/specification/',
+    description: 'Signal K specification.'
+  },
+  servers: [{ url: '/signalk/v2/api/vessels/self/sensors' }],
+  tags: [
+    {
+      name: 'gnss',
+      description:
+        'Configuration of GNSS antenna positions and lever-arm correction of navigation.position to the vessel Common Coordinate Reference Point (CCRP).'
+    }
+  ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT'
+      },
+      cookieAuth: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'JAUTHENTICATION'
+      }
+    },
+    schemas: {
+      GnssCorrectionMode: {
+        type: 'string',
+        enum: ['off', 'replace', 'both'],
+        description:
+          'How configured antenna offsets are applied. `off`: geometry stored only. `replace`: matching navigation.position deltas are rewritten to the CCRP. `both`: the corrected position is additionally published under `<sensorId>.ccrp` alongside the untouched original.'
+      },
+      GnssSensor: {
+        type: 'object',
+        required: ['sensorId', '$source', 'fromBow', 'fromCenter'],
+        properties: {
+          sensorId: {
+            type: 'string',
+            description: 'Stable label for this antenna. Must not contain `.`.',
+            example: 'gnss-bow'
+          },
+          $source: {
+            type: 'string',
+            description:
+              'Source reference of the position provider this antenna maps to. May be empty for a not-yet-linked row.',
+            example: 'n2k-1.160'
+          },
+          fromBow: {
+            type: 'number',
+            nullable: true,
+            description: 'Metres aft of the bow along the centerline.',
+            example: 3.2
+          },
+          fromCenter: {
+            type: 'number',
+            nullable: true,
+            description:
+              'Metres to port (positive) or starboard (negative) of the centerline.',
+            example: -0.5
+          }
+        }
+      },
+      GnssCorrectionStatus: {
+        type: 'object',
+        required: ['mode', 'active'],
+        properties: {
+          mode: { $ref: '#/components/schemas/GnssCorrectionMode' },
+          active: {
+            type: 'boolean',
+            description:
+              'True when a correction mode is selected and both vessel length and true heading are available.'
+          },
+          blocked: {
+            type: 'string',
+            enum: ['no-length', 'no-heading'],
+            description:
+              'The missing input preventing correction, when a mode is selected but `active` is false.'
+          }
+        }
+      },
+      GnssConfig: {
+        type: 'object',
+        required: ['correction', 'sensors'],
+        properties: {
+          correction: { $ref: '#/components/schemas/GnssCorrectionMode' },
+          sensors: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/GnssSensor' }
+          }
+        }
+      }
+    },
+    responses: {
+      ErrorResponse: {
+        description: 'Failed operation',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['state', 'statusCode', 'message'],
+              properties: {
+                state: { type: 'string', enum: ['FAILED'] },
+                statusCode: { type: 'number', enum: [400, 403, 404] },
+                message: { type: 'string' }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+  paths: {
+    '/gnss': {
+      get: {
+        tags: ['gnss'],
+        summary: 'Retrieve GNSS antenna configuration',
+        description:
+          'Returns the configured antennas, the active correction mode, and whether correction can currently run.',
+        responses: {
+          '200': {
+            description: 'GNSS configuration',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['correction', 'sensors', 'status'],
+                  properties: {
+                    correction: {
+                      $ref: '#/components/schemas/GnssCorrectionMode'
+                    },
+                    sensors: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/GnssSensor' }
+                    },
+                    status: {
+                      $ref: '#/components/schemas/GnssCorrectionStatus'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      put: {
+        tags: ['gnss'],
+        summary: 'Set GNSS antenna configuration',
+        description:
+          'Replaces the antenna list and correction mode. Offsets are bounds-checked against the configured vessel length and beam when those are set.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/GnssConfig' }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'Configuration saved',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['result', 'restartRequired'],
+                  properties: {
+                    result: { type: 'string', enum: ['ok'] },
+                    restartRequired: {
+                      type: 'boolean',
+                      description:
+                        'True when legacy per-sensor base-delta entries were swept and a restart is needed to drop them from the data model.'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          '400': { $ref: '#/components/responses/ErrorResponse' },
+          '403': { $ref: '#/components/responses/ErrorResponse' }
+        }
+      },
+      delete: {
+        tags: ['gnss'],
+        summary: 'Clear GNSS antenna configuration',
+        description:
+          'Removes all configured antennas and turns lever-arm correction off.',
+        responses: {
+          '200': {
+            description: 'Configuration cleared',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['result', 'restartRequired'],
+                  properties: {
+                    result: { type: 'string', enum: ['ok'] },
+                    restartRequired: { type: 'boolean' }
+                  }
+                }
+              }
+            }
+          },
+          '403': { $ref: '#/components/responses/ErrorResponse' }
+        }
+      }
+    }
+  }
+}
+
+export const sensorsApiRecord = {
+  name: 'sensors',
+  path: '/signalk/v2/api/vessels/self/sensors',
+  apiDoc: sensorsApiDoc as unknown as OpenApiDescription
+}

--- a/src/api/sensors/openApi.ts
+++ b/src/api/sensors/openApi.ts
@@ -22,7 +22,7 @@ export const sensorsApiDoc: any = {
     {
       name: 'gnss',
       description:
-        'Configuration of GNSS antenna positions and lever-arm correction of navigation.position to the vessel Common Coordinate Reference Point (CCRP).'
+        'Configuration of GNSS antenna positions and vessel reference point correction of navigation.position to the vessel Common Coordinate Reference Point (CCRP).'
     }
   ],
   components: {
@@ -199,7 +199,7 @@ export const sensorsApiDoc: any = {
         tags: ['gnss'],
         summary: 'Clear GNSS antenna configuration',
         description:
-          'Removes all configured antennas and turns lever-arm correction off.',
+          'Removes all configured antennas and turns vessel reference point correction off.',
         responses: {
           '200': {
             description: 'Configuration cleared',

--- a/src/api/sensors/schemas.ts
+++ b/src/api/sensors/schemas.ts
@@ -1,0 +1,102 @@
+import { Static, Type } from '@sinclair/typebox'
+import { Value } from '@sinclair/typebox/value'
+
+// Schema for the PUT .../sensors/gnss body. Each sensor has a stable id, a
+// $source reference that may be empty for not-yet-linked rows, and nullable
+// numeric offsets, mirroring what the admin UI sends. sensorId is the
+// base-delta sweep key for the historical (pre-corrector) per-sensor
+// entries; reject anything containing `.` so the legacy cleanup paths
+// cannot be tricked into removing keys outside `sensors.gps.<sensorId>.*`.
+const gnssSensorSchema = Type.Object(
+  {
+    sensorId: Type.String({ minLength: 1, pattern: '^[^.]+$' }),
+    $source: Type.String(),
+    fromBow: Type.Union([Type.Number(), Type.Null()]),
+    fromCenter: Type.Union([Type.Number(), Type.Null()])
+  },
+  { additionalProperties: false }
+)
+const gnssSensorsSchema = Type.Array(gnssSensorSchema)
+// Lever-arm correction is opt-in: 'off' stores geometry only, 'replace'
+// rewrites matching navigation.position deltas to the CCRP, 'both'
+// publishes the corrected position under <sensorId>.ccrp alongside the
+// untouched original.
+const gnssCorrectionModeSchema = Type.Union([
+  Type.Literal('off'),
+  Type.Literal('replace'),
+  Type.Literal('both')
+])
+const gnssConfigPayloadSchema = Type.Object(
+  {
+    correction: gnssCorrectionModeSchema,
+    sensors: gnssSensorsSchema
+  },
+  { additionalProperties: false }
+)
+
+// Derived from the schemas so the compile-time types and runtime
+// validation stay in lockstep (a schema edit is reflected in the type).
+export type GnssSensorsPayload = Static<typeof gnssSensorsSchema>
+export type GnssConfigPayload = Static<typeof gnssConfigPayloadSchema>
+
+export function validateGnssConfigPayload(
+  body: unknown
+): { ok: true; value: GnssConfigPayload } | { ok: false; error: string } {
+  if (!Value.Check(gnssConfigPayloadSchema, body)) {
+    const first = Value.Errors(gnssConfigPayloadSchema, body).First()
+    return {
+      ok: false,
+      error: first
+        ? `Invalid gnssSensors payload at ${first.path}: ${first.message}`
+        : 'Invalid gnssSensors payload'
+    }
+  }
+  const value = body as GnssConfigPayload
+  // Duplicate sensorIds would silently clobber sensors.gps.<id> entries
+  // in the data model on PUT; reject before we mutate anything. Duplicate
+  // non-empty $source values would create an ambiguous source→sensor mapping.
+  const seenIds = new Set<string>()
+  const seenSources = new Set<string>()
+  for (const s of value.sensors) {
+    if (seenIds.has(s.sensorId)) {
+      return { ok: false, error: `Duplicate sensorId "${s.sensorId}"` }
+    }
+    seenIds.add(s.sensorId)
+    if (s.$source.length > 0) {
+      if (seenSources.has(s.$source)) {
+        return { ok: false, error: `Duplicate $source "${s.$source}"` }
+      }
+      seenSources.add(s.$source)
+    }
+  }
+  return { ok: true, value }
+}
+
+// Reject offsets that would place an antenna outside the configured hull.
+// Skipped silently when the relevant dimension is unset — the user might
+// just not have filled in length/beam yet, and we'd rather let them save
+// reasonable offsets than block on missing vessel metadata.
+export function validateGnssSensorBounds(
+  sensors: GnssSensorsPayload,
+  lengthOverall: number | undefined,
+  beam: number | undefined
+): string | null {
+  for (const s of sensors) {
+    if (
+      s.fromBow !== null &&
+      lengthOverall !== undefined &&
+      (s.fromBow < 0 || s.fromBow > lengthOverall)
+    ) {
+      return `fromBow ${s.fromBow} out of range 0..${lengthOverall} for sensor "${s.sensorId}"`
+    }
+    if (
+      s.fromCenter !== null &&
+      beam !== undefined &&
+      Math.abs(s.fromCenter) > beam / 2
+    ) {
+      const half = beam / 2
+      return `fromCenter ${s.fromCenter} out of range -${half}..${half} for sensor "${s.sensorId}"`
+    }
+  }
+  return null
+}

--- a/src/api/sensors/schemas.ts
+++ b/src/api/sensors/schemas.ts
@@ -17,8 +17,8 @@ const gnssSensorSchema = Type.Object(
   { additionalProperties: false }
 )
 const gnssSensorsSchema = Type.Array(gnssSensorSchema)
-// Lever-arm correction is opt-in: 'off' stores geometry only, 'replace'
-// rewrites matching navigation.position deltas to the CCRP, 'both'
+// Vessel reference point correction is opt-in: 'off' stores geometry only,
+// 'replace' rewrites matching navigation.position deltas to the CCRP, 'both'
 // publishes the corrected position under <sensorId>.ccrp alongside the
 // untouched original.
 const gnssCorrectionModeSchema = Type.Union([

--- a/src/api/sensors/vesselDimensions.ts
+++ b/src/api/sensors/vesselDimensions.ts
@@ -1,0 +1,13 @@
+import DeltaEditor from '../../deltaeditor'
+
+// design.length may be stored as { overall } (current shape) or as a plain
+// number (legacy single-value shape). Normalise both to the overall length,
+// or undefined when it is unset. Shared so the /vessel route and the sensors
+// API read it the same way and cannot drift.
+export function readDesignLengthOverall(de: DeltaEditor): number | undefined {
+  const length = de.getSelfValue('design.length') as
+    { overall?: number } | number | undefined
+  if (typeof length === 'number') return length
+  if (length && typeof length === 'object') return length.overall
+  return undefined
+}

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -14,6 +14,7 @@ import { weatherApiRecord } from './weather/openApi'
 import { appsApiRecord } from './apps/openApi'
 import { historyApiRecord } from './history/openApi'
 import { radarApiRecord } from './radar/openApi'
+import { sensorsApiRecord } from './sensors/openApi'
 import { courseAsyncApiDoc } from './course/asyncApi'
 import { autopilotAsyncApiDoc } from './autopilot/asyncApi'
 import { notificationsAsyncApiDoc } from './notifications/asyncApi'
@@ -44,7 +45,8 @@ const apiDocs = [
   weatherApiRecord,
   securityApiRecord,
   historyApiRecord,
-  radarApiRecord
+  radarApiRecord,
+  sensorsApiRecord
 ].reduce<ApiRecords>((acc, apiRecord: OpenApiRecord) => {
   acc[apiRecord.name] = apiRecord
   return acc

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -129,6 +129,12 @@ export interface Config {
       fromBow: number | null
       fromCenter: number | null
     }[]
+    /** How configured GNSS antenna offsets are applied to
+     * navigation.position: 'off' stores the geometry without touching
+     * data (default), 'replace' rewrites matching deltas to the CCRP,
+     * 'both' additionally publishes the corrected position under
+     * `<sensorId>.ccrp` while leaving the original untouched. */
+    gnssCorrection?: 'off' | 'replace' | 'both'
     trustProxy?: boolean | string | number
     courseApi?: {
       apiOnly?: boolean

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -123,6 +123,12 @@ export interface Config {
     /** Map of "sourceRefA+sourceRefB" (sorted) → ISO timestamp when the
      * conflict was dismissed by the user */
     ignoredInstanceConflicts?: Record<string, string>
+    gnssSensors?: {
+      sensorId: string
+      $source: string
+      fromBow: number | null
+      fromCenter: number | null
+    }[]
     trustProxy?: boolean | string | number
     courseApi?: {
       apiOnly?: boolean

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -29,6 +29,17 @@ import { isFanOutPriorities } from './deltaPriority'
 
 const SOURCES_CACHE_FILE = 'sources-cache.json'
 
+// Maximum time since a source's last accepted delta before it is considered
+// offline for POSITION_SOURCES purposes. Picked to be longer than typical
+// NMEA position update rates (1–10 Hz on N2K, 1 Hz on NMEA0183) but short
+// enough that a disconnected GNSS receiver flips to "offline" in the admin
+// UI within a minute, so users notice missing antennas before they navigate
+// by them.
+const POSITION_SOURCE_TTL_MS = 60 * 1000
+// How often to re-evaluate POSITION_SOURCES so silent publishers fall off
+// even when no new delta arrives to trigger an emit.
+const POSITION_SOURCE_SWEEP_MS = 15 * 1000
+
 interface StringKeyed {
   [key: string]: any
 }
@@ -140,6 +151,7 @@ export default class DeltaCache {
   private lastEmittedMultiSourceCount = 0
   private livePreferredEmitTimer: ReturnType<typeof setTimeout> | null = null
   private livePreferredDirtyPaths: Set<string> = new Set()
+  private lastEmittedPositionSources: string[] = []
 
   // Cached `<label>.<src> → <label>.<canName>` translation, refreshed
   // whenever `app.signalk.sources` is replaced or sourceRefChanged
@@ -189,6 +201,12 @@ export default class DeltaCache {
       },
       5 * 60 * 1000
     )
+
+    // Re-evaluate POSITION_SOURCES on a timer so silent publishers age
+    // out even when no new delta arrives to trigger an emit. The change
+    // detection in emitPositionSources keeps the event off the bus when
+    // the resulting set hasn't shifted.
+    setInterval(() => this.emitPositionSources(), POSITION_SOURCE_SWEEP_MS)
   }
 
   getContextAndPathParts(msg: NormalizedDelta): string[] {
@@ -211,7 +229,7 @@ export default class DeltaCache {
     return contextAndPathParts
   }
 
-  private canonicaliseSourceRef(sourceRef: string): string {
+  canonicaliseSourceRef(sourceRef: string): string {
     const sources = (this.app.signalk as any)?.sources
     if (sources !== this.canonicalSnapshot || this.canonicalMap === null) {
       this.canonicalSnapshot = sources
@@ -236,6 +254,7 @@ export default class DeltaCache {
     )
 
     if (msg.path.length !== 0) {
+      const isNewSource = !leaf[sourceRef]
       leaf[sourceRef] = msg
       const prefKey = msg.context + '\0' + msg.path
       // The priority engine matches by canonical (canName) form. Store
@@ -267,6 +286,9 @@ export default class DeltaCache {
           this.livePreferredDirtyPaths.add(prefKey)
           this.scheduleLivePreferredEmit()
         }
+      }
+      if (isNewSource && msg.path === 'navigation.position') {
+        this.scheduleMultiSourceEmit()
       }
     } else if (msg.value) {
       _.keys(msg.value).forEach((key) => {
@@ -341,6 +363,58 @@ export default class DeltaCache {
     })
     if (countChanged) {
       this.scheduleMultiSourceEmit()
+    }
+    this.emitPositionSources()
+  }
+
+  /**
+   * `getSourcesForPath('navigation.position')` filtered by per-source
+   * freshness so disconnected publishers fall off after the TTL. Shared
+   * between the live event emitter and the REST GET handler so a cold
+   * page-load sees the same set the websocket would deliver moments later.
+   */
+  getActivePositionSources(): string[] {
+    const sources = this.getSourcesForPath('navigation.position')
+    const sourceMeta = (this.app.signalk as any)?.sourceMeta as
+      Record<string, { lastSeen?: number }> | undefined
+    if (!sourceMeta) return sources.slice().sort()
+    const cutoff = Date.now() - POSITION_SOURCE_TTL_MS
+    // sourceMeta is stamped under the raw update.$source while `sources`
+    // holds canonical (canName-form) refs, so a device whose frames are
+    // tagged with the numeric-src alias would look stale under its
+    // canonical key. Fold every alias's freshness onto its canonical ref.
+    const lastSeenByCanonical = new Map<string, number>()
+    for (const [ref, meta] of Object.entries(sourceMeta)) {
+      const t = meta?.lastSeen
+      if (typeof t !== 'number') continue
+      const canonical = this.canonicaliseSourceRef(ref)
+      const prev = lastSeenByCanonical.get(canonical)
+      if (prev === undefined || t > prev) {
+        lastSeenByCanonical.set(canonical, t)
+      }
+    }
+    return sources
+      .filter((ref) => {
+        const t = lastSeenByCanonical.get(ref)
+        return t !== undefined && t >= cutoff
+      })
+      .sort()
+  }
+
+  private emitPositionSources() {
+    const sorted = this.getActivePositionSources()
+    const changed =
+      sorted.length !== this.lastEmittedPositionSources.length ||
+      sorted.some((s, i) => s !== this.lastEmittedPositionSources[i])
+    if (changed) {
+      this.lastEmittedPositionSources = sorted
+      // Emit the sorted list so successive events have stable ordering;
+      // otherwise clients diffing payloads see spurious changes whenever
+      // the cache iteration order happens to swap two refs.
+      ;(this.app as any).emit('serverevent', {
+        type: 'POSITION_SOURCES',
+        data: sorted
+      })
     }
   }
 
@@ -553,17 +627,28 @@ export default class DeltaCache {
         }
 
         if (isNewSource) {
-          const sourceCount = Object.keys(leaf).filter((k) => {
-            const v = leaf[k]
-            return (
-              v &&
-              typeof v === 'object' &&
-              v.path !== undefined &&
-              v.value !== undefined
-            )
-          }).length
-          if (sourceCount >= 2) {
+          if (pathValue.path === 'navigation.position') {
             this.scheduleMultiSourceEmit()
+          } else {
+            // Count sources without allocating a new array on every delta:
+            // break out as soon as we have the two we need to decide the
+            // path is multi-source.
+            let sourceCount = 0
+            for (const k of Object.keys(leaf)) {
+              const v = leaf[k]
+              if (
+                v &&
+                typeof v === 'object' &&
+                v.path !== undefined &&
+                v.value !== undefined
+              ) {
+                sourceCount++
+                if (sourceCount >= 2) {
+                  this.scheduleMultiSourceEmit()
+                  break
+                }
+              }
+            }
           }
         }
       }
@@ -1244,6 +1329,39 @@ export default class DeltaCache {
     }
 
     return out.sort((a, b) => a.id.localeCompare(b.id))
+  }
+
+  /**
+   * Unlike getMultiSourcePaths, includes single-source paths too.
+   */
+  getSourcesForPath(path: string): string[] {
+    const selfParts = this.app.selfContext.split('.')
+    const pathParts = path.split('.')
+    const parts = [...selfParts, ...pathParts]
+
+    let node = this.cache
+    for (const part of parts) {
+      if (!node || !node[part]) return []
+      node = node[part]
+    }
+
+    // Canonicalise to canName form and dedupe: the cache may carry both
+    // `<label>.<src>` and `<label>.<canName>` entries for the same physical
+    // device during address-claim transitions, which would otherwise show
+    // up as two separate GNSS sources in the admin UI.
+    const out = new Set<string>()
+    for (const k of Object.keys(node)) {
+      const v = node[k]
+      if (
+        v &&
+        typeof v === 'object' &&
+        v.path !== undefined &&
+        v.value !== undefined
+      ) {
+        out.add(this.canonicaliseSourceRef(k))
+      }
+    }
+    return [...out]
   }
 
   getSources() {

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -50,7 +50,7 @@ import {
 import { resetPriorities } from './config/priorities-file'
 import { buildDeviceIdentities } from './deviceIdentities'
 import { SERVERROUTESPREFIX } from './constants'
-import type { GnssCorrectionMode } from './api/gnssOffsetCorrector'
+import { readDesignLengthOverall } from './api/sensors/vesselDimensions'
 import { handleAdminUICORSOrigin } from './cors'
 import { createDebug, listKnownDebugs } from './debug'
 import { PluginManager } from './interfaces/plugins'
@@ -117,113 +117,6 @@ const prioritiesPayloadSchema = Type.Object({
   overrides: priorityOverridesSchema,
   defaults: priorityDefaultsSchema
 })
-
-// Schema for the PUT /skServer/gnssSensors body. Each sensor has a stable
-// id, a $source reference that may be empty for not-yet-linked rows, and
-// nullable numeric offsets, mirroring what the admin UI sends.
-// sensorId is the key the corrector reports back as $sensor in
-// meta.gnssOffsetCorrection and the historical (pre-corrector) base-delta
-// sweep key; reject anything containing `.` so the legacy cleanup paths
-// cannot be tricked into removing keys outside `sensors.gps.<sensorId>.*`.
-const gnssSensorSchema = Type.Object(
-  {
-    sensorId: Type.String({ minLength: 1, pattern: '^[^.]+$' }),
-    $source: Type.String(),
-    fromBow: Type.Union([Type.Number(), Type.Null()]),
-    fromCenter: Type.Union([Type.Number(), Type.Null()])
-  },
-  { additionalProperties: false }
-)
-const gnssSensorsSchema = Type.Array(gnssSensorSchema)
-// Lever-arm correction is opt-in: 'off' stores geometry only, 'replace'
-// rewrites matching navigation.position deltas to the CCRP, 'both'
-// publishes the corrected position under <sensorId>.ccrp alongside the
-// untouched original.
-const gnssCorrectionModeSchema = Type.Union([
-  Type.Literal('off'),
-  Type.Literal('replace'),
-  Type.Literal('both')
-])
-const gnssConfigPayloadSchema = Type.Object(
-  {
-    correction: gnssCorrectionModeSchema,
-    sensors: gnssSensorsSchema
-  },
-  { additionalProperties: false }
-)
-
-type GnssSensorsPayload = Array<{
-  sensorId: string
-  $source: string
-  fromBow: number | null
-  fromCenter: number | null
-}>
-type GnssConfigPayload = {
-  correction: GnssCorrectionMode
-  sensors: GnssSensorsPayload
-}
-
-function validateGnssConfigPayload(
-  body: unknown
-): { ok: true; value: GnssConfigPayload } | { ok: false; error: string } {
-  if (!Value.Check(gnssConfigPayloadSchema, body)) {
-    const first = Value.Errors(gnssConfigPayloadSchema, body).First()
-    return {
-      ok: false,
-      error: first
-        ? `Invalid gnssSensors payload at ${first.path}: ${first.message}`
-        : 'Invalid gnssSensors payload'
-    }
-  }
-  const value = body as GnssConfigPayload
-  // Duplicate sensorIds would silently clobber sensors.gps.<id> entries
-  // in the data model on PUT; reject before we mutate anything. Duplicate
-  // non-empty $source values would create an ambiguous source→sensor mapping.
-  const seenIds = new Set<string>()
-  const seenSources = new Set<string>()
-  for (const s of value.sensors) {
-    if (seenIds.has(s.sensorId)) {
-      return { ok: false, error: `Duplicate sensorId "${s.sensorId}"` }
-    }
-    seenIds.add(s.sensorId)
-    if (s.$source.length > 0) {
-      if (seenSources.has(s.$source)) {
-        return { ok: false, error: `Duplicate $source "${s.$source}"` }
-      }
-      seenSources.add(s.$source)
-    }
-  }
-  return { ok: true, value }
-}
-
-// Reject offsets that would place an antenna outside the configured hull.
-// Skipped silently when the relevant dimension is unset — the user might
-// just not have filled in length/beam yet, and we'd rather let them save
-// reasonable offsets than block on missing vessel metadata.
-function validateGnssSensorBounds(
-  sensors: GnssSensorsPayload,
-  lengthOverall: number | undefined,
-  beam: number | undefined
-): string | null {
-  for (const s of sensors) {
-    if (
-      s.fromBow !== null &&
-      lengthOverall !== undefined &&
-      (s.fromBow < 0 || s.fromBow > lengthOverall)
-    ) {
-      return `fromBow ${s.fromBow} out of range 0..${lengthOverall} for sensor "${s.sensorId}"`
-    }
-    if (
-      s.fromCenter !== null &&
-      beam !== undefined &&
-      Math.abs(s.fromCenter) > beam / 2
-    ) {
-      const half = beam / 2
-      return `fromCenter ${s.fromCenter} out of range -${half}..${half} for sensor "${s.sensorId}"`
-    }
-  }
-  return null
-}
 
 type PrioritiesPayload = {
   groups: Array<{ id: string; sources: string[]; inactive?: boolean }>
@@ -401,24 +294,6 @@ interface App
 interface ModuleInfo {
   name: string
   type?: string
-}
-
-// Module-level mutex that serializes every settings.json mutation routed
-// through `withSettingsWriteLock`. Without it, a clone-then-write handler
-// can snapshot `app.config.settings` *before* another handler's rollback
-// and then commit the rejected state back to disk after rollback ran.
-// Only the routes that opt in (currently the gnssSensors flow) are
-// serialized — direct writers to `app.config.settings` remain a known
-// race window relative to those routes.
-let settingsWriteLock: Promise<void> = Promise.resolve()
-function withSettingsWriteLock(fn: () => Promise<void>): Promise<void> {
-  const previous = settingsWriteLock
-  const next = previous.then(fn, fn)
-  // Swallow any rejection on the chain so a thrown handler doesn't wedge
-  // later requests; individual callers are still responsible for sending
-  // their own error responses.
-  settingsWriteLock = next.catch(() => undefined)
-  return next
 }
 
 module.exports = function (
@@ -1308,18 +1183,10 @@ module.exports = function (
     const de = app.config.baseDeltaEditor
     const communication = de.getSelfValue('communication')
     const draft = de.getSelfValue('design.draft')
-    // Mirror the PUT /skServer/gnssSensors handler's normalisation:
-    // design.length may be stored as { overall } or as a plain number, and
-    // /vessel clients (including the GNSS preferences page) expect a
-    // number for both stored shapes.
-    const length = de.getSelfValue('design.length') as
-      { overall?: number } | number | undefined
-    const lengthOverall =
-      typeof length === 'number'
-        ? length
-        : length && typeof length === 'object'
-          ? length.overall
-          : undefined
+    // /vessel clients (including the GNSS preferences page) expect a number
+    // for both stored shapes of design.length; readDesignLengthOverall is
+    // the same normalisation the sensors API uses.
+    const lengthOverall = readDesignLengthOverall(de)
     const type = de.getSelfValue('design.aisShipType')
     const json = {
       name: app.config.vesselName,
@@ -2161,12 +2028,11 @@ module.exports = function (
   app.securityStrategy.addAdminWriteMiddleware(`${SERVERROUTESPREFIX}/debug`)
 
   // Register middleware before the routes so every method picks up auth.
-  // Match the /priorities pattern: source topology and saved GNSS antenna
-  // offsets are admin-only across the board.
+  // Match the /priorities pattern: source topology is admin-only across
+  // the board. (GNSS antenna config has moved to the v2 sensors API.)
   app.securityStrategy.addAdminMiddleware(
     `${SERVERROUTESPREFIX}/positionSources`
   )
-  app.securityStrategy.addAdminMiddleware(`${SERVERROUTESPREFIX}/gnssSensors`)
 
   app.get(
     `${SERVERROUTESPREFIX}/positionSources`,
@@ -2174,228 +2040,6 @@ module.exports = function (
       // Use the same freshness-filtered + sorted set the POSITION_SOURCES
       // event emits, so a cold page-load matches the next websocket update.
       res.json(app.deltaCache.getActivePositionSources())
-    }
-  )
-
-  app.get(
-    `${SERVERROUTESPREFIX}/gnssSensors`,
-    (req: Request, res: Response) => {
-      res.json({
-        correction: app.config.settings.gnssCorrection ?? 'off',
-        sensors: app.config.settings.gnssSensors || []
-      })
-    }
-  )
-
-  // `previous` is snapshotted inside the lock so a later request sees the
-  // outcome of any earlier in-flight settings write, not the state at
-  // handler entry. The lock is shared with any other handler that opts
-  // into `withSettingsWriteLock` so cross-route races on settings.json
-  // can't reintroduce a rolled-back payload.
-  function applyGnssSensorsAtomic(
-    next: GnssConfigPayload | undefined,
-    eventData: unknown,
-    res: Response
-  ): void {
-    withSettingsWriteLock(
-      () =>
-        new Promise<void>((resolve) => {
-          const previous: GnssConfigPayload = {
-            correction: app.config.settings.gnssCorrection ?? 'off',
-            sensors: app.config.settings.gnssSensors ?? []
-          }
-          // A synchronous throw would otherwise reject the lock's
-          // promise unobserved and leave the request hanging; convert
-          // it into a 500 and always release the lock.
-          try {
-            runApplyGnssSensorsAtomic(previous, next, eventData, res, resolve)
-          } catch (err) {
-            console.error('Error applying gnssSensors:', err)
-            if (!res.headersSent) {
-              res.status(500).send('Internal error applying gnssSensors')
-            }
-            resolve()
-          }
-        })
-    )
-  }
-
-  function runApplyGnssSensorsAtomic(
-    previous: GnssConfigPayload,
-    next: GnssConfigPayload | undefined,
-    eventData: unknown,
-    res: Response,
-    done: () => void
-  ): void {
-    const de = app.config.baseDeltaEditor
-    // Sweep any legacy sensors.gps.<sensorId>.fromBow/fromCenter entries
-    // out of the base-delta store on every write. The corrector reads
-    // offsets from settings.gnssSensors directly and no per-sensor
-    // data-model entries are published, so any that exist are stale
-    // leftovers.
-    //
-    // FullSignalK has no per-path tombstone API: removing from the base-delta
-    // store stops the values from being re-emitted at startup, but any
-    // entries already in `app.signalk.self` from a previous run persist
-    // until the next restart. The handler reports that a restart is
-    // required via legacyPathsCleared in the response so the admin UI
-    // can surface the restart banner only when this actually happened.
-    // Swept entries are kept so a failed write can put them back: the
-    // removals live in the same in-memory editor whose baseDeltas.json
-    // write failed (or never ran), and leaving them out would diverge
-    // the editor from what is on disk.
-    const sweptLegacyValues: Array<{ path: string; value: unknown }> = []
-    const legacyPathsCleared = (rows: GnssSensorsPayload): boolean => {
-      for (const s of rows) {
-        for (const path of [
-          `sensors.gps.${s.sensorId}.fromBow`,
-          `sensors.gps.${s.sensorId}.fromCenter`
-        ]) {
-          const value = de.getSelfValue(path)
-          if (value !== undefined) {
-            de.removeSelfValue(path)
-            sweptLegacyValues.push({ path, value })
-          }
-        }
-      }
-      return sweptLegacyValues.length > 0
-    }
-    const hadGnssSensors = Object.prototype.hasOwnProperty.call(
-      app.config.settings,
-      'gnssSensors'
-    )
-    const restorePrevious = () => {
-      for (const { path, value } of sweptLegacyValues) {
-        de.setSelfValue(path, value)
-      }
-      if (!hadGnssSensors) {
-        delete app.config.settings.gnssSensors
-      } else {
-        app.config.settings.gnssSensors = previous.sensors
-      }
-      if (previous.correction === 'off') {
-        delete app.config.settings.gnssCorrection
-      } else {
-        app.config.settings.gnssCorrection = previous.correction
-      }
-    }
-    // Sweep ids from both the outgoing and the incoming rows: a stale
-    // sensors.gps.<id> base-delta entry may predate the first row that
-    // (re)uses that id, so sweeping only `previous` would let it survive
-    // the save that introduces the id.
-    const rowsToSweep = [
-      ...new Map(
-        [...previous.sensors, ...(next?.sensors ?? [])].map((s) => [
-          s.sensorId,
-          s
-        ])
-      ).values()
-    ]
-    let restartRequired = false
-    if (next === undefined) {
-      restartRequired = legacyPathsCleared(rowsToSweep)
-      delete app.config.settings.gnssSensors
-      delete app.config.settings.gnssCorrection
-    } else {
-      restartRequired = legacyPathsCleared(rowsToSweep)
-      app.config.settings.gnssSensors = next.sensors
-      if (next.correction === 'off') {
-        delete app.config.settings.gnssCorrection
-      } else {
-        app.config.settings.gnssCorrection = next.correction
-      }
-    }
-    writeSettingsFile(app, app.config.settings, (err: unknown) => {
-      if (err) {
-        restorePrevious()
-        res.status(500).send('Unable to save gnssSensors in settings file')
-        done()
-        return
-      }
-      // Success and failure are separate .then() arms so that only a
-      // rejected base-deltas write reaches the rollback: a throwing
-      // serverevent listener must not roll back settings.json after
-      // both files are already on disk.
-      writeBaseDeltasFile(app).then(
-        () => {
-          try {
-            app.emit('serverevent', { type: 'GNSS_SENSORS', data: eventData })
-          } catch (err) {
-            console.error('GNSS_SENSORS listener error:', err)
-          }
-          res.json({ result: 'ok', restartRequired })
-          done()
-        },
-        () => {
-          // settings.json is already on disk with the new payload but the
-          // base-deltas write failed — restore in-memory state first, then
-          // re-write settings.json so disk and memory agree on a restart.
-          restorePrevious()
-          writeSettingsFile(
-            app,
-            app.config.settings,
-            (rollbackErr: unknown) => {
-              if (rollbackErr) {
-                res
-                  .status(500)
-                  .send(
-                    'gnssSensors base-delta write failed and rolling back settings.json also failed; restart server to recover'
-                  )
-                done()
-                return
-              }
-              res.status(500).send('Unable to save gnssSensors base deltas')
-              done()
-            }
-          )
-        }
-      )
-    })
-  }
-
-  app.put(
-    `${SERVERROUTESPREFIX}/gnssSensors`,
-    (req: Request, res: Response) => {
-      const validation = validateGnssConfigPayload(req.body)
-      if (!validation.ok) {
-        res.status(400).send(validation.error)
-        return
-      }
-      const sensors = validation.value.sensors
-      const de = app.config.baseDeltaEditor
-      const length = de.getSelfValue('design.length') as
-        { overall?: number } | number | undefined
-      const lengthOverallRaw =
-        typeof length === 'object' && length !== null
-          ? length.overall
-          : typeof length === 'number'
-            ? length
-            : undefined
-      const beamRaw = de.getSelfValue('design.beam')
-      // Non-positive hull dimensions came from a stale or hand-edited
-      // base-delta and would make every offset out of range, blocking the
-      // user from saving an otherwise-valid sensor row. Treat them as
-      // unavailable so bounds-checking is skipped just like when the
-      // dimension was never set.
-      const lengthOverall =
-        typeof lengthOverallRaw === 'number' && lengthOverallRaw > 0
-          ? lengthOverallRaw
-          : undefined
-      const beam =
-        typeof beamRaw === 'number' && beamRaw > 0 ? beamRaw : undefined
-      const boundsError = validateGnssSensorBounds(sensors, lengthOverall, beam)
-      if (boundsError) {
-        res.status(400).send(boundsError)
-        return
-      }
-      applyGnssSensorsAtomic(validation.value, validation.value, res)
-    }
-  )
-
-  app.delete(
-    `${SERVERROUTESPREFIX}/gnssSensors`,
-    (_req: Request, res: Response) => {
-      applyGnssSensorsAtomic(undefined, { correction: 'off', sensors: [] }, res)
     }
   )
 

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -50,6 +50,7 @@ import {
 import { resetPriorities } from './config/priorities-file'
 import { buildDeviceIdentities } from './deviceIdentities'
 import { SERVERROUTESPREFIX } from './constants'
+import type { GnssCorrectionMode } from './api/gnssOffsetCorrector'
 import { handleAdminUICORSOrigin } from './cors'
 import { createDebug, listKnownDebugs } from './debug'
 import { PluginManager } from './interfaces/plugins'
@@ -157,7 +158,6 @@ type GnssSensorsPayload = Array<{
   fromBow: number | null
   fromCenter: number | null
 }>
-type GnssCorrectionMode = 'off' | 'replace' | 'both'
 type GnssConfigPayload = {
   correction: GnssCorrectionMode
   sensors: GnssSensorsPayload
@@ -2204,7 +2204,18 @@ module.exports = function (
             correction: app.config.settings.gnssCorrection ?? 'off',
             sensors: app.config.settings.gnssSensors ?? []
           }
-          runApplyGnssSensorsAtomic(previous, next, eventData, res, resolve)
+          // A synchronous throw would otherwise reject the lock's
+          // promise unobserved and leave the request hanging; convert
+          // it into a 500 and always release the lock.
+          try {
+            runApplyGnssSensorsAtomic(previous, next, eventData, res, resolve)
+          } catch (err) {
+            console.error('Error applying gnssSensors:', err)
+            if (!res.headersSent) {
+              res.status(500).send('Internal error applying gnssSensors')
+            }
+            resolve()
+          }
         })
     )
   }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -119,20 +119,37 @@ const prioritiesPayloadSchema = Type.Object({
 
 // Schema for the PUT /skServer/gnssSensors body. Each sensor has a stable
 // id, a $source reference that may be empty for not-yet-linked rows, and
-// nullable numeric offsets — Number coercion happens in the route handler
-// so the schema mirrors what the admin UI POSTs (numbers or null), not the
-// post-coercion shape.
+// nullable numeric offsets, mirroring what the admin UI sends.
 // sensorId is the key the corrector reports back as $sensor in
 // meta.gnssOffsetCorrection and the historical (pre-corrector) base-delta
 // sweep key; reject anything containing `.` so the legacy cleanup paths
 // cannot be tricked into removing keys outside `sensors.gps.<sensorId>.*`.
-const gnssSensorSchema = Type.Object({
-  sensorId: Type.String({ minLength: 1, pattern: '^[^.]+$' }),
-  $source: Type.String(),
-  fromBow: Type.Union([Type.Number(), Type.Null()]),
-  fromCenter: Type.Union([Type.Number(), Type.Null()])
-})
-const gnssSensorsPayloadSchema = Type.Array(gnssSensorSchema)
+const gnssSensorSchema = Type.Object(
+  {
+    sensorId: Type.String({ minLength: 1, pattern: '^[^.]+$' }),
+    $source: Type.String(),
+    fromBow: Type.Union([Type.Number(), Type.Null()]),
+    fromCenter: Type.Union([Type.Number(), Type.Null()])
+  },
+  { additionalProperties: false }
+)
+const gnssSensorsSchema = Type.Array(gnssSensorSchema)
+// Lever-arm correction is opt-in: 'off' stores geometry only, 'replace'
+// rewrites matching navigation.position deltas to the CCRP, 'both'
+// publishes the corrected position under <sensorId>.ccrp alongside the
+// untouched original.
+const gnssCorrectionModeSchema = Type.Union([
+  Type.Literal('off'),
+  Type.Literal('replace'),
+  Type.Literal('both')
+])
+const gnssConfigPayloadSchema = Type.Object(
+  {
+    correction: gnssCorrectionModeSchema,
+    sensors: gnssSensorsSchema
+  },
+  { additionalProperties: false }
+)
 
 type GnssSensorsPayload = Array<{
   sensorId: string
@@ -140,12 +157,17 @@ type GnssSensorsPayload = Array<{
   fromBow: number | null
   fromCenter: number | null
 }>
+type GnssCorrectionMode = 'off' | 'replace' | 'both'
+type GnssConfigPayload = {
+  correction: GnssCorrectionMode
+  sensors: GnssSensorsPayload
+}
 
-function validateGnssSensorsPayload(
+function validateGnssConfigPayload(
   body: unknown
-): { ok: true; value: GnssSensorsPayload } | { ok: false; error: string } {
-  if (!Value.Check(gnssSensorsPayloadSchema, body)) {
-    const first = Value.Errors(gnssSensorsPayloadSchema, body).First()
+): { ok: true; value: GnssConfigPayload } | { ok: false; error: string } {
+  if (!Value.Check(gnssConfigPayloadSchema, body)) {
+    const first = Value.Errors(gnssConfigPayloadSchema, body).First()
     return {
       ok: false,
       error: first
@@ -153,13 +175,13 @@ function validateGnssSensorsPayload(
         : 'Invalid gnssSensors payload'
     }
   }
-  const value = body as GnssSensorsPayload
+  const value = body as GnssConfigPayload
   // Duplicate sensorIds would silently clobber sensors.gps.<id> entries
   // in the data model on PUT; reject before we mutate anything. Duplicate
   // non-empty $source values would create an ambiguous source→sensor mapping.
   const seenIds = new Set<string>()
   const seenSources = new Set<string>()
-  for (const s of value) {
+  for (const s of value.sensors) {
     if (seenIds.has(s.sensorId)) {
       return { ok: false, error: `Duplicate sensorId "${s.sensorId}"` }
     }
@@ -1286,10 +1308,10 @@ module.exports = function (
     const de = app.config.baseDeltaEditor
     const communication = de.getSelfValue('communication')
     const draft = de.getSelfValue('design.draft')
-    // Mirror the PUT /skServer/gnssSensors handler's normalisation: design.length
-    // may be stored as { overall } or as a plain number, and older /vessel
-    // clients expect a number. Returning undefined for the plain-number case
-    // made the GNSS preferences page treat dimensions as unset.
+    // Mirror the PUT /skServer/gnssSensors handler's normalisation:
+    // design.length may be stored as { overall } or as a plain number, and
+    // /vessel clients (including the GNSS preferences page) expect a
+    // number for both stored shapes.
     const length = de.getSelfValue('design.length') as
       { overall?: number } | number | undefined
     const lengthOverall =
@@ -2158,7 +2180,10 @@ module.exports = function (
   app.get(
     `${SERVERROUTESPREFIX}/gnssSensors`,
     (req: Request, res: Response) => {
-      res.json(app.config.settings.gnssSensors || [])
+      res.json({
+        correction: app.config.settings.gnssCorrection ?? 'off',
+        sensors: app.config.settings.gnssSensors || []
+      })
     }
   )
 
@@ -2168,22 +2193,25 @@ module.exports = function (
   // into `withSettingsWriteLock` so cross-route races on settings.json
   // can't reintroduce a rolled-back payload.
   function applyGnssSensorsAtomic(
-    next: GnssSensorsPayload | undefined,
+    next: GnssConfigPayload | undefined,
     eventData: unknown,
     res: Response
   ): void {
     withSettingsWriteLock(
       () =>
         new Promise<void>((resolve) => {
-          const previous = app.config.settings.gnssSensors ?? []
+          const previous: GnssConfigPayload = {
+            correction: app.config.settings.gnssCorrection ?? 'off',
+            sensors: app.config.settings.gnssSensors ?? []
+          }
           runApplyGnssSensorsAtomic(previous, next, eventData, res, resolve)
         })
     )
   }
 
   function runApplyGnssSensorsAtomic(
-    previous: GnssSensorsPayload,
-    next: GnssSensorsPayload | undefined,
+    previous: GnssConfigPayload,
+    next: GnssConfigPayload | undefined,
     eventData: unknown,
     res: Response,
     done: () => void
@@ -2221,70 +2249,108 @@ module.exports = function (
       }
       return sweptLegacyValues.length > 0
     }
+    const hadGnssSensors = Object.prototype.hasOwnProperty.call(
+      app.config.settings,
+      'gnssSensors'
+    )
     const restorePrevious = () => {
       for (const { path, value } of sweptLegacyValues) {
         de.setSelfValue(path, value)
       }
-      if (next !== undefined && previous.length === 0) {
+      if (!hadGnssSensors) {
         delete app.config.settings.gnssSensors
       } else {
-        app.config.settings.gnssSensors = previous
+        app.config.settings.gnssSensors = previous.sensors
+      }
+      if (previous.correction === 'off') {
+        delete app.config.settings.gnssCorrection
+      } else {
+        app.config.settings.gnssCorrection = previous.correction
       }
     }
+    // Sweep ids from both the outgoing and the incoming rows: a stale
+    // sensors.gps.<id> base-delta entry may predate the first row that
+    // (re)uses that id, so sweeping only `previous` would let it survive
+    // the save that introduces the id.
+    const rowsToSweep = [
+      ...new Map(
+        [...previous.sensors, ...(next?.sensors ?? [])].map((s) => [
+          s.sensorId,
+          s
+        ])
+      ).values()
+    ]
     let restartRequired = false
     if (next === undefined) {
-      restartRequired = legacyPathsCleared(previous)
+      restartRequired = legacyPathsCleared(rowsToSweep)
       delete app.config.settings.gnssSensors
+      delete app.config.settings.gnssCorrection
     } else {
-      restartRequired = legacyPathsCleared(previous)
-      app.config.settings.gnssSensors = next
+      restartRequired = legacyPathsCleared(rowsToSweep)
+      app.config.settings.gnssSensors = next.sensors
+      if (next.correction === 'off') {
+        delete app.config.settings.gnssCorrection
+      } else {
+        app.config.settings.gnssCorrection = next.correction
+      }
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    writeSettingsFile(app, app.config.settings, (err: any) => {
+    writeSettingsFile(app, app.config.settings, (err: unknown) => {
       if (err) {
         restorePrevious()
         res.status(500).send('Unable to save gnssSensors in settings file')
         done()
         return
       }
-      writeBaseDeltasFile(app)
-        .then(() => {
-          app.emit('serverevent', { type: 'GNSS_SENSORS', data: eventData })
+      // Success and failure are separate .then() arms so that only a
+      // rejected base-deltas write reaches the rollback: a throwing
+      // serverevent listener must not roll back settings.json after
+      // both files are already on disk.
+      writeBaseDeltasFile(app).then(
+        () => {
+          try {
+            app.emit('serverevent', { type: 'GNSS_SENSORS', data: eventData })
+          } catch (err) {
+            console.error('GNSS_SENSORS listener error:', err)
+          }
           res.json({ result: 'ok', restartRequired })
           done()
-        })
-        .catch(() => {
+        },
+        () => {
           // settings.json is already on disk with the new payload but the
           // base-deltas write failed — restore in-memory state first, then
           // re-write settings.json so disk and memory agree on a restart.
           restorePrevious()
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          writeSettingsFile(app, app.config.settings, (rollbackErr: any) => {
-            if (rollbackErr) {
-              res
-                .status(500)
-                .send(
-                  'gnssSensors base-delta write failed and rolling back settings.json also failed; restart server to recover'
-                )
+          writeSettingsFile(
+            app,
+            app.config.settings,
+            (rollbackErr: unknown) => {
+              if (rollbackErr) {
+                res
+                  .status(500)
+                  .send(
+                    'gnssSensors base-delta write failed and rolling back settings.json also failed; restart server to recover'
+                  )
+                done()
+                return
+              }
+              res.status(500).send('Unable to save gnssSensors base deltas')
               done()
-              return
             }
-            res.status(500).send('Unable to save gnssSensors base deltas')
-            done()
-          })
-        })
+          )
+        }
+      )
     })
   }
 
   app.put(
     `${SERVERROUTESPREFIX}/gnssSensors`,
     (req: Request, res: Response) => {
-      const validation = validateGnssSensorsPayload(req.body)
+      const validation = validateGnssConfigPayload(req.body)
       if (!validation.ok) {
         res.status(400).send(validation.error)
         return
       }
-      const sensors = validation.value
+      const sensors = validation.value.sensors
       const de = app.config.baseDeltaEditor
       const length = de.getSelfValue('design.length') as
         { overall?: number } | number | undefined
@@ -2311,14 +2377,14 @@ module.exports = function (
         res.status(400).send(boundsError)
         return
       }
-      applyGnssSensorsAtomic(sensors, sensors, res)
+      applyGnssSensorsAtomic(validation.value, validation.value, res)
     }
   )
 
   app.delete(
     `${SERVERROUTESPREFIX}/gnssSensors`,
     (_req: Request, res: Response) => {
-      applyGnssSensorsAtomic(undefined, [], res)
+      applyGnssSensorsAtomic(undefined, { correction: 'off', sensors: [] }, res)
     }
   )
 

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -117,6 +117,92 @@ const prioritiesPayloadSchema = Type.Object({
   defaults: priorityDefaultsSchema
 })
 
+// Schema for the PUT /skServer/gnssSensors body. Each sensor has a stable
+// id, a $source reference that may be empty for not-yet-linked rows, and
+// nullable numeric offsets — Number coercion happens in the route handler
+// so the schema mirrors what the admin UI POSTs (numbers or null), not the
+// post-coercion shape.
+// sensorId is the key the corrector reports back as $sensor in
+// meta.gnssOffsetCorrection and the historical (pre-corrector) base-delta
+// sweep key; reject anything containing `.` so the legacy cleanup paths
+// cannot be tricked into removing keys outside `sensors.gps.<sensorId>.*`.
+const gnssSensorSchema = Type.Object({
+  sensorId: Type.String({ minLength: 1, pattern: '^[^.]+$' }),
+  $source: Type.String(),
+  fromBow: Type.Union([Type.Number(), Type.Null()]),
+  fromCenter: Type.Union([Type.Number(), Type.Null()])
+})
+const gnssSensorsPayloadSchema = Type.Array(gnssSensorSchema)
+
+type GnssSensorsPayload = Array<{
+  sensorId: string
+  $source: string
+  fromBow: number | null
+  fromCenter: number | null
+}>
+
+function validateGnssSensorsPayload(
+  body: unknown
+): { ok: true; value: GnssSensorsPayload } | { ok: false; error: string } {
+  if (!Value.Check(gnssSensorsPayloadSchema, body)) {
+    const first = Value.Errors(gnssSensorsPayloadSchema, body).First()
+    return {
+      ok: false,
+      error: first
+        ? `Invalid gnssSensors payload at ${first.path}: ${first.message}`
+        : 'Invalid gnssSensors payload'
+    }
+  }
+  const value = body as GnssSensorsPayload
+  // Duplicate sensorIds would silently clobber sensors.gps.<id> entries
+  // in the data model on PUT; reject before we mutate anything. Duplicate
+  // non-empty $source values would create an ambiguous source→sensor mapping.
+  const seenIds = new Set<string>()
+  const seenSources = new Set<string>()
+  for (const s of value) {
+    if (seenIds.has(s.sensorId)) {
+      return { ok: false, error: `Duplicate sensorId "${s.sensorId}"` }
+    }
+    seenIds.add(s.sensorId)
+    if (s.$source.length > 0) {
+      if (seenSources.has(s.$source)) {
+        return { ok: false, error: `Duplicate $source "${s.$source}"` }
+      }
+      seenSources.add(s.$source)
+    }
+  }
+  return { ok: true, value }
+}
+
+// Reject offsets that would place an antenna outside the configured hull.
+// Skipped silently when the relevant dimension is unset — the user might
+// just not have filled in length/beam yet, and we'd rather let them save
+// reasonable offsets than block on missing vessel metadata.
+function validateGnssSensorBounds(
+  sensors: GnssSensorsPayload,
+  lengthOverall: number | undefined,
+  beam: number | undefined
+): string | null {
+  for (const s of sensors) {
+    if (
+      s.fromBow !== null &&
+      lengthOverall !== undefined &&
+      (s.fromBow < 0 || s.fromBow > lengthOverall)
+    ) {
+      return `fromBow ${s.fromBow} out of range 0..${lengthOverall} for sensor "${s.sensorId}"`
+    }
+    if (
+      s.fromCenter !== null &&
+      beam !== undefined &&
+      Math.abs(s.fromCenter) > beam / 2
+    ) {
+      const half = beam / 2
+      return `fromCenter ${s.fromCenter} out of range -${half}..${half} for sensor "${s.sensorId}"`
+    }
+  }
+  return null
+}
+
 type PrioritiesPayload = {
   groups: Array<{ id: string; sources: string[]; inactive?: boolean }>
   overrides: Record<
@@ -293,6 +379,24 @@ interface App
 interface ModuleInfo {
   name: string
   type?: string
+}
+
+// Module-level mutex that serializes every settings.json mutation routed
+// through `withSettingsWriteLock`. Without it, a clone-then-write handler
+// can snapshot `app.config.settings` *before* another handler's rollback
+// and then commit the rejected state back to disk after rollback ran.
+// Only the routes that opt in (currently the gnssSensors flow) are
+// serialized — direct writers to `app.config.settings` remain a known
+// race window relative to those routes.
+let settingsWriteLock: Promise<void> = Promise.resolve()
+function withSettingsWriteLock(fn: () => Promise<void>): Promise<void> {
+  const previous = settingsWriteLock
+  const next = previous.then(fn, fn)
+  // Swallow any rejection on the chain so a thrown handler doesn't wedge
+  // later requests; individual callers are still responsible for sending
+  // their own error responses.
+  settingsWriteLock = next.catch(() => undefined)
+  return next
 }
 
 module.exports = function (
@@ -1182,18 +1286,40 @@ module.exports = function (
     const de = app.config.baseDeltaEditor
     const communication = de.getSelfValue('communication')
     const draft = de.getSelfValue('design.draft')
-    const length = de.getSelfValue('design.length')
+    // Mirror the PUT /skServer/gnssSensors handler's normalisation: design.length
+    // may be stored as { overall } or as a plain number, and older /vessel
+    // clients expect a number. Returning undefined for the plain-number case
+    // made the GNSS preferences page treat dimensions as unset.
+    const length = de.getSelfValue('design.length') as
+      { overall?: number } | number | undefined
+    const lengthOverall =
+      typeof length === 'number'
+        ? length
+        : length && typeof length === 'object'
+          ? length.overall
+          : undefined
     const type = de.getSelfValue('design.aisShipType')
     const json = {
       name: app.config.vesselName,
       mmsi: app.config.vesselMMSI,
       uuid: app.config.vesselUUID,
       draft: draft && draft.maximum,
-      length: length && length.overall,
+      length: lengthOverall,
       beam: de.getSelfValue('design.beam'),
       height: de.getSelfValue('design.airHeight'),
-      gpsFromBow: de.getSelfValue('sensors.gps.fromBow'),
-      gpsFromCenter: de.getSelfValue('sensors.gps.fromCenter'),
+      // Older /vessel clients read gpsFromBow/gpsFromCenter; surface the
+      // first configured sensor row so the legacy shape stays meaningful.
+      // The server consumes the same data from settings.gnssSensors to
+      // rewrite navigation.position at the Common Coordinate Reference
+      // Point (vessel center on the centerline). An explicit `null` on
+      // a configured row means "not set yet" — fall back to the legacy
+      // single-GPS base-delta only when there is no sensor row at all.
+      gpsFromBow: app.config.settings.gnssSensors?.[0]
+        ? app.config.settings.gnssSensors[0].fromBow
+        : de.getSelfValue('sensors.gps.fromBow'),
+      gpsFromCenter: app.config.settings.gnssSensors?.[0]
+        ? app.config.settings.gnssSensors[0].fromCenter
+        : de.getSelfValue('sensors.gps.fromCenter'),
       aisShipType: type && type.id,
       callsignVhf: communication && communication.callsignVhf
     }
@@ -2011,6 +2137,190 @@ module.exports = function (
   )
 
   app.securityStrategy.addAdminWriteMiddleware(`${SERVERROUTESPREFIX}/debug`)
+
+  // Register middleware before the routes so every method picks up auth.
+  // Match the /priorities pattern: source topology and saved GNSS antenna
+  // offsets are admin-only across the board.
+  app.securityStrategy.addAdminMiddleware(
+    `${SERVERROUTESPREFIX}/positionSources`
+  )
+  app.securityStrategy.addAdminMiddleware(`${SERVERROUTESPREFIX}/gnssSensors`)
+
+  app.get(
+    `${SERVERROUTESPREFIX}/positionSources`,
+    (req: Request, res: Response) => {
+      // Use the same freshness-filtered + sorted set the POSITION_SOURCES
+      // event emits, so a cold page-load matches the next websocket update.
+      res.json(app.deltaCache.getActivePositionSources())
+    }
+  )
+
+  app.get(
+    `${SERVERROUTESPREFIX}/gnssSensors`,
+    (req: Request, res: Response) => {
+      res.json(app.config.settings.gnssSensors || [])
+    }
+  )
+
+  // `previous` is snapshotted inside the lock so a later request sees the
+  // outcome of any earlier in-flight settings write, not the state at
+  // handler entry. The lock is shared with any other handler that opts
+  // into `withSettingsWriteLock` so cross-route races on settings.json
+  // can't reintroduce a rolled-back payload.
+  function applyGnssSensorsAtomic(
+    next: GnssSensorsPayload | undefined,
+    eventData: unknown,
+    res: Response
+  ): void {
+    withSettingsWriteLock(
+      () =>
+        new Promise<void>((resolve) => {
+          const previous = app.config.settings.gnssSensors ?? []
+          runApplyGnssSensorsAtomic(previous, next, eventData, res, resolve)
+        })
+    )
+  }
+
+  function runApplyGnssSensorsAtomic(
+    previous: GnssSensorsPayload,
+    next: GnssSensorsPayload | undefined,
+    eventData: unknown,
+    res: Response,
+    done: () => void
+  ): void {
+    const de = app.config.baseDeltaEditor
+    // Sweep any legacy sensors.gps.<sensorId>.fromBow/fromCenter entries
+    // out of the base-delta store on every write. The corrector reads
+    // offsets from settings.gnssSensors directly and no per-sensor
+    // data-model entries are published, so any that exist are stale
+    // leftovers.
+    //
+    // FullSignalK has no per-path tombstone API: removing from the base-delta
+    // store stops the values from being re-emitted at startup, but any
+    // entries already in `app.signalk.self` from a previous run persist
+    // until the next restart. The handler reports that a restart is
+    // required via legacyPathsCleared in the response so the admin UI
+    // can surface the restart banner only when this actually happened.
+    // Swept entries are kept so a failed write can put them back: the
+    // removals live in the same in-memory editor whose baseDeltas.json
+    // write failed (or never ran), and leaving them out would diverge
+    // the editor from what is on disk.
+    const sweptLegacyValues: Array<{ path: string; value: unknown }> = []
+    const legacyPathsCleared = (rows: GnssSensorsPayload): boolean => {
+      for (const s of rows) {
+        for (const path of [
+          `sensors.gps.${s.sensorId}.fromBow`,
+          `sensors.gps.${s.sensorId}.fromCenter`
+        ]) {
+          const value = de.getSelfValue(path)
+          if (value !== undefined) {
+            de.removeSelfValue(path)
+            sweptLegacyValues.push({ path, value })
+          }
+        }
+      }
+      return sweptLegacyValues.length > 0
+    }
+    const restorePrevious = () => {
+      for (const { path, value } of sweptLegacyValues) {
+        de.setSelfValue(path, value)
+      }
+      if (next !== undefined && previous.length === 0) {
+        delete app.config.settings.gnssSensors
+      } else {
+        app.config.settings.gnssSensors = previous
+      }
+    }
+    let restartRequired = false
+    if (next === undefined) {
+      restartRequired = legacyPathsCleared(previous)
+      delete app.config.settings.gnssSensors
+    } else {
+      restartRequired = legacyPathsCleared(previous)
+      app.config.settings.gnssSensors = next
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    writeSettingsFile(app, app.config.settings, (err: any) => {
+      if (err) {
+        restorePrevious()
+        res.status(500).send('Unable to save gnssSensors in settings file')
+        done()
+        return
+      }
+      writeBaseDeltasFile(app)
+        .then(() => {
+          app.emit('serverevent', { type: 'GNSS_SENSORS', data: eventData })
+          res.json({ result: 'ok', restartRequired })
+          done()
+        })
+        .catch(() => {
+          // settings.json is already on disk with the new payload but the
+          // base-deltas write failed — restore in-memory state first, then
+          // re-write settings.json so disk and memory agree on a restart.
+          restorePrevious()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          writeSettingsFile(app, app.config.settings, (rollbackErr: any) => {
+            if (rollbackErr) {
+              res
+                .status(500)
+                .send(
+                  'gnssSensors base-delta write failed and rolling back settings.json also failed; restart server to recover'
+                )
+              done()
+              return
+            }
+            res.status(500).send('Unable to save gnssSensors base deltas')
+            done()
+          })
+        })
+    })
+  }
+
+  app.put(
+    `${SERVERROUTESPREFIX}/gnssSensors`,
+    (req: Request, res: Response) => {
+      const validation = validateGnssSensorsPayload(req.body)
+      if (!validation.ok) {
+        res.status(400).send(validation.error)
+        return
+      }
+      const sensors = validation.value
+      const de = app.config.baseDeltaEditor
+      const length = de.getSelfValue('design.length') as
+        { overall?: number } | number | undefined
+      const lengthOverallRaw =
+        typeof length === 'object' && length !== null
+          ? length.overall
+          : typeof length === 'number'
+            ? length
+            : undefined
+      const beamRaw = de.getSelfValue('design.beam')
+      // Non-positive hull dimensions came from a stale or hand-edited
+      // base-delta and would make every offset out of range, blocking the
+      // user from saving an otherwise-valid sensor row. Treat them as
+      // unavailable so bounds-checking is skipped just like when the
+      // dimension was never set.
+      const lengthOverall =
+        typeof lengthOverallRaw === 'number' && lengthOverallRaw > 0
+          ? lengthOverallRaw
+          : undefined
+      const beam =
+        typeof beamRaw === 'number' && beamRaw > 0 ? beamRaw : undefined
+      const boundsError = validateGnssSensorBounds(sensors, lengthOverall, beam)
+      if (boundsError) {
+        res.status(400).send(boundsError)
+        return
+      }
+      applyGnssSensorsAtomic(sensors, sensors, res)
+    }
+  )
+
+  app.delete(
+    `${SERVERROUTESPREFIX}/gnssSensors`,
+    (_req: Request, res: Response) => {
+      applyGnssSensorsAtomic(undefined, [], res)
+    }
+  )
 
   app.post(`${SERVERROUTESPREFIX}/debug`, (req: Request, res: Response) => {
     if (!app.logging.enableDebug(req.body.value)) {

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -1199,7 +1199,7 @@ module.exports = function (
       // Older /vessel clients read gpsFromBow/gpsFromCenter; surface the
       // first configured sensor row so the legacy shape stays meaningful.
       // The server consumes the same data from settings.gnssSensors to
-      // rewrite navigation.position at the Common Coordinate Reference
+      // rewrite navigation.position at the Consistent Common Reference
       // Point (vessel center on the centerline). An explicit `null` on
       // a configured row means "not set yet" — fall back to the legacy
       // single-GPS base-delta only when there is no sensor row at all.

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -1,0 +1,673 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+import { correctPosition } from '../../src/api/gnssOffsetCorrector/leverArm'
+import { GnssOffsetCorrector } from '../../src/api/gnssOffsetCorrector'
+import type { Delta } from '@signalk/server-api'
+
+const SELF = 'vessels.self'
+const R = 6_378_137
+
+// Build a minimal Delta for navigation.position carrying the given source.
+function positionDelta(opts: {
+  $source: string
+  latitude: number
+  longitude: number
+  altitude?: number
+  context?: string
+}): Delta {
+  return {
+    context: (opts.context ?? SELF) as unknown as Delta['context'],
+    updates: [
+      {
+        $source: opts.$source as unknown as never,
+        timestamp: '2026-05-31T00:00:00.000Z' as unknown as never,
+        values: [
+          {
+            path: 'navigation.position' as unknown as never,
+            value: {
+              latitude: opts.latitude,
+              longitude: opts.longitude,
+              altitude: opts.altitude
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+interface AppEnvOptions {
+  // Values to expose under app.signalk.self, keyed by dotted path
+  // (e.g. 'design.length.value' or 'navigation.headingTrue.value').
+  selfPaths?: Record<string, unknown>
+  gnssSensors?: Array<{
+    sensorId: string
+    $source: string
+    fromBow: number | null
+    fromCenter: number | null
+  }>
+  // Alias → canonical source-ref translations, mimicking
+  // deltaCache.canonicaliseSourceRef (identity when absent).
+  canonicalMap?: Record<string, string>
+}
+
+// Build a nested object from a {dottedPath: value} map so lodash `get`
+// resolves the same way it would against the real FullSignalK tree.
+function inflateSelfPaths(paths: Record<string, unknown>): object {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const out: any = {}
+  for (const [path, value] of Object.entries(paths)) {
+    const parts = path.split('.')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cursor: any = out
+    for (let i = 0; i < parts.length - 1; i++) {
+      const key = parts[i]
+      if (cursor[key] === undefined || typeof cursor[key] !== 'object') {
+        cursor[key] = {}
+      }
+      cursor = cursor[key]
+    }
+    cursor[parts[parts.length - 1]] = value
+  }
+  return out
+}
+
+function makeApp(opts: AppEnvOptions = {}) {
+  const bus = new EventEmitter()
+  let registeredHandler:
+    ((delta: Delta, next: (d: Delta) => void) => void) | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const app: any = bus
+  app.selfContext = SELF
+  app.config = {
+    settings: opts.gnssSensors ? { gnssSensors: opts.gnssSensors } : {}
+  }
+  app.signalk = { self: inflateSelfPaths(opts.selfPaths ?? {}) }
+  app.deltaCache = {
+    canonicaliseSourceRef: (ref: string) => opts.canonicalMap?.[ref] ?? ref
+  }
+  app.registerDeltaInputHandler = (
+    handler: (delta: Delta, next: (d: Delta) => void) => void
+  ) => {
+    registeredHandler = handler
+  }
+  return {
+    app,
+    bus,
+    process(delta: Delta): Delta {
+      // Mirror the chain's invocation pattern: handler calls next(delta).
+      // next() in the real chain forwards to the next handler; here we
+      // capture the final delta and return it.
+      let out: Delta = delta
+      registeredHandler?.(delta, (d: Delta) => {
+        out = d
+      })
+      return out
+    }
+  }
+}
+
+describe('leverArm.correctPosition', function () {
+  it('antenna at the bow, vessel pointing north: CCRP is 10m south', function () {
+    // length=20, antenna at fromBow=0 (the bow), heading north.
+    // Physically: bow=north, antenna at the bow, CCRP at midships
+    // (10m astern). So CCRP is 10m south of the antenna -> corrected
+    // latitude decreases by 10/R degrees.
+    const out = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      0
+    )
+    const expectedDLat = ((-10 / R) * 180) / Math.PI
+    expect(out.latitude).to.be.closeTo(60 + expectedDLat, 1e-9)
+    expect(out.longitude).to.equal(24)
+  })
+
+  it('antenna at the bow, vessel pointing east: CCRP is 10m west', function () {
+    // length=20, antenna at fromBow=0, heading east (pi/2).
+    // Physically: bow=east, antenna at the bow, CCRP at midships
+    // (10m astern = 10m west). longitude decreases by 10/(R cos lat).
+    const out = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      Math.PI / 2
+    )
+    const latRad = (60 * Math.PI) / 180
+    const expectedDLon = ((-10 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.longitude).to.be.closeTo(24 + expectedDLon, 1e-9)
+    expect(out.latitude).to.be.closeTo(60, 1e-9)
+  })
+
+  it('port-side antenna at midships, vessel pointing north: CCRP is to the east', function () {
+    // antenna at midships (fromBow = length/2 = 10) with fromCenter=2
+    // (2m to port of centerline). Physically: heading north -> port
+    // is west, so the antenna sits 2m west of the centerline; the
+    // CCRP is on the centerline (2m east of antenna). Longitude
+    // increases by 2/(R cos lat).
+    const out = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 10, fromCenter: 2 },
+      20,
+      0
+    )
+    const latRad = (60 * Math.PI) / 180
+    const expectedDLon = ((2 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.longitude).to.be.closeTo(24 + expectedDLon, 1e-9)
+    expect(out.latitude).to.be.closeTo(60, 1e-9)
+  })
+
+  it('starboard-side antenna at midships, vessel pointing north: CCRP is to the west', function () {
+    // Mirror of the previous case: fromCenter=-2 (starboard) ->
+    // antenna 2m east of centerline at heading north -> CCRP 2m west.
+    const out = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 10, fromCenter: -2 },
+      20,
+      0
+    )
+    const latRad = (60 * Math.PI) / 180
+    const expectedDLon = ((-2 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.longitude).to.be.closeTo(24 + expectedDLon, 1e-9)
+  })
+
+  it('antenna exactly at CCRP yields identity', function () {
+    // fromBow=length/2, fromCenter=0 -> body_x=0, body_y=0 -> zero shift.
+    const out = correctPosition(
+      { latitude: 60, longitude: 24, altitude: 5 },
+      { fromBow: 10, fromCenter: 0 },
+      20,
+      Math.PI / 3
+    )
+    expect(out.latitude).to.be.closeTo(60, 1e-12)
+    expect(out.longitude).to.be.closeTo(24, 1e-12)
+    expect(out.altitude).to.equal(5)
+  })
+
+  it('preserves altitude through correction', function () {
+    const out = correctPosition(
+      { latitude: 60, longitude: 24, altitude: 12.5 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      0
+    )
+    expect(out.altitude).to.equal(12.5)
+  })
+
+  it('handles negative latitude (southern hemisphere)', function () {
+    // Antenna at bow, vessel pointing east at lat=-45: CCRP 10m west.
+    const out = correctPosition(
+      { latitude: -45, longitude: 170 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      Math.PI / 2
+    )
+    const latRad = (-45 * Math.PI) / 180
+    const expectedDLon = ((-10 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.longitude).to.be.closeTo(170 + expectedDLon, 1e-9)
+  })
+
+  it('wraps longitude across the antimeridian (eastward)', function () {
+    // Antenna just west of +180 longitude at the equator, vessel pointing
+    // west (heading 3pi/2). At the bow with length=20 the CCRP sits 10m
+    // east of the antenna. The raw sum 179.9999... + 10/R*180/pi exceeds
+    // +180 and must wrap to a small negative longitude near -180.
+    const out = correctPosition(
+      { latitude: 0, longitude: 179.99999 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      (3 * Math.PI) / 2
+    )
+    const rawLon = 179.99999 + ((10 / R) * 180) / Math.PI
+    const expectedLon = ((((rawLon + 180) % 360) + 360) % 360) - 180
+    expect(out.longitude).to.be.closeTo(expectedLon, 1e-9)
+    // Sanity: the wrap really did cross the antimeridian (raw > 180).
+    expect(rawLon).to.be.greaterThan(180)
+    expect(expectedLon).to.be.lessThan(0)
+  })
+
+  it('wraps longitude across the antimeridian (westward)', function () {
+    // Mirror case: antenna just east of -180 longitude, heading east
+    // (pi/2). At the bow the CCRP is 10m west; raw sum drops below
+    // -180 and must wrap up to a value near +180.
+    const out = correctPosition(
+      { latitude: 0, longitude: -179.99999 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      Math.PI / 2
+    )
+    const rawLon = -179.99999 + ((-10 / R) * 180) / Math.PI
+    const expectedLon = ((((rawLon + 180) % 360) + 360) % 360) - 180
+    expect(out.longitude).to.be.closeTo(expectedLon, 1e-9)
+    // Sanity: the wrap really did cross the antimeridian (raw < -180).
+    expect(rawLon).to.be.lessThan(-180)
+    expect(expectedLon).to.be.greaterThan(0)
+  })
+})
+
+describe('GnssOffsetCorrector handler', function () {
+  it('rewrites navigation.position and adds meta when sensor matches', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: {
+        value: {
+          gnssOffsetCorrection?: {
+            $sensor: string
+            fromBow: number
+            fromCenter: number
+            lengthOverall: number
+            headingTrue: number
+            rawValue: { latitude: number; longitude: number }
+          }
+        }
+      }[]
+    }
+    const expectedDLat = ((-10 / R) * 180) / Math.PI
+    expect(update.values[0].value.latitude).to.be.closeTo(
+      60 + expectedDLat,
+      1e-9
+    )
+    expect(update.meta).to.have.length(1)
+    expect(update.meta![0].value.gnssOffsetCorrection).to.deep.equal({
+      $sensor: 'gnss1',
+      fromBow: 0,
+      fromCenter: 0,
+      lengthOverall: 20,
+      headingTrue: 0,
+      rawValue: { latitude: 60, longitude: 24, altitude: undefined }
+    })
+  })
+
+  it('corrects deltas tagged with a numeric-src alias of the configured source', async function () {
+    // Rows hold the canonical (canName-form) ref offered by
+    // positionSources; N2K frames that arrive before the address claim
+    // is observed carry the numeric-src alias and must still match.
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.can123', fromBow: 0, fromCenter: 0 }
+      ],
+      canonicalMap: { 'n2k.5': 'n2k.can123' }
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const out = process(
+      positionDelta({ $source: 'n2k.5', latitude: 60, longitude: 24 })
+    )
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: { value: { gnssOffsetCorrection?: { $sensor: string } } }[]
+    }
+    const expectedDLat = ((-10 / R) * 180) / Math.PI
+    expect(update.values[0].value.latitude).to.be.closeTo(
+      60 + expectedDLat,
+      1e-9
+    )
+    expect(update.meta![0].value.gnssOffsetCorrection!.$sensor).to.equal(
+      'gnss1'
+    )
+  })
+
+  it('passes through unchanged when $source is not configured', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 5, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'gp.GP',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.values[0].value.longitude).to.equal(24)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('ignores rows with an empty $source (no wildcard hijack)', async function () {
+    // A partially-edited row (offset set, $source still blank) must not
+    // act as a catch-all for every position delta. Otherwise filling in
+    // an offset before assigning a source would silently apply that
+    // correction to whatever stream wins next.
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss0', $source: '', fromBow: 5, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'anything.really',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.values[0].value.longitude).to.equal(24)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('ignores rows where one axis is still null (no zero-fill correction)', async function () {
+    // gnssSensors row schema allows null offsets to mean "not configured
+    // yet". Coercing null to 0 in the correction would silently fabricate
+    // geometry for a half-edited row; the handler skips such rows so the
+    // delta passes through unmodified until the user finishes the row.
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        {
+          sensorId: 'gnss1',
+          $source: 'n2k.0.5',
+          fromBow: 5,
+          fromCenter: null
+        }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.values[0].value.longitude).to.equal(24)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('passes through when heading is unavailable', async function () {
+    const { app, process } = makeApp({
+      selfPaths: { 'design.length.value': { overall: 20 } },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.values[0].value.longitude).to.equal(24)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('passes through when design.length.overall is unset', async function () {
+    const { app, process } = makeApp({
+      selfPaths: { 'navigation.headingTrue.value': 0 },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('accepts plain-number design.length.value (legacy SK shape)', async function () {
+    // design.length.value may be stored as either { overall: N } (new
+    // shape) or a bare number (legacy single-value shape). The corrector
+    // must handle both so users with older defaults files still get
+    // lever-arm correction without rewriting their base deltas.
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': 20,
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number; longitude: number } }[]
+      meta: {
+        value: { gnssOffsetCorrection: { lengthOverall: number } }
+      }[]
+    }
+    const expectedDLat = ((-10 / R) * 180) / Math.PI
+    expect(update.values[0].value.latitude).to.be.closeTo(
+      60 + expectedDLat,
+      1e-9
+    )
+    expect(update.meta[0].value.gnssOffsetCorrection.lengthOverall).to.equal(20)
+  })
+
+  it('falls back to headingMagnetic + magneticVariation when headingTrue is unset', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingMagnetic.value': Math.PI / 2 - 0.1,
+        'navigation.magneticVariation.value': 0.1
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      meta: {
+        value: { gnssOffsetCorrection: { headingTrue: number } }
+      }[]
+    }
+    expect(update.meta[0].value.gnssOffsetCorrection.headingTrue).to.be.closeTo(
+      Math.PI / 2,
+      1e-12
+    )
+  })
+
+  it('passes through deltas from non-self contexts', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24,
+      context: 'vessels.urn:mrn:imo:mmsi:999'
+    })
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('passes through deltas whose path is not navigation.position', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta: Delta = {
+      context: SELF as unknown as Delta['context'],
+      updates: [
+        {
+          $source: 'n2k.0.5' as unknown as never,
+          timestamp: '2026-05-31T00:00:00.000Z' as unknown as never,
+          values: [
+            {
+              path: 'navigation.speedOverGround' as unknown as never,
+              value: 5.2
+            }
+          ]
+        }
+      ]
+    }
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: number }[]
+      meta?: unknown[]
+    }
+    expect(update.values[0].value).to.equal(5.2)
+    expect(update.meta).to.equal(undefined)
+  })
+
+  it('rebuilds lookup on GNSS_SENSORS server event', async function () {
+    const { app, bus, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: []
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    // No sensors configured -> passthrough.
+    const before = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+    )
+    const beforeUpdate = before.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+    }
+    expect(beforeUpdate.values[0].value.latitude).to.equal(60)
+
+    // User edits config. settings.gnssSensors changes BEFORE the event fires.
+    app.config.settings.gnssSensors = [
+      { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+    ]
+    bus.emit('serverevent', { type: 'GNSS_SENSORS', data: [] })
+
+    const after = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+    )
+    const afterUpdate = after.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+    }
+    const expectedDLat = ((-10 / R) * 180) / Math.PI
+    expect(afterUpdate.values[0].value.latitude).to.be.closeTo(
+      60 + expectedDLat,
+      1e-9
+    )
+  })
+
+  it('preserves the raw value object reference (does not mutate it in place)', async function () {
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const rawObj = (
+      delta.updates[0] as never as {
+        values: { value: object }[]
+      }
+    ).values[0].value
+    const out = process(delta)
+    const update = out.updates[0] as never as {
+      values: { value: object }[]
+      meta: { value: { gnssOffsetCorrection: { rawValue: object } } }[]
+    }
+    // Corrected value is a new object.
+    expect(update.values[0].value).to.not.equal(rawObj)
+    // Raw value preserved by reference under meta.
+    expect(update.meta[0].value.gnssOffsetCorrection.rawValue).to.equal(rawObj)
+  })
+})

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -342,6 +342,41 @@ describe('GnssOffsetCorrector handler', function () {
     )
   })
 
+  it('corrects when the config holds an alias and the delta the canonical ref', async function () {
+    // Reverse of the previous case: the row was saved while only the
+    // numeric-src alias was known; the device's canName has since
+    // resolved and deltas arrive canonicalised. rebuildLookup must
+    // canonicalise the configured ref so the row still matches.
+    const { app, process } = makeApp({
+      selfPaths: {
+        'design.length.value': { overall: 20 },
+        'navigation.headingTrue.value': 0
+      },
+      canonicalMap: { 'n2k.0.5': 'n2k.c032820059a81e3f' },
+      gnssCorrection: 'replace',
+      gnssSensors: [
+        { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const out = process(
+      positionDelta({
+        $source: 'n2k.c032820059a81e3f',
+        latitude: 60,
+        longitude: 24
+      })
+    )
+
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta: { value: { gnssOffsetCorrection: { $sensor: string } } }[]
+    }
+    expect(update.values[0].value.latitude).to.not.equal(60)
+    expect(update.meta[0].value.gnssOffsetCorrection.$sensor).to.equal('gnss1')
+  })
+
   it('passes through unchanged when $source is not configured', async function () {
     const { app, process } = makeApp({
       selfPaths: {

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -503,7 +503,7 @@ describe('GnssOffsetCorrector handler', function () {
     // design.length.value may be stored as either { overall: N } (new
     // shape) or a bare number (legacy single-value shape). The corrector
     // must handle both so users with older defaults files still get
-    // lever-arm correction without rewriting their base deltas.
+    // vessel reference point correction without rewriting their base deltas.
     const { app, process } = makeApp({
       selfPaths: {
         'design.length.value': 20,

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -258,7 +258,7 @@ describe('leverArm.correctPosition', function () {
 })
 
 describe('GnssOffsetCorrector handler', function () {
-  it('rewrites navigation.position and adds meta when sensor matches', async function () {
+  it('rewrites navigation.position in place when sensor matches', async function () {
     const { app, process } = makeApp({
       selfPaths: {
         'design.length.value': { overall: 20 },
@@ -279,33 +279,15 @@ describe('GnssOffsetCorrector handler', function () {
     const out = process(delta)
     const update = out.updates[0] as never as {
       values: { value: { latitude: number; longitude: number } }[]
-      meta?: {
-        value: {
-          gnssOffsetCorrection?: {
-            $sensor: string
-            fromBow: number
-            fromCenter: number
-            lengthOverall: number
-            headingTrue: number
-            rawValue: { latitude: number; longitude: number }
-          }
-        }
-      }[]
+      meta?: unknown
     }
     const expectedDLat = ((-10 / R) * 180) / Math.PI
     expect(update.values[0].value.latitude).to.be.closeTo(
       60 + expectedDLat,
       1e-9
     )
-    expect(update.meta).to.have.length(1)
-    expect(update.meta![0].value.gnssOffsetCorrection).to.deep.equal({
-      $sensor: 'gnss1',
-      fromBow: 0,
-      fromCenter: 0,
-      lengthOverall: 20,
-      headingTrue: 0,
-      rawValue: { latitude: 60, longitude: 24, altitude: undefined }
-    })
+    // The correction no longer stamps provenance meta on the delta.
+    expect(update.meta).to.equal(undefined)
   })
 
   it('corrects deltas tagged with a numeric-src alias of the configured source', async function () {
@@ -330,15 +312,11 @@ describe('GnssOffsetCorrector handler', function () {
     )
     const update = out.updates[0] as never as {
       values: { value: { latitude: number } }[]
-      meta?: { value: { gnssOffsetCorrection?: { $sensor: string } } }[]
     }
     const expectedDLat = ((-10 / R) * 180) / Math.PI
     expect(update.values[0].value.latitude).to.be.closeTo(
       60 + expectedDLat,
       1e-9
-    )
-    expect(update.meta![0].value.gnssOffsetCorrection!.$sensor).to.equal(
-      'gnss1'
     )
   })
 
@@ -371,10 +349,8 @@ describe('GnssOffsetCorrector handler', function () {
 
     const update = out.updates[0] as never as {
       values: { value: { latitude: number } }[]
-      meta: { value: { gnssOffsetCorrection: { $sensor: string } } }[]
     }
     expect(update.values[0].value.latitude).to.not.equal(60)
-    expect(update.meta[0].value.gnssOffsetCorrection.$sensor).to.equal('gnss1')
   })
 
   it('passes through unchanged when $source is not configured', async function () {
@@ -548,16 +524,14 @@ describe('GnssOffsetCorrector handler', function () {
     const out = process(delta)
     const update = out.updates[0] as never as {
       values: { value: { latitude: number; longitude: number } }[]
-      meta: {
-        value: { gnssOffsetCorrection: { lengthOverall: number } }
-      }[]
     }
+    // A plain-number design.length.value of 20 puts the CCRP 10 m aft of
+    // the bow; the resulting latitude shift confirms the length was read.
     const expectedDLat = ((-10 / R) * 180) / Math.PI
     expect(update.values[0].value.latitude).to.be.closeTo(
       60 + expectedDLat,
       1e-9
     )
-    expect(update.meta[0].value.gnssOffsetCorrection.lengthOverall).to.equal(20)
   })
 
   it('falls back to headingMagnetic + magneticVariation when headingTrue is unset', async function () {
@@ -581,12 +555,23 @@ describe('GnssOffsetCorrector handler', function () {
     })
     const out = process(delta)
     const update = out.updates[0] as never as {
-      meta: {
-        value: { gnssOffsetCorrection: { headingTrue: number } }
-      }[]
+      values: { value: { latitude: number; longitude: number } }[]
     }
-    expect(update.meta[0].value.gnssOffsetCorrection.headingTrue).to.be.closeTo(
-      Math.PI / 2,
+    // headingMagnetic (π/2 - 0.1) + magneticVariation (0.1) = π/2. The
+    // corrected value must match correctPosition driven with that true
+    // heading, proving the fallback was used.
+    const expected = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      Math.PI / 2
+    )
+    expect(update.values[0].value.latitude).to.be.closeTo(
+      expected.latitude,
+      1e-12
+    )
+    expect(update.values[0].value.longitude).to.be.closeTo(
+      expected.longitude,
       1e-12
     )
   })
@@ -696,7 +681,7 @@ describe('GnssOffsetCorrector handler', function () {
     )
   })
 
-  it('preserves the raw value object reference (does not mutate it in place)', async function () {
+  it('replaces the value with a new object rather than mutating the raw in place', async function () {
     const { app, process } = makeApp({
       selfPaths: {
         'design.length.value': { overall: 20 },
@@ -722,12 +707,10 @@ describe('GnssOffsetCorrector handler', function () {
     const out = process(delta)
     const update = out.updates[0] as never as {
       values: { value: object }[]
-      meta: { value: { gnssOffsetCorrection: { rawValue: object } } }[]
     }
-    // Corrected value is a new object.
+    // Corrected value is a fresh object; correctPosition does not write
+    // back into the provider's raw position object.
     expect(update.values[0].value).to.not.equal(rawObj)
-    // Raw value preserved by reference under meta.
-    expect(update.meta[0].value.gnssOffsetCorrection.rawValue).to.equal(rawObj)
   })
 })
 
@@ -804,7 +787,7 @@ describe('GnssOffsetCorrector correction modes', function () {
       $source: string
       timestamp: string
       values: { path: string; value: { latitude: number } }[]
-      meta: { value: { gnssOffsetCorrection: { $sensor: string } } }[]
+      meta?: unknown
     }
     expect(emittedUpdate.$source).to.equal('gnss1.ccrp')
     expect(emittedUpdate.timestamp).to.equal('2026-05-31T00:00:00.000Z')
@@ -819,12 +802,11 @@ describe('GnssOffsetCorrector correction modes', function () {
       expected.latitude,
       1e-12
     )
-    expect(emittedUpdate.meta[0].value.gnssOffsetCorrection.$sensor).to.equal(
-      'gnss1'
-    )
+    // The companion delta carries only the corrected value, no meta.
+    expect(emittedUpdate.meta).to.equal(undefined)
   })
 
-  it("mode 'both' emits nothing when heading is unavailable", async function () {
+  it("mode 'both' publishes no companion but raises a notification when heading is unavailable", async function () {
     const { app, process, emitted } = makeApp({
       selfPaths: { 'design.length.value': { overall: 20 } },
       gnssCorrection: 'both',
@@ -842,7 +824,16 @@ describe('GnssOffsetCorrector correction modes', function () {
       values: { value: { latitude: number } }[]
     }
     expect(update.values[0].value.latitude).to.equal(60)
-    expect(emitted).to.have.length(0)
+    // Only the headingUnavailable notification is emitted; no <sensor>.ccrp
+    // companion delta because correction could not run.
+    expect(emitted).to.have.length(1)
+    const notif = emitted[0].delta.updates![0] as never as {
+      values: { path: string; value: { state: string } }[]
+    }
+    expect(notif.values[0].path).to.equal(
+      'notifications.navigation.gnss.headingUnavailable'
+    )
+    expect(notif.values[0].value.state).to.equal('warn')
   })
 
   it('never corrects rows bound to a *.ccrp source (no recursion)', async function () {
@@ -923,5 +914,82 @@ describe('GnssOffsetCorrector correction modes', function () {
     expect(update.values[0].value.latitude).to.equal(90)
     expect(update.meta).to.equal(undefined)
     expect(emitted).to.have.length(0)
+  })
+})
+
+describe('GnssOffsetCorrector heading-unavailable notification', function () {
+  const NOTIF_PATH = 'notifications.navigation.gnss.headingUnavailable'
+  const SENSOR = {
+    sensorId: 'gnss1',
+    $source: 'n2k.0.5',
+    fromBow: 0,
+    fromCenter: 0
+  }
+  // Notifications are pushed via handleMessage, captured in `emitted`.
+  const notifs = (
+    emitted: Array<{ id: string; delta: Partial<Delta> }>
+  ): Array<{ path: string; value: { state: string } }> =>
+    emitted
+      .flatMap((e) => e.delta.updates ?? [])
+      .flatMap((u) => (u as { values?: unknown[] }).values ?? [])
+      .filter((v) => (v as { path: string }).path === NOTIF_PATH) as Array<{
+      path: string
+      value: { state: string }
+    }>
+
+  it('raises a warn notification once while heading stays unavailable', async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: { 'design.length.value': { overall: 20 } },
+      gnssCorrection: 'replace',
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    for (let i = 0; i < 3; i++) {
+      process(
+        positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+      )
+    }
+    const raised = notifs(emitted)
+    expect(raised).to.have.length(1)
+    expect(raised[0].value.state).to.equal('warn')
+  })
+
+  it('clears the notification with a normal state when heading returns', async function () {
+    const self = { 'design.length.value': { overall: 20 } } as Record<
+      string,
+      unknown
+    >
+    const { app, process, emitted } = makeApp({
+      selfPaths: self,
+      gnssCorrection: 'replace',
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    // No heading yet: raises the warning.
+    process(positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 }))
+    // Heading appears (mutate the shared self tree the corrector reads).
+    ;(
+      app.signalk.self as { navigation?: { headingTrue?: { value: number } } }
+    ).navigation = { headingTrue: { value: 0 } }
+    process(positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 }))
+
+    const seen = notifs(emitted)
+    expect(seen.map((n) => n.value.state)).to.deep.equal(['warn', 'normal'])
+  })
+
+  it('does not notify when correction is off even without heading', async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: { 'design.length.value': { overall: 20 } },
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    process(positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 }))
+    expect(notifs(emitted)).to.have.length(0)
   })
 })

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -46,6 +46,9 @@ interface AppEnvOptions {
     fromBow: number | null
     fromCenter: number | null
   }>
+  // settings.gnssCorrection; the corrector's production default is 'off',
+  // so tests exercising correction behavior pass 'replace' explicitly.
+  gnssCorrection?: 'off' | 'replace' | 'both'
   // Alias → canonical source-ref translations, mimicking
   // deltaCache.canonicaliseSourceRef (identity when absent).
   canonicalMap?: Record<string, string>
@@ -80,7 +83,10 @@ function makeApp(opts: AppEnvOptions = {}) {
   const app: any = bus
   app.selfContext = SELF
   app.config = {
-    settings: opts.gnssSensors ? { gnssSensors: opts.gnssSensors } : {}
+    settings: {
+      ...(opts.gnssSensors ? { gnssSensors: opts.gnssSensors } : {}),
+      ...(opts.gnssCorrection ? { gnssCorrection: opts.gnssCorrection } : {})
+    }
   }
   app.signalk = { self: inflateSelfPaths(opts.selfPaths ?? {}) }
   app.deltaCache = {
@@ -91,9 +97,14 @@ function makeApp(opts: AppEnvOptions = {}) {
   ) => {
     registeredHandler = handler
   }
+  const emitted: Array<{ id: string; delta: Partial<Delta> }> = []
+  app.handleMessage = (id: string, delta: Partial<Delta>) => {
+    emitted.push({ id, delta })
+  }
   return {
     app,
     bus,
+    emitted,
     process(delta: Delta): Delta {
       // Mirror the chain's invocation pattern: handler calls next(delta).
       // next() in the real chain forwards to the next handler; here we
@@ -253,6 +264,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -305,6 +317,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.can123', fromBow: 0, fromCenter: 0 }
       ],
@@ -335,6 +348,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 5, fromCenter: 0 }
       ]
@@ -366,6 +380,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss0', $source: '', fromBow: 5, fromCenter: 0 }
       ]
@@ -397,6 +412,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         {
           sensorId: 'gnss1',
@@ -426,6 +442,7 @@ describe('GnssOffsetCorrector handler', function () {
   it('passes through when heading is unavailable', async function () {
     const { app, process } = makeApp({
       selfPaths: { 'design.length.value': { overall: 20 } },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -450,6 +467,7 @@ describe('GnssOffsetCorrector handler', function () {
   it('passes through when design.length.overall is unset', async function () {
     const { app, process } = makeApp({
       selfPaths: { 'navigation.headingTrue.value': 0 },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -480,6 +498,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': 20,
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -513,6 +532,7 @@ describe('GnssOffsetCorrector handler', function () {
         'navigation.headingMagnetic.value': Math.PI / 2 - 0.1,
         'navigation.magneticVariation.value': 0.1
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -542,6 +562,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -569,6 +590,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -605,6 +627,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: []
     })
     const corrector = new GnssOffsetCorrector(app)
@@ -644,6 +667,7 @@ describe('GnssOffsetCorrector handler', function () {
         'design.length.value': { overall: 20 },
         'navigation.headingTrue.value': 0
       },
+      gnssCorrection: 'replace',
       gnssSensors: [
         { sensorId: 'gnss1', $source: 'n2k.0.5', fromBow: 0, fromCenter: 0 }
       ]
@@ -669,5 +693,200 @@ describe('GnssOffsetCorrector handler', function () {
     expect(update.values[0].value).to.not.equal(rawObj)
     // Raw value preserved by reference under meta.
     expect(update.meta[0].value.gnssOffsetCorrection.rawValue).to.equal(rawObj)
+  })
+})
+
+describe('GnssOffsetCorrector correction modes', function () {
+  // The 'both'-mode companion delta is published via setImmediate to stay
+  // out of the input-handler call stack; flush it before asserting.
+  const flush = () => new Promise((resolve) => setImmediate(resolve))
+
+  const SENSOR = {
+    sensorId: 'gnss1',
+    $source: 'n2k.0.5',
+    fromBow: 0,
+    fromCenter: 0
+  }
+  const SELF_PATHS = {
+    'design.length.value': { overall: 20 },
+    'navigation.headingTrue.value': 0
+  }
+
+  it('defaults to off: configured offsets leave the delta untouched', async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: SELF_PATHS,
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    await flush()
+
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: unknown
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.meta).to.equal(undefined)
+    expect(emitted).to.have.length(0)
+  })
+
+  it("mode 'both' leaves the original untouched and publishes <sensorId>.ccrp", async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: SELF_PATHS,
+      gnssCorrection: 'both',
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const delta = positionDelta({
+      $source: 'n2k.0.5',
+      latitude: 60,
+      longitude: 24
+    })
+    const out = process(delta)
+    await flush()
+
+    // Original delta unchanged, no meta added.
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: unknown
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.meta).to.equal(undefined)
+
+    // One corrected companion delta under <sensorId>.ccrp.
+    expect(emitted).to.have.length(1)
+    expect(emitted[0].id).to.equal('gnssOffsetCorrector')
+    const emittedUpdate = emitted[0].delta.updates![0] as never as {
+      $source: string
+      timestamp: string
+      values: { path: string; value: { latitude: number } }[]
+      meta: { value: { gnssOffsetCorrection: { $sensor: string } } }[]
+    }
+    expect(emittedUpdate.$source).to.equal('gnss1.ccrp')
+    expect(emittedUpdate.timestamp).to.equal('2026-05-31T00:00:00.000Z')
+    expect(emittedUpdate.values[0].path).to.equal('navigation.position')
+    const expected = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 0, fromCenter: 0 },
+      20,
+      0
+    )
+    expect(emittedUpdate.values[0].value.latitude).to.be.closeTo(
+      expected.latitude,
+      1e-12
+    )
+    expect(emittedUpdate.meta[0].value.gnssOffsetCorrection.$sensor).to.equal(
+      'gnss1'
+    )
+  })
+
+  it("mode 'both' emits nothing when heading is unavailable", async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: { 'design.length.value': { overall: 20 } },
+      gnssCorrection: 'both',
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const out = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+    )
+    await flush()
+
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(emitted).to.have.length(0)
+  })
+
+  it('never corrects rows bound to a *.ccrp source (no recursion)', async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: SELF_PATHS,
+      gnssCorrection: 'both',
+      gnssSensors: [
+        { sensorId: 'gnss2', $source: 'gnss1.ccrp', fromBow: 0, fromCenter: 0 }
+      ]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const out = process(
+      positionDelta({ $source: 'gnss1.ccrp', latitude: 60, longitude: 24 })
+    )
+    await flush()
+
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: unknown
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+    expect(update.meta).to.equal(undefined)
+    expect(emitted).to.have.length(0)
+  })
+
+  it('switches mode live on a GNSS_SENSORS server event', async function () {
+    const { app, bus, process, emitted } = makeApp({
+      selfPaths: SELF_PATHS,
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    // Default 'off': untouched.
+    let out = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+    )
+    let update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+    }
+    expect(update.values[0].value.latitude).to.equal(60)
+
+    // User saves 'replace'. Settings change BEFORE the event fires.
+    app.config.settings.gnssCorrection = 'replace'
+    bus.emit('serverevent', { type: 'GNSS_SENSORS', data: {} })
+
+    out = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 60, longitude: 24 })
+    )
+    update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+    }
+    expect(update.values[0].value.latitude).to.not.equal(60)
+    await flush()
+    expect(emitted).to.have.length(0)
+  })
+
+  it('skips correction at extreme polar latitudes', async function () {
+    const { app, process, emitted } = makeApp({
+      selfPaths: SELF_PATHS,
+      gnssCorrection: 'both',
+      gnssSensors: [SENSOR]
+    })
+    const corrector = new GnssOffsetCorrector(app)
+    await corrector.start()
+
+    const out = process(
+      positionDelta({ $source: 'n2k.0.5', latitude: 90, longitude: 24 })
+    )
+    await flush()
+
+    const update = out.updates[0] as never as {
+      values: { value: { latitude: number } }[]
+      meta?: unknown
+    }
+    expect(update.values[0].value.latitude).to.equal(90)
+    expect(update.meta).to.equal(undefined)
+    expect(emitted).to.have.length(0)
   })
 })

--- a/test/canonical-source-ref.ts
+++ b/test/canonical-source-ref.ts
@@ -134,4 +134,23 @@ describe('DeltaCache.getActivePositionSources', function () {
     meta['YDEN02.226'].lastSeen = Date.now() - 10 * 60 * 1000
     expect(cache.getActivePositionSources()).to.deep.equal([])
   })
+
+  it('fails open (all sources) when sourceMeta is unavailable', function () {
+    // Without freshness data every known position source is reported —
+    // showing a possibly-stale source in the config UI beats hiding a
+    // live one.
+    const sources = {
+      YDEN02: {
+        type: 'NMEA2000',
+        '226': { n2k: { canName: 'c032820059a81e3f' } }
+      }
+    }
+    const cache = makeCache(sources, {})
+    cache.ingestDelta(positionDelta('YDEN02.226'))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(cache as any).app.signalk.sourceMeta = undefined
+    expect(cache.getActivePositionSources()).to.deep.equal([
+      'YDEN02.c032820059a81e3f'
+    ])
+  })
 })

--- a/test/canonical-source-ref.ts
+++ b/test/canonical-source-ref.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { buildSrcToCanonicalMap } from '../src/deltacache'
+import DeltaCache, { buildSrcToCanonicalMap } from '../src/deltacache'
 
 // The Signal K sources summary tree is keyed by `[label][src]` with
 // optional `n2k.canName`. With useCanName on, the canName is recorded
@@ -64,5 +64,74 @@ describe('buildSrcToCanonicalMap', function () {
     }
     const map = buildSrcToCanonicalMap(sources)
     expect(Array.from(map.keys())).to.deep.equal(['YDEN02.90'])
+  })
+})
+
+describe('DeltaCache.getActivePositionSources', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makeCache(sources: unknown, sourceMeta: Record<string, any>) {
+    // DeltaCache's constructor arms periodic sweep timers that emit
+    // server events for the whole mocha run — the fake app must absorb
+    // those emits or they surface as uncaught exceptions in other tests.
+    const app = {
+      selfContext: 'vessels.self',
+      signalk: { sources, sourceMeta },
+      config: {},
+      on: () => undefined,
+      emit: () => undefined
+    }
+    const streambundle = { keys: { onValue: () => undefined } }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new DeltaCache(app as any, streambundle as any)
+  }
+
+  function positionDelta($source: string) {
+    return {
+      context: 'vessels.self',
+      updates: [
+        {
+          $source,
+          timestamp: new Date().toISOString(),
+          values: [
+            {
+              path: 'navigation.position',
+              value: { latitude: 60, longitude: 24 }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  it('treats a source as fresh when only its numeric-src alias was stamped', function () {
+    // Frames tagged with the numeric-src alias stamp sourceMeta under
+    // the raw ref, while getSourcesForPath collapses to the canonical
+    // canName form — freshness must fold onto the canonical key.
+    const sources = {
+      YDEN02: {
+        type: 'NMEA2000',
+        '226': { n2k: { canName: 'c032820059a81e3f' } }
+      }
+    }
+    const cache = makeCache(sources, {})
+    cache.ingestDelta(positionDelta('YDEN02.226'))
+    expect(cache.getActivePositionSources()).to.deep.equal([
+      'YDEN02.c032820059a81e3f'
+    ])
+  })
+
+  it('drops sources whose freshness has expired under every alias', function () {
+    const sources = {
+      YDEN02: {
+        type: 'NMEA2000',
+        '226': { n2k: { canName: 'c032820059a81e3f' } }
+      }
+    }
+    const cache = makeCache(sources, {})
+    cache.ingestDelta(positionDelta('YDEN02.226'))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (cache as any).app.signalk.sourceMeta
+    meta['YDEN02.226'].lastSeen = Date.now() - 10 * 60 * 1000
+    expect(cache.getActivePositionSources()).to.deep.equal([])
   })
 })

--- a/test/sensors.ts
+++ b/test/sensors.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai'
+import { startServer } from './ts-servertestutilities'
+
+describe('Sensors API - gnss', () => {
+  it('GET returns the default (off, no sensors) config with status', async function () {
+    const { selfGetJson, stop } = await startServer()
+    const data = (await selfGetJson('sensors/gnss')) as {
+      correction: string
+      sensors: unknown[]
+      status: { mode: string; active: boolean; blocked?: string }
+    }
+    expect(data.correction).to.equal('off')
+    expect(data.sensors).to.deep.equal([])
+    expect(data.status.mode).to.equal('off')
+    expect(data.status.active).to.equal(false)
+    await stop()
+  })
+
+  it('PUT stores the antenna config and GET reflects it', async function () {
+    const { selfPut, selfGetJson, stop } = await startServer()
+    const payload = {
+      correction: 'off',
+      sensors: [
+        { sensorId: 'gnss1', $source: 'test.1', fromBow: 3, fromCenter: 0 }
+      ]
+    }
+    const put = await selfPut('sensors/gnss', payload)
+    expect(put.status).to.equal(200)
+    const body = (await put.json()) as { result: string }
+    expect(body.result).to.equal('ok')
+
+    const data = (await selfGetJson('sensors/gnss')) as {
+      correction: string
+      sensors: Array<{ sensorId: string; fromBow: number }>
+    }
+    expect(data.correction).to.equal('off')
+    expect(data.sensors).to.have.length(1)
+    expect(data.sensors[0].sensorId).to.equal('gnss1')
+    expect(data.sensors[0].fromBow).to.equal(3)
+    await stop()
+  })
+
+  it('PUT rejects a duplicate sensorId with 400', async function () {
+    const { selfPut, stop } = await startServer()
+    const put = await selfPut('sensors/gnss', {
+      correction: 'off',
+      sensors: [
+        { sensorId: 'dup', $source: 'test.1', fromBow: 1, fromCenter: 0 },
+        { sensorId: 'dup', $source: 'test.2', fromBow: 2, fromCenter: 0 }
+      ]
+    })
+    expect(put.status).to.equal(400)
+    const body = (await put.json()) as { state: string; message: string }
+    expect(body.state).to.equal('FAILED')
+    expect(body.message).to.match(/Duplicate sensorId/)
+    await stop()
+  })
+
+  it('PUT rejects an unknown correction mode with 400', async function () {
+    const { selfPut, stop } = await startServer()
+    const put = await selfPut('sensors/gnss', {
+      correction: 'nonsense',
+      sensors: []
+    })
+    expect(put.status).to.equal(400)
+    await stop()
+  })
+
+  it('DELETE clears the config', async function () {
+    const { selfPut, selfDelete, selfGetJson, stop } = await startServer()
+    const put = await selfPut('sensors/gnss', {
+      correction: 'replace',
+      sensors: [
+        { sensorId: 'gnss1', $source: 'test.1', fromBow: 3, fromCenter: 0 }
+      ]
+    })
+    expect(put.status).to.equal(200)
+    const del = await selfDelete('sensors/gnss')
+    expect(del.status).to.equal(200)
+
+    const data = (await selfGetJson('sensors/gnss')) as {
+      correction: string
+      sensors: unknown[]
+    }
+    expect(data.correction).to.equal('off')
+    expect(data.sensors).to.deep.equal([])
+    await stop()
+  })
+
+  it('PUT rejects an offset outside the configured hull with 400', async function () {
+    const { selfPut, host, stop } = await startServer()
+    // Configure vessel dimensions so the bounds check has something to
+    // check against (skipped otherwise).
+    const vesselPut = await fetch(`${host}/skServer/vessel`, {
+      method: 'PUT',
+      body: JSON.stringify({ length: 20, beam: 6 }),
+      headers: { 'Content-Type': 'application/json' }
+    })
+    expect(vesselPut.status).to.equal(200)
+
+    const put = await selfPut('sensors/gnss', {
+      correction: 'off',
+      sensors: [
+        { sensorId: 'gnss1', $source: 'test.1', fromBow: 99, fromCenter: 0 }
+      ]
+    })
+    expect(put.status).to.equal(400)
+    const body = (await put.json()) as { state: string; message: string }
+    expect(body.state).to.equal('FAILED')
+    expect(body.message).to.match(/fromBow 99 out of range/)
+    await stop()
+  })
+})


### PR DESCRIPTION
## Summary

Implements [#2396](https://github.com/SignalK/signalk-server/issues/2396) (Option A: Source-to-Sensor Linking) — each GNSS source gets its own sensor instance with individual antenna offsets, and the server can correct `navigation.position` to the vessel's Common Coordinate Reference Point (CCRP). Lever-arm correction is **opt-in** with three modes (default: off).

### What changed

**Backend**

- New **v2 `sensors` API** under `/signalk/v2/api/vessels/self/sensors`, documented in OpenAPI:
  - `GET/PUT/DELETE /sensors/gnss` — payload `{ correction, sensors }` where each sensor is `{ sensorId, $source, fromBow, fromCenter }`, plus a `status` field on GET reporting whether correction is currently active (and, if not, the missing input). Offsets are validated against vessel length/beam; stored in `settings.json`.
  - The schemas, validation and the atomic settings + base-delta write live in `src/api/sensors/`, not in `serverroutes.ts`.
- `GET /skServer/positionSources` — returns all sources currently providing `navigation.position` (NMEA 2000, NMEA 0183, and plugins). This is source topology, so it stays a server route.
- `POSITION_SOURCES` and `GNSS_SENSORS` server events for live UI updates.
- Server-side lever-arm correction governed by `settings.gnssCorrection`:
  - `off` (default) — antenna positions are stored and documented, position data is never modified.
  - `replace` — `navigation.position` deltas whose `$source` matches a configured sensor are corrected to the CCRP using vessel length and true heading.
  - `both` — the original delta passes through untouched and the corrected position is additionally published under `<sensorId>.ccrp`, so both positions coexist as regular sources on `navigation.position` and clients choose via source priorities.
- Correction is not flagged in the deltas: position deltas are high volume, so no `meta` is added. When a correction mode is active but true heading is unavailable, the server raises `notifications.navigation.gnss.headingUnavailable` (cleared when heading returns) rather than silently emitting uncorrected positions.
- Legacy `sensors.gps.<id>.*` base-delta entries are swept on save; the single-GPS `sensors.gps.fromBow/fromCenter` values and `/vessel`'s `gpsFromBow`/`gpsFromCenter` keys stay readable for backward compatibility.
- `fromCenter` sign convention follows the SK spec: positive = port, negative = starboard.

Companion spec PR: SignalK/specification#680

**Frontend**

- New **GNSS Antenna Positions** card under Data → Preferences with a lever-arm correction mode selector and a table combining detected and configured GNSS sources.
- The correcting modes are disabled until a vessel length is set (with a link to Vessel Configuration), and the card surfaces whether correction is currently active or waiting on true heading.
- Detected sources are configured by clicking into their row (no separate button); rows keep a stable order across that transition; the Status column is a pure online/offline indicator; a Clear button removes a row's configuration.
- Draggable **SVG boat schematic** for visual antenna placement (bidirectional with the table).
- Warning badge on the Preferences nav item for unconfigured GNSS sources.
- Renamed "Unit Preferences" to "Preferences" (old URL redirects).
- Removed GPS fields from Server → Settings → Vessel Configuration.

### Testing done

- Unit tests: correction math (incl. antimeridian wrap, polar guard and heading fallback), source matching, null/non-finite-offset and empty-`$source` guards, event-driven config refresh, the three correction modes, and the heading-unavailable notification raise/clear transitions.
- Validation: duplicate `sensorId`/`$source`, malformed payloads, unknown payload keys and out-of-hull offsets rejected with 400.
- End-to-end against a live server: the v2 routes round-trip `{ correction, sensors, status }` through GET/PUT/DELETE; `replace` shifts `navigation.position` by the exact CCRP offset with no meta added; `both` publishes `gnss1.ccrp` alongside the untouched original with both visible under `.../position/values`; dropping true heading raises the `headingUnavailable` notification and restoring it clears the notification and resumes correction; out-of-hull offsets are rejected.
- Headless admin-UI run against the same server: the correcting modes disable when vessel length is absent (with the Vessel Configuration link) and enable with a length set, the status line reflects active/inactive correction, detected rows configure on focus and keep their table position, and Clear reverts a row to detected.

### Images
<img width="1450" height="555" alt="image" src="https://github.com/user-attachments/assets/2165cb6e-22f6-43ab-ac2e-8ae0b8255be1" />
<img width="1435" height="772" alt="image" src="https://github.com/user-attachments/assets/10df00ec-2aa0-4e8d-8c61-fa3502216087" />
<img width="1437" height="812" alt="image" src="https://github.com/user-attachments/assets/4533d6ae-dd00-4ff5-84cc-a88281e89a35" />

Fixes: https://github.com/SignalK/signalk-server/issues/2396
Fixes: https://github.com/SignalK/signalk-server/issues/1285
Relates to: https://github.com/SignalK/signalk-server/issues/987


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds multi-GNSS antenna position configuration to the admin UI and server.

On the frontend, it introduces a new Preferences page route that hosts GNSS antenna position settings. The GNSS settings UI merges configured GNSS sensor rows with live-detected `positionSources`, flags unconfigured sources (including a sidebar/Data-submenu warning badge), and supports inline click-to-edit with draft buffering, bounds/uniqueness validation, and Save/Reset flows that track dirty state and surface/auto-clear save errors. It adds a draggable SVG “Boat schematic” editor to place per-sensor lever-arm offsets (`fromBow`/`fromCenter`), and it removes the legacy GPS base-offset inputs from the Vessel Configuration form. Sidebar navigation is updated to reflect the rename from “Unit Preferences” to “Preferences” and to include the new unconfigured-GNSS warning count.

On the backend, it persists per-sensor lever-arm configuration in settings as `gnssSensors` and adds opt-in `gnssCorrection` modes (`off`, `replace`, `both`). It implements a new v2 self “sensors” API at `/signalk/v2/api/vessels/self/sensors` (documented in OpenAPI/Swagger) with `GET`, `PUT`, and `DELETE` for the `/gnss` endpoint. The `PUT` path validates payload structure and uniqueness (`sensorId`, `$source`), validates lever-arm bounds against vessel length/beam, and applies updates atomically with rollback handling on settings/base-delta write failures; it optionally triggers a restart banner when required. A new admin endpoint exposes active position source refs, and `DeltaCache` maintains freshness-aware `POSITION_SOURCES` emission by canonicalizing source refs, deterministically ordering and caching the last emitted set, and periodically re-emitting when needed. The server also wires a new GNSS lever-arm offset corrector that matches canonicalized `$source` values to configured sensors and, depending on `gnssCorrection`, either rewrites `navigation.position` to the vessel CCRP (`replace`) or preserves the original while emitting companion `<sensorId>.ccrp` updates (`both`). Correction runs only when required inputs are available (notably vessel length and usable true heading) and it publishes/clears a “heading unavailable” status/notification as heading data becomes available. Legacy single-GPS reads remain supported by preferring the first `gnssSensors` row and falling back to existing legacy `sensors.gps` values when no GNSS rows exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->