### PR TITLE
fix(admin-ui): encode connection ID in provider API URLs

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -151,7 +151,7 @@ const ProvidersConfiguration: React.FC = () => {
     const id = selectedProvider.originalId
 
     const response = await fetch(
-      `${window.serverRoutesPrefix}/providers/${id && !isNew ? id : ''}`,
+      `${window.serverRoutesPrefix}/providers/${id && !isNew ? encodeURIComponent(id) : ''}`,
       {
         method: isNew ? 'POST' : 'PUT',
         headers: {
@@ -199,7 +199,7 @@ const ProvidersConfiguration: React.FC = () => {
     if (!selectedProvider) return
 
     const response = await fetch(
-      `${window.serverRoutesPrefix}/providers/${selectedProvider.id}`,
+      `${window.serverRoutesPrefix}/providers/${encodeURIComponent(selectedProvider.id)}`,
       {
         method: 'DELETE',
         headers: {


### PR DESCRIPTION
Fixes #1125

### Summary

Connection IDs containing a forward slash (`/`) cannot be updated or deleted from the admin UI. The unencoded slash is interpreted as a URL path separator, causing Express route mismatches (404).

Adds `encodeURIComponent()` to provider ID in PUT and DELETE fetch URLs. Express auto-decodes the parameter on the server side, so no backend changes are needed.

### Manually tested
- **Without encoding**: 404 `Cannot DELETE /skServer/providers/test/slash` (the bug)
- **With encoding** (`%2F`): 200 `Connection deleted` (the fix)
