### PR TITLE
fix(security): require admin auth for config mutation endpoints

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -230,6 +230,8 @@ export interface SecurityStrategy {
   ) => boolean
 
   addAdminMiddleware: (path: string) => void
+  addAdminWriteMiddleware: (path: string) => void
+  addWriteMiddleware: (path: string) => void
 
   /** Update OIDC config in memory (optional - only available when token security is active) */
   updateOIDCConfig?: (newOidcConfig: PartialOIDCConfig) => void

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -754,6 +754,8 @@ module.exports = function (
     )
   }
 
+  app.securityStrategy.addAdminWriteMiddleware(`${SERVERROUTESPREFIX}/settings`)
+
   app.put(`${SERVERROUTESPREFIX}/settings`, (req: Request, res: Response) => {
     const settings = req.body
 
@@ -946,6 +948,8 @@ module.exports = function (
     })
   }
 
+  app.securityStrategy.addAdminWriteMiddleware(`${SERVERROUTESPREFIX}/vessel`)
+
   app.put(`${SERVERROUTESPREFIX}/vessel`, (req: Request, res: Response) => {
     const de = app.config.baseDeltaEditor
     const vessel = req.body
@@ -1057,6 +1061,10 @@ module.exports = function (
     }
   )
 
+  app.securityStrategy.addAdminWriteMiddleware(
+    `${SERVERROUTESPREFIX}/sourcePriorities`
+  )
+
   app.get(
     `${SERVERROUTESPREFIX}/sourcePriorities`,
     (req: Request, res: Response) => {
@@ -1081,6 +1089,8 @@ module.exports = function (
       })
     }
   )
+
+  app.securityStrategy.addAdminWriteMiddleware(`${SERVERROUTESPREFIX}/debug`)
 
   app.post(`${SERVERROUTESPREFIX}/debug`, (req: Request, res: Response) => {
     if (!app.logging.enableDebug(req.body.value)) {
@@ -1109,6 +1119,10 @@ module.exports = function (
       recommendedNodeVersion
     })
   })
+
+  app.securityStrategy.addAdminWriteMiddleware(
+    `${SERVERROUTESPREFIX}/rememberDebug`
+  )
 
   app.post(
     `${SERVERROUTESPREFIX}/rememberDebug`,


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<ul>
<li>Five server configuration endpoints in <code>serverroutes.ts</code> lack authentication checks, allowing unauthenticated users to modify server config when security is enabled</li>
<li>Add <code>addAdminWriteMiddleware</code> to protect <code>PUT /skServer/settings</code>, <code>PUT /skServer/vessel</code>, <code>PUT /skServer/sourcePriorities</code>, <code>POST /skServer/debug</code>, and <code>POST /skServer/rememberDebug</code></li>
<li>Add missing <code>addAdminWriteMiddleware</code> and <code>addWriteMiddleware</code> declarations to the <code>SecurityStrategy</code> interface — both were already implemented in <code>dummysecurity</code> and <code>tokensecurity</code> but never declared in the type</li>
<li>Uses the same pattern as <code>eventsRoutingData</code>, <code>unitpreferences-api</code>, and <code>applicationData</code></li>
<li>No behavior change when security is not configured (dummy security is a no-op)</li>
</ul>
<h2 data-heading="Manual test results">Manual test results</h2>
<p>Tested against a running server (port 4000) with security enabled and <code>allow_readonly: false</code>:</p>

Endpoint | Method | Without auth | Expected
-- | -- | -- | --
/skServer/sourcePriorities | PUT | 401 | 401
/skServer/settings | PUT | 401 | 401
/skServer/vessel | PUT | 401 | 401
/skServer/debug | POST | 401 | 401
/skServer/rememberDebug | POST | 401 | 401

<!--EndFragment-->
</body>
</html>