### PR TITLE
feat: add AsyncAPI docs for WebSocket delta APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "json-patch": "^0.7.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
+    "marked": "^17.0.5",
     "mathjs": "^12.4.0",
     "mdns-js": "^1.0.3",
     "minimist": "^1.2.8",

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -228,6 +228,12 @@ export default function Sidebar({ location }: SidebarProps) {
       }
     })
 
+    result.push({
+      name: 'AsyncApi',
+      url: '/asyncapi',
+      icon: 'icon-feed'
+    })
+
     return result
   }, [appStore, accessRequests, expiredDeviceCount, loginStatus])
 

--- a/packages/server-admin-ui/src/containers/Full/Full.tsx
+++ b/packages/server-admin-ui/src/containers/Full/Full.tsx
@@ -11,6 +11,7 @@ import Footer from '../../components/Footer/Footer'
 import Dashboard from '../../views/Dashboard/Dashboard'
 import Embedded from '../../views/Webapps/Embedded'
 import EmbeddedDocs from '../../views/Webapps/EmbeddedDocs'
+import EmbeddedAsyncApi from '../../views/Webapps/EmbeddedAsyncApi'
 import Webapps from '../../views/Webapps/Webapps'
 import DataBrowser from '../../views/DataBrowser/DataBrowser'
 import Playground from '../../views/Playground'
