### PR TITLE
 fix: pin @module-federation/vite to 1.9.4 to fix CI build

### DIFF
--- a/packages/server-admin-ui-react19/package.json
+++ b/packages/server-admin-ui-react19/package.json
@@ -28,7 +28,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^3.1.1",
-    "@module-federation/vite": "^1.9.4",
+    "@module-federation/vite": "1.9.4",
     "@rjsf/core": "^5.24.13",
     "@rjsf/utils": "^5.24.13",
     "@rjsf/validator-ajv8": "^5.24.13",


### PR DESCRIPTION

## Summary

CI has been failing since March 5 due to a broken upstream release, not due to any code change in this repo.

`@module-federation/dts-plugin@2.1.0` (published 2026-03-05 05:59 UTC) changed its package exports to point at real `.mjs` files that use named ESM imports from `fs-extra`:

```
import fse, { ensureDirSync, existsSync, writeFileSync } from "fs-extra";
```

`fs-extra@9.x` is CJS-only and doesn't provide named ESM exports, so Node.js rejects this at module load time — before Vite even starts. The `dts: false` config doesn't help because Node validates all static imports eagerly regardless of whether the code path executes.

With `package-lock=false`, every `npm install` resolves the latest matching versions. `^1.9.4` resolved to `@module-federation/vite@1.12.0`, which added `@module-federation/dts-plugin@^2.0.1` as a transitive dependency (not present in 1.9.4). That picked up the broken 2.1.0 release.

## Fix

Pin `@module-federation/vite` to exact `1.9.4`. This is the correct dependency for our configuration:

- DTS generation is disabled (`dts: false` in vite.config.js)
- Version 1.9.4 does not depend on `dts-plugin` at all (added in 1.9.5)
- This also removes ~50 unnecessary transitive dependencies (typescript, axios, log4js, etc.) that were pulled in by the unused dts-plugin

The version can be bumped again once the upstream fixes their ESM exports.

## Verification

- `npm run build:all` passes locally
- Last green CI: March 3 21:16 UTC (before dts-plugin 2.1.0 was published)
- First red CI: March 5 06:30 UTC (31 minutes after dts-plugin 2.1.0 was published)