### PR TITLE
fix(security): add auth middleware for v2 API endpoints

### DIFF
--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -761,6 +761,7 @@ function tokenSecurityFactory(
     app.put('/signalk/v1/*', writeAuthenticationMiddleware())
     app.put('/signalk/v2/*', writeAuthenticationMiddleware())
     app.post('/signalk/v2/*', writeAuthenticationMiddleware())
+    app.delete('/signalk/v2/*', writeAuthenticationMiddleware())
   }
 
   function login(

--- a/test/acls.js
+++ b/test/acls.js
@@ -99,7 +99,8 @@ const dummyApp = {
   use: () => {},
   get: () => {},
   post: () => {},
-  put: () => {}
+  put: () => {},
+  delete: () => {}
 }
 
 const securityStrategy = require('../dist/tokensecurity')(


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<ul>
<li>The <code>/signalk/v2/api/*</code> path is missing the <code>http_authorize</code> and <code>writeAuthenticationMiddleware</code> coverage that <code>/signalk/v1/api/*</code> has</li>
<li>This leaves all v2 API endpoints accessible without authentication when security is enabled, most critically the notifications API which has no inline auth checks at all</li>
<li>Add <code>http_authorize</code> for all v2 API requests and <code>writeAuthenticationMiddleware</code> for PUT, POST, and DELETE, matching the existing v1 pattern</li>
<li>Other v2 APIs (course, autopilot, resources, radar, weather, history) already have inline <code>shouldAllowPut</code> checks but benefit from the <code>http_authorize</code> middleware populating auth context correctly</li>
<li>Add <code>delete</code> to the test mock in <code>test/acls.js</code> to support the new DELETE middleware registration</li>
</ul>
<h2 data-heading="Manual test results">Manual test results</h2>
<p>Tested against a running server (port 4000) with security enabled and <code>allow_readonly: false</code>:</p>

Endpoint | Method | Without auth | Expected
-- | -- | -- | --
/signalk/v2/api/notifications | GET | 401 | 401
/signalk/v2/api/notifications | POST | 401 | 401
/signalk/v2/api/notifications/:id | PUT | 401 | 401
/signalk/v2/api/notifications/:id | DELETE | 401 | 401
/signalk/v2/api/notifications/mob | POST | 401 | 401
/signalk/v2/api/notifications/silenceAll | POST | 401 | 401
/signalk/v2/api/notifications/:id/silence | POST | 401 | 401
/signalk/v2/api/notifications/acknowledgeAll | POST | 401 | 401
/signalk/v2/api/notifications/:id/acknowledge | POST | 401 | 401

<!--EndFragment-->
</body>
</html>