### PR TITLE
fix: R19 admin UI corrections

### DIFF
--- a/packages/server-admin-ui-react19/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui-react19/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -218,15 +218,17 @@ const ProvidersConfiguration: React.FC = () => {
       })
       setSelectedProvider(null)
       setSelectedIndex(-1)
+      runDiscovery()
     } else {
       const text = await response.text()
       alert(text)
     }
-  }, [selectedProvider, selectedIndex])
+  }, [selectedProvider, selectedIndex, runDiscovery])
 
   const providerClicked = useCallback((provider: Provider, index: number) => {
     setSelectedProvider({
       ...structuredClone(provider),
+      enabled: true,
       originalId: provider.id
     })
     setSelectedIndex(index)

--- a/packages/server-admin-ui-react19/src/views/security/AccessRequests.tsx
+++ b/packages/server-admin-ui-react19/src/views/security/AccessRequests.tsx
@@ -68,7 +68,7 @@ export default function AccessRequests() {
       const payload = {
         permissions: selectedRequest?.permissions || 'readonly',
         config: selectedRequest?.config,
-        expiration: selectedRequest?.expiration || '1y'
+        expiration: selectedRequest?.expiration || 'NEVER'
       }
 
       try {
@@ -208,7 +208,7 @@ export default function AccessRequests() {
                         name="expiration"
                         autoComplete="off"
                         onChange={handleRequestChange}
-                        value={selectedRequest.expiration || ''}
+                        value={selectedRequest.expiration || 'NEVER'}
                       />
                       <Form.Text className="text-muted">
                         Examples: 60s, 1m, 1h, 1d, NEVER
@@ -221,8 +221,7 @@ export default function AccessRequests() {
                     </Col>
                     <Col xs="12" md="8" lg="3">
                       {!selectedRequest.requestedPermissions && (
-                        <Form.Control
-                          type="select"
+                        <Form.Select
                           id="permissions"
                           name="permissions"
                           value={selectedRequest.permissions || 'readonly'}
@@ -231,7 +230,7 @@ export default function AccessRequests() {
                           <option value="readonly">Read Only</option>
                           <option value="readwrite">Read/Write</option>
                           <option value="admin">Admin</option>
-                        </Form.Control>
+                        </Form.Select>
                       )}
                       {selectedRequest.requestedPermissions && (
                         <Form.Label>

--- a/packages/server-admin-ui-react19/src/views/security/Devices.tsx
+++ b/packages/server-admin-ui-react19/src/views/security/Devices.tsx
@@ -213,8 +213,7 @@ export default function Devices() {
                     </Col>
                     <Col xs="12" md="2">
                       {!selectedDevice.requestedPermissions && (
-                        <Form.Control
-                          type="select"
+                        <Form.Select
                           id="permissions"
                           name="permissions"
                           value={selectedDevice.permissions || 'readonly'}
@@ -223,7 +222,7 @@ export default function Devices() {
                           <option value="readonly">Read Only</option>
                           <option value="readwrite">Read/Write</option>
                           <option value="admin">Admin</option>
-                        </Form.Control>
+                        </Form.Select>
                       )}
                       {selectedDevice.requestedPermissions && (
                         <span className="form-control-plaintext">

--- a/packages/server-admin-ui/src/views/security/AccessRequests.js
+++ b/packages/server-admin-ui/src/views/security/AccessRequests.js
@@ -38,7 +38,7 @@ class AccessRequests extends Component {
     var payload = {
       permissions: this.state.selectedRequest.permissions || 'readonly',
       config: this.state.selectedRequest.config,
-      expiration: this.state.selectedRequest.expiration || '1y'
+      expiration: this.state.selectedRequest.expiration || 'NEVER'
     }
 
     fetch(


### PR DESCRIPTION
Several small fixes for the React 19 admin UI:

- **Fix permissions dropdown**: Replace deprecated `Form.Control type="select"` with `Form.Select` (React Bootstrap 5) in Access Requests and Devices views — the dropdown was rendering as a text input instead of a select
- **Default token expiration to NEVER**: Match the server-side default in both R19 and R16 admin UIs (was `1y`)
- **Force discovered providers to enabled**: When clicking a discovered provider in Connections, set `enabled: true` so it's ready to use
- **Re-run discovery after delete**: After deleting a connection, re-run mDNS discovery so the provider reappears in the discovered list without a page reload

## Testing done

- Sent a device access request, verified the permissions dropdown renders as a proper `<select>` element
- Verified expiration field defaults to `NEVER`