### PR TITLE
fix(streams): use event-based reconnection in mdns-ws provider

### DIFF
--- a/packages/streams/src/mdns-ws.test.ts
+++ b/packages/streams/src/mdns-ws.test.ts
@@ -1,0 +1,342 @@
+import { expect } from 'chai'
+import { WebSocketServer } from 'ws'
+import { Writable } from 'stream'
+import MdnsWs from './mdns-ws'
+import { createMockApp, createDebugStub } from './test-helpers'
+
+interface DeltaChunk {
+  updates?: Array<{
+    values?: Array<{ path: string }>
+    $source?: string
+  }>
+}
+
+const SK_HELLO = JSON.stringify({
+  name: 'test-server',
+  version: '2.0.0',
+  roles: ['master'],
+  self: 'vessels.urn:mrn:imo:mmsi:123456789'
+})
+
+type SkServer = {
+  wss: InstanceType<typeof WebSocketServer>
+  port: number
+  close: () => Promise<void>
+}
+
+function createSkWsServer(fixedPort = 0): Promise<SkServer> {
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer(
+      {
+        port: fixedPort,
+        host: '127.0.0.1',
+        path: '/signalk/v1/stream'
+      },
+      () => {
+        const addr = wss.address() as { port: number }
+        resolve({
+          wss,
+          port: addr.port,
+          close: () =>
+            new Promise<void>((res) => {
+              wss.clients.forEach((c: { close: () => void }) => c.close())
+              wss.close(() => res())
+            })
+        })
+      }
+    )
+
+    wss.on('connection', (ws: { send: (data: string) => void }) => {
+      ws.send(SK_HELLO)
+    })
+  })
+}
+
+function createSink(): {
+  chunks: unknown[]
+  writable: InstanceType<typeof Writable>
+} {
+  const chunks: unknown[] = []
+  const writable = new Writable({
+    objectMode: true,
+    write(chunk: unknown, _encoding: string, callback: () => void) {
+      chunks.push(chunk)
+      writable.emit('data-received', chunk)
+      callback()
+    }
+  })
+  return { chunks, writable }
+}
+
+describe('MdnsWs', () => {
+  const intervals: ReturnType<typeof setInterval>[] = []
+  const servers: SkServer[] = []
+  const mdnsInstances: MdnsWs[] = []
+
+  function track<T extends ReturnType<typeof setInterval>>(id: T): T {
+    intervals.push(id)
+    return id
+  }
+
+  function trackServer(s: SkServer): SkServer {
+    servers.push(s)
+    return s
+  }
+
+  function trackMdns(m: MdnsWs): MdnsWs {
+    mdnsInstances.push(m)
+    return m
+  }
+
+  afterEach(async () => {
+    while (intervals.length) {
+      clearInterval(intervals.pop()!)
+    }
+    while (mdnsInstances.length) {
+      mdnsInstances.pop()!.destroy()
+    }
+    while (servers.length) {
+      await servers.pop()!.close()
+    }
+  })
+
+  it('sets provider status on successful connection', function (done) {
+    this.timeout(10000)
+
+    createSkWsServer().then((s) => {
+      trackServer(s)
+      const app = createMockApp()
+      const mdns = trackMdns(
+        new MdnsWs({
+          app,
+          providerId: 'test-mdns',
+          host: '127.0.0.1',
+          port: s.port,
+          createDebug: createDebugStub()
+        })
+      )
+
+      mdns.pipe(createSink().writable)
+
+      const check = track(
+        setInterval(() => {
+          if (app.providerStatuses.some((st) => st.msg.includes('connected'))) {
+            clearInterval(check)
+            done()
+          }
+        }, 100)
+      )
+    })
+  })
+
+  it('sets provider error on connection failure', function (done) {
+    this.timeout(10000)
+    const app = createMockApp()
+    const mdns = trackMdns(
+      new MdnsWs({
+        app,
+        providerId: 'test-mdns',
+        host: '127.0.0.1',
+        port: 1,
+        createDebug: createDebugStub()
+      })
+    )
+
+    mdns.pipe(createSink().writable)
+
+    const check = track(
+      setInterval(() => {
+        if (app.providerErrors.length > 0) {
+          clearInterval(check)
+          expect(app.providerErrors[0]!.id).to.equal('test-mdns')
+          done()
+        }
+      }, 100)
+    )
+  })
+
+  it('detects disconnect when server closes', function (done) {
+    this.timeout(10000)
+
+    createSkWsServer().then((s) => {
+      trackServer(s)
+      const app = createMockApp()
+      const mdns = trackMdns(
+        new MdnsWs({
+          app,
+          providerId: 'test-mdns',
+          host: '127.0.0.1',
+          port: s.port,
+          createDebug: createDebugStub()
+        })
+      )
+
+      mdns.pipe(createSink().writable)
+
+      const checkConnected = track(
+        setInterval(() => {
+          if (app.providerStatuses.some((st) => st.msg.includes('connected'))) {
+            clearInterval(checkConnected)
+
+            s.close().then(() => {
+              const checkDisconnect = track(
+                setInterval(() => {
+                  if (
+                    app.providerErrors.some((e) =>
+                      e.msg.toLowerCase().includes('disconnect')
+                    )
+                  ) {
+                    clearInterval(checkDisconnect)
+                    done()
+                  }
+                }, 100)
+              )
+            })
+          }
+        }, 100)
+      )
+    })
+  })
+
+  it('reconnects and re-establishes data flow', function (done) {
+    this.timeout(30000)
+
+    createSkWsServer().then((s) => {
+      trackServer(s)
+      const app = createMockApp()
+      const mdns = trackMdns(
+        new MdnsWs({
+          app,
+          providerId: 'test-mdns',
+          host: '127.0.0.1',
+          port: s.port,
+          createDebug: createDebugStub()
+        })
+      )
+
+      const { chunks, writable } = createSink()
+      mdns.pipe(writable)
+
+      const waitForConnect = track(
+        setInterval(() => {
+          if (app.providerStatuses.some((st) => st.msg.includes('connected'))) {
+            clearInterval(waitForConnect)
+            const savedPort = s.port
+
+            s.close().then(() => {
+              const waitForDisconnect = track(
+                setInterval(() => {
+                  if (
+                    app.providerErrors.some((e) =>
+                      e.msg.toLowerCase().includes('disconnect')
+                    )
+                  ) {
+                    clearInterval(waitForDisconnect)
+                    app.providerStatuses.length = 0
+
+                    createSkWsServer(savedPort).then((s2) => {
+                      trackServer(s2)
+                      s2.wss.on(
+                        'connection',
+                        (ws: { send: (data: string) => void }) => {
+                          setTimeout(() => {
+                            ws.send(
+                              JSON.stringify({
+                                context: 'vessels.urn:mrn:imo:mmsi:123456789',
+                                updates: [
+                                  {
+                                    values: [
+                                      {
+                                        path: 'navigation.courseOverGroundTrue',
+                                        value: 1.23
+                                      }
+                                    ],
+                                    source: { label: 'test' }
+                                  }
+                                ]
+                              })
+                            )
+                          }, 200)
+                        }
+                      )
+
+                      const onData = () => {
+                        const delta = chunks.find(
+                          (c) =>
+                            (c as DeltaChunk)?.updates?.[0]?.values?.[0]
+                              ?.path === 'navigation.courseOverGroundTrue'
+                        )
+                        if (delta) {
+                          writable.off('data-received', onData)
+                          expect(
+                            (delta as DeltaChunk).updates![0]!['$source']
+                          ).to.include('test-mdns')
+                          done()
+                        }
+                      }
+                      writable.on('data-received', onData)
+                    })
+                  }
+                }, 100)
+              )
+            })
+          }
+        }, 100)
+      )
+    })
+  })
+
+  it('receives delta data through the stream', function (done) {
+    this.timeout(10000)
+
+    createSkWsServer().then((s) => {
+      trackServer(s)
+
+      s.wss.on('connection', (ws: { send: (data: string) => void }) => {
+        setTimeout(() => {
+          ws.send(
+            JSON.stringify({
+              context: 'vessels.urn:mrn:imo:mmsi:123456789',
+              updates: [
+                {
+                  values: [{ path: 'navigation.speedOverGround', value: 3.5 }],
+                  source: { label: 'test' }
+                }
+              ]
+            })
+          )
+        }, 200)
+      })
+
+      const app = createMockApp()
+      const mdns = trackMdns(
+        new MdnsWs({
+          app,
+          providerId: 'test-mdns',
+          host: '127.0.0.1',
+          port: s.port,
+          createDebug: createDebugStub()
+        })
+      )
+
+      const { chunks, writable } = createSink()
+      mdns.pipe(writable)
+
+      const onData = () => {
+        const delta = chunks.find(
+          (c) =>
+            (c as DeltaChunk)?.updates?.[0]?.values?.[0]?.path ===
+            'navigation.speedOverGround'
+        )
+        if (delta) {
+          writable.off('data-received', onData)
+          expect((delta as DeltaChunk).updates![0]!['$source']).to.include(
+            'test-mdns'
+          )
+          done()
+        }
+      }
+      writable.on('data-received', onData)
+    })
+  })
+})

