### PR TITLE
perf(admin-ui): split bundles with lazy routes and vendor chunks

### DIFF
--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -28,49 +28,62 @@ import Webapps from '../../views/Webapps/Webapps'
 import Login from '../../views/security/Login'
 import Register from '../../views/security/Register'
 
-const DataBrowser = React.lazy(
+// One retry covers transient network blips; persistent failures (e.g. stale
+// chunk hashes after a redeploy) fall through to the ErrorBoundary, which
+// triggers a one-shot reload.
+function lazyWithRetry<T extends ComponentType<unknown>>(
+  importer: () => Promise<{ default: T }>
+) {
+  return React.lazy(() => importer().catch(() => importer()))
+}
+
+const DataBrowser = lazyWithRetry(
   () => import('../../views/DataBrowser/DataBrowser')
 )
-const MetaDataPage = React.lazy(
+const MetaDataPage = lazyWithRetry(
   () => import('../../views/DataBrowser/MetaDataPage')
 )
-const SourceDiscovery = React.lazy(
+const SourceDiscovery = lazyWithRetry(
   () => import('../../views/DataBrowser/SourceDiscovery')
 )
-const SourcePriorityPage = React.lazy(
+const SourcePriorityPage = lazyWithRetry(
   () => import('../../views/DataBrowser/SourcePriorityPage')
 )
-const Playground = React.lazy(() => import('../../views/Playground'))
-const Apps = React.lazy(() => import('../../views/appstore/Apps/Apps'))
-const DetailView = React.lazy(
+const Playground = lazyWithRetry(() => import('../../views/Playground'))
+const Apps = lazyWithRetry(() => import('../../views/appstore/Apps/Apps'))
+const DetailView = lazyWithRetry(
   () => import('../../views/appstore/Detail/DetailView')
 )
-const Configuration = React.lazy(
+const Configuration = lazyWithRetry(
   () => import('../../views/Configuration/Configuration')
 )
-const Settings = React.lazy(() => import('../../views/ServerConfig/Settings'))
-const UnitPreferencesSettings = React.lazy(
+const Settings = lazyWithRetry(
+  () => import('../../views/ServerConfig/Settings')
+)
+const UnitPreferencesSettings = lazyWithRetry(
   () => import('../../views/ServerConfig/UnitPreferencesSettings')
 )
-const BackupRestore = React.lazy(
+const BackupRestore = lazyWithRetry(
   () => import('../../views/ServerConfig/BackupRestore')
 )
-const ProvidersConfiguration = React.lazy(
+const ProvidersConfiguration = lazyWithRetry(
   () => import('../../views/ServerConfig/ProvidersConfiguration')
 )
-const ServerLog = React.lazy(() => import('../../views/ServerConfig/ServerLog'))
-const ServerUpdate = React.lazy(
+const ServerLog = lazyWithRetry(
+  () => import('../../views/ServerConfig/ServerLog')
+)
+const ServerUpdate = lazyWithRetry(
   () => import('../../views/ServerConfig/ServerUpdate')
 )
-const SecuritySettings = React.lazy(
+const SecuritySettings = lazyWithRetry(
   () => import('../../views/security/Settings')
 )
-const Users = React.lazy(() => import('../../views/security/Users'))
-const Devices = React.lazy(() => import('../../views/security/Devices'))
-const AccessRequests = React.lazy(
+const Users = lazyWithRetry(() => import('../../views/security/Users'))
+const Devices = lazyWithRetry(() => import('../../views/security/Devices'))
+const AccessRequests = lazyWithRetry(
   () => import('../../views/security/AccessRequests')
 )
-const PathReference = React.lazy(
+const PathReference = lazyWithRetry(
   () => import('../../views/PathReference/PathReference')
 )
 
@@ -85,6 +98,17 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+const CHUNK_RELOAD_FLAG = 'signalk:chunkReloaded'
+
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    /Failed to fetch dynamically imported module|Importing a module script failed/i.test(
+      error.message
+    )
+  )
+}
+
 // Must be a class component — React error boundaries don't support hooks
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -97,6 +121,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    // Hashed chunk filenames change on redeploy; an open tab will fail to
+    // fetch its old chunks. Reload once to pick up the new index, but guard
+    // against loops if the failure is caused by something else.
+    if (isChunkLoadError(error) && !sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+      sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1')
+      window.location.reload()
+      return
+    }
     console.error('ErrorBoundary caught an error:', error, errorInfo)
   }
 
@@ -212,6 +244,7 @@ export default function Full() {
   const location = useLocation()
 
   useEffect(() => {
+    sessionStorage.removeItem(CHUNK_RELOAD_FLAG)
     fetchAllData()
   }, [])
 

--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, Component, ReactNode, ComponentType } from 'react'
+import React, {
+  Suspense,
+  useEffect,
+  Component,
+  ReactNode,
+  ComponentType
+} from 'react'
 import {
   Routes,
   Route,
@@ -19,27 +25,54 @@ import Embedded from '../../views/Webapps/Embedded'
 import EmbeddedDocs from '../../views/Webapps/EmbeddedDocs'
 import EmbeddedAsyncApi from '../../views/Webapps/EmbeddedAsyncApi'
 import Webapps from '../../views/Webapps/Webapps'
-import DataBrowser from '../../views/DataBrowser/DataBrowser'
-import MetaDataPage from '../../views/DataBrowser/MetaDataPage'
-import SourceDiscovery from '../../views/DataBrowser/SourceDiscovery'
-import SourcePriorityPage from '../../views/DataBrowser/SourcePriorityPage'
-import Playground from '../../views/Playground'
-import Apps from '../../views/appstore/Apps/Apps'
-import DetailView from '../../views/appstore/Detail/DetailView'
-import Configuration from '../../views/Configuration/Configuration'
 import Login from '../../views/security/Login'
-import SecuritySettings from '../../views/security/Settings'
-import Users from '../../views/security/Users'
-import Devices from '../../views/security/Devices'
 import Register from '../../views/security/Register'
-import AccessRequests from '../../views/security/AccessRequests'
-import ProvidersConfiguration from '../../views/ServerConfig/ProvidersConfiguration'
-import Settings from '../../views/ServerConfig/Settings'
-import UnitPreferencesSettings from '../../views/ServerConfig/UnitPreferencesSettings'
-import BackupRestore from '../../views/ServerConfig/BackupRestore'
-import ServerLog from '../../views/ServerConfig/ServerLog'
-import ServerUpdate from '../../views/ServerConfig/ServerUpdate'
-import PathReference from '../../views/PathReference/PathReference'
+
+const DataBrowser = React.lazy(
+  () => import('../../views/DataBrowser/DataBrowser')
+)
+const MetaDataPage = React.lazy(
+  () => import('../../views/DataBrowser/MetaDataPage')
+)
+const SourceDiscovery = React.lazy(
+  () => import('../../views/DataBrowser/SourceDiscovery')
+)
+const SourcePriorityPage = React.lazy(
+  () => import('../../views/DataBrowser/SourcePriorityPage')
+)
+const Playground = React.lazy(() => import('../../views/Playground'))
+const Apps = React.lazy(() => import('../../views/appstore/Apps/Apps'))
+const DetailView = React.lazy(
+  () => import('../../views/appstore/Detail/DetailView')
+)
+const Configuration = React.lazy(
+  () => import('../../views/Configuration/Configuration')
+)
+const Settings = React.lazy(() => import('../../views/ServerConfig/Settings'))
+const UnitPreferencesSettings = React.lazy(
+  () => import('../../views/ServerConfig/UnitPreferencesSettings')
+)
+const BackupRestore = React.lazy(
+  () => import('../../views/ServerConfig/BackupRestore')
+)
+const ProvidersConfiguration = React.lazy(
+  () => import('../../views/ServerConfig/ProvidersConfiguration')
+)
+const ServerLog = React.lazy(() => import('../../views/ServerConfig/ServerLog'))
+const ServerUpdate = React.lazy(
+  () => import('../../views/ServerConfig/ServerUpdate')
+)
+const SecuritySettings = React.lazy(
+  () => import('../../views/security/Settings')
+)
+const Users = React.lazy(() => import('../../views/security/Users'))
+const Devices = React.lazy(() => import('../../views/security/Devices'))
+const AccessRequests = React.lazy(
+  () => import('../../views/security/AccessRequests')
+)
+const PathReference = React.lazy(
+  () => import('../../views/PathReference/PathReference')
+)
 
 import { fetchAllData } from '../../actions'
 
@@ -102,6 +135,16 @@ function loginRequired(
   return (
     loginStatus.authenticationRequired === true &&
     loginStatus.status === 'notLoggedIn'
+  )
+}
+
+function LoadingSpinner() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', padding: '2rem' }}>
+      <div className="spinner-border text-primary" role="status">
+        <span className="visually-hidden">Loading...</span>
+      </div>
+    </div>
   )
 }
 
@@ -185,141 +228,158 @@ export default function Full() {
         <Sidebar location={location} />
         <main className="main">
           <Container fluid style={suppressPadding}>
-            <Routes>
-              <Route
-                path="/dashboard"
-                element={
-                  <ProtectedRoute component={Dashboard} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/webapps"
-                element={
-                  <ProtectedRoute component={Webapps} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/e/:moduleId"
-                element={
-                  <ProtectedRoute component={Embedded} supportsReadOnly />
-                }
-              />
-              {/* Data menu routes */}
-              <Route
-                path="/data/browser"
-                element={
-                  <ProtectedRoute component={DataBrowser} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/data/meta"
-                element={
-                  <ProtectedRoute component={MetaDataPage} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/data/sources"
-                element={<ProtectedRoute component={SourceDiscovery} />}
-              />
-              <Route
-                path="/data/priorities"
-                element={<ProtectedRoute component={SourcePriorityPage} />}
-              />
-              <Route
-                path="/data/units"
-                element={<ProtectedRoute component={UnitPreferencesSettings} />}
-              />
-              <Route
-                path="/data/fiddler"
-                element={
-                  <ProtectedRoute component={Playground} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/data/connections/:providerId"
-                element={<ProtectedRoute component={ProvidersConfiguration} />}
-              />
-              {/* Backward-compatible redirects */}
-              <Route
-                path="/databrowser"
-                element={<Navigate to="/data/browser" replace />}
-              />
-              <Route
-                path="/serverConfiguration/datafiddler"
-                element={<Navigate to="/data/fiddler" replace />}
-              />
-              <Route
-                path="/apps/store/plugin/:name"
-                element={<ProtectedRoute component={DetailView} />}
-              />
-              <Route
-                path="/apps/store/*"
-                element={<ProtectedRoute component={Apps} />}
-              />
-              <Route
-                path="/apps/configuration/:pluginid"
-                element={<ProtectedRoute component={Configuration} />}
-              />
-              <Route path="/appstore" element={<LegacyAppstoreRedirect />} />
-              <Route
-                path="/appstore/plugin/:name"
-                element={<LegacyAppstorePluginRedirect />}
-              />
-              <Route path="/appstore/*" element={<LegacyAppstoreRedirect />} />
-              <Route
-                path="/serverConfiguration/plugins/:pluginid"
-                element={<LegacyPluginConfigRedirect />}
-              />
-              <Route
-                path="/serverConfiguration/settings"
-                element={<ProtectedRoute component={Settings} />}
-              />
-              <Route
-                path="/serverConfiguration/backuprestore"
-                element={<ProtectedRoute component={BackupRestore} />}
-              />
-              <Route
-                path="/serverConfiguration/connections/:providerId"
-                element={<ProtectedRoute component={ProvidersConfiguration} />}
-              />
-              <Route
-                path="/serverConfiguration/log"
-                element={
-                  <ProtectedRoute component={ServerLog} supportsReadOnly />
-                }
-              />
-              <Route
-                path="/serverConfiguration/update"
-                element={<ProtectedRoute component={ServerUpdate} />}
-              />
-              <Route
-                path="/security/settings"
-                element={<ProtectedRoute component={SecuritySettings} />}
-              />
-              <Route
-                path="/security/users"
-                element={<ProtectedRoute component={Users} />}
-              />
-              <Route
-                path="/security/devices"
-                element={<ProtectedRoute component={Devices} />}
-              />
-              <Route
-                path="/security/access/requests"
-                element={<ProtectedRoute component={AccessRequests} />}
-              />
-              <Route path="/asyncapi" element={<EmbeddedAsyncApi />} />
-              <Route
-                path="/documentation/paths"
-                element={
-                  <ProtectedRoute component={PathReference} supportsReadOnly />
-                }
-              />
-              <Route path="/documentation/*" element={<EmbeddedDocs />} />
-              <Route path="/login" element={<Login />} />
-              <Route path="/register" element={<Register />} />
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            </Routes>
+            <Suspense fallback={<LoadingSpinner />}>
+              <Routes>
+                <Route
+                  path="/dashboard"
+                  element={
+                    <ProtectedRoute component={Dashboard} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/webapps"
+                  element={
+                    <ProtectedRoute component={Webapps} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/e/:moduleId"
+                  element={
+                    <ProtectedRoute component={Embedded} supportsReadOnly />
+                  }
+                />
+                {/* Data menu routes */}
+                <Route
+                  path="/data/browser"
+                  element={
+                    <ProtectedRoute component={DataBrowser} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/data/meta"
+                  element={
+                    <ProtectedRoute component={MetaDataPage} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/data/sources"
+                  element={<ProtectedRoute component={SourceDiscovery} />}
+                />
+                <Route
+                  path="/data/priorities"
+                  element={<ProtectedRoute component={SourcePriorityPage} />}
+                />
+                <Route
+                  path="/data/units"
+                  element={
+                    <ProtectedRoute component={UnitPreferencesSettings} />
+                  }
+                />
+                <Route
+                  path="/data/fiddler"
+                  element={
+                    <ProtectedRoute component={Playground} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/data/connections/:providerId"
+                  element={
+                    <ProtectedRoute component={ProvidersConfiguration} />
+                  }
+                />
+                {/* Backward-compatible redirects */}
+                <Route
+                  path="/databrowser"
+                  element={<Navigate to="/data/browser" replace />}
+                />
+                <Route
+                  path="/serverConfiguration/datafiddler"
+                  element={<Navigate to="/data/fiddler" replace />}
+                />
+                <Route
+                  path="/apps/store/plugin/:name"
+                  element={<ProtectedRoute component={DetailView} />}
+                />
+                <Route
+                  path="/apps/store/*"
+                  element={<ProtectedRoute component={Apps} />}
+                />
+                <Route
+                  path="/apps/configuration/:pluginid"
+                  element={<ProtectedRoute component={Configuration} />}
+                />
+                <Route path="/appstore" element={<LegacyAppstoreRedirect />} />
+                <Route
+                  path="/appstore/plugin/:name"
+                  element={<LegacyAppstorePluginRedirect />}
+                />
+                <Route
+                  path="/appstore/*"
+                  element={<LegacyAppstoreRedirect />}
+                />
+                <Route
+                  path="/serverConfiguration/plugins/:pluginid"
+                  element={<LegacyPluginConfigRedirect />}
+                />
+                <Route
+                  path="/serverConfiguration/settings"
+                  element={<ProtectedRoute component={Settings} />}
+                />
+                <Route
+                  path="/serverConfiguration/backuprestore"
+                  element={<ProtectedRoute component={BackupRestore} />}
+                />
+                <Route
+                  path="/serverConfiguration/connections/:providerId"
+                  element={
+                    <ProtectedRoute component={ProvidersConfiguration} />
+                  }
+                />
+                <Route
+                  path="/serverConfiguration/log"
+                  element={
+                    <ProtectedRoute component={ServerLog} supportsReadOnly />
+                  }
+                />
+                <Route
+                  path="/serverConfiguration/update"
+                  element={<ProtectedRoute component={ServerUpdate} />}
+                />
+                <Route
+                  path="/security/settings"
+                  element={<ProtectedRoute component={SecuritySettings} />}
+                />
+                <Route
+                  path="/security/users"
+                  element={<ProtectedRoute component={Users} />}
+                />
+                <Route
+                  path="/security/devices"
+                  element={<ProtectedRoute component={Devices} />}
+                />
+                <Route
+                  path="/security/access/requests"
+                  element={<ProtectedRoute component={AccessRequests} />}
+                />
+                <Route path="/asyncapi" element={<EmbeddedAsyncApi />} />
+                <Route
+                  path="/documentation/paths"
+                  element={
+                    <ProtectedRoute
+                      component={PathReference}
+                      supportsReadOnly
+                    />
+                  }
+                />
+                <Route path="/documentation/*" element={<EmbeddedDocs />} />
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+                <Route
+                  path="/"
+                  element={<Navigate to="/dashboard" replace />}
+                />
+              </Routes>
+            </Suspense>
           </Container>
         </main>
         <Aside />

--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -28,13 +28,25 @@ import Webapps from '../../views/Webapps/Webapps'
 import Login from '../../views/security/Login'
 import Register from '../../views/security/Register'
 
+const CHUNK_RELOAD_FLAG = 'signalk:chunkReloaded'
+
 // One retry covers transient network blips; persistent failures (e.g. stale
 // chunk hashes after a redeploy) fall through to the ErrorBoundary, which
 // triggers a one-shot reload.
 function lazyWithRetry<T extends ComponentType<unknown>>(
   importer: () => Promise<{ default: T }>
 ) {
-  return React.lazy(() => importer().catch(() => importer()))
+  return React.lazy(() =>
+    importer()
+      .catch(() => importer())
+      .then((module) => {
+        // A successful chunk load proves the served bundle is consistent, so
+        // re-arm the one-shot reload for the next redeploy. Re-arming on
+        // mount instead would reload in a loop while chunks keep failing.
+        sessionStorage.removeItem(CHUNK_RELOAD_FLAG)
+        return module
+      })
+  )
 }
 
 const DataBrowser = lazyWithRetry(
@@ -98,12 +110,10 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
-const CHUNK_RELOAD_FLAG = 'signalk:chunkReloaded'
-
 function isChunkLoadError(error: Error): boolean {
   return (
     error.name === 'ChunkLoadError' ||
-    /Failed to fetch dynamically imported module|Importing a module script failed/i.test(
+    /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module/i.test(
       error.message
     )
   )
@@ -244,7 +254,6 @@ export default function Full() {
   const location = useLocation()
 
   useEffect(() => {
-    sessionStorage.removeItem(CHUNK_RELOAD_FLAG)
     fetchAllData()
   }, [])
 

--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -43,7 +43,11 @@ function lazyWithRetry<T extends ComponentType<unknown>>(
         // A successful chunk load proves the served bundle is consistent, so
         // re-arm the one-shot reload for the next redeploy. Re-arming on
         // mount instead would reload in a loop while chunks keep failing.
-        sessionStorage.removeItem(CHUNK_RELOAD_FLAG)
+        try {
+          sessionStorage.removeItem(CHUNK_RELOAD_FLAG)
+        } catch {
+          // Storage blocked — the chunk still loaded, so carry on.
+        }
         return module
       })
   )
@@ -134,10 +138,17 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     // Hashed chunk filenames change on redeploy; an open tab will fail to
     // fetch its old chunks. Reload once to pick up the new index, but guard
     // against loops if the failure is caused by something else.
-    if (isChunkLoadError(error) && !sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
-      sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1')
-      window.location.reload()
-      return
+    if (isChunkLoadError(error)) {
+      try {
+        if (!sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+          sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1')
+          window.location.reload()
+          return
+        }
+      } catch {
+        // Storage blocked — without the one-shot flag a reload could loop,
+        // so fall through to the error panel instead.
+      }
     }
     console.error('ErrorBoundary caught an error:', error, errorInfo)
   }

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -1,4 +1,3 @@
-import { isUndefined } from 'lodash'
 import { useStore } from './store'
 
 declare global {
@@ -80,7 +79,7 @@ export async function fetchAllData(): Promise<void> {
   ) => {
     try {
       const response = await authFetch(
-        `${isUndefined(prefix) ? window.serverRoutesPrefix : prefix}${endpoint}`
+        `${prefix === undefined ? window.serverRoutesPrefix : prefix}${endpoint}`
       )
       if (response.status === 200) {
         const data = await response.json()

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -136,13 +136,9 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (
-            id.includes('node_modules/mathjs/') ||
-            id.includes('node_modules/decimal.js/') ||
-            id.includes('node_modules/typed-function/') ||
-            id.includes('node_modules/complex.js/') ||
-            id.includes('node_modules/fraction.js/') ||
-            id.includes('node_modules/seedrandom/') ||
-            id.includes('node_modules/tiny-emitter/')
+            /[\\/]node_modules[\\/](mathjs|decimal\.js|typed-function|complex\.js|fraction\.js|seedrandom|escape-latex|javascript-natural-sort)[\\/]/.test(
+              id
+            )
           ) {
             return 'vendor-mathjs'
           }

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -70,6 +70,13 @@ function stripSvgFonts() {
   }
 }
 
+// mathjs and its runtime dependencies, split into a lazy vendor chunk.
+// Deliberately excludes @babel/runtime: it is shared with eagerly loaded
+// dependencies, so bundling it here would pull the whole chunk into the
+// initial load.
+const MATHJS_VENDOR_PATTERN =
+  /[\\/]node_modules[\\/](mathjs|decimal\.js|typed-function|complex\.js|fraction\.js|seedrandom|escape-latex|javascript-natural-sort)[\\/]/
+
 export default defineConfig({
   base: './',
   publicDir: 'public_src',
@@ -135,11 +142,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (
-            /[\\/]node_modules[\\/](mathjs|decimal\.js|typed-function|complex\.js|fraction\.js|seedrandom|escape-latex|javascript-natural-sort)[\\/]/.test(
-              id
-            )
-          ) {
+          if (MATHJS_VENDOR_PATTERN.test(id)) {
             return 'vendor-mathjs'
           }
         }

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -131,7 +131,24 @@ export default defineConfig({
     target: 'es2023',
     assetsInlineLimit: 0, // Prevent inlining assets to allow server-side logo override
     cssCodeSplit: false, // Generate single CSS file to ensure it's always loaded
-    manifest: true // Emit .vite/manifest.json so plugins can resolve hashed asset URLs
+    manifest: true, // Emit .vite/manifest.json so plugins can resolve hashed asset URLs
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes('node_modules/mathjs/') ||
+            id.includes('node_modules/decimal.js/') ||
+            id.includes('node_modules/typed-function/') ||
+            id.includes('node_modules/complex.js/') ||
+            id.includes('node_modules/fraction.js/') ||
+            id.includes('node_modules/seedrandom/') ||
+            id.includes('node_modules/tiny-emitter/')
+          ) {
+            return 'vendor-mathjs'
+          }
+        }
+      }
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Motivation 

- `math.js` now in the UI and ballooned the bundle to > 2MB. 
- A PI3 needes depending on load and config 3-8s to process the data when cached. 
- My Pi4 with wifi is already close to unusable slow. 

<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>The admin UI shipped everything in a single 2.1MB JavaScript bundle. This splits it using route-level code splitting and vendor chunk extraction, reducing the initial page load to ~500KB.</p>
<ul>
<li>Convert 13 routes to <code>React.lazy()</code> with a <code>Suspense</code> boundary — Dashboard, Login, Register, Webapps, Embedded, and EmbeddedDocs stay eagerly loaded</li>
<li>Extract mathjs and its dependencies (decimal.js, typed-function, complex.js, fraction.js, seedrandom) into a separate <code>vendor-mathjs</code> chunk via <code>manualChunks</code> — only fetched when navigating to the Data Browser</li>
<li>Remove full lodash CJS import (138KB) from <code>actions.ts</code>, replacing a single <code>isUndefined()</code> call with <code>=== undefined</code></li>
</ul>
<p>Vite's own code splitting naturally groups @rjsf/ajv into the Configuration route chunk (~418KB, loaded only on plugin config) and react-select into a shared chunk (~86KB, loaded by Data Browser/Server Log/Connections).</p>
<p>Note: <code>manualChunks</code> is limited to mathjs (pure math, no React imports) because <code>@module-federation/vite</code> rewrites React imports into async share-scope resolution with top-level await — forcing React-dependent packages into separate vendor chunks breaks the MF initialization order.</p>
<h2 data-heading="Bundle comparison">Bundle comparison</h2>

  | Before | After
-- | -- | --
Initial load (bootstrap) | 2,098 KB | 498 KB
/databrowser | — | +637 KB (mathjs) +131 KB (views)
/serverConfiguration/plugins/:id | — | +418 KB (rjsf+ajv+views)
Other routes | — | 2–62 KB each on demand

<!--EndFragment-->
</body>
</html>


## Note

- The downfall is that we have now have a short loading animation when a new, uncached chunk is loaded
-  This branch is based upon https://github.com/SignalK/signalk-server/pull/2452 to be able to test embedded R16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Performance optimization: bundle splitting with lazy routes and vendor chunks

This PR optimizes the admin UI bundle size by splitting the UI into lazy-loaded route chunks and extracting heavy dependencies into dedicated vendor chunks. It reduces the initial bootstrap bundle to about 500 KB, improving startup performance on constrained hardware (for example, Raspberry Pi 3/4).

### Key changes

**Route lazy-loading (Full.tsx)**
This PR defines most route target views as `React.lazy()` imports via a `lazyWithRetry()` wrapper and renders the router inside a `React.Suspense` boundary with a `LoadingSpinner` fallback. It adds a chunk-load failure classifier (`isChunkLoadError`) and enhances an `ErrorBoundary` to handle dynamic-import/chunk-load failures with a guarded one-time `window.location.reload()`, tracked through `sessionStorage` to avoid reload loops. It also tolerates environments that block `sessionStorage` by falling back to the error panel instead of attempting reloads. Dashboard, Login, Register, Webapps, Embedded, and EmbeddedDocs remain eagerly loaded.

**Vendor chunk extraction (vite.config.ts)**
This PR configures Rollup/Vite `output.manualChunks` with a path-anchored `MATHJS_VENDOR_PATTERN` that matches `mathjs` and related runtime dependencies under `node_modules`, emitting them into a dedicated `vendor-mathjs` chunk. That chunk loads only when the Data Browser route is accessed. The `manualChunks` configuration stays limited to `mathjs` due to `@module-federation/vite` React import rewriting and initialization-order constraints. Vite also groups `@rjsf/ajv` into the Configuration route chunk and shares `react-select` across relevant routes.

**Dependency trimming (dataFetching.ts)**
This PR removes the lodash CJS usage in `dataFetching.ts` by replacing `isUndefined()` with a direct `=== undefined` check, keeping the existing `authFetch` flow and error handling unchanged.

### Bundle impact (overall)
- Initial bootstrap: ~498 KB (from ~2,098 KB)
- `/databrowser`: increases on-demand due to the `vendor-mathjs` chunk load
- `/serverConfiguration/plugins/:id`: increases on-demand due to `@rjsf/ajv` grouping
- Other routes: small on-demand increments when their chunks load
<!-- end of auto-generated comment: release notes by coderabbit.ai -->