### PR TITLE
refactor(history): add HistoryProvider type and HistoryProviderRegistry

### DIFF
--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -112,10 +112,16 @@ export type ContextsRequestQueryParams = TimeRangeQueryParams
 export type ContextsResponse = Context[]
 
 /** @category  History API */
-export type HistoryApiRegistry = {
-  registerHistoryApiProvider(provider: HistoryApi): void
+export type HistoryProviderRegistry = {
+  registerHistoryApiProvider(provider: HistoryProvider): void
   unregisterHistoryApiProvider(): void
 }
+
+/**
+ * @deprecated Use {@link HistoryProviderRegistry} instead.
+ * @category  History API
+ */
+export type HistoryApiRegistry = HistoryProviderRegistry
 /** @category  History API */
 export type WithHistoryApi = {
   /**
@@ -130,6 +136,16 @@ export type WithHistoryApi = {
    */
   getHistoryApi?: (providerId?: string) => Promise<HistoryApi>
 }
+
+/**
+ * Provider interface for the History API.
+ *
+ * Plugins that supply historical data implement this interface and register
+ * it via {@link HistoryProviderRegistry.registerHistoryApiProvider}.
+ *
+ * @category  History API
+ */
+export type HistoryProvider = HistoryApi
 
 /** @category  History API */
 export interface HistoryApi {
@@ -161,16 +177,21 @@ export interface HistoryApi {
   getPaths(query: PathsRequest): Promise<PathsResponse>
 }
 
-export function isHistoryApi(obj: unknown): obj is HistoryApi {
+export function isHistoryProvider(obj: unknown): obj is HistoryProvider {
   if (typeof obj !== 'object' || obj === null) {
     return false
   }
   return (
-    typeof (obj as HistoryApi).getValues === 'function' &&
-    typeof (obj as HistoryApi).getContexts === 'function' &&
-    typeof (obj as HistoryApi).getPaths === 'function'
+    typeof (obj as HistoryProvider).getValues === 'function' &&
+    typeof (obj as HistoryProvider).getContexts === 'function' &&
+    typeof (obj as HistoryProvider).getPaths === 'function'
   )
 }
+
+/**
+ * @deprecated Use {@link isHistoryProvider} instead.
+ */
+export const isHistoryApi = isHistoryProvider
 
 /**
  * @hidden visible through ServerAPI

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -11,7 +11,7 @@ import {
 } from '.'
 import { RadarProviderRegistry, WithRadarApi } from './radarapi'
 import { CourseApi } from './course'
-import { HistoryApiRegistry, WithHistoryApi } from './history'
+import { HistoryProviderRegistry, WithHistoryApi } from './history'
 import { StreamBundle } from './streambundle'
 import { SubscriptionManager } from './subscriptionmanager'
 
@@ -40,7 +40,7 @@ export interface ServerAPI
     RadarProviderRegistry,
     WithRadarApi,
     WithHistoryApi,
-    HistoryApiRegistry,
+    HistoryProviderRegistry,
     WithFeatures,
     CourseApi,
     WithNotificationsApi,

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -3,8 +3,9 @@ import {
   ContextsRequest,
   ContextsResponse,
   HistoryApi,
+  HistoryProvider,
   HistoryProviders,
-  isHistoryApi,
+  isHistoryProvider,
   PathSpec,
   PathsRequest,
   PathsResponse,
@@ -29,7 +30,7 @@ const HISTORY_API_PATH = `/signalk/v2/api/history`
 interface HistoryApplication extends WithSecurityStrategy, IRouter {}
 
 export class HistoryApiHttpRegistry {
-  private historyProviders: Map<string, HistoryApi> = new Map()
+  private historyProviders: Map<string, HistoryProvider> = new Map()
   private defaultProviderId?: string
   proxy: HistoryApi
 
@@ -61,8 +62,11 @@ export class HistoryApiHttpRegistry {
     }
   }
 
-  registerHistoryApiProvider(pluginId: string, provider: HistoryApi): void {
-    if (!isHistoryApi(provider)) {
+  registerHistoryApiProvider(
+    pluginId: string,
+    provider: HistoryProvider
+  ): void {
+    if (!isHistoryProvider(provider)) {
       throw new Error('Invalid history api provider')
     }
     if (!this.historyProviders.has(pluginId)) {
@@ -101,7 +105,7 @@ export class HistoryApiHttpRegistry {
         debug(`**route = ${req.method} ${req.path}`)
         try {
           const r: HistoryProviders = {}
-          this.historyProviders.forEach((_v: HistoryApi, k: string) => {
+          this.historyProviders.forEach((_v: HistoryProvider, k: string) => {
             r[k] = {
               isDefault: k === this.defaultProviderId
             }
@@ -217,7 +221,7 @@ export class HistoryApiHttpRegistry {
     )
   }
 
-  private defaultProvider(): HistoryApi {
+  private defaultProvider(): HistoryProvider {
     if (
       this.defaultProviderId &&
       this.historyProviders.has(this.defaultProviderId)
@@ -227,7 +231,7 @@ export class HistoryApiHttpRegistry {
     throw new Error('No history api provider configured')
   }
 
-  private useProvider(req: Request): HistoryApi | undefined {
+  private useProvider(req: Request): HistoryProvider | undefined {
     if (req.query.provider) {
       const provider = this.historyProviders.get(req.query.provider as string)
       if (!provider) {
@@ -242,8 +246,8 @@ export class HistoryApiHttpRegistry {
 }
 
 async function respondWith<T>(
-  getProvider: () => HistoryApi | undefined,
-  handler: (provider: HistoryApi) => Promise<T> | undefined,
+  getProvider: () => HistoryProvider | undefined,
+  handler: (provider: HistoryProvider) => Promise<T> | undefined,
   res: Response
 ) {
   try {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -65,7 +65,7 @@ const _putPath = put.putPath
 const getModulePublic = require('../config/get').getModulePublic
 import { queryRequest } from '../requestResponse'
 import { getMetadata } from '@signalk/signalk-schema'
-import { HistoryApi } from '@signalk/server-api/history'
+import { HistoryProvider } from '@signalk/server-api/history'
 import { HistoryApiHttpRegistry } from '../api/history'
 import { derivePluginId } from '../pluginid'
 
@@ -661,7 +661,7 @@ module.exports = (theApp: any) => {
     const historyApiRegistry: HistoryApiHttpRegistry =
       app.historyApiHttpRegistry
     delete (appCopy as any).historyApiHttpRegistry // expose only the plugin-specific proxy
-    appCopy.registerHistoryApiProvider = (provider: HistoryApi) => {
+    appCopy.registerHistoryApiProvider = (provider: HistoryProvider) => {
       historyApiRegistry.registerHistoryApiProvider(plugin.id, provider)
       onStopHandlers[plugin.id].push(() => {
         historyApiRegistry.unregisterHistoryApiProvider(plugin.id)


### PR DESCRIPTION
## Summary

Phase 1 of #2417 — introduces consistent naming conventions for the History API, aligning it with the unified provider/API naming template (`WeatherProvider`/`WeatherApi` pattern).

- Add `HistoryProvider` type alias as the provider interface (what plugins implement)
- Add `HistoryProviderRegistry` type (replaces `HistoryApiRegistry` in `ServerAPI`)
- Add `isHistoryProvider()` type guard (replaces `isHistoryApi()`)
- Deprecate `HistoryApiRegistry` and `isHistoryApi` with `@deprecated` JSDoc tags
- `HistoryApi` remains the consumer API name (not deprecated)
- Registration method stays `registerHistoryApiProvider()` because the legacy `registerHistoryProvider()` (callback-based `hasAnydata`/`getHistory`/`streamHistory`) still occupies that name

All old names are kept as deprecated aliases — no breaking changes.

## What's NOT in this PR (future phases)

- Notifications property bug (`notificationApi` vs `notificationsApi`) — separate PR
- `ResourcesApi` plural naming — deferred, "Resources" is a valid domain name
- Renaming `registerHistoryApiProvider` → `registerHistoryProvider` — blocked until legacy API is deprecated

## Manual testing

Verified against a running server (port 4000) with a history provider plugin ("kip") registered:

- `GET /signalk/v2/api/history/_providers` — returns `{"kip":{"isDefault":true}}`
- `GET /signalk/v2/api/history/_providers/_default` — returns `{"id":"kip"}`
- `GET /signalk/v2/api/history/values?duration=PT5M&paths=navigation.speedOverGround` — returns valid response with time range and values array
- `GET /signalk/v2/api/history/contexts?duration=PT1H` — responds 200
- `GET /signalk/v2/api/history/paths?duration=PT1H` — responds 200
Refs #2417