### PR TITLE
fix(appstore): handle invalid semver versions gracefully

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -261,6 +261,14 @@ module.exports = function (app) {
       const name = plugin.package.name
       const version = plugin.package.version
 
+      if (!semver.valid(version)) {
+        console.warn(
+          `Skipping ${name}: invalid semver version '${version}'. ` +
+            `Please inform the plugin developer to publish a valid semver version.`
+        )
+        return
+      }
+
       const pluginInfo = {
         name: name,
         version: version,
@@ -327,8 +335,16 @@ module.exports = function (app) {
         pluginInfo.isRemove = modulesInstalledSinceStartup[name].isRemove
         addIfNotDuplicate(result.installing, pluginInfo)
       } else if (installedModule) {
-        if (gt(version, installedModule.version)) {
+        if (
+          semver.valid(installedModule.version) &&
+          gt(version, installedModule.version)
+        ) {
           addIfNotDuplicate(result.updates, pluginInfo)
+        } else if (!semver.valid(installedModule.version)) {
+          console.warn(
+            `Installed module ${name} has invalid semver version '${installedModule.version}'. ` +
+              `Please inform the plugin developer.`
+          )
         }
         addIfNotDuplicate(result.installed, pluginInfo)
       }


### PR DESCRIPTION
## Summary

Plugins or webapps with non-semver versions (e.g. `0.1.01`) cause `semver.gt()` to throw, crashing the entire appstore listing. On v2.23.0 this makes the appstore appear offline; on v2.19.1 it returns empty results.

The fix validates versions before comparing:
- Invalid npm registry version: skip the module from the listing and log a warning naming the package
- Invalid locally installed version: show the module in the installed list but skip the update check, with a warning

## Tested manually

- Confirmed `semver.gt('1.0.0', '0.1.01')` throws `Invalid Version: 0.1.01` (reproduces the crash)
- Confirmed `semver.valid('0.1.01')` returns `null` (guard works)
- Verified invalid npm version skips module, valid modules still listed normally
- Verified invalid installed version logs warning, module still appears in installed list
- Verified normal update detection (valid versions) is unaffected

Fixes: https://github.com/SignalK/signalk-server/issues/2455