### PR TITLE
fix: resolve baconjs version mismatch between server and plugins

### DIFF
--- a/packages/server-api/src/streambundle.ts
+++ b/packages/server-api/src/streambundle.ts
@@ -4,7 +4,7 @@ import * as Bacon from 'baconjs'
 /** @category Server API */
 export interface StreamBundle {
   /**
-   * Get a [Bacon JS 1.0](https://baconjs.github.io/api.html) stream for a Signal K path that will stream values from any context.
+   * Get a [Bacon JS](https://baconjs.github.io/) stream for a Signal K path that will stream values from any context.
    *
    * Stream values are objects with the following structure:
    * ```javascript

--- a/src/baconjs-compat.ts
+++ b/src/baconjs-compat.ts
@@ -1,0 +1,67 @@
+/*
+ * BaconJS backward-compatibility shim
+ *
+ * The server uses BaconJS 3.x which has breaking API changes from 1.x/0.7.x.
+ * Plugins may bundle their own older BaconJS, causing version mismatches when
+ * they operate on Bacon.Bus objects from the server's StreamBundle.
+ *
+ * The critical incompatibility: BaconJS 3.x Event objects use boolean
+ * properties (event.isEnd), while 1.x uses methods (event.isEnd()). When a
+ * plugin's 1.x code subscribes to a server 3.x Bus, it receives 3.x Events
+ * and crashes with "TypeError: e.isEnd is not a function".
+ *
+ * This module solves the problem by:
+ * 1. Hooking Node's module resolution so ALL require('baconjs') calls in the
+ *    process return the server's 3.x version — eliminating version mismatches
+ * 2. Patching 3.x to restore the .map('.property') string shorthand that
+ *    existed in 1.x (used by plugins like signalk-to-nmea2000)
+ *
+ * This module MUST be imported before any other module that uses BaconJS.
+ */
+
+import Module from 'module'
+import * as Bacon from 'baconjs'
+
+const serverBaconPath = require.resolve('baconjs')
+
+type ResolveFilename = (
+  request: string,
+  parent: NodeModule | undefined,
+  isMain: boolean,
+  options: Record<string, unknown>
+) => string
+
+const ModuleInternal = Module as unknown as Record<string, unknown>
+
+const origResolveFilename = ModuleInternal._resolveFilename as ResolveFilename
+ModuleInternal._resolveFilename = function (
+  request: string,
+  parent: NodeModule | undefined,
+  isMain: boolean,
+  options: Record<string, unknown>
+) {
+  if (request === 'baconjs') {
+    return serverBaconPath
+  }
+  return origResolveFilename.call(this, request, parent, isMain, options)
+}
+
+type Mappable = { map: (f: unknown) => unknown }
+
+function patchMapShorthand(proto: Mappable) {
+  const origMap = proto.map
+  proto.map = function (this: Mappable, f: unknown) {
+    if (typeof f === 'string' && f.startsWith('.')) {
+      const prop = f.substring(1)
+      return origMap.call(
+        this,
+        (v: Record<string, unknown> | null | undefined) =>
+          v !== null && v !== undefined ? v[prop] : undefined
+      )
+    }
+    return origMap.call(this, f)
+  }
+}
+
+patchMapShorthand(Bacon.EventStream.prototype)
+patchMapShorthand(Bacon.Property.prototype)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
 */
 
+import './baconjs-compat'
 import {
   Context,
   Delta,


### PR DESCRIPTION
### Summary

  Plugins bundling BaconJS 0.7.x/1.x crash with `TypeError: e.isEnd is not a function` when operating on the server's 3.x StreamBundle buses. The 3.x upgrade (bedef536) changed Event objects from methods (`event.isEnd()`) to boolean properties (`event.isEnd`), but plugins like signalk-to-nmea0183 bundle their own old BaconJS — so two incompatible versions coexist in the same process.

Rather than reverting to 1.x or maintaining a fork, this hooks `Module._resolveFilename` so all `require('baconjs')` calls in the process resolve to the server's 3.x copy. With a single BaconJS instance there is no cross-version Event mismatch. The `.map('.property')` string shorthand from 1.x is restored via a small prototype patch.

Affected plugins include signalk-to-nmea0183, signalk-to-nmea2000, aisreporter, signalk-switch-automation, signalk-to-csv, and community plugins like pdjr-skplugin-solarhotwater — any plugin that `require('baconjs')` with an old version and passes StreamBundle buses to its own Bacon operators.


### Manual testing performed

**Server started with:**

```
PORT=4000 npm start -- -c ~/.signalk_beacon --sample-nmea0183-data
```

Server receives live NMEA 2000 data from YDWG02 plus sample NMEA 0183 data.

**signalk-to-nmea0183 plugin enabled** via config API with sentences: RMC, HDT, MWV, VHW, DPT, GLL, VTG. This is the exact plugin and code path from Teppo's bug report — it uses `Bacon.combineWith(fn, [app.streambundle.getSelfStream(...)])` with its own bundled BaconJS 1.0.1.

**Results:**

- Plugin started without "TypeError: e.isEnd is not a function"
- 198 deltas received over WebSocket in 4 seconds — server streaming normally
- 111 NMEA 0183 output sentences generated in 4 seconds — plugin actively converting Signal K to 0183
- All 384 unit tests pass
- All 16 server-api tests pass
- `npm run format` clean

**Automated cross-version pattern tests** (node script simulating plugin code against server buses):

- `Bacon.combineWith(fn, [bus1, bus2])` — signalk-to-nmea0183, aisreporter, signalk-switch-automation pattern
- `bus.map('.value')` — signalk-to-nmea2000 pattern (1.x string property shorthand)
- `Bacon.combineAsArray([stream.skipDuplicates()])` — pdjr-skplugin-solarhotwater pattern
- `Bacon.mergeAll([bus1, bus2]).onValue()` — signalk-to-csv pattern
  
 Closes: https://github.com/SignalK/signalk-server/pull/2485