### PR TITLE
feat: include resolved IP address in mDNS discovery results

### DIFF
--- a/src/discovery.js
+++ b/src/discovery.js
@@ -217,17 +217,9 @@ module.exports.runDiscovery = function (app) {
             !findWSProvider(data.addresses[0], wsType, data.host, data.port)
           ) {
             debug('discoverSignalkWs found data[' + wsType + ']:', data)
-            const providerId =
-              wsType +
-              '-' +
-              data.host +
-              ':' +
-              data.port +
-              ' (' +
-              data.addresses[0] +
-              ')'
+            const id = providerId = `${wsType}-${data.host}:${data.port} (${data.addresses[0]})`
             app.emit('discovered', {
-              id: providerId,
+              id,
               enabled: false,
               pipeElements: [
                 {
@@ -239,9 +231,9 @@ module.exports.runDiscovery = function (app) {
                       host: data.host,
                       port: data.port,
                       address: data.addresses[0],
-                      providerId: providerId
+                      providerId
                     },
-                    providerId: providerId
+                    providerId
                   }
                 }
               ]


### PR DESCRIPTION
Include the resolved IP address from mDNS in the discovered provider ID and pass it as the `address` option in discovery results.

- The provider ID now includes the resolved IP (e.g. `ws-hostname:3000 (192.168.1.5)`) which disambiguates providers that advertise different hostnames but resolve to the same address
- The resolved IP is passed as `address` in the provider options, making it available for direct connections

## Testing done

- Manually tested in my LAN