### PR TITLE
chore: use just tag in container image tracking

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -269,7 +269,7 @@ jobs:
               "docker://${REGISTRY}@${DIGEST}" | \
               jq '[.layers[].size] | add')
 
-            echo "${TIMESTAMP},${COMMIT},${TAG},${SIZE}" >> "$CSV"
+            echo "${TIMESTAMP},${COMMIT},${TAG%-${RUN_ID}},${SIZE}" >> "$CSV"
           done
       - name: Commit and push
         run: |


### PR DESCRIPTION
- use just tag without RUN_ID