### PR TITLE
refactor: rename ResourcesApi to ResourceApi (singular)

### DIFF
--- a/packages/server-api/src/resourcesapi.ts
+++ b/packages/server-api/src/resourcesapi.ts
@@ -36,7 +36,7 @@ export interface ResourceApi {
    *
    * @example
    * ```javascript
-   * app.resourcesApi.listResources(
+   * app.resourceApi.listResources(
    *   'waypoints',
    *   {region: 'fishing_zone'}
    * ).then (data => {
@@ -71,7 +71,7 @@ export interface ResourceApi {
    * @example
    * ```javascript
    * try {
-   *   const waypoint = await app.resourcesApi.getResource('waypoints', 'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a');
+   *   const waypoint = await app.resourceApi.getResource('waypoints', 'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a');
    *   // success
    * } catch (error) {
    *   // handle error
@@ -98,7 +98,7 @@ export interface ResourceApi {
    *
    * @example
    * ```javascript
-   * app.resourcesApi.setResource(
+   * app.resourceApi.setResource(
    *   'waypoints',
    *   'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a',
    *   {
@@ -142,7 +142,7 @@ export interface ResourceApi {
    *
    * @example
    * ```javascript
-   * app.resourcesApi.deleteResource(
+   * app.resourceApi.deleteResource(
    *   'notes',
    *   'ac3a3b2d-07e8-4f25-92bc-98e7c92f7f1a'
    * ).then ( () => {

--- a/packages/server-api/src/resourcesapi.ts
+++ b/packages/server-api/src/resourcesapi.ts
@@ -24,7 +24,7 @@ export const isSignalKResourceType = (s: string) =>
 export type ResourceType = SignalKResourceType | string
 
 /** @category  Resources API */
-export interface ResourcesApi {
+export interface ResourceApi {
   register(pluginId: string, provider: ResourceProvider): void
   unRegister(pluginId: string): void
 
@@ -167,9 +167,23 @@ export interface ResourcesApi {
 }
 
 /** @category  Resources API */
-export interface WithResourcesApi {
-  resourcesApi: ResourcesApi
+export interface WithResourceApi {
+  resourceApi: ResourceApi
+  /** @deprecated Use {@link WithResourceApi.resourceApi} instead. */
+  resourcesApi: ResourceApi
 }
+
+/**
+ * @deprecated Use {@link WithResourceApi} instead.
+ * @category  Resources API
+ */
+export type WithResourcesApi = WithResourceApi
+
+/**
+ * @deprecated Use {@link ResourceApi} instead.
+ * @category  Resources API
+ */
+export type ResourcesApi = ResourceApi
 
 /** @category  Resources API */
 export interface ResourceProvider {
@@ -402,5 +416,8 @@ export interface ResourceProviderRegistry {
    *
    * @category Resources API
    */
-  resourcesApi: ResourcesApi
+  resourceApi: ResourceApi
+
+  /** @deprecated Use {@link ResourceProviderRegistry.resourceApi} instead. */
+  resourcesApi: ResourceApi
 }

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -6,7 +6,7 @@ import {
   ResourceProviderRegistry,
   WeatherProviderRegistry,
   Delta,
-  WithResourcesApi,
+  WithResourceApi,
   WithNotificationsApi
 } from '.'
 import { RadarProviderRegistry, WithRadarApi } from './radarapi'
@@ -34,7 +34,7 @@ export interface ServerAPI
   extends
     PropertyValuesEmitter,
     ResourceProviderRegistry,
-    WithResourcesApi,
+    WithResourceApi,
     AutopilotProviderRegistry,
     WeatherProviderRegistry,
     RadarProviderRegistry,

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -39,7 +39,7 @@ import { Store } from '../../serverstate/store'
 
 import { buildSchemaSync } from 'api-schema-builder'
 import { courseApiDoc } from './openApi'
-import { ResourcesApi } from '../resources'
+import { ResourceApi } from '../resources'
 import { ConfigApp, writeSettingsFile } from '../../config/config'
 
 const COURSE_API_SCHEMA = buildSchemaSync(courseApiDoc)
@@ -89,7 +89,7 @@ export class CourseApi {
 
   constructor(
     private app: CourseApplication,
-    private resourcesApi: ResourcesApi
+    private resourcesApi: ResourceApi
   ) {
     this.store = new Store(app, 'course')
     this.parseSettings()

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,7 +3,7 @@ import { SignalKMessageHub, WithConfig } from '../app'
 import { WithSecurityStrategy } from '../security'
 import { CourseApi, CourseApplication } from './course'
 import { FeaturesApi } from './discovery'
-import { ResourcesApi } from './resources'
+import { ResourceApi } from './resources'
 import { WeatherApi } from './weather'
 import { AutopilotApi } from './autopilot'
 import { RadarApi } from './radar'
@@ -64,9 +64,11 @@ export const startApis = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initializeBinaryStreams(app as any)
 
-  const resourcesApi = new ResourcesApi(app)
+  const resourcesApi = new ResourceApi(app)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(app as any).resourcesApi = resourcesApi
+  ;(app as any).resourceApi = resourcesApi
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).resourcesApi = resourcesApi // deprecated: use resourceApi
   apiList.push('resources')
 
   const courseApi = new CourseApi(app as CourseApplication, resourcesApi)

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -38,7 +38,7 @@ interface ResourceSettings {
   defaultProviders: DefaultProviders
 }
 
-export class ResourcesApi {
+export class ResourceApi {
   private resProvider: { [key: string]: Map<string, ResourceProviderMethods> } =
     {}
   private app: ResourceApplication

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -46,7 +46,7 @@ import _ from 'lodash'
 import path from 'path'
 import { AutopilotApi } from '../api/autopilot'
 import { CourseApi } from '../api/course'
-import { ResourcesApi } from '../api/resources'
+import { ResourceApi } from '../api/resources'
 import { SERVERROUTESPREFIX } from '../constants'
 import { createDebug } from '../debug'
 import {
@@ -669,9 +669,9 @@ module.exports = (theApp: any) => {
       })
     }
 
-    const resourcesApi: ResourcesApi = app.resourcesApi
+    const resourceApi: ResourceApi = app.resourceApi
     appCopy.registerResourceProvider = (provider: ResourceProvider) => {
-      resourcesApi.register(plugin.id, provider)
+      resourceApi.register(plugin.id, provider)
     }
 
     const autopilotApi: AutopilotApi = app.autopilotApi


### PR DESCRIPTION
## Summary

Renames `ResourcesApi` to singular `ResourceApi` for consistency with `WeatherApi`, `RadarApi`, `AutopilotApi`, etc.

All changes are additive with deprecated aliases — no plugin breaks.

## Deprecated aliases (removed in server-api v3)

| Old name | New name |
|----------|----------|
| `ResourcesApi` | `ResourceApi` |
| `WithResourcesApi` | `WithResourceApi` |
| `app.resourcesApi` | `app.resourceApi` |

## Tested

- `npm run build` — clean
- `npm test` — 57 passing, 0 failing
- `npm run format` — clean

Refs #2417