### PR TITLE
feat(appstore): show update-disabled plugins in admin UI

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -86,10 +86,12 @@ const Apps: React.FC = () => {
     )
 
     appStore.installed.forEach((app) => {
+      const update = appStore.updates.find((u) => u.name === app.name)
       allApps[app.name] = {
         ...app,
         installed: true,
-        newVersion: updateAvailable(app, appStore) ? app.version : undefined
+        newVersion: update ? app.version : undefined,
+        updateDisabled: update?.updateDisabled
       }
     })
 
@@ -132,7 +134,7 @@ const Apps: React.FC = () => {
   const handleUpdateAll = useCallback(() => {
     if (confirm(`Are you sure you want to install all updates?`)) {
       for (const app of rowData) {
-        if (app.newVersion && app.installed) {
+        if (app.newVersion && app.installed && !app.updateDisabled) {
           fetch(
             `${window.serverRoutesPrefix}/appstore/install/${app.name}/${app.version}`,
             {

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -164,17 +164,23 @@ export default function ActionCellRenderer({
         <Dropdown as={ButtonGroup} className="w-100">
           {app.installed ? (
             app.newVersion ? (
-              <Button
-                className="text-start"
-                variant="success"
-                onClick={handleInstallClick}
-              >
-                <FontAwesomeIcon
-                  className="icon__update me-2"
-                  icon={faCloudArrowDown}
-                />
-                Update
-              </Button>
+              app.updateDisabled ? (
+                <span className="btn btn-outline-secondary text-start disabled">
+                  Update disabled
+                </span>
+              ) : (
+                <Button
+                  className="text-start"
+                  variant="success"
+                  onClick={handleInstallClick}
+                >
+                  <FontAwesomeIcon
+                    className="icon__update me-2"
+                    icon={faCloudArrowDown}
+                  />
+                  Update
+                </Button>
+              )
             ) : app.isPlugin ? (
               <NavLink
                 to={`/serverConfiguration/plugins/${app.id}`}

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -249,8 +249,12 @@ module.exports = function (app) {
     getModulesInfo(webapps, getWebApp, all, distTagsMap)
 
     if (process.env.PLUGINS_WITH_UPDATE_DISABLED) {
-      let disabled = process.env.PLUGINS_WITH_UPDATE_DISABLED.split(',')
-      all.updates = all.updates.filter((info) => !disabled.includes(info.name))
+      const disabled = process.env.PLUGINS_WITH_UPDATE_DISABLED.split(',')
+      all.updates.forEach((info) => {
+        if (disabled.includes(info.name)) {
+          info.updateDisabled = true
+        }
+      })
     }
 
     return all


### PR DESCRIPTION
Fixes #1526

### Summary

Plugins with updates blocked via PLUGINS_WITH_UPDATE_DISABLED were silently filtered from the updates list, giving no indication that updates existed but were intentionally held back. Now these plugins appear in the Updates view with a greyed-out "Update disabled" label instead of the update button, and are skipped by "Update all".

### Test 
Manually tested with PLUGINS_WITH_UPDATE_DISABLED=@mxtommy/kip — KIP shows in the Updates view with the disabled indicator while other plugins can still be updated normally.

### Image
<img width="1191" height="314" alt="image" src="https://github.com/user-attachments/assets/d8ae3ac4-6574-4b8e-8d6f-55fbdf3befbd" />
