### PR TITLE
fix(chore): gitignore debug remember-me artifacts in test configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ nul
 
 # debug artefacts
 *.sln
+test/server-test-config/debug


### PR DESCRIPTION
## Summary

- Add `test/server-test-config/debug` and `test/plugin-test-config/debug` to `.gitignore`
- The logging module writes a `debug` file to the config directory when "Remember debug" is enabled in the Admin UI — same category of runtime artifact as `plugin-config-data/` which is already ignored for both test config dirs