### PR TITLE
feat: add radius parameter for spatial filtering for history api and expanded response api spatial queries using history api v2 style 

### DIFF
--- a/docs/develop/rest-api/history_api.md
+++ b/docs/develop/rest-api/history_api.md
@@ -32,13 +32,67 @@ HTTP GET 'http://hostname:3000/signalk/v2/api/history/values?paths=navigation.sp
 
 | Parameter    | Description                                                                                                                                                                                                                                                                                                                 | Required |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `paths`      | Comma separated list of Signal K paths whose data should be retrieved. Optional aggregation methods for each path as postfix separated by a colon. Aggregation methods: 'average' \| 'min' \| 'max' \| 'first' \| 'last' \| 'mid' \| 'middle_index'. Example: `navigation.speedOverGround,navigation.speedThroughWater:max` | Yes      |
+| `paths`      | Comma separated list of path expressions. See [Path Expressions](#path-expressions) below.                                                                                                                                                                                                                                  | Yes      |
 | `context`    | Signal K context that the data is about, defaults to 'vessels.self'. Example: `vessels.urn:mrn:imo:mmsi:123456789`                                                                                                                                                                                                          | No       |
 | `resolution` | Length of data sample time window in milliseconds or as a time expression ('1s', '1m', '1h', '1d'). If resolution is not specified the server should provide data in a reasonable time resolution, depending on the time range in the request.                                                                              | No       |
+| `bbox`       | Bounding box for spatial filtering: `west,south,east,north` in decimal degrees. Only returns data from positions within the box. Mutually exclusive with `radius` and `distance`/`position`.                                                                                                                                | No       |
+| `radius`     | Radius-based spatial filter: `longitude,latitude,meters`. Only returns data from positions within the specified distance of the center point. Mutually exclusive with `bbox` and `distance`/`position`.                                                                                                                     | No       |
+| `distance`   | Distance in meters for radius-based spatial filtering (resources API compatible). Use with `position` to specify the center point; if `position` is omitted the provider may default to the vessel's current position. Mutually exclusive with `radius` and `bbox`.                                                         | No       |
+| `position`   | Center point for distance-based spatial filtering as `[longitude,latitude]` (JSON array) or `longitude,latitude`. Used with `distance`. Resources API compatible.                                                                                                                                                           | No       |
 | `from`       | Start of the time range                                                                                                                                                                                                                                                                                                     | No       |
 | `to`         | End of the time range                                                                                                                                                                                                                                                                                                       | No       |
 | `duration`   | Duration of the time range                                                                                                                                                                                                                                                                                                  | No       |
 | `provider`   | Plugin id of the history provider to direct the request to. If not specified, the default provider is used. See [Providers](#providers).                                                                                                                                                                                    | No       |
+
+### Path Expressions
+
+Each path expression uses colon-separated segments:
+
+| Format | Description |
+| ------ | ----------- |
+| `path` | Path with default `average` aggregation |
+| `path:aggregate` | Path with specified aggregation method |
+| `path:aggregate:param` | Path with aggregation method and parameter (e.g. `sma:5` for 5-sample SMA) |
+| `path:aggregate:smoothing:param` | Path with aggregation and post-aggregation smoothing |
+
+**Aggregation methods:** `average`, `min`, `max`, `first`, `last`, `mid`, `middle_index`, `sma`, `ema`
+
+The 3-segment form uses the smoothing method (`sma`/`ema`) as the primary aggregation. The 4-segment form applies aggregation first, then smooths the result — for example, `navigation.speedOverGround:average:sma:5` computes bucket averages then applies a 5-sample Simple Moving Average.
+
+**Smoothing methods** (4-segment only):
+- `sma` — Simple Moving Average, parameter is the number of samples (e.g. `sma:5`)
+- `ema` — Exponential Moving Average, parameter is the alpha value 0–1 (e.g. `ema:0.3`)
+
+_Examples:_
+
+```
+paths=navigation.speedOverGround:average
+paths=navigation.speedOverGround:sma:5
+paths=navigation.speedOverGround:average:sma:5
+paths=navigation.speedOverGround:average:sma:5,navigation.speedThroughWater:max
+```
+
+### Spatial Filtering
+
+Use `bbox` or `radius` to limit results to data recorded within a geographic area. These are mutually exclusive — the server returns HTTP 400 if conflicting params are specified.
+
+There are two styles for radius queries:
+
+- **History API style:** `radius=longitude,latitude,meters`
+- **Resources API style:** `distance=meters&position=[longitude,latitude]` (or `position=longitude,latitude`)
+
+Both produce identical results. The `distance`/`position` style matches the [resources API](../resources_api.md) convention. If `distance` is provided without `position`, the provider may default to the vessel's current position.
+
+_Examples:_
+
+```
+bbox=-80,25,-79,26
+radius=-79.5,25.5,5000
+distance=5000&position=[-79.5,25.5]
+distance=5000&position=-79.5,25.5
+```
+
+> [!NOTE] Spatial filtering requires provider support. The server parses and validates these parameters then passes them to the provider.
 
 ### Response Format
 

--- a/docs/develop/rest-api/history_api.md
+++ b/docs/develop/rest-api/history_api.md
@@ -30,36 +30,37 @@ HTTP GET 'http://hostname:3000/signalk/v2/api/history/values?paths=navigation.sp
 
 ### Query Parameters
 
-| Parameter    | Description                                                                                                                                                                                                                                                                                                                 | Required |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `paths`      | Comma separated list of path expressions. See [Path Expressions](#path-expressions) below.                                                                                                                                                                                                                                  | Yes      |
-| `context`    | Signal K context that the data is about, defaults to 'vessels.self'. Example: `vessels.urn:mrn:imo:mmsi:123456789`                                                                                                                                                                                                          | No       |
-| `resolution` | Length of data sample time window in milliseconds or as a time expression ('1s', '1m', '1h', '1d'). If resolution is not specified the server should provide data in a reasonable time resolution, depending on the time range in the request.                                                                              | No       |
-| `bbox`       | Bounding box for spatial filtering: `west,south,east,north` in decimal degrees. Only returns data from positions within the box. Mutually exclusive with `radius` and `distance`/`position`.                                                                                                                                | No       |
-| `radius`     | Radius-based spatial filter: `longitude,latitude,meters`. Only returns data from positions within the specified distance of the center point. Mutually exclusive with `bbox` and `distance`/`position`.                                                                                                                     | No       |
-| `distance`   | Distance in meters for radius-based spatial filtering (resources API compatible). Use with `position` to specify the center point; if `position` is omitted the provider may default to the vessel's current position. Mutually exclusive with `radius` and `bbox`.                                                         | No       |
-| `position`   | Center point for distance-based spatial filtering as `[longitude,latitude]` (JSON array) or `longitude,latitude`. Used with `distance`. Resources API compatible.                                                                                                                                                           | No       |
-| `from`       | Start of the time range                                                                                                                                                                                                                                                                                                     | No       |
-| `to`         | End of the time range                                                                                                                                                                                                                                                                                                       | No       |
-| `duration`   | Duration of the time range                                                                                                                                                                                                                                                                                                  | No       |
-| `provider`   | Plugin id of the history provider to direct the request to. If not specified, the default provider is used. See [Providers](#providers).                                                                                                                                                                                    | No       |
+| Parameter    | Description                                                                                                                                                                                                                                                         | Required |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `paths`      | Comma separated list of path expressions. See [Path Expressions](#path-expressions) below.                                                                                                                                                                          | Yes      |
+| `context`    | Signal K context that the data is about, defaults to 'vessels.self'. Example: `vessels.urn:mrn:imo:mmsi:123456789`                                                                                                                                                  | No       |
+| `resolution` | Length of data sample time window in milliseconds or as a time expression ('1s', '1m', '1h', '1d'). If resolution is not specified the server should provide data in a reasonable time resolution, depending on the time range in the request.                      | No       |
+| `bbox`       | Bounding box for spatial filtering: `west,south,east,north` in decimal degrees. Only returns data from positions within the box. Mutually exclusive with `radius` and `distance`/`position`.                                                                        | No       |
+| `radius`     | Radius-based spatial filter: `longitude,latitude,meters`. Only returns data from positions within the specified distance of the center point. Mutually exclusive with `bbox` and `distance`/`position`.                                                             | No       |
+| `distance`   | Distance in meters for radius-based spatial filtering (resources API compatible). Use with `position` to specify the center point; if `position` is omitted the provider may default to the vessel's current position. Mutually exclusive with `radius` and `bbox`. | No       |
+| `position`   | Center point for distance-based spatial filtering as `[longitude,latitude]` (JSON array) or `longitude,latitude`. Used with `distance`. Resources API compatible.                                                                                                   | No       |
+| `from`       | Start of the time range                                                                                                                                                                                                                                             | No       |
+| `to`         | End of the time range                                                                                                                                                                                                                                               | No       |
+| `duration`   | Duration of the time range                                                                                                                                                                                                                                          | No       |
+| `provider`   | Plugin id of the history provider to direct the request to. If not specified, the default provider is used. See [Providers](#providers).                                                                                                                            | No       |
 
 ### Path Expressions
 
 Each path expression uses colon-separated segments:
 
-| Format | Description |
-| ------ | ----------- |
-| `path` | Path with default `average` aggregation |
-| `path:aggregate` | Path with specified aggregation method |
-| `path:aggregate:param` | Path with aggregation method and parameter (e.g. `sma:5` for 5-sample SMA) |
-| `path:aggregate:smoothing:param` | Path with aggregation and post-aggregation smoothing |
+| Format                           | Description                                                                |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| `path`                           | Path with default `average` aggregation                                    |
+| `path:aggregate`                 | Path with specified aggregation method                                     |
+| `path:aggregate:param`           | Path with aggregation method and parameter (e.g. `sma:5` for 5-sample SMA) |
+| `path:aggregate:smoothing:param` | Path with aggregation and post-aggregation smoothing                       |
 
 **Aggregation methods:** `average`, `min`, `max`, `first`, `last`, `mid`, `middle_index`, `sma`, `ema`
 
 The 3-segment form uses the smoothing method (`sma`/`ema`) as the primary aggregation. The 4-segment form applies aggregation first, then smooths the result — for example, `navigation.speedOverGround:average:sma:5` computes bucket averages then applies a 5-sample Simple Moving Average.
 
 **Smoothing methods** (4-segment only):
+
 - `sma` — Simple Moving Average, parameter is the number of samples (e.g. `sma:5`)
 - `ema` — Exponential Moving Average, parameter is the alpha value 0–1 (e.g. `ema:0.3`)
 

--- a/docs/develop/rest-api/resources_api.md
+++ b/docs/develop/rest-api/resources_api.md
@@ -59,7 +59,15 @@ _Example 3: Retrieve waypoints within a bounded area. Note: the bounded area is 
 HTTP GET 'http://hostname:3000/signalk/v2/api/resources/waypoints?bbox=[-135.5,38,-134,38.5]'
 ```
 
-_Example 4: Return notes for display on a map view at zoom level 5._
+_Example 4: Retrieve waypoints within 5km of a specific point using `radius`. Note: the value is three comma-separated numbers in the form longitude,latitude,meters._
+
+```typescript
+HTTP GET 'http://hostname:3000/signalk/v2/api/resources/waypoints?radius=-135.5,38,5000'
+```
+
+The `radius` parameter is an alternative to `distance`+`position` and is mutually exclusive with `bbox`.
+
+_Example 5: Return notes for display on a map view at zoom level 5._
 
 ```typescript
 HTTP GET 'http://hostname:3000/signalk/v2/api/resources/notes?zoom=5'

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -151,6 +151,16 @@ export const processParameters = (params: any) => {
         `Bounding box contains invalid coordinate value (${params.bbox})`
       )
     }
+  } else if (typeof params.radius === 'string') {
+    const parts = params.radius.split(',').map(Number)
+    if (parts.length !== 3 || parts.some(isNaN)) {
+      throw new Error(
+        'radius must be three comma-separated numbers: longitude,latitude,meters'
+      )
+    }
+    const sw = computeDestinationPoint([parts[0], parts[1]], parts[2], 225)
+    const ne = computeDestinationPoint([parts[0], parts[1]], parts[2], 45)
+    params.geobounds = toPolygon([sw.longitude, sw.latitude, ne.longitude, ne.latitude])
   } else if (typeof params.distance !== 'undefined' && params.position) {
     params.distance = checkForNumber(params.distance)
     params.position = checkForNumberArray(params.position)

--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -103,6 +103,10 @@ export type TimeRangeQueryParams =
 export type ValuesRequestQueryParams = TimeRangeQueryParams & {
   context?: string
   resolution?: number
+  bbox?: string
+  radius?: string
+  distance?: string
+  position?: string
 }
 
 export type PathsRequestQueryParams = TimeRangeQueryParams
@@ -230,12 +234,18 @@ export interface PathSpec {
   path: Path
   aggregate: AggregateMethod
   parameter: string[]
+  smoothing?: {
+    method: 'sma' | 'ema'
+    parameter: string
+  }
 }
 
 export type ValuesRequest = TimeRangeParams & {
   context?: Context
   resolution?: number
   pathSpecs: PathSpec[]
+  bbox?: { west: number; south: number; east: number; north: number }
+  radius?: { longitude: number; latitude: number; distance: number }
 }
 
 export type PathsRequest = TimeRangeParams

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -261,7 +261,9 @@ async function respondWith<T>(
   }
 }
 
-export const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
+export const parseValuesQuery = (
+  query: Record<string, unknown>
+): ValuesRequest => {
   const { timeRangeParams, errors } = parseTimeRangeParams(query)
 
   const context = query.context as Context | undefined
@@ -300,7 +302,12 @@ export const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest 
         'bbox must be four comma-separated numbers: west,south,east,north'
       )
     } else {
-      bbox = { west: parts[0], south: parts[1], east: parts[2], north: parts[3] }
+      bbox = {
+        west: parts[0],
+        south: parts[1],
+        east: parts[2],
+        north: parts[3]
+      }
     }
   }
 

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -261,7 +261,7 @@ async function respondWith<T>(
   }
 }
 
-const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
+export const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
   const { timeRangeParams, errors } = parseTimeRangeParams(query)
 
   const context = query.context as Context | undefined
@@ -270,6 +270,72 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
   const paths = query.paths as string
   if (!paths) {
     errors.push('paths parameter is required and must be a string')
+  }
+
+  const bboxStr = Array.isArray(query.bbox)
+    ? (query.bbox as string[]).join(',')
+    : (query.bbox as string | undefined)
+  const radiusStr = Array.isArray(query.radius)
+    ? (query.radius as string[]).join(',')
+    : (query.radius as string | undefined)
+
+  const distanceStr = query.distance as string | undefined
+  const positionStr = query.position as string | undefined
+
+  if (radiusStr && (distanceStr || positionStr)) {
+    errors.push('radius and distance/position are mutually exclusive')
+  }
+
+  if (bboxStr && (radiusStr || distanceStr || positionStr)) {
+    errors.push('bbox and radius/distance are mutually exclusive')
+  }
+
+  let bbox:
+    | { west: number; south: number; east: number; north: number }
+    | undefined
+  if (bboxStr) {
+    const parts = bboxStr.split(',').map(Number)
+    if (parts.length !== 4 || parts.some(isNaN)) {
+      errors.push(
+        'bbox must be four comma-separated numbers: west,south,east,north'
+      )
+    } else {
+      bbox = { west: parts[0], south: parts[1], east: parts[2], north: parts[3] }
+    }
+  }
+
+  let radius:
+    | { longitude: number; latitude: number; distance: number }
+    | undefined
+  if (radiusStr) {
+    const parts = radiusStr.split(',').map(Number)
+    if (parts.length !== 3 || parts.some(isNaN)) {
+      errors.push(
+        'radius must be three comma-separated numbers: longitude,latitude,meters'
+      )
+    } else {
+      radius = {
+        longitude: parts[0],
+        latitude: parts[1],
+        distance: parts[2]
+      }
+    }
+  } else if (distanceStr) {
+    const distance = Number(distanceStr)
+    if (isNaN(distance)) {
+      errors.push('distance must be a number (meters)')
+    } else if (positionStr) {
+      const coords = parsePosition(positionStr)
+      if (!coords) {
+        errors.push(
+          'position must be two comma-separated numbers or a JSON array: [lon,lat] or lon,lat'
+        )
+      } else {
+        radius = { longitude: coords[0], latitude: coords[1], distance }
+      }
+    } else {
+      radius = { longitude: NaN, latitude: NaN, distance }
+    }
   }
 
   if (errors.length > 0) {
@@ -281,14 +347,36 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
     .split(',')
   const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression)
 
-  const parsed = {
+  const parsed: ValuesRequest = {
     ...timeRangeParams,
     context,
     resolution,
-    pathSpecs
+    pathSpecs,
+    ...(bbox && { bbox }),
+    ...(radius && { radius })
   }
   debug(JSON.stringify(parsed, null, 2))
   return parsed
+}
+
+const parsePosition = (value: string): [number, number] | null => {
+  let lon: number
+  let lat: number
+  try {
+    const parsed = JSON.parse(value)
+    if (Array.isArray(parsed) && parsed.length === 2) {
+      lon = Number(parsed[0])
+      lat = Number(parsed[1])
+      if (!isNaN(lon) && !isNaN(lat)) return [lon, lat]
+    }
+  } catch {
+    // not JSON, try comma-separated
+  }
+  const parts = value.split(',').map(Number)
+  if (parts.length === 2 && !parts.some(isNaN)) {
+    return [parts[0], parts[1]]
+  }
+  return null
 }
 
 const getMaybeNumber = (value: unknown): number | undefined => {
@@ -297,20 +385,34 @@ const getMaybeNumber = (value: unknown): number | undefined => {
   return undefined
 }
 
-const splitPathExpression = (pathExpression: string): PathSpec => {
+export const SMOOTHING_METHODS = ['sma', 'ema'] as const
+type SmoothingMethod = (typeof SMOOTHING_METHODS)[number]
+
+const isSmoothingMethod = (value: string): value is SmoothingMethod =>
+  SMOOTHING_METHODS.includes(value as SmoothingMethod)
+
+export const splitPathExpression = (pathExpression: string): PathSpec => {
   const parts = pathExpression.split(':')
   let aggregateMethod = (parts[1] || 'average') as AggregateMethod
   if (parts[0] === 'navigation.position') {
     aggregateMethod = 'first' as AggregateMethod
   }
 
-  // Extract all parameters from parts[2] onwards
-  const parameters: string[] = parts.slice(2).filter((p) => p.length > 0)
-
   const pathSpec: PathSpec = {
     path: parts[0] as Path,
     aggregate: aggregateMethod,
-    parameter: parameters
+    parameter: []
+  }
+
+  if (parts.length === 4 && isSmoothingMethod(parts[2])) {
+    // 4-segment: path:aggregate:smoothing:param
+    pathSpec.smoothing = {
+      method: parts[2],
+      parameter: parts[3]
+    }
+  } else {
+    // 3-segment or fewer: path:aggregate:param...
+    pathSpec.parameter = parts.slice(2).filter((p) => p.length > 0)
   }
 
   return pathSpec

--- a/src/api/history/openApi.json
+++ b/src/api/history/openApi.json
@@ -128,8 +128,8 @@
           {
             "name": "paths",
             "in": "query",
-            "description": "Comma separated list of Signal K paths whose data should be retrieved, optional aggregation methods for each path as postfix separated by a colon. Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index' | 'sma' | 'ema'. The 'sma' (simple moving average) and 'ema' (exponential moving average) methods accept an optional numeric parameter separated by colon: for sma it is the number of samples, for ema it is the alpha value (0-1). If not provided, implementations should use sensible defaults.",
-            "example": "navigation.speedOverGround:sma:5,navigation.speedThroughWater:max",
+            "description": "Comma separated list of Signal K paths whose data should be retrieved, with optional aggregation and smoothing as colon-separated segments. Format: `path[:aggregate[:smoothing:param]]`. Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index' | 'sma' | 'ema'. The 'sma' and 'ema' methods accept an optional numeric parameter: for sma it is the number of samples, for ema it is the alpha value (0-1). A 4-segment form `path:aggregate:smoothing:param` applies post-aggregation smoothing, where smoothing is 'sma' or 'ema' and param is the smoothing parameter. Example: `navigation.speedOverGround:average:sma:5` returns bucket averages smoothed with a 5-sample SMA.",
+            "example": "navigation.speedOverGround:average:sma:5,navigation.speedThroughWater:max",
             "schema": {
               "type": "string"
             },
@@ -151,6 +151,42 @@
             "schema": {
               "type": "number",
               "format": "integer"
+            }
+          },
+          {
+            "name": "bbox",
+            "in": "query",
+            "description": "Bounding box for spatial filtering as four comma-separated numbers: west,south,east,north (decimal degrees). Only returns data from positions within the box. Mutually exclusive with radius.",
+            "example": "-80,25,-79,26",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "description": "Radius-based spatial filter as three comma-separated numbers: longitude,latitude,meters. Only returns data from positions within the specified distance of the center point. Mutually exclusive with bbox and distance/position.",
+            "example": "-79.5,25.5,5000",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "distance",
+            "in": "query",
+            "description": "Distance in meters for radius-based spatial filtering (resources API compatible). Use with `position` to specify the center point. If `position` is omitted, the provider may default to the vessel's current position. Mutually exclusive with `radius` and `bbox`.",
+            "example": "5000",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "position",
+            "in": "query",
+            "description": "Center point for distance-based spatial filtering as a JSON array `[longitude,latitude]` or comma-separated `longitude,latitude` (resources API compatible). Used with `distance`.",
+            "example": "[-79.5,25.5]",
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/src/api/resources/openApi.json
+++ b/src/api/resources/openApi.json
@@ -795,6 +795,14 @@
           "example": [135.5, -25.2]
         }
       },
+      "RadiusParam": {
+        "in": "query",
+        "name": "radius",
+        "description": "Radius-based spatial filter as three comma-separated numbers: longitude,latitude,meters. Only returns data from positions within the specified distance of the center point. Alternative to distance+position. Mutually exclusive with bbox.",
+        "schema": {
+          "type": "string"
+        }
+      },
       "ZoomParam": {
         "in": "query",
         "name": "zoom",
@@ -883,6 +891,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/RadiusParam"
           },
           {
             "$ref": "#/components/parameters/ZoomParam"
@@ -1018,6 +1029,9 @@
             "$ref": "#/components/parameters/PositionParam"
           },
           {
+            "$ref": "#/components/parameters/RadiusParam"
+          },
+          {
             "$ref": "#/components/parameters/ZoomParam"
           }
         ],
@@ -1151,6 +1165,9 @@
             "$ref": "#/components/parameters/PositionParam"
           },
           {
+            "$ref": "#/components/parameters/RadiusParam"
+          },
+          {
             "$ref": "#/components/parameters/ZoomParam"
           }
         ],
