### PR TITLE
fix: reconnect WebSocket after login/logout in R19 admin UI

### DIFF
--- a/packages/server-admin-ui-react19/src/actions.ts
+++ b/packages/server-admin-ui-react19/src/actions.ts
@@ -23,11 +23,12 @@ export async function logoutAction(): Promise<void> {
     if (!response.ok) {
       throw new Error(response.statusText)
     }
-    await fetchLoginStatus()
   } catch (error) {
     console.error('Logout failed:', error)
-    await fetchLoginStatus()
   }
+  // Reconnect WebSocket so admin event subscriptions are dropped
+  webSocketService.reconnect()
+  await fetchLoginStatus()
 }
 
 export function restartAction(): void {
@@ -63,6 +64,9 @@ export async function loginAction(
   if (request.status !== 200) {
     return response.message
   }
+  // Reconnect WebSocket so the server subscribes the new authenticated
+  // connection to admin events (ACCESS_REQUEST, etc.)
+  webSocketService.reconnect()
   await fetchAllData()
   return null
 }

--- a/packages/server-admin-ui-react19/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui-react19/src/services/WebSocketService.ts
@@ -237,6 +237,9 @@ export class WebSocketService {
       case 'ACCESS_REQUEST':
         this.zustandSetState({ accessRequests: data } as Partial<SignalKStore>)
         break
+      case 'RECEIVE_LOGIN_STATUS':
+        this.zustandSetState({ loginStatus: data } as Partial<SignalKStore>)
+        break
       case 'DISCOVERY_CHANGED':
         this.zustandSetState({
           discoveredProviders: data


### PR DESCRIPTION
After login or logout, the R19 admin UI did not reconnect its WebSocket. This meant the server kept the old authentication state for the connection — an admin who logged in wouldn't receive admin-only events like `ACCESS_REQUEST`, and logging out wouldn't drop those subscriptions until page refresh.

Now the WebSocket is explicitly reconnected after login and logout so the server associates the correct authentication state with event subscriptions.

Also adds handling for the `RECEIVE_LOGIN_STATUS` server event so login state updates are pushed to the UI in real time.

## Testing done

- Verified anonymous WS connection receives hello message
- Verified authenticated WS connection receives server events (`VESSEL_INFO`, `PROVIDERSTATUS`, `SERVERSTATISTICS`, `RECEIVE_LOGIN_STATUS`, etc.)
- Verified WS reconnect flow: disconnect and reconnect with new auth state correctly establishes new server event subscriptions