### PR TITLE
fix: filter bundled Admin UI packages from Appstore and Webapps list

### DIFF
--- a/packages/server-admin-ui-react19/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui-react19/src/views/Webapps/Webapps.tsx
@@ -48,7 +48,9 @@ export default function Webapps() {
           <div className="row">
             {webapps
               .filter(
-                (webAppInfo) => webAppInfo.name !== '@signalk/server-admin-ui'
+                (webAppInfo) =>
+                  webAppInfo.name !== '@signalk/server-admin-ui' &&
+                  webAppInfo.name !== '@signalk/server-admin-ui-react19'
               )
               .map((webAppInfo) => {
                 return (

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.js
@@ -40,7 +40,9 @@ class Webapps extends Component {
             <div className="row">
               {this.props.webapps
                 .filter(
-                  (webAppInfo) => webAppInfo.name !== '@signalk/server-admin-ui'
+                  (webAppInfo) =>
+                    webAppInfo.name !== '@signalk/server-admin-ui' &&
+                    webAppInfo.name !== '@signalk/server-admin-ui-react19'
                 )
                 .map((webAppInfo) => {
                   return (

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -31,6 +31,11 @@ const {
 const { SERVERROUTESPREFIX } = require('../constants')
 const { getCategories, getAvailableCategories } = require('../categories')
 
+const bundledAdminUIs = [
+  '@signalk/server-admin-ui',
+  '@signalk/server-admin-ui-react19'
+]
+
 const npmServerInstallLocations = [
   '/usr/bin/signalk-server',
   '/usr/lib/node_modules/signalk-server/bin/signalk-server',
@@ -153,7 +158,10 @@ module.exports = function (app) {
       findModulesWithKeyword('signalk-embeddable-webapp'),
       findModulesWithKeyword('signalk-webapp')
     ]).then(([plugins, embeddableWebapps, webapps]) => {
-      const allWebapps = [].concat(embeddableWebapps).concat(webapps)
+      const allWebapps = []
+        .concat(embeddableWebapps)
+        .concat(webapps)
+        .filter((m) => !bundledAdminUIs.includes(m.package.name))
       return [
         plugins,
         _.uniqBy(allWebapps, (plugin) => {


### PR DESCRIPTION
## Summary

Fixes #2428

The Admin UI packages (`@signalk/server-admin-ui`, `@signalk/server-admin-ui-react19`) are bundled with the server and tightly coupled to its version. Installing or updating them independently via the Appstore breaks the Admin UI with MIME type errors, since the assets are served via the server's built-in static routes rather than from a standalone `node_modules` install.

This PR filters both packages at two levels:

- **Server-side** (`appstore.js`): filters them from NPM search results in `findPluginsAndWebapps()`, so they never appear in the Appstore (available, updates, or installing)
- **Client-side** (`Webapps.js` / `Webapps.tsx`): extends the existing filter in the installed Webapps list to also hide `@signalk/server-admin-ui-react19` (previously only the old UI was filtered)

## Tested manually in R16 and R19 

- Start server, open Admin UI
- Go to Appstore → Webapps tab — neither `server-admin-ui` nor `server-admin-ui-react19` should appear
- Go to Webapps page — neither admin UI should be listed
- Other webapps and plugins remain unaffected