@@ -206,6 +207,7 @@ export default function Full() {
                 path="/security/access/requests"
                 element={<ProtectedRoute component={AccessRequests} />}
               />
+              <Route path="/asyncapi" element={<EmbeddedAsyncApi />} />
               <Route path="/documentation/*" element={<EmbeddedDocs />} />
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />

--- a/packages/server-admin-ui/src/views/Webapps/EmbeddedAsyncApi.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/EmbeddedAsyncApi.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useState } from 'react'
+
+interface AsyncApiSpec {
+  title: string
+  url: string
+}
+
+interface AsyncApiDoc {
+  asyncapi: string
+  info: {
+    title: string
+    version: string
+    description?: string
+    descriptionHtml?: string
+  }
+  servers?: Record<
+    string,
+    { host: string; protocol: string; pathname?: string; description?: string }
+  >
+  channels?: Record<
+    string,
+    {
+      address?: string
+      description?: string
+      messages?: Record<
+        string,
+        {
+          name?: string
+          title?: string
+          summary?: string
+          payload?: Record<string, unknown>
+        }
+      >
+    }
+  >
+  operations?: Record<
+    string,
+    { action: string; summary?: string; description?: string }
+  >
+}
+
+function schemaToString(schema: Record<string, unknown>, indent = 0): string {
+  if (!schema) return 'any'
+  const pad = '  '.repeat(indent)
+  if (schema.anyOf)
+    return (schema.anyOf as Record<string, unknown>[])
+      .map((s) => schemaToString(s, indent))
+      .join(' | ')
+  if (schema.const !== undefined) return JSON.stringify(schema.const)
+  if (
+    schema.type === 'object' &&
+    schema.properties &&
+    typeof schema.properties === 'object'
+  ) {
+    const props = schema.properties as Record<string, Record<string, unknown>>
+    const lines = ['{']
+    for (const k of Object.keys(props)) {
+      lines.push(`${pad}  ${k}: ${schemaToString(props[k], indent + 1)}`)
+    }
+    lines.push(`${pad}}`)
+    return lines.join('\n')
+  }
+  if (schema.type === 'array' && schema.items)
+    return (
+      schemaToString(schema.items as Record<string, unknown>, indent) + '[]'
+    )
+  if (schema.type) return schema.type as string
+  return 'any'
+}
+
+export default function EmbeddedAsyncApi() {
+  const [specs, setSpecs] = useState<AsyncApiSpec[]>([])
+  const [selectedIdx, setSelectedIdx] = useState(0)
+  const [doc, setDoc] = useState<AsyncApiDoc | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetch('/skServer/asyncapi')
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((list) => {
+        const s = list.map((item: { title: string; jsonUrl: string }) => ({
+          title: item.title,
+          url: item.jsonUrl
+        }))
+        setSpecs(s)
+      })
+      .catch((e) => setError(e.message))
+  }, [])
+
+  useEffect(() => {
+    if (specs.length === 0) return
+    setError('')
+    setDoc(null)
+    fetch(specs[selectedIdx].url)
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then(setDoc)
+      .catch((e) => setError(e.message))
+  }, [specs, selectedIdx])
+
+  if (error) return <p style={{ color: 'red', padding: 20 }}>Error: {error}</p>
+
+  return (
+    <div style={{ padding: 20 }}>
+      <div style={{ marginBottom: 16 }}>
+        <label htmlFor="api-select" style={{ marginRight: 8, fontWeight: 500 }}>
+          API:
+        </label>
+        <select
+          id="api-select"
+          value={selectedIdx}
+          onChange={(e) => setSelectedIdx(Number(e.target.value))}
+          style={{ padding: '4px 8px' }}
+        >
+          {specs.map((s, i) => (
+            <option key={s.url} value={i}>
+              {s.title}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {!doc ? (
+        <p>Loading...</p>
+      ) : (
+        <>
+          <h4>{doc.info.title}</h4>
+          <small className="text-muted">
+            v{doc.info.version} — AsyncAPI {doc.asyncapi}
+          </small>
+          {doc.info.descriptionHtml && (
+            <div
+              style={{ marginTop: 12, fontSize: 14, lineHeight: 1.6 }}
+              dangerouslySetInnerHTML={{ __html: doc.info.descriptionHtml }}
+            />
+          )}
+
+          {doc.servers && (
+            <>
+              <h5 style={{ marginTop: 24 }}>Servers</h5>
+              {Object.entries(doc.servers).map(([name, srv]) => (
+                <div
+                  key={name}
+                  className="card"
+                  style={{ marginBottom: 8, padding: 12 }}
+                >
+                  <strong>{name}</strong>{' '}
+                  <span className="badge bg-primary">{srv.protocol}</span>
+                  <div style={{ fontSize: 13, marginTop: 4 }}>
+                    Host: {srv.host}
+                    {srv.pathname && <> — Path: {srv.pathname}</>}
+                  </div>
+                  {srv.description && (
+                    <div className="text-muted" style={{ fontSize: 13 }}>
+                      {srv.description}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+
+          {doc.channels && (
+            <>
+              <h5 style={{ marginTop: 24 }}>Channels</h5>
+              {Object.entries(doc.channels).map(([cname, ch]) => (
+                <div
+                  key={cname}
+                  className="card"
+                  style={{ marginBottom: 12, padding: 12 }}
+                >
+                  <code style={{ fontSize: 14 }}>{ch.address || cname}</code>
+                  {ch.description && (
+                    <div
+                      className="text-muted"
+                      style={{ fontSize: 13, marginTop: 4 }}
+                    >
+                      {ch.description}
+                    </div>
+                  )}
+                  {ch.messages && (
+                    <>
+                      <h6 style={{ marginTop: 12 }}>Messages</h6>
+                      {Object.entries(ch.messages).map(([mname, msg]) => (
+                        <div
+                          key={mname}
+                          style={{
+                            marginBottom: 10,
+                            paddingLeft: 12,
+                            borderLeft: '2px solid #dee2e6'
+                          }}
+                        >
+                          <code style={{ fontSize: 13 }}>
+                            {msg.name || mname}
+                          </code>
+                          {msg.title && (
+                            <span style={{ marginLeft: 8, fontWeight: 500 }}>
+                              {msg.title}
+                            </span>
+                          )}
+                          {msg.summary && (
+                            <div
+                              className="text-muted"
+                              style={{ fontSize: 12 }}
+                            >
+                              {msg.summary}
+                            </div>
+                          )}
+                          {msg.payload && (
+                            <pre
+                              style={{
+                                background: '#f5f5f5',
+                                padding: 8,
+                                borderRadius: 4,
+                                fontSize: 12,
+                                marginTop: 4
+                              }}
+                            >
+                              {schemaToString(
+                                msg.payload as Record<string, unknown>
+                              )}
+                            </pre>
+                          )}
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+
+          {doc.operations && (
+            <>
+              <h5 style={{ marginTop: 24 }}>Operations</h5>
+              {Object.entries(doc.operations).map(([oname, op]) => (
+                <div
+                  key={oname}
+                  className="card"
+                  style={{ marginBottom: 8, padding: 12 }}
+                >
+                  <span className="badge bg-success" style={{ marginRight: 8 }}>
+                    {op.action}
+                  </span>
+                  <strong>{oname}</strong>
+                  {op.summary && (
+                    <div
+                      className="text-muted"
+                      style={{ fontSize: 13, marginTop: 4 }}
+                    >
+                      {op.summary}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/api/autopilot/asyncApi.ts
+++ b/src/api/autopilot/asyncApi.ts
@@ -1,0 +1,132 @@
+import { AutopilotInfoSchema } from '@signalk/server-api/typebox'
+import { Type } from '@sinclair/typebox'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const serverVersion: string = require('../../../' + 'package.json').version
+
+export const autopilotAsyncApiDoc = {
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Signal K Autopilot API - WebSocket Deltas',
+    version: serverVersion,
+    description: `
+WebSocket delta channels for the Signal K Autopilot API.
+
+## Overview
+The Autopilot API emits deltas under \`steering.autopilot.*\` when autopilot
+state changes (mode, target, engaged, actions) and under
+\`notifications.steering.autopilot.*\` for alarms.
+
+## Delta Paths
+- \`steering.autopilot.mode\` — current autopilot mode
+- \`steering.autopilot.state\` — current autopilot state
+- \`steering.autopilot.target\` — current target heading (radians)
+- \`steering.autopilot.engaged\` — whether the autopilot is engaged
+- \`steering.autopilot.availableActions\` — list of available action IDs
+- \`steering.autopilot.defaultPilot\` — default device ID
+- \`notifications.steering.autopilot.*\` — autopilot alarms
+
+## REST API
+For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
+    `.trim(),
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: {
+    signalk: {
+      host: 'localhost:3000',
+      protocol: 'ws',
+      description: 'Signal K server WebSocket endpoint',
+      pathname: '/signalk/v2/stream'
+    }
+  },
+  channels: {
+    'steering.autopilot': {
+      address: 'steering.autopilot',
+      description:
+        'Autopilot delta channel. Emits when autopilot state changes via provider updates.',
+      messages: {
+        mode: {
+          name: 'steering.autopilot.mode',
+          title: 'Autopilot Mode',
+          summary: 'Current autopilot mode (e.g. standby, auto, wind, route)',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        state: {
+          name: 'steering.autopilot.state',
+          title: 'Autopilot State',
+          summary: 'Current autopilot operational state',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        target: {
+          name: 'steering.autopilot.target',
+          title: 'Autopilot Target',
+          summary: 'Current target heading in radians',
+          contentType: 'application/json',
+          payload: Type.Union([Type.Number(), Type.Null()])
+        },
+        engaged: {
+          name: 'steering.autopilot.engaged',
+          title: 'Autopilot Engaged',
+          summary: 'Whether the autopilot is currently engaged',
+          contentType: 'application/json',
+          payload: Type.Boolean()
+        },
+        availableActions: {
+          name: 'steering.autopilot.availableActions',
+          title: 'Available Actions',
+          summary: 'List of currently available autopilot action IDs',
+          contentType: 'application/json',
+          payload: Type.Array(Type.String())
+        },
+        defaultPilot: {
+          name: 'steering.autopilot.defaultPilot',
+          title: 'Default Pilot',
+          summary: 'Device ID of the default autopilot',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        }
+      }
+    },
+    'notifications.steering.autopilot': {
+      address: 'notifications.steering.autopilot',
+      description:
+        'Autopilot alarm notifications. Emitted for waypoint advance/arrival, route complete, cross-track error, heading, and wind alarms.',
+      messages: {
+        alarm: {
+          name: 'notifications.steering.autopilot.*',
+          title: 'Autopilot Alarm',
+          summary:
+            'Alarm notification (waypointAdvance, waypointArrival, routeComplete, xte, heading, wind)',
+          contentType: 'application/json',
+          payload: Type.Object({
+            state: Type.String({ description: 'Alarm state' }),
+            method: Type.Array(Type.String()),
+            message: Type.String()
+          })
+        }
+      }
+    }
+  },
+  operations: {
+    receiveAutopilot: {
+      action: 'receive',
+      channel: { $ref: '#/channels/steering.autopilot' },
+      summary: 'Receive autopilot state updates'
+    },
+    receiveAutopilotAlarms: {
+      action: 'receive',
+      channel: { $ref: '#/channels/notifications.steering.autopilot' },
+      summary: 'Receive autopilot alarm notifications'
+    }
+  },
+  components: {
+    schemas: {
+      AutopilotInfo: AutopilotInfoSchema
+    }
+  }
+}

--- a/src/api/course/asyncApi.ts
+++ b/src/api/course/asyncApi.ts
@@ -1,0 +1,234 @@
+import {
+  ActiveRouteSchema,
+  NextPreviousPointSchema,
+  PositionSchema,
+  IsoTimeSchema,
+  ArrivalCircleSchema,
+  CoursePointTypeSchema
+} from '@signalk/server-api/typebox'
+import { Type } from '@sinclair/typebox'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const serverVersion: string = require('../../../' + 'package.json').version
+
+export const courseAsyncApiDoc = {
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Signal K Course API - WebSocket Deltas',
+    version: serverVersion,
+    description: `
+WebSocket delta channels for the Signal K Course API.
+
+## Protocol Versions
+- **v2** (recommended): Deltas under \`navigation.course.*\`
+- **v1** (legacy): Deltas under \`navigation.courseGreatCircle.*\` and
+  \`navigation.courseRhumbline.*\` (duplicated for both calculation methods)
+
+## Subscribing
+\`\`\`json
+{
+  "context": "vessels.self",
+  "subscribe": [
+    { "path": "navigation.course.*", "period": 1000 }
+  ]
+}
+\`\`\`
+
+## REST API
+For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
+    `.trim(),
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: {
+    signalk: {
+      host: 'localhost:3000',
+      protocol: 'ws',
+      description: 'Signal K server WebSocket endpoint',
+      pathname: '/signalk/v2/stream'
+    }
+  },
+  channels: {
+    'navigation.course': {
+      address: 'navigation.course',
+      description:
+        'v2 course delta channel. Emits when course state changes (destination set/cleared, route operations, arrival circle changes).',
+      messages: {
+        startTime: {
+          name: 'navigation.course.startTime',
+          title: 'Course Start Time',
+          summary:
+            'Time at which navigation to the current destination commenced',
+          contentType: 'application/json',
+          payload: Type.Union([IsoTimeSchema, Type.Null()])
+        },
+        targetArrivalTime: {
+          name: 'navigation.course.targetArrivalTime',
+          title: 'Target Arrival Time',
+          summary: 'The desired time at which to arrive at the destination',
+          contentType: 'application/json',
+          payload: Type.Union([IsoTimeSchema, Type.Null()])
+        },
+        activeRoute: {
+          name: 'navigation.course.activeRoute',
+          title: 'Active Route',
+          summary: 'Currently active route information',
+          contentType: 'application/json',
+          payload: Type.Union([ActiveRouteSchema, Type.Null()])
+        },
+        arrivalCircle: {
+          name: 'navigation.course.arrivalCircle',
+          title: 'Arrival Circle',
+          summary: 'Radius of the arrival zone in meters',
+          contentType: 'application/json',
+          payload: ArrivalCircleSchema
+        },
+        previousPoint: {
+          name: 'navigation.course.previousPoint',
+          title: 'Previous Point',
+          summary: 'The point the vessel is navigating from',
+          contentType: 'application/json',
+          payload: Type.Union([NextPreviousPointSchema, Type.Null()])
+        },
+        nextPoint: {
+          name: 'navigation.course.nextPoint',
+          title: 'Next Point',
+          summary: 'The point the vessel is navigating towards',
+          contentType: 'application/json',
+          payload: Type.Union([NextPreviousPointSchema, Type.Null()])
+        }
+      }
+    },
+    'navigation.courseGreatCircle': {
+      address: 'navigation.courseGreatCircle',
+      description:
+        'v1 course delta channel (Great Circle calculations). Mirrors courseRhumbline.',
+      messages: {
+        activeRouteHref: {
+          name: 'navigation.courseGreatCircle.activeRoute.href',
+          title: 'Active Route Href',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        activeRouteStartTime: {
+          name: 'navigation.courseGreatCircle.activeRoute.startTime',
+          title: 'Active Route Start Time',
+          contentType: 'application/json',
+          payload: Type.Union([IsoTimeSchema, Type.Null()])
+        },
+        nextPointHref: {
+          name: 'navigation.courseGreatCircle.nextPoint.value.href',
+          title: 'Next Point Href',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        nextPointType: {
+          name: 'navigation.courseGreatCircle.nextPoint.value.type',
+          title: 'Next Point Type',
+          contentType: 'application/json',
+          payload: Type.Union([CoursePointTypeSchema, Type.Null()])
+        },
+        nextPointPosition: {
+          name: 'navigation.courseGreatCircle.nextPoint.position',
+          title: 'Next Point Position',
+          contentType: 'application/json',
+          payload: Type.Union([PositionSchema, Type.Null()])
+        },
+        nextPointArrivalCircle: {
+          name: 'navigation.courseGreatCircle.nextPoint.arrivalCircle',
+          title: 'Arrival Circle',
+          contentType: 'application/json',
+          payload: ArrivalCircleSchema
+        },
+        previousPointPosition: {
+          name: 'navigation.courseGreatCircle.previousPoint.position',
+          title: 'Previous Point Position',
+          contentType: 'application/json',
+          payload: Type.Union([PositionSchema, Type.Null()])
+        },
+        previousPointType: {
+          name: 'navigation.courseGreatCircle.previousPoint.value.type',
+          title: 'Previous Point Type',
+          contentType: 'application/json',
+          payload: Type.Union([CoursePointTypeSchema, Type.Null()])
+        }
+      }
+    },
+    'navigation.courseRhumbline': {
+      address: 'navigation.courseRhumbline',
+      description:
+        'v1 course delta channel (Rhumbline calculations). Mirrors courseGreatCircle.',
+      messages: {
+        activeRouteHref: {
+          name: 'navigation.courseRhumbline.activeRoute.href',
+          title: 'Active Route Href',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        activeRouteStartTime: {
+          name: 'navigation.courseRhumbline.activeRoute.startTime',
+          title: 'Active Route Start Time',
+          contentType: 'application/json',
+          payload: Type.Union([IsoTimeSchema, Type.Null()])
+        },
+        nextPointHref: {
+          name: 'navigation.courseRhumbline.nextPoint.value.href',
+          title: 'Next Point Href',
+          contentType: 'application/json',
+          payload: Type.Union([Type.String(), Type.Null()])
+        },
+        nextPointType: {
+          name: 'navigation.courseRhumbline.nextPoint.value.type',
+          title: 'Next Point Type',
+          contentType: 'application/json',
+          payload: Type.Union([CoursePointTypeSchema, Type.Null()])
+        },
+        nextPointPosition: {
+          name: 'navigation.courseRhumbline.nextPoint.position',
+          title: 'Next Point Position',
+          contentType: 'application/json',
+          payload: Type.Union([PositionSchema, Type.Null()])
+        },
+        nextPointArrivalCircle: {
+          name: 'navigation.courseRhumbline.nextPoint.arrivalCircle',
+          title: 'Arrival Circle',
+          contentType: 'application/json',
+          payload: ArrivalCircleSchema
+        },
+        previousPointPosition: {
+          name: 'navigation.courseRhumbline.previousPoint.position',
+          title: 'Previous Point Position',
+          contentType: 'application/json',
+          payload: Type.Union([PositionSchema, Type.Null()])
+        },
+        previousPointType: {
+          name: 'navigation.courseRhumbline.previousPoint.value.type',
+          title: 'Previous Point Type',
+          contentType: 'application/json',
+          payload: Type.Union([CoursePointTypeSchema, Type.Null()])
+        }
+      }
+    }
+  },
+  operations: {
+    receiveCourseV2: {
+      action: 'receive',
+      channel: { $ref: '#/channels/navigation.course' },
+      summary: 'Receive v2 course delta updates',
+      description:
+        'Emitted when course state changes. Contains path values under navigation.course.*'
+    },
+    receiveCourseGreatCircle: {
+      action: 'receive',
+      channel: { $ref: '#/channels/navigation.courseGreatCircle' },
+      summary: 'Receive v1 course delta updates (Great Circle)'
+    },
+    receiveCourseRhumbline: {
+      action: 'receive',
+      channel: { $ref: '#/channels/navigation.courseRhumbline' },
+      summary: 'Receive v1 course delta updates (Rhumbline)'
+    }
+  }
+}

--- a/src/api/notifications/asyncApi.ts
+++ b/src/api/notifications/asyncApi.ts
@@ -1,0 +1,67 @@
+import { AlarmSchema } from '@signalk/server-api/typebox'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const serverVersion: string = require('../../../' + 'package.json').version
+
+export const notificationsAsyncApiDoc = {
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Signal K Notifications API - WebSocket Deltas',
+    version: serverVersion,
+    description: `
+WebSocket delta channels for Signal K notifications.
+
+## Overview
+Notifications are emitted as deltas under \`notifications.*\` paths when
+alarms are raised, updated, or cleared by the server or plugins.
+
+## Subscribing
+\`\`\`json
+{
+  "context": "vessels.self",
+  "subscribe": [
+    { "path": "notifications.*", "period": 1000 }
+  ]
+}
+\`\`\`
+
+## REST API
+For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
+    `.trim(),
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: {
+    signalk: {
+      host: 'localhost:3000',
+      protocol: 'ws',
+      description: 'Signal K server WebSocket endpoint',
+      pathname: '/signalk/v2/stream'
+    }
+  },
+  channels: {
+    notifications: {
+      address: 'notifications.*',
+      description:
+        'Notification delta channel. Emits when alarms are raised, updated, or cleared.',
+      messages: {
+        notification: {
+          name: 'notifications.*',
+          title: 'Notification',
+          summary: 'An alarm or notification state change',
+          contentType: 'application/json',
+          payload: AlarmSchema
+        }
+      }
+    }
+  },
+  operations: {
+    receiveNotification: {
+      action: 'receive',
+      channel: { $ref: '#/channels/notifications' },
+      summary: 'Receive notification deltas'
+    }
+  }
+}

--- a/src/api/radar/asyncApi.ts
+++ b/src/api/radar/asyncApi.ts
@@ -1,0 +1,73 @@
+import { RadarInfoSchema, RadarStatusSchema } from '@signalk/server-api/typebox'
+import { Type } from '@sinclair/typebox'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const serverVersion: string = require('../../../' + 'package.json').version
+
+export const radarAsyncApiDoc = {
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Signal K Radar API - WebSocket Streams',
+    version: serverVersion,
+    description: `
+WebSocket streams for the Signal K Radar API.
+
+## Spoke Stream
+Radar providers stream spoke data over a dedicated WebSocket endpoint.
+Clients connect to receive raw radar returns for rendering.
+
+## REST API
+For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
+    `.trim(),
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: {
+    signalk: {
+      host: 'localhost:3000',
+      protocol: 'ws',
+      description: 'Signal K server WebSocket endpoint',
+      pathname: '/signalk/v2/api/vessels/self/radars/{radarId}/stream'
+    }
+  },
+  channels: {
+    'radars.stream': {
+      address: 'radars/{radarId}/stream',
+      description: 'Radar spoke data stream. Binary spoke data for rendering.',
+      parameters: {
+        radarId: {
+          description: 'The radar identifier'
+        }
+      },
+      messages: {
+        spokeData: {
+          name: 'spokeData',
+          title: 'Spoke Data',
+          summary: 'Raw radar spoke data for display rendering',
+          contentType: 'application/octet-stream',
+          payload: Type.Object({
+            angle: Type.Number({ description: 'Spoke angle in degrees' }),
+            data: Type.String({
+              description: 'Base64-encoded spoke sample data'
+            })
+          })
+        }
+      }
+    }
+  },
+  operations: {
+    receiveSpokeData: {
+      action: 'receive',
+      channel: { $ref: '#/channels/radars.stream' },
+      summary: 'Receive radar spoke data'
+    }
+  },
+  components: {
+    schemas: {
+      RadarInfo: RadarInfoSchema,
+      RadarStatus: RadarStatusSchema
+    }
+  }
+}

--- a/src/api/resources/asyncApi.ts
+++ b/src/api/resources/asyncApi.ts
@@ -1,0 +1,171 @@
+import { Type } from '@sinclair/typebox'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const serverVersion: string = require('../../../' + 'package.json').version
+
+export const resourcesAsyncApiDoc = {
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Signal K Resources API - WebSocket Deltas',
+    version: serverVersion,
+    description: `
+WebSocket delta channels for Signal K resource changes.
+
+## Overview
+The Resources API emits deltas under \`resources.{type}.{id}\` when
+resources are created, updated, or deleted. Resource types include
+routes, waypoints, notes, regions, and charts.
+
+## Subscribing
+\`\`\`json
+{
+  "context": "vessels.self",
+  "subscribe": [
+    { "path": "resources.*", "period": 1000 }
+  ]
+}
+\`\`\`
+
+## REST API
+For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
+    `.trim(),
+    license: {
+      name: 'Apache 2.0',
+      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: {
+    signalk: {
+      host: 'localhost:3000',
+      protocol: 'ws',
+      description: 'Signal K server WebSocket endpoint',
+      pathname: '/signalk/v2/stream'
+    }
+  },
+  channels: {
+    'resources.routes': {
+      address: 'resources.routes.*',
+      description: 'Route resource changes (created, updated, or deleted).',
+      messages: {
+        route: {
+          name: 'resources.routes.*',
+          title: 'Route Change',
+          summary: 'A route resource was created, updated, or deleted',
+          contentType: 'application/json',
+          payload: Type.Union([
+            Type.Object({
+              name: Type.Optional(Type.String()),
+              description: Type.Optional(Type.String()),
+              feature: Type.Object({
+                type: Type.Literal('Feature'),
+                geometry: Type.Object({
+                  type: Type.Literal('LineString'),
+                  coordinates: Type.Array(
+                    Type.Array(Type.Number(), { minItems: 2, maxItems: 3 })
+                  )
+                })
+              })
+            }),
+            Type.Null()
+          ])
+        }
+      }
+    },
+    'resources.waypoints': {
+      address: 'resources.waypoints.*',
+      description: 'Waypoint resource changes (created, updated, or deleted).',
+      messages: {
+        waypoint: {
+          name: 'resources.waypoints.*',
+          title: 'Waypoint Change',
+          summary: 'A waypoint resource was created, updated, or deleted',
+          contentType: 'application/json',
+          payload: Type.Union([
+            Type.Object({
+              name: Type.Optional(Type.String()),
+              description: Type.Optional(Type.String()),
+              feature: Type.Object({
+                type: Type.Literal('Feature'),
+                geometry: Type.Object({
+                  type: Type.Literal('Point'),
+                  coordinates: Type.Array(Type.Number(), {
+                    minItems: 2,
+                    maxItems: 3
+                  })
+                })
+              })
+            }),
+            Type.Null()
+          ])
+        }
+      }
+    },
+    'resources.notes': {
+      address: 'resources.notes.*',
+      description: 'Note resource changes.',
+      messages: {
+        note: {
+          name: 'resources.notes.*',
+          title: 'Note Change',
+          contentType: 'application/json',
+          payload: Type.Union([
+            Type.Object({
+              title: Type.Optional(Type.String()),
+              description: Type.Optional(Type.String()),
+              url: Type.Optional(Type.String()),
+              mimeType: Type.Optional(Type.String())
+            }),
+            Type.Null()
+          ])
+        }
+      }
+    },
+    'resources.regions': {
+      address: 'resources.regions.*',
+      description: 'Region resource changes.',
+      messages: {
+        region: {
+          name: 'resources.regions.*',
+          title: 'Region Change',
+          contentType: 'application/json',
+          payload: Type.Union([
+            Type.Object({
+              feature: Type.Object({
+                type: Type.Literal('Feature'),
+                geometry: Type.Object({
+                  type: Type.Union([
+                    Type.Literal('Polygon'),
+                    Type.Literal('MultiPolygon')
+                  ])
+                })
+              })
+            }),
+            Type.Null()
+          ])
+        }
+      }
+    }
+  },
+  operations: {
+    receiveRouteChange: {
+      action: 'receive',
+      channel: { $ref: '#/channels/resources.routes' },
+      summary: 'Receive route resource changes'
+    },
+    receiveWaypointChange: {
+      action: 'receive',
+      channel: { $ref: '#/channels/resources.waypoints' },
+      summary: 'Receive waypoint resource changes'
+    },
+    receiveNoteChange: {
+      action: 'receive',
+      channel: { $ref: '#/channels/resources.notes' },
+      summary: 'Receive note resource changes'
+    },
+    receiveRegionChange: {
+      action: 'receive',
+      channel: { $ref: '#/channels/resources.regions' },
+      summary: 'Receive region resource changes'
+    }
+  }
+}

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import nodePath from 'path'
+import { marked } from 'marked'
 import { IRouter, NextFunction, Request, Response } from 'express'
 import swaggerUi from 'swagger-ui-express'
 import { SERVERROUTESPREFIX } from '../constants'
@@ -12,6 +14,11 @@ import { weatherApiRecord } from './weather/openApi'
 import { appsApiRecord } from './apps/openApi'
 import { historyApiRecord } from './history/openApi'
 import { radarApiRecord } from './radar/openApi'
+import { courseAsyncApiDoc } from './course/asyncApi'
+import { autopilotAsyncApiDoc } from './autopilot/asyncApi'
+import { notificationsAsyncApiDoc } from './notifications/asyncApi'
+import { radarAsyncApiDoc } from './radar/asyncApi'
+import { resourcesAsyncApiDoc } from './resources/asyncApi'
 import { PluginId, PluginManager } from '../interfaces/plugins'
 import { Brand } from '@signalk/server-api'
 
@@ -105,4 +112,290 @@ export function mountSwaggerUi(app: IRouter & PluginManager, path: string) {
     apiDefinitionHandler
   )
   app.get(`${SERVERROUTESPREFIX}/openapi/:api`, apiDefinitionHandler)
+
+  // -------------------------------------------------------------------------
+  // AsyncAPI endpoints
+  // -------------------------------------------------------------------------
+
+  interface AsyncApiRecord {
+    name: string
+    title: string
+    doc: object
+  }
+
+  const asyncApiDocs: Record<string, AsyncApiRecord> = {
+    course: {
+      name: 'course',
+      title: 'Course API',
+      doc: courseAsyncApiDoc
+    },
+    autopilot: {
+      name: 'autopilot',
+      title: 'Autopilot API',
+      doc: autopilotAsyncApiDoc
+    },
+    notifications: {
+      name: 'notifications',
+      title: 'Notifications API',
+      doc: notificationsAsyncApiDoc
+    },
+    radar: {
+      name: 'radar',
+      title: 'Radar API',
+      doc: radarAsyncApiDoc
+    },
+    resources: {
+      name: 'resources',
+      title: 'Resources API',
+      doc: resourcesAsyncApiDoc
+    }
+  }
+
+  // List available AsyncAPI docs
+  app.get(`${SERVERROUTESPREFIX}/asyncapi`, (_req: Request, res: Response) => {
+    res.json(
+      Object.values(asyncApiDocs).map(({ name, title }) => ({
+        name,
+        title,
+        jsonUrl: `${SERVERROUTESPREFIX}/asyncapi/${name}`,
+        docsUrl: `${SERVERROUTESPREFIX}/asyncapi/docs`
+      }))
+    )
+  })
+
+  // Serve marked.js from node_modules
+  app.get('/skServer/vendor/marked.umd.js', (_req: Request, res: Response) => {
+    res.sendFile(
+      nodePath.join(
+        nodePath.dirname(require.resolve('marked/package.json')),
+        'lib',
+        'marked.umd.js'
+      )
+    )
+  })
+
+  // Serve unified AsyncAPI viewer with dropdown
+  // MUST be registered before /asyncapi/:api to avoid matching "docs" as :api
+  const asyncApiUrls = Object.values(asyncApiDocs).map(({ name, title }) => ({
+    name: title,
+    url: `${SERVERROUTESPREFIX}/asyncapi/${name}`
+  }))
+
+  app.get(
+    `${SERVERROUTESPREFIX}/asyncapi/docs`,
+    (_req: Request, res: Response) => {
+      const specsJson = JSON.stringify(
+        asyncApiUrls.map((u) => ({
+          title: u.name,
+          url: u.url
+        }))
+      )
+      res.send(asyncApiViewerHtml(specsJson))
+    }
+  )
+
+  // Serve individual AsyncAPI JSON documents
+  app.get(
+    `${SERVERROUTESPREFIX}/asyncapi/:api`,
+    (req: Request, res: Response) => {
+      const record = asyncApiDocs[req.params.api]
+      if (record) {
+        const cleaned = JSON.parse(
+          JSON.stringify(record.doc, (key, value) =>
+            key === '$id' ? undefined : value
+          )
+        )
+        resolveRefs(cleaned, cleaned)
+        if (cleaned.info?.description) {
+          cleaned.info.descriptionHtml = marked(cleaned.info.description)
+        }
+        res.json(cleaned)
+      } else {
+        res.status(404).json('Not found')
+      }
+    }
+  )
+}
+
+function resolveRefs(obj: any, root: any): void {
+  if (!obj || typeof obj !== 'object') return
+  for (const key of Object.keys(obj)) {
+    if (
+      key === '$ref' &&
+      typeof obj[key] === 'string' &&
+      obj[key].startsWith('#/')
+    ) {
+      const path = obj[key].slice(2).split('/')
+      let target = root
+      for (const p of path) {
+        target = target?.[p]
+      }
+      if (target && typeof target === 'object') {
+        delete obj.$ref
+        Object.assign(obj, JSON.parse(JSON.stringify(target)))
+      }
+    } else {
+      resolveRefs(obj[key], root)
+    }
+  }
+}
+
+function asyncApiViewerHtml(specsJson: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Signal K AsyncAPI Documentation</title>
+  <script src="/skServer/vendor/marked.umd.js"><\/script>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #1e1e1e; color: #d4d4d4; }
+    #nav { display: flex; align-items: center; gap: 12px; padding: 10px 20px; background: #252526; color: #cccccc; border-bottom: 1px solid #3c3c3c; }
+    #nav label { font-size: 14px; font-weight: 500; }
+    #nav select { padding: 4px 8px; border-radius: 4px; border: 1px solid #3c3c3c; background: #3c3c3c; color: #cccccc; font-size: 14px; }
+    #nav select:focus { outline: none; border-color: #007acc; }
+    .container { max-width: 960px; margin: 0 auto; padding: 20px; height: calc(100vh - 45px); overflow-y: auto; }
+    h1 { color: #e0e0e0; font-size: 22px; margin: 0 0 4px 0; }
+    h2 { color: #569cd6; font-size: 18px; margin: 28px 0 12px 0; border-bottom: 1px solid #3c3c3c; padding-bottom: 6px; }
+    h3 { color: #9cdcfe; font-size: 15px; margin: 16px 0 8px 0; }
+    .version { color: #858585; font-size: 13px; margin-bottom: 16px; }
+    .description { line-height: 1.6; margin-bottom: 20px; }
+    .description code { background: #2d2d2d; color: #ce9178; padding: 1px 5px; border-radius: 3px; font-size: 13px; }
+    .description pre { background: #1a1a1a; border: 1px solid #3c3c3c; border-radius: 4px; padding: 12px; overflow-x: auto; }
+    .description pre code { background: none; padding: 0; }
+    a { color: #3794ff; text-decoration: none; }
+    a:hover { color: #4daafc; text-decoration: underline; }
+    .card { background: #252526; border: 1px solid #3c3c3c; border-radius: 6px; padding: 16px; margin-bottom: 12px; }
+    .card-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
+    .badge-ws { background: #2b5797; color: #9cdcfe; }
+    .badge-receive { background: #264f36; color: #6a9955; }
+    .summary { color: #b0b0b0; font-size: 13px; margin-bottom: 8px; }
+    .channel-addr { font-family: monospace; color: #dcdcaa; font-size: 14px; }
+    .msg-name { font-family: monospace; color: #ce9178; font-size: 13px; }
+    .prop-table { width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 8px; }
+    .prop-table th { text-align: left; padding: 6px 8px; border-bottom: 1px solid #3c3c3c; color: #858585; font-weight: 500; }
+    .prop-table td { padding: 6px 8px; border-bottom: 1px solid #2d2d2d; }
+    .type-tag { color: #4ec9b0; font-family: monospace; font-size: 12px; }
+    dl.server-info { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 8px 0 0 0; font-size: 13px; }
+    dl.server-info dt { color: #858585; }
+    dl.server-info dd { margin: 0; }
+    .schema-block { background: #1a1a1a; border: 1px solid #3c3c3c; border-radius: 4px; padding: 12px; font-family: monospace; font-size: 12px; white-space: pre-wrap; overflow-x: auto; margin-top: 8px; }
+    #loading { text-align: center; padding: 60px; color: #858585; }
+  </style>
+</head>
+<body>
+  <div id="nav">
+    <label for="spec-select">API:</label>
+    <select id="spec-select"></select>
+  </div>
+  <div class="container" id="content"><div id="loading">Loading...</div></div>
+  <script>
+    var SPECS = ${specsJson};
+
+    function esc(s) { var d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+    function md(s) { return typeof marked !== 'undefined' ? marked.parse(s) : '<p>' + esc(s) + '</p>'; }
+
+    function schemaToString(schema, indent) {
+      indent = indent || 0;
+      if (!schema) return 'any';
+      var pad = '  '.repeat(indent);
+      if (schema.anyOf) return schema.anyOf.map(function(s) { return schemaToString(s, indent); }).join(' | ');
+      if (schema.const !== undefined) return JSON.stringify(schema.const);
+      if (schema.type === 'object' && schema.properties) {
+        var lines = ['{'];
+        Object.keys(schema.properties).forEach(function(k) {
+          lines.push(pad + '  ' + k + ': ' + schemaToString(schema.properties[k], indent + 1));
+        });
+        lines.push(pad + '}');
+        return lines.join('\\n');
+      }
+      if (schema.type === 'array' && schema.items) return schemaToString(schema.items, indent) + '[]';
+      if (schema.type) return schema.type;
+      return 'any';
+    }
+
+    function renderDoc(doc) {
+      var html = '<h1>' + esc(doc.info.title) + '</h1>';
+      html += '<div class="version">v' + esc(doc.info.version) + ' — AsyncAPI ' + esc(doc.asyncapi) + '</div>';
+      if (doc.info.description) {
+        html += '<div class="description">' + md(doc.info.description) + '</div>';
+      }
+
+      if (doc.servers) {
+        html += '<h2>Servers</h2>';
+        Object.keys(doc.servers).forEach(function(sname) {
+          var srv = doc.servers[sname];
+          html += '<div class="card"><div class="card-header"><span class="badge badge-ws">' + esc(srv.protocol) + '</span><strong>' + esc(sname) + '</strong></div>';
+          html += '<dl class="server-info">';
+          html += '<div><dt>Host</dt><dd>' + esc(srv.host) + '</dd></div>';
+          if (srv.pathname) html += '<div><dt>Path</dt><dd>' + esc(srv.pathname) + '</dd></div>';
+          if (srv.description) html += '<div><dt>Description</dt><dd>' + esc(srv.description) + '</dd></div>';
+          html += '</dl></div>';
+        });
+      }
+
+      if (doc.channels) {
+        html += '<h2>Channels</h2>';
+        Object.keys(doc.channels).forEach(function(cname) {
+          var ch = doc.channels[cname];
+          html += '<div class="card">';
+          html += '<div class="card-header"><span class="channel-addr">' + esc(ch.address || cname) + '</span></div>';
+          if (ch.description) html += '<div class="summary">' + esc(ch.description) + '</div>';
+          if (ch.messages) {
+            html += '<h3>Messages</h3>';
+            Object.keys(ch.messages).forEach(function(mname) {
+              var msg = ch.messages[mname];
+              html += '<div style="margin-bottom:12px">';
+              html += '<div class="msg-name">' + esc(msg.name || mname) + '</div>';
+              if (msg.title) html += '<div><strong>' + esc(msg.title) + '</strong></div>';
+              if (msg.summary) html += '<div class="summary">' + esc(msg.summary) + '</div>';
+              if (msg.payload) {
+                html += '<div class="schema-block">' + esc(schemaToString(msg.payload)) + '</div>';
+              }
+              html += '</div>';
+            });
+          }
+          html += '</div>';
+        });
+      }
+
+      if (doc.operations) {
+        html += '<h2>Operations</h2>';
+        Object.keys(doc.operations).forEach(function(oname) {
+          var op = doc.operations[oname];
+          html += '<div class="card">';
+          html += '<div class="card-header"><span class="badge badge-receive">' + esc(op.action) + '</span><strong>' + esc(oname) + '</strong></div>';
+          if (op.summary) html += '<div class="summary">' + esc(op.summary) + '</div>';
+          if (op.description) html += '<div class="summary">' + esc(op.description) + '</div>';
+          html += '</div>';
+        });
+      }
+      return html;
+    }
+
+    var select = document.getElementById('spec-select');
+    SPECS.forEach(function(s, i) {
+      var opt = document.createElement('option');
+      opt.value = i;
+      opt.textContent = s.title;
+      select.appendChild(opt);
+    });
+
+    function loadSpec(idx) {
+      var spec = SPECS[idx];
+      document.getElementById('content').innerHTML = '<div id="loading">Loading...</div>';
+      fetch(spec.url).then(function(r) { return r.json(); }).then(function(doc) {
+        document.getElementById('content').innerHTML = renderDoc(doc);
+      }).catch(function(err) {
+        document.getElementById('content').innerHTML = '<p style="color:#f48771">Error: ' + esc(err.message) + '</p>';
+      });
+    }
+
+    select.addEventListener('change', function() { loadSpec(parseInt(this.value)); });
+    loadSpec(0);
+  <\/script>
+</body>
+</html>`
 }


### PR DESCRIPTION
## Summary

AsyncAPI 3.0 documents describing the WebSocket delta channels for Signal K APIs, with a React viewer integrated in the admin UI.

APIs documented:
- **Course** — v2 `navigation.course.*` and v1 legacy `courseGreatCircle/courseRhumbline` channels
- **Autopilot** — `steering.autopilot.*` state deltas and alarm notifications
- **Notifications** — `notifications.*` alarm state changes
- **Radar** — spoke data streaming via dedicated WebSocket
- **Resources** — `resources.{type}.*` CRUD change deltas

Server endpoints:
- `GET /skServer/asyncapi` — list available docs
- `GET /skServer/asyncapi/docs` — standalone dark-themed viewer
- `GET /skServer/asyncapi/:api` — individual JSON documents (with server-rendered markdown)

Admin UI viewer at `#/asyncapi` with API dropdown selector, rendered markdown descriptions, and Bootstrap-styled channel/message/operation cards.

Message payloads reference TypeBox schemas from #2480. A future improvement could auto-generate channel definitions from a delta channel registry, but the current APIs are stable enough that manual authoring is practical.

Depends on #2480.

## Tested

- Manual: admin UI viewer renders all 5 API docs with markdown, channels, messages, schemas
- Manual: standalone viewer at `/skServer/asyncapi/docs` works independently

## Note

I am currently not happy that each PR has a different UI/UX but decided to have a technical focus for now. 
Once it's clear how to proceed I can work on the UI/UX. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AsyncAPI documentation viewer in the admin UI with a dropdown to select and load specs.
  * Available specs: Autopilot, Course, Notifications, Radar, Resources.
  * New sidebar item for quick access to AsyncAPI docs.
  * Viewer route added (accessible directly from the UI).

* **Chores**
  * Added markdown runtime library to render AsyncAPI descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->