### PR TITLE
fix(streams): fetch remote metadata on demand via HTTP

### DIFF
--- a/packages/streams/src/mdns-ws.ts
+++ b/packages/streams/src/mdns-ws.ts
@@ -16,6 +16,7 @@
 
 import { Transform, TransformCallback } from 'stream'
 import { Client } from '@signalk/client'
+import { getMetadata } from '@signalk/signalk-schema'
 import { CreateDebug, DebugLogger } from './types'
 
 interface MdnsWsOptions {
@@ -53,6 +54,7 @@ export default class MdnsWs extends Transform {
   private readonly dataDebug: DebugLogger
   private handleContext: (delta: DeltaMessage) => void
   private signalkClient?: Client
+  private fetchedMetaPaths = new Set<string>()
 
   constructor(options: MdnsWsOptions) {
     super({ objectMode: true })
@@ -110,6 +112,7 @@ export default class MdnsWs extends Transform {
   }
 
   private connectClient(client: Client): void {
+    this.fetchedMetaPaths.clear()
     client
       .connect()
       .then(() => {
@@ -184,7 +187,47 @@ export default class MdnsWs extends Transform {
       }
 
       this.push(data)
+
+      if (data?.updates) {
+        for (const update of data.updates) {
+          const values = update.values as Array<{ path: string }> | undefined
+          if (values) {
+            for (const pv of values) {
+              if (!this.fetchedMetaPaths.has(pv.path)) {
+                this.fetchedMetaPaths.add(pv.path)
+                this.fetchMetaIfNeeded(client, data.context, pv.path)
+              }
+            }
+          }
+        }
+      }
     })
+  }
+
+  private fetchMetaIfNeeded(
+    client: Client,
+    context: string | undefined,
+    path: string
+  ): void {
+    if (getMetadata('vessels.self.' + path)) {
+      return
+    }
+
+    client
+      .API()
+      .then((api) => api.getMeta(`/vessels/self/${path.replace(/\./g, '/')}`))
+      .then((meta) => {
+        if (meta) {
+          this.debug(`fetched meta for ${path} from remote`)
+          this.push({
+            context,
+            updates: [{ meta: [{ path, value: meta }] }]
+          })
+        }
+      })
+      .catch((err: Error) => {
+        this.debug(`failed to fetch meta for ${path}: ${err.message}`)
+      })
   }
 
   _transform(

--- a/packages/streams/src/vendor.d.ts
+++ b/packages/streams/src/vendor.d.ts
@@ -67,7 +67,10 @@ declare module '@signalk/client' {
     constructor(options: ClientOptions)
     connect(): Promise<void>
     subscribe(subscription: object, id: string): void
-    API(): Promise<{ get(path: string): Promise<string> }>
+    API(): Promise<{
+      get(path: string): Promise<string>
+      getMeta(path: string): Promise<unknown>
+    }>
   }
   export { Client }
 }
@@ -98,6 +101,11 @@ declare module 'aws-sdk' {
     getObject(params: S3GetObjectParams): S3Request
   }
   export { S3 }
+}
+
+declare module '@signalk/signalk-schema' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function getMetadata(path: string): any
 }
 
 declare module 'node-gpsd-client' {


### PR DESCRIPTION
## Summary

- Instead of streaming all metadata via `sendMeta: 'all'` (which overwrites local meta and unit preferences with potential race conditions), fetch metadata on demand via HTTP for paths not already in the local schema
- When a value delta arrives for a new path, the provider checks `getMetadata()` — if the schema already covers it, no fetch occurs; otherwise it makes a single HTTP request to the remote server's REST API
- Local metadata is never overwritten; each path is fetched at most once per connection lifetime

Fixes #2073

## Tested manually

- Two servers: p4100 (with N2K data source) and p4200 (WS provider connecting to p4100 with `useRemoteSelf`)
- Set custom meta description on both servers for `navigation.position` before connecting
- After p4200 connected and data flowed from p4100, verified p4200's local meta was preserved intact — the custom description was not overwritten by the remote server's meta
- Standard SK schema paths (like `navigation.position`) skip HTTP fetching entirely since `getMetadata()` returns schema-level meta for them
- Set custom meta on p4100 for a non-schema path (`electrical.ac.130.average.current` — `description: "AC average current from remote"`, `units: "A"`). Verified p4200 fetched this meta via HTTP and it appeared on p4200