### PR TITLE
Use 2048-bit key for self-signed SSL certificates

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -406,7 +406,7 @@ export function createCertificateOptions(
   debug(`Creating certificate files in ${location}`)
   generate(
     [{ name: 'commonName', value: 'localhost' }],
-    { days: 3650 },
+    { days: 3650, keySize: 2048 },
     function (err, pems) {
       writeFileSync(keyFile, pems.private)
       chmodSync(keyFile, '600')

--- a/test/ssl.ts
+++ b/test/ssl.ts
@@ -1,0 +1,38 @@
+import path from 'path'
+import { unlinkSync, existsSync } from 'fs'
+import { freeport } from './ts-servertestutilities'
+import { startServerP, serverTestConfigDirectory } from './servertestutilities'
+
+describe('SSL certificate generation', function () {
+  this.timeout(15000)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+
+  afterEach(async function () {
+    if (server) {
+      await server.stop()
+      server = null
+    }
+  })
+
+  it('generates a cert that works with modern OpenSSL', async function () {
+    const configDir = serverTestConfigDirectory()
+    const certFile = path.join(configDir, 'ssl-cert.pem')
+    const keyFile = path.join(configDir, 'ssl-key.pem')
+
+    // Delete cached certs to force regeneration
+    if (existsSync(certFile)) unlinkSync(certFile)
+    if (existsSync(keyFile)) unlinkSync(keyFile)
+
+    const port = await freeport()
+    const sslPort = await freeport()
+
+    // Start server with SSL enabled — this will generate new certs
+    // and create an HTTPS server. With 1024-bit keys this throws
+    // ERR_SSL_EE_KEY_TOO_SMALL on Node with OpenSSL 3.x
+    server = await startServerP(port, false, {
+      settings: { ssl: true, sslport: sslPort }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Increases self-signed certificate key size from 1024-bit to 2048-bit in `createCertificateOptions()`

## Context

The `selfsigned` library defaults to 1024-bit RSA keys, which are rejected by OpenSSL 3.x at SECLEVEL=2 (the default). This causes `ERR_SSL_EE_KEY_TOO_SMALL` when starting the server with `settings.ssl: true` or `SSLPORT` set. Confirmed on Node.js v25.8.1 (OpenSSL 3.6.1), but affects any Node.js version shipping OpenSSL 3.x (including some Node 18+ builds depending on distribution).

Existing deployments with cached 1024-bit certs in `ssl-key.pem`/`ssl-cert.pem` will need to delete and regenerate their certificate files.

## Test plan

- [x] New test in `test/ssl.ts` verifies server starts successfully with SSL enabled after regenerating certs
- [x] Full test suite passes (392 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)