### PR TITLE
fix: Add root-level `plugin-config-data/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ settings/ssl-cert.pem
 *.tgz
 work/
 data/
+plugin-config-data/
 unitpreferences/custom-units-definitions.json
 unitpreferences/custom/
 unitpreferences/presets/custom/


### PR DESCRIPTION
## Summary

Running `npm test` creates a `plugin-config-data/` directory at the repository root (with kip plugin SQLite files), which then shows up as untracked in `git status`.

The test-specific subdirectories (`test/plugin-test-config/plugin-config-data/` and `test/server-test-config/plugin-config-data/`) are already ignored, but the root-level directory was missed.

## Steps to reproduce

```bash
git clone https://github.com/SignalK/signalk-server.git fresh
cd fresh
npm install
npm run build:all
npm run test
git status
# shows: plugin-config-data/
```

## Fix

Add `plugin-config-data/` to `.gitignore` alongside the other data directories (`work/`, `data/`).