### PR TITLE
fix: filter version list in R19 app store versions modal

### DIFF
--- a/packages/server-admin-ui-react19/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui-react19/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -83,13 +83,13 @@ export default function ActionCellRenderer({
           (v) => !packageData.versions[v].deprecated
         )
 
-        // Default view: last 5 stable releases + all pre-releases above/between them
+        // Default view: last 5 stable releases + only pre-releases newer than latest stable
         const filtered: string[] = []
         let stableCount = 0
         for (const v of nonDeprecated) {
           if (semver.prerelease(v)) {
-            if (stableCount < 5) {
-              filtered.push(v)
+            if (stableCount === 0) {
+              filtered.push(v) // only pre-releases above latest stable
             }
           } else {
             if (stableCount < 5) {


### PR DESCRIPTION
## Summary

- Show only the **last 5 stable releases** and all **pre-releases on top** by default in the Versions modal
- **Hide deprecated versions** entirely (they are never shown)
- Add a **"Show all N versions"** toggle at the bottom for advanced users who need older releases

## Motivation

The Versions modal currently dumps every version ever published to npm — often 100-200+ entries including deprecated and ancient builds. This is overwhelming and makes it easy to accidentally install an unstable version. See #2410.

## Changes

Single file: `packages/server-admin-ui-react19/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx`

- Filter out versions where npm's `deprecated` field is set
- Walk the sorted version list collecting pre-releases and stable releases until 5 stable versions are collected
- Store the full non-deprecated list separately for the "Show all" toggle
- Existing badges (Installed, latest, pre-release) are unchanged

## Images
<img width="805" height="367" alt="image" src="https://github.com/user-attachments/assets/cb944f53-eff3-4cce-be1d-a44e91eb1f27" />
<img width="799" height="592" alt="image" src="https://github.com/user-attachments/assets/02e921a0-d3c8-4c91-93ff-b96c0c1d5870" />
<img width="806" height="418" alt="image" src="https://github.com/user-attachments/assets/f731e8e1-39da-40c8-a22a-62ee5c4ad560" />
<img width="810" height="378" alt="image" src="https://github.com/user-attachments/assets/66398ea3-e7a3-4ad9-97fc-bd6c5dcd2b7f" />
<img width="814" height="598" alt="image" src="https://github.com/user-attachments/assets/9e358896-bd96-4c37-b7d4-4664e22f4ff8" />



Fixes #2410