### PR TITLE
fix: guard against ENOENT when deleting debug persistence file

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -101,7 +101,7 @@ module.exports = function (app) {
       if (debugPath) {
         if (enabled) {
           fs.writeFileSync(debugPath, debugEnabled)
-        } else {
+        } else if (fs.existsSync(debugPath)) {
           fs.unlinkSync(debugPath)
         }
       }


### PR DESCRIPTION
When "Persist debug settings over server restarts" is turned off,
logging.js called `fs.unlinkSync(debugPath)` unconditionally. If the
debug file did not exist, unlinkSync threw `ENOENT`. The exception
prevented `rememberDebug` from being set to false and the DEBUG_SETTINGS
event from being emitted, leaving the server in an inconsistent state.

Fix by checking `fs.existsSync` before calling `unlinkSync`.

Related: see issue https://github.com/SignalK/signalk-server/issues/2422 for the broader discussion on
debug persistence mechanisms.