### PR TITLE
perf(streams): lazy-load N2K dependencies

### DIFF
--- a/packages/streams/src/nmea0183-signalk.test.ts
+++ b/packages/streams/src/nmea0183-signalk.test.ts
@@ -215,4 +215,24 @@ describe('Nmea0183ToSignalK', () => {
     expect(results).to.have.length(1)
     expect(app.nmea0183Events).to.deep.equal([RMC_SENTENCE])
   })
+
+  it('parses N2K-over-0183 (PCDIN) sentence into Signal K delta', async () => {
+    const app = createNmeaApp()
+    const stream = new Nmea0183ToSignalK({
+      app,
+      providerId: 'test'
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+
+    // PGN 127250 (Vessel Heading) via PCDIN encapsulation
+    stream.write('$PCDIN,01F112,00000000,0F,2AAF00D1067414FF*59')
+    stream.end()
+
+    const results = await outputPromise
+    expect(results.length).to.be.greaterThan(0)
+    const delta = results[0] as { updates: Array<{ values: unknown[] }> }
+    expect(delta.updates).to.be.an('array')
+    expect(delta.updates[0]!.values).to.be.an('array')
+  })
 })

--- a/packages/streams/src/nmea0183-signalk.ts
+++ b/packages/streams/src/nmea0183-signalk.ts
@@ -75,6 +75,12 @@ export default class Nmea0183ToSignalK extends Transform {
         ...this.options,
         useCamelCompat: this.options.useCamelCompat ?? true
       })
+      n2kParser.on('warning', (pgn: { pgn: number }, warning: string) => {
+        this.debug.enabled && this.debug(`[warning] ${pgn.pgn} ${warning}`)
+      })
+      n2kParser.on('error', (pgn: { input: string }, err: Error) => {
+        this.debug.enabled && this.debug(`[error] ${pgn.input} ${err.message}`)
+      })
       this.parseN2KOver0183 = n2kParser.parseN2KOver0183.bind(n2kParser)
       this.n2kToDelta = require('@signalk/n2k-signalk').toDelta as N2kToDelta
       return this.parseN2KOver0183(sentence, () => {})

--- a/packages/streams/src/nmea0183-signalk.ts
+++ b/packages/streams/src/nmea0183-signalk.ts
@@ -17,9 +17,14 @@
 import { Transform, TransformCallback } from 'stream'
 import Parser from '@signalk/nmea0183-signalk'
 import { appendChecksum } from '@signalk/nmea0183-utilities'
