### PR TITLE
fix(demo): enable security with readonly access for demo.signalk.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write  # Required for OIDC
+  id-token: write # Required for OIDC
   contents: read
 
 jobs:

--- a/fly_io/demo_signalk_org/Dockerfile
+++ b/fly_io/demo_signalk_org/Dockerfile
@@ -1,3 +1,4 @@
 ARG SK_VERSION
 FROM signalk/signalk-server:${SK_VERSION}
-ENTRYPOINT /home/node/signalk/node_modules/signalk-server/bin/signalk-server --sample-n2k-data
+COPY --chown=node:node --chmod=600 security.json /home/node/.signalk/security.json
+ENTRYPOINT ["/home/node/signalk/node_modules/signalk-server/bin/signalk-server", "--securityenabled", "--sample-n2k-data"]

--- a/fly_io/demo_signalk_org/security.json
+++ b/fly_io/demo_signalk_org/security.json
@@ -1,0 +1,8 @@
+{
+  "allow_readonly": true,
+  "allowNewUserRegistration": false,
+  "allowDeviceAccessRequests": false,
+  "users": [],
+  "devices": [],
+  "acls": []
+}


### PR DESCRIPTION
## Summary

- Enable token security on the demo.signalk.org Fly.io deployment by adding `--securityenabled` to the entrypoint
- Pre-seed `security.json` with `allow_readonly: true` so unauthenticated users can still browse Signal K data
- Disable user registration and device access requests on the demo
- Switch ENTRYPOINT to JSON form for proper OS signal handling

## Manual test 

Tested locally with podman against `signalk/signalk-server:latest`:

- `GET /loginStatus` returns `readOnlyAccess: true`, `allowNewUserRegistration: false`
- `GET /signalk/v1/api/` returns vessel data without authentication
- `PUT /signalk/v1/api/...` returns 401 Unauthorized