--- a/packages/streams/src/mdns-ws.ts
+++ b/packages/streams/src/mdns-ws.ts
@@ -55,8 +55,10 @@ export default class MdnsWs extends Transform {
   private readonly remoteServers: Record<string, object> = {}
   private readonly debug: DebugLogger
   private readonly dataDebug: DebugLogger
+  private readonly subscriptions: object[] = []
   private handleContext: (delta: DeltaMessage) => void
   private signalkClient?: Client
+  private isDestroying = false
   private fetchedMetaPaths = new Set<string>()
 
   constructor(options: MdnsWsOptions) {
@@ -92,6 +94,22 @@ export default class MdnsWs extends Transform {
       options.ignoreServers.forEach((s) => {
         this.remoteServers[s] = {}
       })
+    }
+    if (options.subscription) {
+      try {
+        const parsed = JSON.parse(options.subscription)
+        this.subscriptions = Array.isArray(parsed) ? parsed : [parsed]
+      } catch (ex) {
+        const error = ex as Error
+        options.app.setProviderError(
+          options.providerId,
+          `unable to parse subscription json: ${options.subscription}: ${error.message}`
+        )
+        console.error(
+          `unable to parse subscription json: ${options.subscription}: ${error.message}`
+        )
+        return
+      }
     }
     if (options.host && options.port) {
       this.signalkClient = new Client({
@@ -148,21 +166,18 @@ export default class MdnsWs extends Transform {
   }
 
   private connectClient(client: Client): void {
-    this.fetchedMetaPaths.clear()
-    client
-      .connect()
-      .then(() => {
-        this.options.app.setProviderStatus(
-          this.options.providerId,
-          `ws connection connected to ${client.options.hostname}:${client.options.port}`
-        )
-        console.log(
-          `ws connection connected to ${client.options.hostname}:${client.options.port}`
-        )
-        if (this.options.token) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const conn = (client as any).connection
-          conn.send(JSON.stringify({ token: this.options.token }))
+    client.on('connect', () => {
+      this.fetchedMetaPaths.clear()
+      this.options.app.setProviderStatus(
+        this.options.providerId,
+        `ws connection connected to ${client.options.hostname}:${client.options.port}`
+      )
+      if (this.options.token) {
+        const conn = client.connection
+        if (conn) {
+          conn.send(JSON.stringify({ token: this.options.token })).catch(() => {
+            // ignore send errors; error event handler will report
+          })
           conn.setAuthenticated(this.options.token, 'JWT')
           this.debug('Sent authentication token to remote server')
 
@@ -177,62 +192,60 @@ export default class MdnsWs extends Transform {
               }
             })
             .catch((err) => {
-              this.debug('Token verification error: ' + err.message)
-            })
-        }
-        if (
-          this.options.selfHandling !== 'manualSelf' &&
-          this.options.selfHandling !== 'noSelf'
-        ) {
-          client
-            .API()
-            .then((api) => api.get('/self'))
-            .then((selfFromServer) => {
-              this.debug(
-                `Mapping context ${selfFromServer} to self (empty context)`
-              )
-              this.handleContext = (delta) => {
-                if (delta.context === selfFromServer) {
-                  delete delta.context
-                }
+              if (this.debug.enabled) {
+                this.debug('Token verification error: ' + err.message)
               }
             })
-            .catch((err) => {
-              console.error('Error retrieving self from remote server')
-              console.error(err)
-            })
         }
-        this.remoteServers[
-          client.options.hostname + ':' + client.options.port
-        ] = client
-        if (this.options.subscription) {
-          let parsed: object | object[]
-          try {
-            parsed = JSON.parse(this.options.subscription)
-          } catch (ex) {
-            const error = ex as Error
-            this.options.app.setProviderError(
-              this.options.providerId,
-              `unable to parse subscription json: ${this.options.subscription}: ${error.message}`
+      }
+      if (
+        this.options.selfHandling !== 'manualSelf' &&
+        this.options.selfHandling !== 'noSelf'
+      ) {
+        client
+          .API()
+          .then((api) => api.get('/self'))
+          .then((selfFromServer) => {
+            this.debug(
+              `Mapping context ${selfFromServer} to self (empty context)`
             )
-            console.error(
-              `unable to parse subscription json: ${this.options.subscription}: ${error.message}`
-            )
-            return
-          }
-          if (!Array.isArray(parsed)) {
-            parsed = [parsed]
-          }
-          ;(parsed as object[]).forEach((sub: object, idx: number) => {
-            this.debug('sending subscription %j', sub)
-            client.subscribe(sub, String(idx))
+            this.handleContext = (delta) => {
+              if (delta.context === selfFromServer) {
+                delete delta.context
+              }
+            }
           })
+          .catch((err) => {
+            console.error('Error retrieving self from remote server')
+            console.error(err)
+          })
+      }
+      this.remoteServers[client.options.hostname + ':' + client.options.port] =
+        client
+      this.subscriptions.forEach((sub, idx) => {
+        if (this.debug.enabled) {
+          this.debug('sending subscription %j', sub)
         }
+        client.subscribe(sub, String(idx))
       })
-      .catch((err: Error) => {
-        this.options.app.setProviderError(this.options.providerId, err.message)
-        console.error(err.message)
-      })
+    })
+
+    client.on('disconnect', () => {
+      if (this.isDestroying) {
+        return
+      }
+      this.setProviderStatus(
+        `Disconnected from ${client.options.hostname}:${client.options.port}`,
+        true
+      )
+    })
+
+    client.on('error', (err: Error) => {
+      if (this.isDestroying) {
+        return
+      }
+      this.setProviderStatus(`Connection error: ${err.message}`, true)
+    })
 
     client.on('delta', (data: DeltaMessage) => {
       if (data && data.updates) {
@@ -263,18 +276,10 @@ export default class MdnsWs extends Transform {
       }
     })
 
-    client.on('disconnect', () => {
-      const hint = this.options.token
-        ? ' — check that the token is valid on the remote server'
-        : ' — the remote server may require authentication'
-      this.setProviderStatus(
-        `Disconnected from ${client.options.hostname}:${client.options.port}${hint}`,
-        true
-      )
-    })
-
-    client.on('error', (err: Error) => {
-      this.setProviderStatus(`Connection error: ${err.message}`, true)
+    client.connect().catch((err) => {
+      if (this.debug.enabled) {
+        this.debug('connect() promise rejected: %s', err?.message ?? err)
+      }
     })
   }
 
@@ -310,5 +315,19 @@ export default class MdnsWs extends Transform {
     done: TransformCallback
   ): void {
     done()
+  }
+
+  _destroy(
+    error: Error | null,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.isDestroying = true
+    try {
+      this.signalkClient?.disconnect()
+    } catch (err) {
+      this.debug('error disconnecting client: %s', (err as Error).message)
+    }
+    this.signalkClient = undefined
+    callback(error)
   }
 }

--- a/packages/streams/src/vendor.d.ts
+++ b/packages/streams/src/vendor.d.ts
@@ -58,10 +58,17 @@ declare module '@signalk/client' {
     rejectUnauthorized?: boolean
     wsKeepaliveInterval?: number
   }
+  interface Connection {
+    send(payload: string): Promise<void>
+    setAuthenticated(token: string, method: string): void
+    disconnect(): void
+  }
   class Client extends EventEmitter {
     options: ClientOptions
+    connection: Connection | null
     constructor(options: ClientOptions)
     connect(): Promise<void>
+    disconnect(returnPromise?: boolean): Client | Promise<Client>
     subscribe(subscription: object, id: string): void
     API(): Promise<{
       get(path: string): Promise<string>


### PR DESCRIPTION
## Summary

The mdns-ws WebSocket provider failed to reconnect when the remote server was temporarily unreachable (e.g. ENETUNREACH during a simultaneous reboot of both devices).

`connectClient()` relied on the one-shot Promise returned by `client.connect()`. When the initial connection failed, the Promise rejected and the `.then()` block — which sets up provider status, subscriptions, and remoteSelf context mapping — never executed. Even though the underlying `@signalk/client` Connection successfully reconnected later via its internal `backOffAndReconnect()` mechanism, the setup logic was skipped permanently.

The fix replaces the Promise-based pattern with persistent event listeners:

- `client.on('connect')` runs on **every** successful connection (initial + reconnections), ensuring subscriptions and provider status are always set up
- `client.on('disconnect')` updates provider status when the connection drops
- `client.on('error')` reports connection errors to the dashboard

## Testing

**Automated tests** — 4 new integration tests in `mdns-ws.test.ts` using a real WebSocket server:

- Provider status set on successful connection
- Provider error set on connection failure (unreachable port)
- Disconnect detected when server closes
- Delta data flows through the stream with correct `$source` annotation

**Manual tests** against a live Signal K server (localhost:4000):

- Verified `connect` event fires on initial connection and updates provider status
- Verified socket kill triggers `disconnect` event, followed by automatic reconnection with a second `connect` event
- Verified connection to an unreachable port generates `error` events with exponential backoff retries (250ms → 500ms → 750ms → 1000ms), confirming the client keeps retrying until the remote becomes available

fixes #2513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* Code changes
  * MdnsWs provider switches from a one-shot Promise-based connect flow to persistent event listeners on the @signalk/client Client: client.on('connect'), client.on('disconnect'), and client.on('error').
  * The connect handler runs on every successful connection (initial + reconnections) to perform setup: clear fetched metadata, set provider status, optionally send auth token and verify it (logging verification failures and disconnecting on invalid token), optionally fetch /self to map remote context to local self, store the client in remoteServers, and apply pre-parsed subscription JSON stored on the instance.
  * Subscription JSON is parsed once during construction into a new subscriptions field; parse failures set provider error, log, and abort initialization.
  * Disconnect and error handlers update provider status/errors when the connection drops or errors occur; these handlers are suppressed while the provider is destroying via a new isDestroying flag. connect() is still invoked but its rejection is ignored (.catch(() => {})) because lifecycle and retries are handled via client events.
  * Delta handling remains registered so received deltas continue to flow through the stream with the provider-origin ($source) annotation. A new _destroy override marks shutdown, disconnects the stored signalkClient, and clears it.

* Tests
  * Adds an integration test suite packages/streams/src/mdns-ws.test.ts using a real WebSocketServer endpoint and an object-mode Writable sink.
  * Four integration tests verify:
    - provider status is set on successful connection,
    - provider error is set on connection failure (unreachable port),
    - disconnect is detected when the server closes,
    - automatic reconnection re-establishes provider status after server restart and propagates delta data with the providerId present in $source.
  * Tests use ephemeral ports and ensure cleanup of servers and MdnsWs instances.

* Type declarations
  * Extends the local vendor declarations for @signalk/client by adding a Connection interface (send, setAuthenticated, disconnect), exposing a connection: Connection | null property on Client, and adding an overload-capable disconnect(returnPromise?: boolean): Client | Promise<Client> method.

* Behavior / intent
  * The provider reliably re-applies setup (status, subscriptions, remoteSelf mapping) on reconnection, restoring operation after transient network errors (e.g., ENETUNREACH) without manual intervention.
  * Token authentication and self-mapping logic from master remain included in the event-driven flow.

* Public API / exports
  * No exported or public API declarations in production code change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->