### PR TITLE
fix(admin-ui): preserve enabled state when editing data connections

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -228,7 +228,6 @@ const ProvidersConfiguration: React.FC = () => {
   const providerClicked = useCallback((provider: Provider, index: number) => {
     setSelectedProvider({
       ...structuredClone(provider),
-      enabled: true,
       originalId: provider.id
     })
     setSelectedIndex(index)


### PR DESCRIPTION
## Summary

- Remove hardcoded `enabled: true` in `providerClicked` that overwrote the actual saved state when opening a data connection for editing
- Clicking a disabled connection now correctly shows it as disabled in the edit dialog

The `structuredClone(provider)` spread already carries the correct `enabled` value from the server. The hardcoded override was only appropriate for new connections (separate code path, unchanged).

## Manually tested
- Added and remove several connections
- Enabled/Disabled save, reopen verified