### PR TITLE
fix: Deduplicate geolib to single version

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "express-rate-limit": "^8.2.1",
     "figlet": "^1.2.0",
     "file-timestamp-stream": "^2.1.2",
-    "geolib": "3.2.2",
+    "geolib": "^3.3.3",
     "helmet": "^8.1.0",
     "inquirer": "^7.0.0",
     "jose": "^6.1.0",


### PR DESCRIPTION
## Summary
- Bump root geolib from pinned `3.2.2` to `^3.3.3`, matching the resources-provider-plugin workspace requirement
- Eliminates duplicate geolib versions in the dependency tree

Fixes #2231