### PR TITLE
 fix(lint): disable @typescript-eslint/no-unused-expressions in test files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,7 +55,8 @@ module.exports = defineConfig([
     ],
     plugins: { chai },
     rules: {
-      'no-unused-expressions': 'off', // disable original rule
+      'no-unused-expressions': 'off',
+      '@typescript-eslint/no-unused-expressions': 'off',
       'chai/no-unused-expressions': 'error'
     },
     languageOptions: {


### PR DESCRIPTION
## Summary

The test eslint config disables `no-unused-expressions` so chai property assertions (`.to.be.true`, `.to.exist`) work in test files. However, `.ts` test files also have `@typescript-eslint/no-unused-expressions` active from the TypeScript config, which is not covered by the chai-friendly override.

This went unnoticed because all existing test files using chai property assertions are `.js`. Any new `.ts` test using `.to.be.true` or `.to.exist` would fail linting.

Adds `'@typescript-eslint/no-unused-expressions': 'off'` alongside the existing base rule override in the test config.