### PR TITLE
fix(meta): prevent deleted metadata fields from reappearing

### DIFF
--- a/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
@@ -103,7 +103,7 @@ describe('dataSlice', () => {
       )
     })
 
-    it('should merge metadata with existing values', () => {
+    it('should replace metadata on update', () => {
       useStore
         .getState()
         .updateMeta('vessels.self', 'navigation.speedOverGround', {
@@ -113,6 +113,7 @@ describe('dataSlice', () => {
       useStore
         .getState()
         .updateMeta('vessels.self', 'navigation.speedOverGround', {
+          units: 'm/s',
           description: 'Speed over ground'
         })
 

--- a/packages/server-admin-ui/src/store/slices/dataSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.ts
@@ -92,11 +92,10 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
   updateMeta: (context, path, metaData) => {
     set((state) => {
       const contextMeta = state.signalkMeta[context] || {}
-      const existingMeta = contextMeta[path] || {}
 
       const newContextMeta = {
         ...contextMeta,
-        [path]: { ...existingMeta, ...metaData }
+        [path]: metaData as MetaData
       }
 
       return {

--- a/src/put.ts
+++ b/src/put.ts
@@ -223,12 +223,22 @@ export function start(app: PutApp): void {
       }
     }
 
+    const previousMeta = app.config.baseDeltaEditor.getMeta(context, metaPath)
     app.config.baseDeltaEditor.setMeta(context, metaPath, metaValue)
 
+    // Remove fields that were deleted from the in-memory metadata registry
+    // so they don't get re-injected via the spread below
     const full_meta = getMetadata('vessels.self.' + metaPath) as Record<
       string,
       unknown
     >
+    if (previousMeta && full_meta) {
+      for (const key of Object.keys(previousMeta)) {
+        if (!(key in metaValue)) {
+          delete full_meta[key]
+        }
+      }
+    }
 
     app.handleMessage('defaults', {
       context: 'vessels.self' as Context,

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -169,4 +169,50 @@ describe('Metadata end to end', function () {
     })
     expect(meta3).to.have.property('description', 'A test path')
   })
+
+  it('deletes a metadata field and it does not reappear', async () => {
+    const zones = [{ lower: 14.4, state: 'alarm', message: 'High voltage' }]
+    const setupResult = await selfPutV1(`${TEST_PATH_SLASHES}/meta/zones`, {
+      value: zones
+    })
+    expect(setupResult.status).to.equal(202)
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    const metaBefore = await selfGetMetaJson()
+    expect(metaBefore).to.have.property('zones')
+
+    const deleteResult = await fetch(
+      `${v1Api}/vessels/self/${TEST_PATH_SLASHES}/meta/zones`,
+      { method: 'DELETE' }
+    )
+    expect(deleteResult.status).to.equal(202)
+
+    const metaAfterDelete = await selfGetMetaJson()
+    expect(metaAfterDelete).to.not.have.property('zones')
+
+    const putResult = await selfPutV1(`${TEST_PATH_SLASHES}/meta/description`, {
+      value: 'Updated description'
+    })
+    expect(putResult.status).to.equal(202)
+
+    const metaAfterPut = await selfGetMetaJson()
+    expect(metaAfterPut).to.not.have.property('zones')
+    expect(metaAfterPut).to.have.property('description', 'Updated description')
+
+    await server.stop()
+    server = await startServerP(port, false, {
+      settings: {
+        interfaces: {
+          plugins: false
+        }
+      }
+    })
+
+    const metaAfterRestart = await selfGetMetaJson()
+    expect(metaAfterRestart).to.not.have.property('zones')
+    expect(metaAfterRestart).to.have.property(
+      'description',
+      'Updated description'
+    )
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #2475 — deleted metadata fields reappear in the Data Browser after saving other meta or reconnecting.

**Root cause:** `putMetaHandler` builds the outgoing delta as `{ ...full_meta, ...metaValue }` where `full_meta` comes from `getMetadata()`. This returns the in-memory metadata registry object which still contains previously added fields. When a user deletes a field and then saves, the deleted field gets re-injected via the spread from `full_meta`.

**Fix (server):** Before building the delta, compare the new `metaValue` against what `baseDeltaEditor` previously stored. Any fields that were removed get deleted from the `getMetadata()` registry object so they can't be re-injected.

**Fix (client):** Change `updateMeta` in `dataSlice.ts` from merge semantics (`{ ...existing, ...new }`) to replace semantics. The server always sends the complete meta object (schema defaults + user additions), so replace is safe and prevents stale fields from surviving in the Zustand store across WebSocket reconnects.

## Manual test

Tested against a running server (`PORT=4100 npm start -- -c ~/.signalk-meta`):

1. PUT custom fields `testField` and `zones` to `environment.wind.speedApparent.meta` — both visible in REST API and `baseDeltas.json`
2. DELETE `testField` — gone from REST API immediately
3. PUT `anotherField` — `testField` does NOT reappear (this was the bug)
4. Verified `baseDeltas.json` is consistent: only `zones` and `anotherField`, no `testField`

## New Test
Automated e2e test added covering: add → delete → PUT-after-delete → restart → verify deleted field stays gone.