### PR TITLE
fix(rest): serve snapshot at spec-compliant path /signalk/v1/snapshot

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -66,6 +66,7 @@ module.exports = function (app) {
   const pathPrefix = '/signalk'
   const versionPrefix = '/v1'
   const apiPathPrefix = pathPrefix + versionPrefix + '/api/'
+  const snapshotPathPrefix = pathPrefix + versionPrefix + '/snapshot/'
   const streamPath = pathPrefix + versionPrefix + '/stream'
 
   const KNOWN_OTHER_PATH_PREFIXES = ['resources']
@@ -73,6 +74,62 @@ module.exports = function (app) {
   return {
     start: function () {
       app.use('/', express.static(__dirname + '/../../public'))
+
+      function snapshotHandler(snapshotPath, req, res, next) {
+        if (!req.query.time) {
+          res.status(400).send('Snapshot api requires time query parameter')
+        } else if (!iso8601rexexp.test(req.query.time)) {
+          res
+            .status(400)
+            .send(
+              'Time query parameter must be a valid ISO 8601 UTC time value like 2018-12-11T18:40:03.246'
+            )
+        } else if (!app.historyProvider) {
+          res.status(501).send('No history provider')
+        } else {
+          app.historyProvider.getHistory(
+            new Date(req.query.time),
+            snapshotPath,
+            (deltas) => {
+              if (deltas.length === 0) {
+                res.status(404).send('No data found for the given time')
+                return
+              }
+              const full = app.deltaCache.buildFullFromDeltas(
+                req.skPrincipal,
+                deltas
+              )
+              if (!full) {
+                next()
+                return
+              }
+              let result = full
+              for (const p of snapshotPath) {
+                if (typeof result[p] !== 'undefined') {
+                  result = result[p]
+                } else {
+                  next()
+                  return
+                }
+              }
+              res.json(result)
+            }
+          )
+        }
+      }
+
+      // Spec-compliant snapshot path: /signalk/v1/snapshot/...
+      app.get(snapshotPathPrefix + '*', function (req, res, next) {
+        const pathStr = req.params[0] || ''
+        const snapshotPath =
+          pathStr.length > 0
+            ? pathStr
+                .replace(/\/$/, '')
+                .split('/')
+                .map((p) => (p === 'self' ? app.selfId : p))
+            : []
+        snapshotHandler(snapshotPath, req, res, next)
+      })
 
       app.get(apiPathPrefix + '*', function (req, res, next) {
         let path = String(req.path).replace(apiPathPrefix, '')
@@ -134,36 +191,7 @@ module.exports = function (app) {
         }
 
         if (path[0] && path[0] === 'snapshot') {
-          if (!req.query.time) {
-            res.status(400).send('Snapshot api requires time query parameter')
-          } else {
-            if (!iso8601rexexp.test(req.query.time)) {
-              res
-                .status(400)
-                .send(
-                  'Time query parameter must be a valid ISO 8601 UTC time value like 2018-12-11T18:40:03.246'
-                )
-            } else if (!app.historyProvider) {
-              res.status(501).send('No history provider')
-            } else {
-              const realPath = path.slice(1)
-              app.historyProvider.getHistory(
-                new Date(req.query.time),
-                realPath,
-                (deltas) => {
-                  if (deltas.length === 0) {
-                    res.status(404).send('No data found for the given time')
-                    return
-                  }
-                  const last = app.deltaCache.buildFullFromDeltas(
-                    req.skPrincipal,
-                    deltas
-                  )
-                  sendResult(last, realPath)
-                }
-              )
-            }
-          }
+          return snapshotHandler(path.slice(1), req, res, next)
         } else {
           let last
           if (app.securityStrategy.anyACLs()) {

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -734,6 +734,12 @@ function tokenSecurityFactory(
         no_redir(req, res, next)
       }
     )
+    app.use(
+      '/signalk/v1/snapshot/*',
+      function (req: Request, res: Response, next: NextFunction) {
+        no_redir(req, res, next)
+      }
+    )
     app.put('/signalk/v1/*', writeAuthenticationMiddleware())
   }
 

--- a/test/history.js
+++ b/test/history.js
@@ -87,7 +87,23 @@ describe('History', (_) => {
     msg.should.equal('timeout')
   })
 
-  it('REST time request works', async function () {
+  it('REST time request works at spec-compliant path', async function () {
+    const result = await fetch(
+      `${url}/signalk/v1/snapshot/vessels/self?time=2018-08-09T14:07:29.695Z`
+    )
+    result.status.should.equal(200)
+    const json = await result.json()
+    json.should.have.nested.property('performance.velocityMadeGood')
+  })
+
+  it('REST time request with no data works at spec-compliant path', async function () {
+    const result = await fetch(
+      `${url}/signalk/v1/snapshot/vessels/self?time=2018-08-09T14:07:29.694Z`
+    )
+    result.status.should.equal(404)
+  })
+
+  it('REST time request works at legacy path', async function () {
     const result = await fetch(
       `${url}/signalk/v1/api/snapshot/vessels/self?time=2018-08-09T14:07:29.695Z`
     )
@@ -96,7 +112,7 @@ describe('History', (_) => {
     json.should.have.nested.property('performance.velocityMadeGood')
   })
 
-  it('REST time request with no data  works', async function () {
+  it('REST time request with no data works at legacy path', async function () {
     const result = await fetch(
       `${url}/signalk/v1/api/snapshot/vessels/self?time=2018-08-09T14:07:29.694Z`
     )


### PR DESCRIPTION
Fixes #898

### Summary 

The Signal K spec defines the history snapshot endpoint at `/signalk/v1/snapshot/` but the server only exposed it at `/signalk/v1/api/snapshot/`. This means spec-compliant clients could not reach the snapshot endpoint.

The fix extracts the snapshot handler into a shared function and registers it at the correct path, while keeping the old path fully intact for backwards compatibility. The security middleware (`http_authorize`) is also applied to the new path so authentication works identically.

### Manual tests 

- `GET /signalk/v1/snapshot/vessels/self?time=...` → `501` (no history provider installed — correct, route is reached)
- `GET /signalk/v1/api/snapshot/vessels/self?time=...` → `501` (legacy path unchanged)
- `GET /signalk/v1/snapshot/vessels/self` (no `time` param) → `400 Bad Request`
- `GET /signalk/v1/snapshot/vessels/self?time=not-a-date` → `400 Bad Request`
- Both paths return identical responses in all cases

