### PR TITLE
fix(streams): set default TCP idle timeout to 60 seconds

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -758,7 +758,7 @@ function NoDataReceivedTimeoutInput({
     <TextInput
       title="No data timeout"
       name="options.noDataReceivedTimeout"
-      helpText="Timeout for no data received in seconds. Socket is disconnected and reconnection attempted if timeout is reached. Leave empty or 0 to disable."
+      helpText="Timeout for no data received in seconds (default: 60). Socket is disconnected and reconnection attempted if timeout is reached. Set to 0 to disable."
       value={value.noDataReceivedTimeout}
       onChange={onChange}
     />

--- a/packages/streams/src/tcp.ts
+++ b/packages/streams/src/tcp.ts
@@ -25,6 +25,7 @@ export default class TcpStream extends Transform {
   private readonly options: TcpOptions
   private readonly debug: DebugLogger
   private readonly debugData: DebugLogger
+  private static readonly DEFAULT_TIMEOUT_SECONDS = 60
   private readonly noDataReceivedTimeout: number
   private tcpStream: net.Socket | undefined
   private reconnector: { disconnect(): void } | null = null
@@ -32,8 +33,13 @@ export default class TcpStream extends Transform {
   constructor(options: TcpOptions) {
     super()
     this.options = options
+    const parsedTimeout = Number.parseInt(
+      (this.options.noDataReceivedTimeout + '').trim()
+    )
     this.noDataReceivedTimeout =
-      Number.parseInt((this.options.noDataReceivedTimeout + '').trim()) * 1000
+      (isNaN(parsedTimeout)
+        ? TcpStream.DEFAULT_TIMEOUT_SECONDS
+        : parsedTimeout) * 1000
     const createDebug = options.createDebug ?? require('debug')
     this.debug = createDebug('signalk:streams:tcp')
     this.debug(`noDataReceivedTimeout:${this.noDataReceivedTimeout}`)
@@ -71,7 +77,7 @@ export default class TcpStream extends Transform {
     this.reconnector = reconnect((opts: object) => {
       return net.connect(opts as { host: string; port: number })
     })({ maxDelay: 5 * 1000 }, (tcpStream: net.Socket) => {
-      if (!isNaN(this.noDataReceivedTimeout)) {
+      if (this.noDataReceivedTimeout > 0) {
         tcpStream.setTimeout(this.noDataReceivedTimeout)
         this.debug(
           `Setting socket idle timeout ${this.options.host}:${this.options.port} ${this.noDataReceivedTimeout}`


### PR DESCRIPTION
Fixes #1562

### Summary

TCP connections had no idle timeout unless explicitly configured, so stale connections went undetected and never reconnected. Defaults to 60 seconds. Users can still set a custom value or explicitly set 0 to disable.

### Manually verified timeout parsing logic:

- No config / empty string → defaults to 60000ms
- Explicit value (e.g. "30") → uses that value (30000ms)
- "0" → timeout disabled, no setTimeout call
