### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Default: normalize line endings to LF in the repo, auto-detect on checkout
+* text=auto eol=lf
+
+# Force LF for files that must never be CRLF
+*.sh text eol=lf
+*.bash text eol=lf
+*.json text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+*.conf text eol=lf
+Dockerfile text eol=lf
+
+# Binary files — do not normalize
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
## Summary

Adds a `.gitattributes` file to enforce LF line endings at the Git level, ensuring consistent line endings regardless of the contributor's OS or local Git configuration.

## Motivation

Contributors working across multiple platforms (macOS, Windows, WSL2, Linux) risk pushing CRLF line endings if they forget to set `core.autocrlf` in each new environment or VM. The existing `.editorconfig` specifies `end_of_line = lf`, but not all tools respect it — Git itself does not read `.editorconfig`.

A `.gitattributes` file is the standard, reliable way to solve this: it travels with the repo, applies automatically on clone, and requires zero per-machine configuration.

## What this does

- Normalizes all text files to LF in the repository
- Explicitly marks shell scripts, source files, and config files as LF
- Marks common binary formats to prevent corruption
- No existing files are renormalized in this commit