### PR TITLE
test(security): add auth tests for config and v2 API endpoints

### DIFF
--- a/test/endpoint-auth.ts
+++ b/test/endpoint-auth.ts
@@ -1,0 +1,181 @@
+import chai from 'chai'
+import { freeport } from './ts-servertestutilities'
+import {
+  startServerP,
+  getReadOnlyToken,
+  getAdminToken
+} from './servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(chai as any).Should()
+
+describe('Endpoint authentication', function () {
+  let url: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let adminToken: string
+  let readToken: string
+
+  before(async function () {
+    const port = await freeport()
+    url = `http://0.0.0.0:${port}`
+    server = await startServerP(port, true)
+    adminToken = await getAdminToken(server)
+    readToken = await getReadOnlyToken(server)
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  function authHeaders(token: string) {
+    return {
+      Cookie: `JAUTHENTICATION=${token}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  async function fetchEndpoint(
+    method: string,
+    path: string,
+    token?: string,
+    body?: object
+  ): Promise<number> {
+    const options: RequestInit = {
+      method,
+      headers: token
+        ? authHeaders(token)
+        : { 'Content-Type': 'application/json' }
+    }
+    if (body) {
+      options.body = JSON.stringify(body)
+    }
+    const result = await fetch(`${url}${path}`, options)
+    return result.status
+  }
+
+  describe('skServer config endpoints require admin auth', function () {
+    const endpoints: Array<{ method: string; path: string; body: object }> = [
+      {
+        method: 'PUT',
+        path: '/skServer/sourcePriorities',
+        body: {}
+      },
+      {
+        method: 'PUT',
+        path: '/skServer/vessel',
+        body: { name: 'TestVessel', mmsi: '123456789' }
+      },
+      { method: 'POST', path: '/skServer/debug', body: { value: 'test:*' } },
+      {
+        method: 'POST',
+        path: '/skServer/rememberDebug',
+        body: { value: 'test:*' }
+      }
+    ]
+
+    for (const { method, path, body } of endpoints) {
+      it(`${method} ${path} rejects unauthenticated requests`, async function () {
+        const status = await fetchEndpoint(method, path, undefined, body)
+        status.should.equal(
+          401,
+          `${method} ${path}: expected 401, got ${status}`
+        )
+      })
+
+      it(`${method} ${path} rejects read-only users`, async function () {
+        const status = await fetchEndpoint(method, path, readToken, body)
+        status.should.equal(
+          401,
+          `${method} ${path}: expected 401, got ${status}`
+        )
+      })
+
+      it(`${method} ${path} accepts admin users`, async function () {
+        const status = await fetchEndpoint(method, path, adminToken, body)
+        status.should.not.equal(
+          401,
+          `${method} ${path}: admin request should not be rejected`
+        )
+      })
+    }
+
+    it('PUT /skServer/settings rejects unauthenticated requests', async function () {
+      const status = await fetchEndpoint(
+        'PUT',
+        '/skServer/settings',
+        undefined,
+        {}
+      )
+      status.should.equal(401)
+    })
+
+    it('PUT /skServer/settings rejects read-only users', async function () {
+      const status = await fetchEndpoint(
+        'PUT',
+        '/skServer/settings',
+        readToken,
+        {}
+      )
+      status.should.equal(401)
+    })
+
+    it('PUT /skServer/settings accepts admin users', async function () {
+      const status = await fetchEndpoint(
+        'PUT',
+        '/skServer/settings',
+        adminToken,
+        { interfaces: {}, options: {} }
+      )
+      status.should.not.equal(401)
+    })
+  })
+
+  describe('v2 notification endpoints require authentication', function () {
+    const endpoints: Array<{
+      method: string
+      path: string
+      body?: object
+    }> = [
+      { method: 'POST', path: '/signalk/v2/api/notifications/silenceAll' },
+      { method: 'POST', path: '/signalk/v2/api/notifications/acknowledgeAll' },
+      {
+        method: 'POST',
+        path: '/signalk/v2/api/notifications/mob',
+        body: {}
+      },
+      {
+        method: 'POST',
+        path: '/signalk/v2/api/notifications',
+        body: { message: 'test', state: 'alert' }
+      },
+      {
+        method: 'PUT',
+        path: '/signalk/v2/api/notifications/test-id',
+        body: { message: 'test', state: 'alert' }
+      },
+      {
+        method: 'DELETE',
+        path: '/signalk/v2/api/notifications/test-id'
+      },
+      {
+        method: 'POST',
+        path: '/signalk/v2/api/notifications/test-id/silence'
+      },
+      {
+        method: 'POST',
+        path: '/signalk/v2/api/notifications/test-id/acknowledge'
+      }
+    ]
+
+    for (const { method, path, body } of endpoints) {
+      it(`${method} ${path} rejects unauthenticated requests`, async function () {
+        const status = await fetchEndpoint(method, path, undefined, body)
+        status.should.equal(
+          401,
+          `${method} ${path}: expected 401, got ${status}`
+        )
+      })
+    }
+  })
+})


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<ul>
<li>Add 23 tests verifying that config mutation endpoints and v2 notification endpoints enforce authentication when security is enabled</li>
<li>Tests cover three access levels: unauthenticated (expect 401), read-only user (expect 401), and admin user (expect not 401)</li>
</ul>
<h2 data-heading="Depends on">Depends on</h2>
<p>This PR must be merged after both fix PRs:</p>
<ul>
<li><code>fix-unauth-config-endpoints</code> — adds <code>addAdminWriteMiddleware</code> for skServer routes</li>
<li><code>fix-unauth-v2-api-endpoints</code> — adds <code>http_authorize</code> and <code>writeAuthenticationMiddleware</code> for v2 API</li>
</ul>
<h2 data-heading="Test coverage">Test coverage</h2>
<h3 data-heading="skServer config endpoints (15 tests)">skServer config endpoints (15 tests)</h3>

Endpoint | Unauth | Read-only | Admin
-- | -- | -- | --
PUT /skServer/sourcePriorities | 401 | 401 | not 401
PUT /skServer/vessel | 401 | 401 | not 401
POST /skServer/debug | 401 | 401 | not 401
POST /skServer/rememberDebug | 401 | 401 | not 401
PUT /skServer/settings | 401 | 401 | not 401

<!--EndFragment-->
