### PR TITLE
fix(resources): return 404 for nonexistent resource ID

### DIFF
--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -406,6 +406,9 @@ export class ResourcesApi {
         Object.assign(result, r.value)
       }
     })
+    if (Object.keys(result).length === 0) {
+      throw new Error(`Resource not found! (${resId})`)
+    }
     return result
   }
 


### PR DESCRIPTION
## Description:

`getResource()` returned `{}` instead of an error when a resource ID didn't exist, making it impossible for callers to distinguish "not found" from a valid empty resource.

The `getFromAll()` helper used `Promise.allSettled` and silently ignored all rejections, always returning the initial `{}`. Now throws when no provider returns data, so HTTP endpoints return 404 and the programmatic API (`app.resourcesApi.getResource()`) rejects the promise.

## Manually tested 

- `GET /signalk/v2/api/resources/waypoints/nonexistent-id` → 404 `{"state":"FAILED","statusCode":404,"message":"Resource not found! (nonexistent-id)"}`
- `GET /signalk/v2/api/resources/waypoints/` → 200 `{}` (empty collection, unaffected)

Fixes #1612