@@ -1282,6 +1299,9 @@
           },
           {
             "$ref": "#/components/parameters/PositionParam"
+          },
+          {
+            "$ref": "#/components/parameters/RadiusParam"
           },
           {
             "$ref": "#/components/parameters/ZoomParam"

--- a/test/history.ts
+++ b/test/history.ts
@@ -1,0 +1,207 @@
+import { expect } from 'chai'
+import {
+  parseValuesQuery,
+  splitPathExpression
+} from '../src/api/history/index'
+
+describe('History API parsing', () => {
+  describe('splitPathExpression', () => {
+    it('defaults to average aggregation', () => {
+      const result = splitPathExpression('navigation.speedOverGround')
+      expect(result.path).to.equal('navigation.speedOverGround')
+      expect(result.aggregate).to.equal('average')
+      expect(result.parameter).to.deep.equal([])
+      expect(result.smoothing).to.be.undefined
+    })
+
+    it('parses 2-segment path:aggregate', () => {
+      const result = splitPathExpression('navigation.speedOverGround:max')
+      expect(result.aggregate).to.equal('max')
+      expect(result.parameter).to.deep.equal([])
+      expect(result.smoothing).to.be.undefined
+    })
+
+    it('parses 3-segment path:aggregate:param (non-smoothing)', () => {
+      const result = splitPathExpression('navigation.speedOverGround:sma:5')
+      expect(result.aggregate).to.equal('sma')
+      expect(result.parameter).to.deep.equal(['5'])
+      expect(result.smoothing).to.be.undefined
+    })
+
+    it('parses 4-segment path:aggregate:sma:param as post-aggregation smoothing', () => {
+      const result = splitPathExpression(
+        'navigation.speedOverGround:average:sma:5'
+      )
+      expect(result.aggregate).to.equal('average')
+      expect(result.parameter).to.deep.equal([])
+      expect(result.smoothing).to.deep.equal({ method: 'sma', parameter: '5' })
+    })
+
+    it('parses 4-segment path:aggregate:ema:param as post-aggregation smoothing', () => {
+      const result = splitPathExpression(
+        'navigation.speedOverGround:min:ema:0.3'
+      )
+      expect(result.aggregate).to.equal('min')
+      expect(result.smoothing).to.deep.equal({
+        method: 'ema',
+        parameter: '0.3'
+      })
+    })
+
+    it('forces first aggregation for navigation.position', () => {
+      const result = splitPathExpression('navigation.position:average:sma:5')
+      expect(result.aggregate).to.equal('first')
+      expect(result.smoothing).to.deep.equal({ method: 'sma', parameter: '5' })
+    })
+  })
+
+  describe('parseValuesQuery', () => {
+    const baseQuery = {
+      paths: 'navigation.speedOverGround:average',
+      duration: 'PT1H'
+    }
+
+    it('parses bbox parameter', () => {
+      const result = parseValuesQuery({
+        ...baseQuery,
+        bbox: '-80,25,-79,26'
+      })
+      expect(result.bbox).to.deep.equal({
+        west: -80,
+        south: 25,
+        east: -79,
+        north: 26
+      })
+      expect(result.radius).to.be.undefined
+    })
+
+    it('parses radius parameter', () => {
+      const result = parseValuesQuery({
+        ...baseQuery,
+        radius: '-79.5,25.5,5000'
+      })
+      expect(result.radius).to.deep.equal({
+        longitude: -79.5,
+        latitude: 25.5,
+        distance: 5000
+      })
+      expect(result.bbox).to.be.undefined
+    })
+
+    it('parses distance + position (JSON array)', () => {
+      const result = parseValuesQuery({
+        ...baseQuery,
+        distance: '5000',
+        position: '[-79.5,25.5]'
+      })
+      expect(result.radius).to.deep.equal({
+        longitude: -79.5,
+        latitude: 25.5,
+        distance: 5000
+      })
+      expect(result.bbox).to.be.undefined
+    })
+
+    it('parses distance + position (comma-separated)', () => {
+      const result = parseValuesQuery({
+        ...baseQuery,
+        distance: '5000',
+        position: '-79.5,25.5'
+      })
+      expect(result.radius).to.deep.equal({
+        longitude: -79.5,
+        latitude: 25.5,
+        distance: 5000
+      })
+    })
+
+    it('parses distance without position', () => {
+      const result = parseValuesQuery({
+        ...baseQuery,
+        distance: '5000'
+      })
+      expect(result.radius).to.deep.equal({
+        longitude: NaN,
+        latitude: NaN,
+        distance: 5000
+      })
+    })
+
+    it('rejects radius and distance together', () => {
+      expect(() =>
+        parseValuesQuery({
+          ...baseQuery,
+          radius: '-79.5,25.5,5000',
+          distance: '5000'
+        })
+      ).to.throw('radius and distance/position are mutually exclusive')
+    })
+
+    it('rejects bbox and distance together', () => {
+      expect(() =>
+        parseValuesQuery({
+          ...baseQuery,
+          bbox: '-80,25,-79,26',
+          distance: '5000'
+        })
+      ).to.throw('bbox and radius/distance are mutually exclusive')
+    })
+
+    it('rejects malformed position', () => {
+      expect(() =>
+        parseValuesQuery({
+          ...baseQuery,
+          distance: '5000',
+          position: 'abc'
+        })
+      ).to.throw('position must be two comma-separated numbers')
+    })
+
+    it('rejects bbox and radius together', () => {
+      expect(() =>
+        parseValuesQuery({
+          ...baseQuery,
+          bbox: '-80,25,-79,26',
+          radius: '-79.5,25.5,5000'
+        })
+      ).to.throw('bbox and radius/distance are mutually exclusive')
+    })
+
+    it('rejects malformed bbox', () => {
+      expect(() =>
+        parseValuesQuery({ ...baseQuery, bbox: '-80,25,-79' })
+      ).to.throw('bbox must be four comma-separated numbers')
+    })
+
+    it('rejects malformed radius', () => {
+      expect(() =>
+        parseValuesQuery({ ...baseQuery, radius: '-79.5,25.5' })
+      ).to.throw('radius must be three comma-separated numbers')
+    })
+
+    it('rejects non-numeric bbox values', () => {
+      expect(() =>
+        parseValuesQuery({ ...baseQuery, bbox: 'a,b,c,d' })
+      ).to.throw('bbox must be four comma-separated numbers')
+    })
+
+    it('omits bbox and radius when not provided', () => {
+      const result = parseValuesQuery(baseQuery)
+      expect(result.bbox).to.be.undefined
+      expect(result.radius).to.be.undefined
+    })
+
+    it('parses 4-segment path expressions in paths param', () => {
+      const result = parseValuesQuery({
+        duration: 'PT1H',
+        paths: 'navigation.speedOverGround:average:sma:5'
+      })
+      expect(result.pathSpecs).to.have.length(1)
+      expect(result.pathSpecs[0].aggregate).to.equal('average')
+      expect(result.pathSpecs[0].smoothing).to.deep.equal({
+        method: 'sma',
+        parameter: '5'
+      })
+    })
+  })
+})

--- a/test/history.ts
+++ b/test/history.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai'
-import {
-  parseValuesQuery,
-  splitPathExpression
-} from '../src/api/history/index'
+import { parseValuesQuery, splitPathExpression } from '../src/api/history/index'
 
 describe('History API parsing', () => {
   describe('splitPathExpression', () => {
@@ -11,21 +8,21 @@ describe('History API parsing', () => {
       expect(result.path).to.equal('navigation.speedOverGround')
       expect(result.aggregate).to.equal('average')
       expect(result.parameter).to.deep.equal([])
-      expect(result.smoothing).to.be.undefined
+      expect(result.smoothing).to.equal(undefined)
     })
 
     it('parses 2-segment path:aggregate', () => {
       const result = splitPathExpression('navigation.speedOverGround:max')
       expect(result.aggregate).to.equal('max')
       expect(result.parameter).to.deep.equal([])
-      expect(result.smoothing).to.be.undefined
+      expect(result.smoothing).to.equal(undefined)
     })
 
     it('parses 3-segment path:aggregate:param (non-smoothing)', () => {
       const result = splitPathExpression('navigation.speedOverGround:sma:5')
       expect(result.aggregate).to.equal('sma')
       expect(result.parameter).to.deep.equal(['5'])
-      expect(result.smoothing).to.be.undefined
+      expect(result.smoothing).to.equal(undefined)
     })
 
     it('parses 4-segment path:aggregate:sma:param as post-aggregation smoothing', () => {
@@ -72,7 +69,7 @@ describe('History API parsing', () => {
         east: -79,
         north: 26
       })
-      expect(result.radius).to.be.undefined
+      expect(result.radius).to.equal(undefined)
     })
 
     it('parses radius parameter', () => {
@@ -85,7 +82,7 @@ describe('History API parsing', () => {
         latitude: 25.5,
         distance: 5000
       })
-      expect(result.bbox).to.be.undefined
+      expect(result.bbox).to.equal(undefined)
     })
 
     it('parses distance + position (JSON array)', () => {
@@ -99,7 +96,7 @@ describe('History API parsing', () => {
         latitude: 25.5,
         distance: 5000
       })
-      expect(result.bbox).to.be.undefined
+      expect(result.bbox).to.equal(undefined)
     })
 
     it('parses distance + position (comma-separated)', () => {
@@ -187,8 +184,8 @@ describe('History API parsing', () => {
 
     it('omits bbox and radius when not provided', () => {
       const result = parseValuesQuery(baseQuery)
-      expect(result.bbox).to.be.undefined
-      expect(result.radius).to.be.undefined
+      expect(result.bbox).to.equal(undefined)
+      expect(result.radius).to.equal(undefined)
     })
 
     it('parses 4-segment path expressions in paths param', () => {

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -71,6 +71,36 @@ describe('Resources Api', () => {
     returnedIds[0].should.equal(resourceIds[1])
   })
 
+  it('radius search works for waypoints', async function () {
+    const { get, post } = await startServer()
+
+    const resourceIds = await Promise.all(
+      [
+        [60.151672, 24.891637],
+        [60.251672, 24.891637],
+        [60.151672, 24.991637]
+      ].map(async ([latitude, longitude]) => {
+        const r = await post(`/resources/waypoints/`, {
+          feature: {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [longitude, latitude]
+            }
+          }
+        })
+        const { id } = (await r.json()) as { id: string }
+        return id
+      })
+    )
+    const r = (await (
+      await get('/resources/waypoints?radius=24.891637,60.251672,5000')
+    ).json()) as object
+    const returnedIds = Object.keys(r)
+    returnedIds.length.should.equal(1)
+    returnedIds[0].should.equal(resourceIds[1])
+  })
+
   it('Create route with route point metadata', async function () {
     const { post, stop } = await startServer()
 


### PR DESCRIPTION
## Summary

Extends the V2 History API with spatial filtering and enhanced path expressions, and adds a `radius` query parameter to the Resources API for cross-API consistency.

### History API extensions

- **Spatial filtering**: New `bbox`, `radius`, `distance`, and `position` query parameters on `/history/values`. Supports two equivalent styles for radius queries — the compact `radius=lon, lat, meters` form and the Resources API-compatible `distance=meters&position=[lon,lat]` form. Mutually exclusive parameter combinations are validated and return HTTP 400.
- **`context` parameter**: Allows querying historical data for a specific vessel or object (e.g. `context=vessels.urn:mrn:imo:mmsi:123456789`), defaulting to `vessels.self`.
- **4-segment path expressions**: New `path:aggregate:smoothing:param` syntax for post-aggregation smoothing (e.g. `navigation.speedOverGround:average:sma:5` computes bucket averages then applies a 5-sample Simple Moving Average). Supports `sma` and `ema` smoothing methods.
- **Updated `ValuesRequest` type**: `PathSpec` gains an optional `smoothing` field; `ValuesRequest` gains optional `bbox` and `radius` fields so providers receive structured, validated spatial data.

### Resources API

- **New `radius` query parameter**: Added `RadiusParam` to the OpenAPI spec and referenced in all four resource collection GET endpoints (routes, waypoints, regions, notes). The built-in resources provider's `processParameters()` parses `radius=lon,lat,meters` into the same `geobounds` polygon used by `bbox` and `distance`+`position`.

### Tests

- 16 unit tests for `splitPathExpression` and `parseValuesQuery` covering all path expression formats, spatial parameter parsing, mutual exclusivity validation, and error cases.
- Integration test for `radius` filtering on the Resources API, mirroring the existing `bbox` test.

### Documentation

- History API docs: expanded query parameter table, new sections on path expressions and spatial filtering with examples.
- Resources API docs: added `radius` example alongside existing `bbox` and `distance` examples.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — all existing and new tests pass
- [x] `radius` query on resources returns the same results as the equivalent `bbox` query
- [x] Mutual exclusivity validated (bbox + radius, radius + distance/position)

