### PR TITLE
fix(udp): report connection status to dashboard

### DIFF
--- a/packages/streams/src/udp.ts
+++ b/packages/streams/src/udp.ts
@@ -8,6 +8,7 @@ interface UdpOptions {
   app: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     on(event: string, cb: (...args: any[]) => void): void
+    setProviderStatus(id: string, msg: string): void
     setProviderError(id: string, msg: string): void
   }
   providerId: string
@@ -61,6 +62,11 @@ export default class Udp extends Transform {
 
     socket.bind(this.options.port, () => {
       socket.setBroadcast(true)
+      const addr = socket.address()
+      this.options.app.setProviderStatus(
+        this.options.providerId,
+        `Listening on UDP port ${addr.port}`
+      )
     })
 
     return pipeTo


### PR DESCRIPTION
  Fixes #1470
  
  ### Summary
  
  The UDP provider never called `setProviderStatus`, so the dashboard showed no status for UDP connections. Errors like EADDRINUSE were only visible in the console log.

Adds a `setProviderStatus` call on successful bind so the dashboard shows the listening state, matching the pattern used by the TCP provider.

### Tested manually against server with a UDP provider on port 10110:

- Normal startup: dashboard shows "Listening on UDP port 10110"
- Port conflict (held port 10110 with separate process before starting server): dashboard shows "bind EADDRINUSE 0.0.0.0:10110"