### PR TITLE
fix(settings): show correct mDNS status in admin UI

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -641,7 +641,7 @@ module.exports = function (
     const settings: any = {
       interfaces: {},
       options: {
-        mdns: app.config.settings.mdns || false,
+        mdns: isUndefined(app.config.settings.mdns) || app.config.settings.mdns,
         wsCompression: app.config.settings.wsCompression || false,
         wsPingInterval: app.config.settings.wsPingInterval ?? 30000,
         accessLogging:


### PR DESCRIPTION
Fixes #1531

mDNS runs by default (only disabled when explicitly set to `false`), but the settings GET endpoint used `app.config.settings.mdns || false`, which returned `false` when the setting was never configured. This made the admin UI toggle show "Off" for a service that was actually running. Changed to use the same `isUndefined() ||` pattern already used by other default-on settings like `accessLogging`.