### PR TITLE
feat: R19 Data Browser multi-term OR search

### DIFF
--- a/packages/server-admin-ui-react19/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui-react19/src/views/DataBrowser/DataBrowser.tsx
@@ -44,6 +44,17 @@ const searchStorageKey = 'admin.v1.dataBrowser.search'
 const selectedSourcesStorageKey = 'admin.v1.dataBrowser.selectedSources'
 const sourceFilterActiveStorageKey = 'admin.v1.dataBrowser.sourceFilterActive'
 
+function matchesSearch(key: string, search: string): boolean {
+  if (!search || search.length === 0) return true
+  const lowerKey = key.toLowerCase()
+  const terms = search
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+  if (terms.length === 0) return true
+  return terms.some((term) => lowerKey.includes(term))
+}
+
 interface DeltaMessage {
   context?: string
   updates?: Array<{
@@ -398,10 +409,8 @@ const DataBrowser: React.FC = () => {
     for (const ctx of contexts) {
       const contextData = currentData[ctx] || {}
       for (const key of Object.keys(contextData)) {
-        if (deferredSearch && deferredSearch.length > 0) {
-          if (key.toLowerCase().indexOf(deferredSearch.toLowerCase()) === -1) {
-            continue
-          }
+        if (!matchesSearch(key, deferredSearch)) {
+          continue
         }
 
         if (sourceFilterActive && selectedSources.size > 0) {
@@ -519,10 +528,8 @@ const DataBrowser: React.FC = () => {
     for (const ctx of contexts) {
       const contextData = currentData[ctx] || {}
       for (const key of Object.keys(contextData)) {
-        if (search && search.length > 0) {
-          if (key.toLowerCase().indexOf(search.toLowerCase()) === -1) {
-            continue
-          }
+        if (!matchesSearch(key, search)) {
+          continue
         }
         const data = contextData[key] as PathData | undefined
         const path = data?.path || key
@@ -648,6 +655,7 @@ const DataBrowser: React.FC = () => {
                     id="databrowser-search"
                     name="search"
                     autoComplete="off"
+                    placeholder="e.g. pos wind (space = OR)"
                     onChange={handleSearch}
                     value={search}
                   />


### PR DESCRIPTION
## Summary

The Data Browser search now supports multiple search terms separated by spaces, where each term acts as an OR filter.

Typing `pos wind` shows all paths matching either `pos` or `wind` — making it easy to quickly filter for unrelated path groups without multiple searches.

## What changed

- Added a `matchesSearch` helper that splits the search input on whitespace and matches if **any** term is a substring of the path key (case-insensitive)
- Applied to both the Data table and Meta table filter paths
- Added a placeholder hint to the search input: `e.g. pos wind (space = OR)`
- Single-term searches behave exactly as before — no breaking change

## Tested

- Manual test of vaious search patterns in data browser and meta data
## Image
<img width="1123" height="553" alt="image" src="https://github.com/user-attachments/assets/34ddfbd6-6a61-45c6-b572-6ef8c08fe9b5" />
