### PR TITLE
fix(course): use courseApi provider id for v2 deltas

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1261,11 +1261,7 @@ export class CourseApi {
         }
       ]
     })
-    this.app.handleMessage(
-      'N/A', //no-op as updates already have $source
-      v2Delta,
-      SKVersion.v2
-    )
+    this.app.handleMessage(API_CMD_SRC.$source, v2Delta, SKVersion.v2)
 
     const p = typeof noSave === 'undefined' ? this.isAPICmdSource() : !noSave
     if (p) {


### PR DESCRIPTION
Fixes #1880

`emitCourseInfo()` passed `'N/A'` as the provider id for v2 deltas, while v1 deltas correctly used `API_CMD_SRC.$source` (`'courseApi'`). The `'N/A'` string was tracked by `incDeltaStatistics()`, creating a phantom connection in the dashboard.

## Manual testing

Server running with NMEA 2000 data. Subscribed to `SERVERSTATISTICS` WebSocket events and confirmed `N/A` does not appear in `providerStatistics`. Verified across multiple polling intervals.