-import { toDelta as n2kToDelta } from '@signalk/n2k-signalk'
-import { FromPgn } from '@canboat/canboatjs'
-import type { CreateDebug } from './types'
+import type { CreateDebug, DebugLogger } from './types'
+
+function isN2KOver0183(msg: string): boolean {
+  const sentence = msg.charAt(0) === '\\' ? msg.split('\\')[2] : msg
+  return sentence
+    ? sentence.startsWith('$PCDIN,') || sentence.startsWith('$MXPGN,')
+    : false
+}
 
 interface Nmea0183ToSignalKOptions {
   app: {
@@ -48,14 +53,38 @@ interface Delta {
   updates: DeltaUpdate[]
 }
 
+type N2kToDelta = (
+  pgn: object,
+  state: Record<string, unknown>,
+  options: { sendMetaData: boolean }
+) => Delta | null
+
 export default class Nmea0183ToSignalK extends Transform {
-  private readonly debug: (...args: unknown[]) => void
+  private readonly debug: DebugLogger
   private readonly parser: InstanceType<typeof Parser>
-  private readonly n2kParser: InstanceType<typeof FromPgn>
+
+  private parseN2KOver0183: (
+    sentence: string,
+    callback: (err: Error | null, pgn?: unknown) => void
+  ) => object | undefined =
+    // runs only once when needed, replaces itself with the actual function
+    // after loading the required modules
+    (sentence: string) => {
+      const { FromPgn } = require('@canboat/canboatjs')
+      const n2kParser = new FromPgn({
+        ...this.options,
+        useCamelCompat: this.options.useCamelCompat ?? true
+      })
+      this.parseN2KOver0183 = n2kParser.parseN2KOver0183.bind(n2kParser)
+      this.n2kToDelta = require('@signalk/n2k-signalk').toDelta as N2kToDelta
+      return this.parseN2KOver0183(sentence, () => {})
+    }
+  private n2kToDelta?: N2kToDelta
   private readonly n2kState: Record<string, unknown> = {}
   private readonly app: Nmea0183ToSignalKOptions['app']
   private readonly sentenceEvents: string[]
   private readonly appendChecksumFlag: boolean
+  private readonly options: Nmea0183ToSignalKOptions
 
   constructor(options: Nmea0183ToSignalKOptions) {
     super({ objectMode: true })
@@ -64,7 +93,7 @@ export default class Nmea0183ToSignalK extends Transform {
     )
 
     this.parser = new Parser(options)
-    this.n2kParser = new FromPgn(options)
+    this.options = options
 
     this.app = options.app
     this.appendChecksumFlag = options.appendChecksum ?? false
@@ -130,12 +159,12 @@ export default class Nmea0183ToSignalK extends Transform {
         })
 
         let delta: Delta | null = null
-        if (this.n2kParser.isN2KOver0183(sentence)) {
-          const pgn = this.n2kParser.parseN2KOver0183(sentence, () => {})
+        if (isN2KOver0183(sentence)) {
+          const pgn = this.parseN2KOver0183(sentence, () => {})
           if (pgn) {
-            delta = n2kToDelta(pgn, this.n2kState, {
+            delta = this.n2kToDelta!(pgn, this.n2kState, {
               sendMetaData: true
-            }) as unknown as Delta | null
+            })
           }
         } else {
           delta = this.parser.parse(sentence) as Delta | null

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -2,8 +2,6 @@ import { Transform, TransformCallback } from 'stream'
 import N2kAnalyzer from './n2kAnalyzer'
 import FromJson from './from_json'
 import MultiplexedLog from './multiplexedlog'
-import Nmea0183ToSignalK from './nmea0183-signalk'
-import N2kToSignalK from './n2k-signalk'
 import Log from './log'
 import Liner from './liner'
 import SplittingLiner from './splitting-liner'
@@ -15,8 +13,6 @@ import FileStream from './filestream'
 import Replacer from './replacer'
 import Throttle from './throttle'
 import TimestampThrottle from './timestamp-throttle'
-import CanboatJs from './canboatjs'
-import { iKonvert, Ydwg02, W2k01 } from '@canboat/canboatjs'
 import Gpsd from './gpsd'
 import PigpioSeatalk from './pigpio-seatalk'
 import GpiodSeatalk from './gpiod-seatalk'
@@ -28,9 +24,35 @@ import type { CreateDebug, DeltaCache } from './types'
 interface CanboatCtor {
   new (options: object, ...args: unknown[]): Transform
 }
-const W2k01Ctor = W2k01 as unknown as CanboatCtor
-const Ydwg02Ctor = Ydwg02 as unknown as CanboatCtor
-const iKonvertCtor = iKonvert as unknown as CanboatCtor
+
+// CJS/ESM compat: these modules export the constructor on .default
+// when compiled from ESM, or as the module itself in plain CJS.
+function requireN2K(): {
+  CanboatJs: new (options: object) => PipeElement
+  N2kToSignalK: new (options: object) => PipeElement
+} {
+  const cb = require('./canboatjs')
+  const n2k = require('./n2k-signalk')
+  return {
+    CanboatJs: cb.default ?? cb,
+    N2kToSignalK: n2k.default ?? n2k
+  }
+}
+
+function requireN2kToSignalK(): new (options: object) => PipeElement {
+  const n2k = require('./n2k-signalk')
+  return n2k.default ?? n2k
+}
+
+function requireNmea0183ToSignalK(): new (options: object) => PipeElement {
+  const mod = require('./nmea0183-signalk')
+  return mod.default ?? mod
+}
+
+function requireW2k01(): CanboatCtor {
+  return (require('@canboat/canboatjs') as { W2k01: unknown })
+    .W2k01 as unknown as CanboatCtor
+}
 
 interface SimpleApp {
   selfContext: string
@@ -130,14 +152,18 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     options.subOptions.type !== 'wss' && options.subOptions.type !== 'ws'
       ? [new FromJson()]
       : [],
-  Seatalk: (options) => [
-    new Nmea0183ToSignalK({
-      ...options.subOptions,
-      validateChecksum: false
-    } as SubOptions & { app: SimpleApp; providerId: string })
-  ],
+  Seatalk: (options) => {
+    const Ctor = requireNmea0183ToSignalK()
+    return [
+      new Ctor({
+        ...options.subOptions,
+        validateChecksum: false
+      })
+    ]
+  },
   NMEA0183: (options) => {
-    const result: PipeElement[] = [new Nmea0183ToSignalK(options.subOptions)]
+    const Ctor = requireNmea0183ToSignalK()
+    const result: PipeElement[] = [new Ctor(options.subOptions)]
     if (options.type === 'FileStream') {
       result.unshift(
         new Throttle({
@@ -149,13 +175,15 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     return result
   },
   NMEA2000: (options) => {
+    const N2kCtor = requireN2kToSignalK()
     const result: PipeElement[] = [new N2kAnalyzer(options.subOptions)]
     if (options.type === 'FileStream') {
       result.push(new TimestampThrottle())
     }
-    return [...result, new N2kToSignalK(options.subOptions)]
+    return [...result, new N2kCtor(options.subOptions)]
   },
   NMEA2000JS: (options) => {
+    const { CanboatJs, N2kToSignalK } = requireN2K()
     const result: PipeElement[] = [new CanboatJs(options.subOptions)]
     if (options.type === 'FileStream') {
       result.push(new TimestampThrottle())
@@ -163,6 +191,11 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     return [...result, new N2kToSignalK(options.subOptions)]
   },
   NMEA2000IK: (options) => {
+    const { CanboatJs, N2kToSignalK } = requireN2K()
+    const canboatjs = require('@canboat/canboatjs') as {
+      iKonvert: unknown
+    }
+    const iKonvertCtor = canboatjs.iKonvert as unknown as CanboatCtor
     const result: PipeElement[] = [new CanboatJs(options.subOptions)]
     if (options.type === 'FileStream') {
       result.push(
@@ -185,6 +218,11 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     return [...result, new N2kToSignalK(options.subOptions)]
   },
   NMEA2000YD: (options) => {
+    const N2kCtor = requireN2kToSignalK()
+    const canboatjs = require('@canboat/canboatjs') as {
+      Ydwg02: unknown
+    }
+    const Ydwg02Ctor = canboatjs.Ydwg02 as unknown as CanboatCtor
     const result: PipeElement[] = [
       new Ydwg02Ctor(
         { ...options.subOptions },
@@ -194,9 +232,11 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     if (options.type === 'FileStream') {
       result.push(new TimestampThrottle())
     }
-    return [...result, new N2kToSignalK(options.subOptions)]
+    return [...result, new N2kCtor(options.subOptions)]
   },
   NMEA2000W2K_ASCII: (options) => {
+    const N2kCtor = requireN2kToSignalK()
+    const W2k01Ctor = requireW2k01()
     const result: PipeElement[] = [
       new W2k01Ctor({
         format: 'ascii',
@@ -206,9 +246,11 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     if (options.type === 'FileStream') {
       result.push(new TimestampThrottle())
     }
-    return [...result, new N2kToSignalK(options.subOptions)]
+    return [...result, new N2kCtor(options.subOptions)]
   },
   NMEA2000W2K_ACTISENSE: (options) => {
+    const N2kCtor = requireN2kToSignalK()
+    const W2k01Ctor = requireW2k01()
     const result: PipeElement[] = [
       new W2k01Ctor({
         format: 'actisense',
@@ -218,7 +260,7 @@ const dataTypeMapping: Record<string, PipelineFactory> = {
     if (options.type === 'FileStream') {
       result.push(new TimestampThrottle())
     }
-    return [...result, new N2kToSignalK(options.subOptions)]
+    return [...result, new N2kCtor(options.subOptions)]
   },
   Multiplexed: (options) => [new MultiplexedLog(options.subOptions)]
 }
@@ -288,6 +330,7 @@ function nmea2000input(
       new Liner(subOptions)
     ]
   } else if (subOptions.type === 'w2k-1-n2k-ascii-canboatjs') {
+    const W2k01Ctor = requireW2k01()
     return [
       new Tcp({ ...subOptions, outEvent: 'w2k-1-out' } as SubOptions & {
         host: string
@@ -298,6 +341,7 @@ function nmea2000input(
       new W2k01Ctor(subOptions, 'ascii', 'w2k-1-out')
     ]
   } else if (subOptions.type === 'w2k-1-n2k-actisense-canboatjs') {
+    const W2k01Ctor = requireW2k01()
     return [
       new Tcp({ ...subOptions, outEvent: 'w2k-1-out' } as SubOptions & {
         host: string


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>Defer loading of <code>@canboat/canboatjs</code>, <code>@signalk/n2k-signalk</code>, and their transitive dependency <code>@canboat/ts-pgns</code> (~1.6 MB) until an N2K provider is actually constructed.</p>
<p>With canboat/ts-pgns#44 merged, <code>@canboat/ts-pgns</code> now offers a lightweight <code>./lookups</code> subpath (~115 KB). However the real win in the server isn't switching import paths — it's not loading the full package at all when it isn't needed.</p>
<p>Previously, <code>simple.ts</code> eagerly imported <code>CanboatJs</code>, <code>N2kToSignalK</code>, <code>Nmea0183ToSignalK</code>, and the canboatjs hardware constructors (<code>iKonvert</code>, <code>Ydwg02</code>, <code>W2k01</code>) at the top level. This caused the entire ts-pgns PGN definition stack (~358 KB pgns.js + 270 KB enums.js + 105 KB lookups JSON) to load on every server startup — even for NMEA 0183-only or SignalK-only setups.</p>
<p>Additionally, <code>nmea0183-signalk.ts</code> eagerly imported <code>FromPgn</code> and <code>toDelta</code> for N2K-over-0183 support, so even a pure NMEA 0183 setup paid the full N2K cost.</p>
<p><strong>Changes:</strong></p>
<ul>
<li>All N2K-heavy modules in <code>simple.ts</code> now use inline <code>require()</code> inside their factory functions, following the existing lazy-load pattern already used for <code>actisense-serial</code>, <code>canbus</code>, <code>serialport</code>, and <code>mdns-ws</code> in the same file</li>
<li><code>nmea0183-signalk.ts</code> inlines a lightweight <code>isN2KOver0183()</code> check (PCDIN/MXPGN prefix detection) and defers <code>FromPgn</code>/<code>toDelta</code> loading until a N2K-over-0183 sentence actually appears on the wire</li>
</ul>
<h2 data-heading="Savings for non-N2K setups">Savings for non-N2K setups</h2>

Metric | Saved
-- | --
Heap | ~14–23 MB
RSS | ~50 MB
Startup time | ~200 ms
</body>
</html>

### Tested
- Verified on live server with NMEA 2000 data flowing from multiple sources

closes #2486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **Performance / Lazy-loading**
  * Defers loading heavy N2K dependencies (@canboat/canboatjs, @signalk/n2k-signalk and transitive ts-pgns payload) until an NMEA2000 provider is constructed or an N2K-over-0183 sentence is observed.
  * Moves N2K-heavy imports in packages/streams/src/simple.ts to runtime require() calls inside provider factory functions with CJS/ESM interop handling, so N2K code only loads when a pipeline factory runs.
  * Changes NMEA2000 pipelines to obtain CanboatJs/N2kToSignalK and hardware constructors (iKonvert, Ydwg02, W2k01) at factory execution time via require(); adds a consolidated requireW2k01() helper alongside existing lazy-load helpers (requireN2K, requireN2kToSignalK, requireNmea0183ToSignalK) to remove duplicated W2k01 preludes.
  * Updates packages/streams/src/nmea0183-signalk.ts to detect N2K-over-0183 sentences (PCDIN / MXPGN) with a new isN2KOver0183(msg) helper and lazily require() FromPgn and n2k->delta conversion only when such a sentence appears; the lazy initializer registers warning/error handlers and replaces itself after first use.
  * Avoids eager loading of the ts-pgns PGN/enums/lookups payload for setups that do not use N2K, yielding reported savings on non-N2K setups (~14–23 MB heap, ~50 MB RSS, ~200 ms startup). The change leverages the lightweight ./lookups option in ts-pgns but relies primarily on avoiding full package load until needed.

* **Tests**
  * Adds an async unit test in packages/streams/src/nmea0183-signalk.test.ts that writes a $PCDIN (N2K-over-0183) sentence into Nmea0183ToSignalK, ends the stream, and asserts the stream produces at least one output delta. The test validates output shape (updates/values arrays) rather than specific payload values, exercising the lazy N2K initialization path.

* **Behavioral / Compatibility**
  * Keeps exported/public APIs and type signatures unchanged; changes are internal runtime-loading and initialization only.
  * Implements the optimization intent from issue #2486 and is tested on a live server with NMEA 2000 traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->