### PR TITLE
fix: reject revoked tokens instead of downgrading to anonymous read-only

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1067,7 +1067,13 @@ function wrapWithVerifyWS(
           }
         )
       }
-      console.error(error)
+      const identifier =
+        spark.request.skPrincipal?.identifier ||
+        spark.request.connection.remoteAddress ||
+        'unknown'
+      console.error(
+        `WebSocket security error for ${identifier}: ${(error as Error).message}`
+      )
       return
     }
   }

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -1343,14 +1343,18 @@ function tokenSecurityFactory(
       }
     }
 
-    if (!token || error) {
+    if (error) {
+      // Token was provided but is invalid — always reject
+      debug(error.message)
+      throw error
+    }
+
+    if (!token) {
       if (configuration.allow_readonly) {
         req.skPrincipal = { identifier: 'AUTO', permissions: 'readonly' }
         return
       } else {
-        if (!error) {
-          error = new Error('Missing access token')
-        }
+        error = new Error('Missing access token')
         debug(error.message)
         throw error
       }
@@ -1526,19 +1530,12 @@ function tokenSecurityFactory(
               }
             } else {
               debug(`bad token: ${err.message} ${req.path}`)
-              res.clearCookie('JAUTHENTICATION')
             }
 
-            if (configuration.allow_readonly) {
-              skReq.skPrincipal = {
-                identifier: 'AUTO',
-                permissions: 'readonly'
-              }
-              skReq.skIsAuthenticated = false
-              next()
-            } else {
-              res.status(401).send('bad auth token')
-            }
+            // Token was provided but is invalid/revoked — always reject.
+            // allow_readonly only applies when no token is provided at all.
+            res.clearCookie('JAUTHENTICATION')
+            res.status(401).send('bad auth token')
           }
         )
       } else {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><p>When a WebSocket or HTTP request presents an invalid or revoked token, the server previously downgraded the connection to anonymous read-only access (if <code>allow_readonly</code> was enabled). This made it impossible for clients to detect authentication failures — they would silently receive read-only data instead of an error.</p>
<p>This splits the token validation logic so that:</p>
<ul>
<li>A <strong>provided but invalid</strong> token is always rejected with an appropriate error</li>
<li>The <code>allow_readonly</code> fallback only applies when <strong>no token is provided</strong> at all</li>
</ul>
<p>Also improves the WebSocket security error log to include the client identifier (username or remote IP) for easier debugging.</p>
<h2 data-heading="Testing done">Testing done</h2>
<p>Tested against a secured server with <code>allow_readonly: true</code>:</p>

Scenario | Expected | Result
-- | -- | --
No token (anonymous) | 200 — readonly fallback | 200
Invalid token via Authorization: Bearer header | 401 — rejected | 401
Invalid token via JAUTHENTICATION cookie | 401 — rejected | 401
Valid token via Authorization: Bearer header | 200 — authenticated | 200
Tampered JWT (valid format, bad signature) | 401 — rejected | 401

<!--EndFragment-->
</body>
</html>