### PR TITLE
fix: Validate permissions in device access requests

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -620,10 +620,10 @@ module.exports = function (
       }
       const config = getSecurityConfig(app)
       const ip = req.ip
-      if (!app.securityStrategy.requestAccess) {
+      if (app.securityStrategy.isDummy()) {
         res.status(404).json({
           message:
-            'Access requests not available. Server security may not be enabled.'
+            'Access requests not available. Server security is not enabled.'
         })
         return
       }

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -88,6 +88,7 @@ const skAuthPrefix = `${skPrefix}/auth`
 const BROWSER_LOGININFO_COOKIE_NAME = 'skLoginInfo'
 
 const LOGIN_FAILED_MESSAGE = 'Invalid username/password'
+const VALID_PERMISSIONS = new Set(['readonly', 'readwrite', 'admin'])
 
 // Dummy hash for timing attack prevention - pre-generated bcrypt hash
 const DUMMY_HASH = '$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012'
@@ -1618,6 +1619,13 @@ function tokenSecurityFactory(
 
     let approved: boolean
     if (status === 'approved') {
+      if (
+        !request.clientRequest.requestedPermissions &&
+        !VALID_PERMISSIONS.has(body.permissions)
+      ) {
+        cb(new Error('Invalid permissions value'), theConfig)
+        return
+      }
       if (request.clientRequest.accessRequest.clientId) {
         const payload: JWTPayload = { device: identifier }
         const jwtOptions: SignOptions = {}
@@ -1734,6 +1742,16 @@ function tokenSecurityFactory(
         .then((request: AccessRequest) => {
           const accessRequest = clientRequest.accessRequest
           if (!validateAccessRequest(accessRequest)) {
+            updateRequest(request.requestId, 'COMPLETED', { statusCode: 400 })
+              .then(resolve)
+              .catch(reject)
+            return
+          }
+
+          if (
+            accessRequest.permissions !== undefined &&
+            !VALID_PERMISSIONS.has(accessRequest.permissions)
+          ) {
             updateRequest(request.requestId, 'COMPLETED', { statusCode: 400 })
               .then(resolve)
               .catch(reject)

--- a/test/security.js
+++ b/test/security.js
@@ -590,6 +590,47 @@ describe('Security', () => {
     res.status.should.equal(413)
   })
 
+  it('should reject access request with invalid permissions', async function () {
+    const result = await fetch(`${url}/signalk/v1/access/requests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: 'device-invalid-perm',
+        description: 'Bad Sensor',
+        permissions: 'badvalue'
+      })
+    })
+    result.status.should.equal(400)
+  })
+
+  it('should reject approval with invalid permissions', async function () {
+    let result = await fetch(`${url}/signalk/v1/access/requests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: 'device-invalid-approve',
+        description: 'Another Sensor'
+      })
+    })
+    result.status.should.equal(202)
+
+    result = await fetch(
+      `${url}/skServer/security/access/requests/device-invalid-approve/approved`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `JAUTHENTICATION=${adminToken}`
+        },
+        body: JSON.stringify({
+          expiration: '1y',
+          permissions: 'badvalue'
+        })
+      }
+    )
+    result.status.should.equal(500)
+  })
+
   it('User registration request and approval works', async function () {
     const testUserId = 'newuser@test.com'
     const testPassword = 'testpassword123'


### PR DESCRIPTION
## Summary
- Reject invalid permission values in device access requests — only `readonly`, `readwrite`, and `admin` are accepted
- Fix server crash (500) when posting access requests with security disabled

Fixes #2224

## Test plan
- [x] POST `/signalk/v1/access/requests` with `permissions: "badvalue"` → 400
- [x] POST `/signalk/v1/access/requests` with `permissions: "readwrite"` → 202 PENDING
- [x] POST `/signalk/v1/access/requests` with security disabled → 404 (no crash)
- [x] PUT approval with `permissions: "badvalue"` → rejected
- [x] Automated test suite passes (382 tests)