### PR TITLE
fix: respect forLoginStatus flag in bad-token branch of http_authorize

### DIFF
--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -1535,6 +1535,10 @@ function tokenSecurityFactory(
             // Token was provided but is invalid/revoked — always reject.
             // allow_readonly only applies when no token is provided at all.
             res.clearCookie('JAUTHENTICATION')
+            if (forLoginStatus) {
+              skReq.skIsAuthenticated = false
+              return next()
+            }
             res.status(401).send('bad auth token')
           }
         )


### PR DESCRIPTION
## Summary

Fixes #2427

PR #2401 correctly made `http_authorize` reject invalid/revoked tokens with `401 'bad auth token'` instead of silently granting read-only access. However, the bad-token branch unconditionally returns 401 — even for the `/loginStatus` endpoint, which passes `forLoginStatus=true`.

The no-token branch already respects `forLoginStatus` and calls `next()` so `getLoginStatus()` can run. The bad-token branch did not, causing the Admin UI to get a silent 401, never populate its Redux login state, and render blank instead of redirecting to the login page.

## Fix

After clearing the bad cookie, check `forLoginStatus` before returning 401. When true, set `skIsAuthenticated = false` and call `next()` so `getLoginStatus()` returns `{ status: 'notLoggedIn', authenticationRequired: true }` — exactly what the Admin UI needs to redirect to login.

The security guarantee from #2401 is fully preserved for all other endpoints.

## Manually tested

- Start server with security enabled
- Log in to Admin UI, confirm normal operation
- Mangle the `JAUTHENTICATION` cookie in browser devtools
- Reload — Admin UI redirects to login page (previously showed blank/broken state)
- Verify `curl -H 'Cookie: JAUTHENTICATION=garbage' /skServer/plugins` still returns 401