### PR TITLE
fix(admin-ui): warn about disk space when enabling data logging

### DIFF
--- a/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
@@ -574,6 +574,12 @@ function PluginConfigCard({
                   <span className="switch-handle" />
                 </Form.Label>
                 <span className="ms-1">Data logging</span>
+                {optimisticData.enableLogging && (
+                  <Form.Text className="text-warning d-block">
+                    Creates hourly log files that can consume significant disk
+                    space
+                  </Form.Text>
+                )}
               </Col>
               <Col lg={4} className={'mt-2 mt-lg-0'}>
                 <Form.Label

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -389,6 +389,11 @@ function LoggingInput({ value, onChange }: LoggingInputProps) {
           <span className="switch-label" data-on="Yes" data-off="No" />
           <span className="switch-handle" />
         </Form.Label>
+        {value.logging && (
+          <Form.Text className="text-warning">
+            Creates hourly log files that can consume significant disk space
+          </Form.Text>
+        )}
       </Col>
     </Form.Group>
   )

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -317,8 +317,10 @@ const ServerSettings: React.FC = () => {
                   value={settings.loggingDirectory || ''}
                 />
                 <Form.Text muted>
-                  Connections that have logging enabled create hourly log files
-                  in Multiplexed format in this directory
+                  Connections and plugins that have logging enabled create
+                  hourly log files in Multiplexed format in this directory. This
+                  can consume significant disk space — enable the option below
+                  to limit retention.
                 </Form.Text>
               </Col>
             </Form.Group>


### PR DESCRIPTION
## Description

Users enabling data logging on connections or plugins may not realize it creates hourly log files that can fill up the disk, potentially rendering the system unusable.

Adds a yellow warning text that appears when data logging is toggled on (connections and plugins), and improves the Settings page hint to mention disk space impact and point to the retention option.


## Test 
Manually tested on a running server.

Fixes #1611