### PR TITLE
fix(admin-ui): unpin @module-federation/vite version

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -28,7 +28,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^3.1.1",
-    "@module-federation/vite": "1.9.4",
+    "@module-federation/vite": "^1.9.4",
     "@rjsf/core": "^5.24.13",
     "@rjsf/utils": "^5.24.13",
     "@rjsf/validator-ajv8": "^5.24.13",

--- a/packages/server-admin-ui/vite.config.js
+++ b/packages/server-admin-ui/vite.config.js
@@ -70,6 +70,8 @@ function stripSvgFonts() {
   }
 }
 
+const isTest = process.env.VITEST === 'true'
+
 export default defineConfig({
   base: './',
   publicDir: 'public_src',
@@ -91,22 +93,28 @@ export default defineConfig({
         presets: [['@babel/preset-react', { runtime: 'automatic' }]]
       }
     }),
-    federation({
-      name: 'adminUI',
-      filename: 'remoteEntry.js',
-      remotes: {},
-      dts: false, // dts plugin tries to connect on port 16322 in dev mode
-      shared: {
-        react: {
-          singleton: true,
-          requiredVersion: '^19.0.0'
-        },
-        'react-dom': {
-          singleton: true,
-          requiredVersion: '^19.0.0'
-        }
-      }
-    })
+    // Module Federation runtime injects http: imports incompatible with
+    // Node.js ESM loader, so skip it during vitest runs.
+    ...(!isTest
+      ? [
+          federation({
+            name: 'adminUI',
+            filename: 'remoteEntry.js',
+            remotes: {},
+            dts: false,
+            shared: {
+              react: {
+                singleton: true,
+                requiredVersion: '^19.0.0'
+              },
+              'react-dom': {
+                singleton: true,
+                requiredVersion: '^19.0.0'
+              }
+            }
+          })
+        ]
+      : [])
   ],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## Summary

The exact pin to `1.9.4` was introduced in #2412 to work around a broken ESM import in `@module-federation/dts-plugin@2.1.0` — it used named ESM imports from `fs-extra@9.x` which is CJS-only, causing Node.js to reject the module at load time.

The upstream issue has been fixed in `dts-plugin@2.2.2` (shipped with `@module-federation/vite@1.13.1`). This restores the caret range (`^1.9.4`) so the package picks up future fixes and improvements.

The newer module federation runtime injects initialization code that uses `http:` URLs, which is incompatible with the Node.js ESM loader used by vitest. The federation plugin is now skipped during test runs since unit tests do not exercise module federation features.

## Verification

- Server started manually on N2k bus, tried various plugins and functions
- `npm run build:all` passes (admin UI build still produces `remoteEntry.js`)
- All 384 server tests pass
- All 87 admin UI tests pass
- All 55 streams tests pass
- All 16 server-api tests pass
- Lint and formatting clean

closes #2414