### PR TITLE
fix(security): include timeToLive in login responses

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -140,7 +140,11 @@ interface SecurityStrategy {
   login: (
     username: string,
     password: string
-  ) => Promise<{ token?: string; statusCode: number }>
+  ) => Promise<{
+    token?: string
+    statusCode: number
+    timeToLive?: number | null
+  }>
   isDummy: () => boolean
 }
 
@@ -755,6 +759,7 @@ function wsInterface(app: WsApp): WsApi {
           state: 'COMPLETED',
           statusCode: reply.statusCode,
           login: {
+            timeToLive: reply.timeToLive,
             token: reply.token
           }
         })

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -130,6 +130,7 @@ interface LoginResponse {
   token?: string
   user?: string
   message?: string
+  timeToLive?: number | null
 }
 
 interface CookieOptions {
@@ -649,7 +650,10 @@ function tokenSecurityFactory(
               })
 
               if (requestType === 'application/json') {
-                res.json({ token: reply.token })
+                res.json({
+                  timeToLive: reply.timeToLive,
+                  token: reply.token
+                })
               } else {
                 res.redirect(getSafeDestination(req.body.destination))
               }
@@ -812,7 +816,15 @@ function tokenSecurityFactory(
                 configuration.secretKey,
                 jwtOptions
               )
-              resolve({ statusCode: 200, token, user: user.username })
+              const timeToLive = !isNever(theExpiration)
+                ? Math.floor(ms(theExpiration as StringValue) / 1000)
+                : null
+              resolve({
+                statusCode: 200,
+                token,
+                user: user.username,
+                timeToLive
+              })
             } catch (signErr) {
               resolve({
                 statusCode: 500,


### PR DESCRIPTION
Fixes #1476

### Summary 

The Signal K specification requires login responses to include a `timeToLive` field indicating how long the token is valid, in seconds. The server was only returning the `token` field.

Adds `timeToLive` to both REST (`/signalk/v1/auth/login`) and WebSocket login responses. When the server's token expiration is set to `NEVER`, the field is omitted.


### Test

Tested manually against a server with security enabled (port 4000):

**REST login:**

```
curl -s -X POST http://localhost:4000/signalk/v1/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"username":"admin","password":"***"}' | jq
```

Response includes `timeToLive` (in seconds) alongside `token`.

**WebSocket login:**

```
wscat -c ws://localhost:4000/signalk/v1/stream
> {"requestId":"1","login":{"username":"admin","password":"***"}}
```

Response includes `timeToLive` in the login reply.

**NEVER expiration:** With server configured for `NEVER` token expiration, verified `timeToLive` is correctly omitted from the response.

**Duration calculations verified:** `1h`→3600, `24h`→86400, `7d`→604800.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login responses now include token expiration time, enabling applications to inform users about session duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->