### PR TITLE
Add input filtering for SeaTalk1 connections

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -976,10 +976,12 @@ function StdOutInput({
 
 function IgnoredSentences({
   value,
-  onChange
+  onChange,
+  helpText
 }: {
   value: ProviderOptions
   onChange: OnChangeHandler
+  helpText: string
 }) {
   let displayValue = value.ignoredSentences
   if (Array.isArray(displayValue)) {
@@ -1001,7 +1003,7 @@ function IgnoredSentences({
     <TextInput
       title="Ignored Sentences"
       name="options.ignoredSentences"
-      helpText="NMEA0183 sentences to throw away from the input data. Example: RMC,ROT"
+      helpText={helpText}
       value={displayValue as string}
       onChange={handleChange}
     />
@@ -1400,7 +1402,11 @@ function NMEA0183({ value, onChange }: TypeComponentProps) {
       <ValidateChecksumInput value={value.options} onChange={onChange} />
       <AppendChecksum value={value.options} onChange={onChange} />
       <RemoveNullsInput value={value.options} onChange={onChange} />
-      <IgnoredSentences value={value.options} onChange={onChange} />
+      <IgnoredSentences
+        value={value.options}
+        onChange={onChange}
+        helpText="NMEA0183 sentences to throw away from the input data. Example: RMC,ROT"
+      />
     </div>
   )
 }
@@ -1579,6 +1585,11 @@ function Seatalk({ value, onChange }: TypeComponentProps) {
           </Form.Label>
         </Col>
       </Form.Group>
+      <IgnoredSentences
+        value={value.options}
+        onChange={onChange}
+        helpText="SeaTalk1 command bytes (hex) to throw away from the input data. Example: 84,9C,11"
+      />
     </span>
   )
 }

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -375,16 +375,7 @@ function nmea0183input(subOptions: SubOptions): PipeElement[] {
     if (subOptions.removeNulls) {
       pipePart.push(new Replacer({ regexp: '\u0000', template: '' }))
     }
-    if (subOptions.ignoredSentences) {
-      console.log(subOptions.ignoredSentences)
-      subOptions.ignoredSentences.forEach((sentence) => {
-        if (sentence.length > 0) {
-          pipePart!.push(
-            new Replacer({ regexp: `^...${sentence}.*`, template: '' })
-          )
-        }
-      })
-    }
+    pipePart.push(...nmea0183inputFilter(subOptions.ignoredSentences ?? []))
     return pipePart
   } else {
     throw new Error(`Unknown networking type: ${subOptions.type}`)
@@ -430,11 +421,42 @@ function signalKInput(subOptions: SubOptions): PipeElement[] {
 }
 
 function seatalkInput(subOptions: SubOptions): PipeElement[] {
+  const pipePart: PipeElement[] = []
   if (subOptions.type === 'gpiod') {
-    return [new GpiodSeatalk(subOptions)]
+    pipePart.push(new GpiodSeatalk(subOptions))
   } else {
-    return [new PigpioSeatalk(subOptions)]
+    pipePart.push(new PigpioSeatalk(subOptions))
   }
+  pipePart.push(...seatalk1inputFilter(subOptions.ignoredSentences ?? []))
+  return pipePart
+}
+
+// Returns an array of pipe elements that filter NMEA0183 sentences by matching
+// the three-letter sentence identifier that follows the talker id. For example,
+// filtering "RMC" removes lines like "$GPRMC,123519,A,..." because the pattern
+// "^...RMC.*" skips the "$GP" talker prefix (3 chars) and matches "RMC" plus
+// the rest of the line.
+function nmea0183inputFilter(ignoredSentences: string[]): PipeElement[] {
+  return ignoredSentences
+    .filter((sentence) => sentence.length > 0)
+    .map(
+      (sentence) => new Replacer({ regexp: `^...${sentence}.*`, template: '' })
+    )
+}
+
+// Returns an array of pipe elements that filter SeaTalk1 datagrams by matching
+// the command byte in $STALK sentences. SeaTalk1 data arrives as
+// "$STALK,<cmd>,<d1>,<d2>,..." where <cmd> is a hex byte identifying the
+// datagram type. For example, filtering "84" removes
+// "$STALK,84,56,FA,01,03,37,2F,1C,0B" (depth) while letting other datagrams
+// like "$STALK,9C,01,23,45" (compass heading) pass through.
+function seatalk1inputFilter(ignoredCommands: string[]): PipeElement[] {
+  return ignoredCommands
+    .filter((command) => command.length > 0)
+    .map(
+      (command) =>
+        new Replacer({ regexp: `^\\$STALK,${command}\\b.*`, template: '' })
+    )
 }
 
 const pipeStartByType: Record<string, PipeStartFactory> = {

--- a/test/filter-test-helper.ts
+++ b/test/filter-test-helper.ts
@@ -1,0 +1,15 @@
+import Replacer from '../packages/streams/src/replacer'
+
+export function filter(regexp: string, input: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const replacer = new Replacer({ regexp, template: '' })
+    const results: string[] = []
+    replacer.on('data', (d: string) => results.push(d))
+    replacer.on('error', (err: Error) => reject(err))
+    replacer.write(input)
+    replacer.end()
+    replacer.on('finish', () => {
+      resolve(results.join(''))
+    })
+  })
+}

--- a/test/nmea0183-filtering.ts
+++ b/test/nmea0183-filtering.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+import { filter } from './filter-test-helper'
+
+describe('NMEA0183 sentence filtering', () => {
+  function nmea0183filter(sentence: string, input: string) {
+    return filter(`^...${sentence}.*`, input)
+  }
+
+  it('should filter a matching NMEA0183 sentence', async () => {
+    const result = await nmea0183filter(
+      'RMC',
+      '$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A'
+    )
+    expect(result).to.equal('')
+  })
+
+  it('should pass through a non-matching NMEA0183 sentence', async () => {
+    const input = '$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M*47'
+    const result = await nmea0183filter('RMC', input)
+    expect(result).to.equal(input)
+  })
+
+  it('should filter regardless of talker id', async () => {
+    const gp = await nmea0183filter(
+      'RMC',
+      '$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A'
+    )
+    const gn = await nmea0183filter(
+      'RMC',
+      '$GNRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A'
+    )
+    expect(gp).to.equal('')
+    expect(gn).to.equal('')
+  })
+
+  it('should not filter SeaTalk1 datagrams', async () => {
+    const input = '$STALK,84,56,FA,01,03,37,2F,1C,0B'
+    const result = await nmea0183filter('84', input)
+    expect(result).to.equal(input)
+  })
+})

--- a/test/seatalk1-filtering.ts
+++ b/test/seatalk1-filtering.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai'
+import { filter } from './filter-test-helper'
+
+describe('SeaTalk1 sentence filtering', () => {
+  function seatalk1filter(command: string, input: string) {
+    return filter(`^\\$STALK,${command}\\b.*`, input)
+  }
+
+  it('should filter a matching SeaTalk1 command byte', async () => {
+    const result = await seatalk1filter(
+      '84',
+      '$STALK,84,56,FA,01,03,37,2F,1C,0B'
+    )
+    expect(result).to.equal('')
+  })
+
+  it('should pass through a non-matching SeaTalk1 command byte', async () => {
+    const input = '$STALK,9C,01,23,45'
+    const result = await seatalk1filter('84', input)
+    expect(result).to.equal(input)
+  })
+
+  it('should not filter partial command byte matches', async () => {
+    const input = '$STALK,84,56,FA'
+    const result = await seatalk1filter('8', input)
+    expect(result).to.equal(input)
+  })
+
+  it('should not filter NMEA0183 sentences', async () => {
+    const nmea =
+      '$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A'
+    const result = await seatalk1filter('84', nmea)
+    expect(result).to.equal(nmea)
+  })
+})


### PR DESCRIPTION
## Summary
- Add the ability to filter out SeaTalk1 datagrams by command byte, mirroring the existing NMEA0183 sentence filtering
- Rename the `ignoredSentences` option to `ignore` for both NMEA0183 and SeaTalk1
- Factor out filter logic into dedicated `nmea0183inputFilter` and `seatalk1inputFilter` functions

Closes #2497

## Test plan
- [x] Unit tests for NMEA0183 sentence filtering (4 tests)
- [x] Unit tests for SeaTalk1 command byte filtering (4 tests)
- [x] Full test suite passes with no regressions
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* Features
  * Adds SeaTalk1 input filtering by command byte, mirroring existing NMEA0183 sentence filtering.
  * Exposes an Ignored Sentences (renamed to ignore) field for SeaTalk in the server-admin UI and updates NMEA0183 UI to use a shared Ignored Sentences component with a required helpText prop.

* Enhancements
  * Factors filtering logic into dedicated helpers: nmea0183inputFilter and seatalk1inputFilter.
  * Integrates SeaTalk1 filters into the SeaTalk input pipeline and unifies pipeline assembly for input streams.
  * Replaces inline per-sentence Replacer construction with centralized filter construction (no console logging of the ignored list).

* Tests
  * Adds a reusable test helper filter(regexp, input) for exercising Replacer transforms.
  * Adds 4 NMEA0183 unit tests covering matching, non-matching, talker-id independence, and non-applicability to SeaTalk1.
  * Adds 4 SeaTalk1 unit tests covering matching command bytes, non-matching bytes, prevention of partial matches via word boundary, and non-applicability to NMEA0183.

* Other
  * All tests pass in the suite; TypeScript compiles cleanly.
  * Closes issue #2497.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->