### PR TITLE
feat: add conversion formulas to active preset and bulk metadata endpoint  

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -57,6 +57,41 @@ function enhanceMetadataResponse(metadata, signalkPath, username) {
   return metadata
 }
 
+const SKIP_KEYS = new Set([
+  'value',
+  'meta',
+  '$source',
+  'timestamp',
+  'pgn',
+  'sentence',
+  'values'
+])
+
+function enhanceTreeMetadata(node, pathParts, username) {
+  if (node === null || typeof node !== 'object') return
+  if (node.meta) {
+    const signalkPath = pathParts.join('.')
+    enhanceMetadataResponse(node.meta, signalkPath, username)
+  }
+  for (const key in node) {
+    if (!SKIP_KEYS.has(key)) {
+      enhanceTreeMetadata(node[key], pathParts.concat(key), username)
+    }
+  }
+}
+
+function collectMeta(node, pathParts, result) {
+  if (node === null || typeof node !== 'object') return
+  if (node.meta) {
+    result[pathParts.join('.')] = node.meta
+  }
+  for (const key in node) {
+    if (!SKIP_KEYS.has(key)) {
+      collectMeta(node[key], pathParts.concat(key), result)
+    }
+  }
+}
+
 const iso8601rexexp =
   /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?Z$/
 
@@ -88,6 +123,31 @@ module.exports = function (app) {
           return
         }
 
+        // GET /vessels/<id>/meta — return all metadata for a vessel
+        if (path.length === 3 && path[0] === 'vessels' && path[2] === 'meta') {
+          const vesselId = path[1] === 'self' ? app.selfId : path[1]
+          const vesselPath = ['vessels', vesselId]
+          let full
+          if (app.securityStrategy.anyACLs()) {
+            full = app.deltaCache.buildFull(req.skPrincipal, vesselPath)
+          } else {
+            full = app.signalk.retrieve()
+          }
+          const vessel = full?.vessels?.[vesselId]
+          if (vessel) {
+            const result = {}
+            const username = req.skPrincipal?.identifier
+            collectMeta(vessel, [], result)
+            for (const [skPath, meta] of Object.entries(result)) {
+              enhanceMetadataResponse(meta, skPath, username)
+            }
+            res.json(result)
+          } else {
+            next()
+          }
+          return
+        }
+
         if (path.length > 4 && path[path.length - 1] === 'meta') {
           const metaPath = path.slice(0, path.length - 1).join('.')
           const meta = getMetadata(metaPath)
@@ -115,15 +175,33 @@ module.exports = function (app) {
 
         function sendResult(last, aPath) {
           if (last) {
+            const traversedPath = []
             for (const i in aPath) {
               const p = aPath[i]
 
               if (typeof last[p] !== 'undefined') {
+                traversedPath.push(p)
                 last = last[p]
               } else {
                 next()
                 return
               }
+            }
+
+            // Inject displayUnits into meta objects throughout the tree.
+            // Strip the vessels.<id> prefix to get signalk-relative paths.
+            if (
+              traversedPath[0] === 'vessels' ||
+              aPath[0] === 'vessels' ||
+              aPath.length === 0
+            ) {
+              const username = req.skPrincipal?.identifier
+              let baseParts = traversedPath.slice()
+              // Remove vessels.<id> prefix if present
+              if (baseParts[0] === 'vessels' && baseParts.length >= 2) {
+                baseParts = baseParts.slice(2)
+              }
+              enhanceTreeMetadata(last, baseParts, username)
             }
           } else {
             next()

--- a/src/interfaces/unitpreferences-api.js
+++ b/src/interfaces/unitpreferences-api.js
@@ -435,7 +435,24 @@ module.exports = function (app) {
   router.get('/active', (req, res) => {
     try {
       const preset = getActivePreset()
-      res.json(preset)
+      const definitions = getMergedDefinitions()
+      const result = {
+        ...preset,
+        categories: { ...preset.categories }
+      }
+      for (const [category, catDef] of Object.entries(result.categories)) {
+        const unitDef = definitions[catDef.baseUnit]
+        const conversion = unitDef?.conversions?.[catDef.targetUnit]
+        if (conversion) {
+          result.categories[category] = {
+            ...catDef,
+            formula: conversion.formula,
+            inverseFormula: conversion.inverseFormula,
+            symbol: conversion.symbol
+          }
+        }
+      }
+      res.json(result)
     } catch (err) {
       debug('Error getting active preset:', err)
       res.status(500).json({ error: 'Failed to get active preset' })


### PR DESCRIPTION
**Description:**                                                                                     
              
  **Summary**                                                                                          
                                                                                                   
  - Enhance GET /signalk/v1/unitpreferences/active to include formula, inverseFormula, and symbol  
  from unit definitions for each category
  - Add GET /signalk/v1/api/vessels/<id>/meta endpoint that returns all metadata for a vessel as a 
  flat path-keyed map with displayUnits resolved                                                   
  - Inject displayUnits into meta objects throughout the vessel tree for GET 
  /signalk/v1/api/vessels/self responses                                                           
              
  Motivation                                                                                       
              
  REST clients (like Freeboard-SK) previously had no single endpoint to get all paths with resolved
   display unit preferences and conversion formulas. displayUnits was only available per-path or
  via WebSocket sendMeta=all. These changes close that gap.        