### PR TITLE
fix(settings): correct mDNS default status in admin UI

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -641,7 +641,7 @@ module.exports = function (
     const settings: any = {
       interfaces: {},
       options: {
-        mdns: app.config.settings.mdns || false,
+        mdns: app.config.settings.mdns ?? true,
         wsCompression: app.config.settings.wsCompression || false,
         wsPingInterval: app.config.settings.wsPingInterval ?? 30000,
         accessLogging:


### PR DESCRIPTION
Fixes #1039

### Summary

On a fresh install where `settings.mdns` is not yet set, the server enables mDNS (treating `undefined` as enabled) but the settings API returns `false`, causing the admin UI to show mDNS as disabled. Fixes the mismatch by using `?? true` instead of `|| false` so the API reflects the server's actual default.

