### PR TITLE
fix(streams): handle serial port write backpressure correctly

### DIFF
--- a/packages/streams/src/serialport.ts
+++ b/packages/streams/src/serialport.ts
@@ -48,29 +48,33 @@ export default class SerialStream extends Transform {
     const standardOutEventName = `serial-${this.options.providerId}-toStdout`
     stdOutEvents.push(standardOutEventName)
 
-    const onDrain = (): void => {
-      pendingWrites--
-    }
-
     for (const event of stdOutEvents) {
       this.options.app.on(event, (d: string | Buffer) => {
+        if (!this.serial) {
+          return
+        }
         if (pendingWrites > this.maxPendingWrites) {
           this.debug('Buffer overflow, not writing:' + d)
           return
         }
         this.debug('Writing:' + d)
-        if (Buffer.isBuffer(d)) {
-          this.serial?.write(d)
-        } else {
-          this.serial?.write(d + '\r\n')
-        }
+        const data = Buffer.isBuffer(d) ? d : d + '\r\n'
+        const flushed = this.serial.write(data, (err) => {
+          if (err) {
+            this.debug('Write error: ' + err.message)
+          }
+        })
         setImmediate(() => {
           this.options.app.emit('connectionwrite', {
             providerId: this.options.providerId
           })
         })
-        pendingWrites++
-        this.serial?.drain(onDrain)
+        if (!flushed) {
+          pendingWrites++
+          this.serial.once('drain', () => {
+            pendingWrites--
+          })
+        }
       })
     }
 


### PR DESCRIPTION
Fixes #1575

The serial port write handler ignored the return value of `serial.write()` and called `serial.drain(callback)` on every write regardless of buffer state. This caused two problems:

1. **No backpressure handling** — when the kernel buffer was full, writes continued without waiting for drain, potentially overwhelming the serial device
2. **Stuck pending counter** — if `drain()` failed, the `pendingWrites` counter never decremented, eventually exceeding `maxPendingWrites` and permanently blocking all further writes

The fix uses the standard Node.js streams backpressure pattern: check the `write()` return value and only listen for the `drain` event when the buffer is actually full. Write errors are now logged via debug instead of being silently swallowed.