### PR TITLE
fix: Skip CI/CD workflows on forks

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-images:
+    if: github.repository == 'SignalK/signalk-server'
     name: Ubuntu base image
     strategy:
       matrix:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   signalk-server_npm_files:
+    if: github.repository == 'SignalK/signalk-server'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build_and_publish:
+    if: github.repository == 'SignalK/signalk-server'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   security-scan:
+    if: github.repository == 'SignalK/signalk-server'
     name: Security Scan
     runs-on: ubuntu-24.04
     strategy:


### PR DESCRIPTION
## Summary

Contributor forks that sync master get failing GitHub Actions runs because scheduled and push-triggered workflows attempt to use secrets and permissions that are only available on the upstream repository.

This adds `if: github.repository == 'SignalK/signalk-server'` to the first job of 4 workflows:

- **build-base-image.yml** — weekly scheduled Docker base image builds
- **security-scan.yml** — weekly scheduled Trivy security scans
- **build-docker.yml** — Docker dev container builds on push to master
- **release.yml** — release publishing on version tags

`test.yml` and `require_pr_label.yml` are intentionally **not** changed — CI tests and PR label checks should continue to work on forks/PRs.

## Steps to reproduce

```bash
# Fork the repo, sync master, then check Actions tab
# Scheduled workflows fail with permission/secret errors
```

Examples: [https://github.com/dirkwa/signalk-server/actions/runs/22835017906](https://github.com/dirkwa/signalk-server/actions/runs/22835017906)