### PR TITLE
feat(api): add container job API for unified plugin container execution

### DIFF
--- a/docs/develop/rest-api/README.md
+++ b/docs/develop/rest-api/README.md
@@ -3,6 +3,7 @@ title: REST APIs
 children:
   - conventions.md
   - autopilot_api.md
+  - container_jobs_api.md
   - course_api.md
   - history_api.md
   - notifications_api.md
@@ -26,6 +27,7 @@ APIs are available via `/signalk/v2/api/<endpoint>`
 | API                                       | Description                                                                                                                                          | Endpoint                         |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
 | [`Autopilot`](./autopilot_api.md)         | Provide the ability to send common commands to an autopilot via a provider plugin.                                                                   | `vessels/self/autopilot`         |
+| [Container Jobs](./container_jobs_api.md) | Run containerized workloads (podman/docker) from plugins with runtime detection, progress streaming, and concurrency control.                        | `containerjobs`                  |
 | [Course](./course_api.md)                 | Set a course, follow a route, advance to next point, etc.                                                                                            | `vessels/self/navigation/course` |
 | [History](./history_api.md)               | Query historical data.                                                                                                                               | `history`                        |
 | [Radar](./radar_api.md)                   | View and control marine radar equipment via a provider plugin. _(In development)_                                                                    | `vessels/self/radars`            |

--- a/docs/develop/rest-api/container_jobs_api.md
+++ b/docs/develop/rest-api/container_jobs_api.md
@@ -1,0 +1,153 @@
+---
+title: Container Jobs API
+---
+
+# Container Jobs API
+
+The Container Jobs API allows plugins to run containerized workloads (using podman or docker) through the server, without managing container runtimes directly.
+
+The server automatically detects the available container runtime at startup (podman is preferred, with docker as fallback). Plugins use `app.runContainerJob()` to run containers, while the REST endpoints provide monitoring and management for the Admin UI and other clients.
+
+## Plugin API
+
+### Check runtime availability
+
+```typescript
+const runtime = app.getContainerRuntime()
+if (runtime) {
+  app.debug(`Container runtime: ${runtime.runtime} ${runtime.version}`)
+} else {
+  app.debug('No container runtime available')
+}
+```
+
+Returns `null` if neither podman nor docker is installed, or a `ContainerRuntimeInfo` object:
+
+```typescript
+interface ContainerRuntimeInfo {
+  runtime: 'podman' | 'docker'
+  version: string
+  isPodmanDockerShim?: boolean
+}
+```
+
+### Run a container job
+
+```typescript
+import {
+  ContainerJobConfig,
+  ContainerJobResult,
+  ContainerJobError
+} from '@signalk/server-api'
+
+try {
+  const result: ContainerJobResult = await app.runContainerJob({
+    image: 'ghcr.io/osgeo/gdal:alpine-small-latest',
+    command: [
+      'ogr2ogr',
+      '-f',
+      'GeoJSON',
+      '/output/data.json',
+      '/input/source.shp'
+    ],
+    inputs: { '/input': '/path/to/input/dir' },
+    outputs: { '/output': '/path/to/output/dir' },
+    env: { OGR_GEOMETRY_ACCEPT_UNCLOSED_RING: 'YES' },
+    timeout: 300000,
+    label: 'my-plugin:convert-shapefile',
+    onProgress: ({ stream, data }) => {
+      app.debug(`[${stream}] ${data}`)
+    }
+  })
+
+  if (result.exitCode === 0) {
+    app.debug(`Job completed: ${result.id}`)
+  } else {
+    app.debug(`Container exited with code ${result.exitCode}`)
+  }
+} catch (err) {
+  if (err instanceof ContainerJobError) {
+    // err.statusCode: 503 (no runtime) or 429 (concurrency limit)
+    app.debug(`Container job error: ${err.message}`)
+  }
+}
+```
+
+### ContainerJobConfig
+
+| Property     | Type                     | Required | Description                                                                               |
+| ------------ | ------------------------ | -------- | ----------------------------------------------------------------------------------------- |
+| `image`      | `string`                 | yes      | Container image to run (pulled automatically if not present)                              |
+| `command`    | `string[]`               | yes      | Command and arguments to execute                                                          |
+| `inputs`     | `Record<string, string>` | no       | Read-only volume mounts (container path → host path)                                      |
+| `outputs`    | `Record<string, string>` | no       | Read-write volume mounts (container path → host path)                                     |
+| `env`        | `Record<string, string>` | no       | Environment variables passed to the container                                             |
+| `timeout`    | `number`                 | no       | Total timeout in milliseconds across image pull and container execution (default: 600000) |
+| `label`      | `string`                 | no       | Label for filtering jobs via `listContainerJobs()`                                        |
+| `onProgress` | `function`               | no       | Callback receiving `{ stream: 'stdout' \| 'stderr', data: string }` chunks in real-time   |
+
+### ContainerJobResult
+
+| Property      | Type             | Description                                                |
+| ------------- | ---------------- | ---------------------------------------------------------- |
+| `id`          | `string`         | Unique job ID (UUID)                                       |
+| `status`      | `string`         | `pending`, `pulling`, `running`, `completed`, or `failed`  |
+| `image`       | `string`         | Container image used                                       |
+| `command`     | `string[]`       | Command executed                                           |
+| `label`       | `string`         | Job label (if provided)                                    |
+| `exitCode`    | `number \| null` | Container exit code (`null` while running)                 |
+| `log`         | `string[]`       | Rolling buffer of container stdout/stderr (last 100 lines) |
+| `error`       | `string`         | Error message (if failed)                                  |
+| `createdAt`   | `string`         | ISO 8601 timestamp                                         |
+| `startedAt`   | `string`         | ISO 8601 timestamp (when container started running)        |
+| `completedAt` | `string`         | ISO 8601 timestamp (when job finished)                     |
+| `runtime`     | `string`         | Runtime used (`podman` or `docker`)                        |
+
+### List tracked jobs
+
+```typescript
+const allJobs = app.listContainerJobs()
+const myJobs = app.listContainerJobs('my-plugin')
+```
+
+Returns an array of `ContainerJobResult` objects, optionally filtered by label substring.
+
+## Server behavior
+
+- **Runtime detection** runs at startup. The server prefers podman over docker and detects podman-docker shims.
+- **Image pulling** happens automatically before each job if the image is not present locally. Dangling images are pruned after each pull.
+- **SELinux**: on systems with SELinux, the server adds `:Z` flags to volume mounts automatically when using podman.
+- **Concurrency**: the server limits concurrent container jobs (default: 2, configurable via settings). Excess jobs receive a 429 error.
+- **Timeouts** use a deadline model: the timeout budget is shared across image pull and container execution. If pulling takes 30 seconds of a 60-second timeout, the container gets the remaining 30 seconds.
+- **Shutdown**: active containers are killed and cleanup timers cleared when the server stops.
+
+## REST API
+
+All endpoints require authentication with the `containerJobs` feature permission.
+
+### `GET /signalk/v2/api/containerjobs/runtime`
+
+Returns the detected container runtime, or 503 if none is available.
+
+```json
+{
+  "runtime": "podman",
+  "version": "podman version 5.4.2"
+}
+```
+
+### `GET /signalk/v2/api/containerjobs`
+
+Returns all tracked jobs (active and recently completed).
+
+### `GET /signalk/v2/api/containerjobs/:jobId`
+
+Returns a specific job by ID, or 404 if not found.
+
+### `DELETE /signalk/v2/api/containerjobs/:jobId`
+
+Removes a completed or failed job from tracking. Returns 409 if the job is still active.
+
+### `POST /signalk/v2/api/containerjobs/images/prune`
+
+Removes dangling (untagged) container images. Returns the output from the prune command.

--- a/packages/server-api/src/containerjobapi.ts
+++ b/packages/server-api/src/containerjobapi.ts
@@ -1,0 +1,94 @@
+/** @category Container Jobs API */
+export type ContainerJobStatus =
+  | 'pending'
+  | 'pulling'
+  | 'running'
+  | 'completed'
+  | 'failed'
+
+/** @category Container Jobs API */
+export type ContainerRuntime = 'podman' | 'docker'
+
+/** @category Container Jobs API */
+export interface ContainerJobProgress {
+  stream: 'stdout' | 'stderr'
+  data: string
+}
+
+/** @category Container Jobs API */
+export interface ContainerJobConfig {
+  image: string
+  command: string[]
+  /**
+   * Input volume mounts: keys are container paths, values are host paths.
+   * Mounted read-only.
+   */
+  inputs?: Record<string, string>
+  /**
+   * Output volume mounts: keys are container paths, values are host paths.
+   * Mounted read-write.
+   */
+  outputs?: Record<string, string>
+  env?: Record<string, string>
+  /**
+   * Total timeout in milliseconds across pull and run phases (default: 600000).
+   * If exceeded, the container is killed and the job fails.
+   */
+  timeout?: number
+  onProgress?: (data: ContainerJobProgress) => void
+  label?: string
+}
+
+/** @category Container Jobs API */
+export interface ContainerJobResult {
+  id: string
+  status: ContainerJobStatus
+  image: string
+  command: string[]
+  label?: string
+  exitCode: number | null
+  log: string[]
+  error?: string
+  createdAt: string
+  startedAt?: string
+  completedAt?: string
+  runtime: ContainerRuntime
+}
+
+/** @category Container Jobs API */
+export interface ContainerRuntimeInfo {
+  runtime: ContainerRuntime
+  version: string
+  isPodmanDockerShim?: boolean
+}
+
+/** @category Container Jobs API */
+export class ContainerJobError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number
+  ) {
+    super(message)
+    this.name = 'ContainerJobError'
+  }
+}
+
+/**
+ * @ignore this is extended by {@link ServerAPI}, no need to document separately
+ */
+export interface WithContainerJobsApi {
+  /**
+   * Run a container job using the server's detected container runtime.
+   *
+   * @throws {ContainerJobError} statusCode 503 if no container runtime is available
+   * @throws {ContainerJobError} statusCode 429 if concurrency limit is reached
+   */
+  runContainerJob(config: ContainerJobConfig): Promise<ContainerJobResult>
+
+  /**
+   * List tracked container jobs, optionally filtered by label substring.
+   */
+  listContainerJobs(label?: string): ContainerJobResult[]
+
+  getContainerRuntime(): ContainerRuntimeInfo | null
+}

--- a/packages/server-api/src/features.ts
+++ b/packages/server-api/src/features.ts
@@ -77,3 +77,4 @@ export type SignalKApiId =
   | 'historyplayback' //https://signalk.org/specification/1.7.0/doc/streaming_api.html#history-playback
   | 'historysnapshot' //https://signalk.org/specification/1.7.0/doc/rest_api.html#history-snapshot-retrieval
   | 'notifications'
+  | 'containerjobs'

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -18,6 +18,8 @@ export * from './subscriptionmanager'
 export * as history from './history'
 /** @category Notifications API */
 export * from './notificationsapi'
+/** @category Container Jobs API */
+export * from './containerjobapi'
 
 /** @category  Server API */
 export interface Position {

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -7,7 +7,8 @@ import {
   WeatherProviderRegistry,
   Delta,
   WithResourcesApi,
-  WithNotificationsApi
+  WithNotificationsApi,
+  WithContainerJobsApi
 } from '.'
 import { RadarProviderRegistry, WithRadarApi } from './radarapi'
 import { CourseApi } from './course'
@@ -44,6 +45,7 @@ export interface ServerAPI
     WithFeatures,
     CourseApi,
     WithNotificationsApi,
+    WithContainerJobsApi,
     SelfIdentity {
   /**
    * Returns the entry for the provided path starting from `vessels.self` in the full data model.

--- a/src/api/containerjobs/index.ts
+++ b/src/api/containerjobs/index.ts
@@ -1,0 +1,384 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createDebug } from '../../debug'
+const debug = createDebug('signalk-server:api:containerjobs')
+
+import { IRouter, Request, Response } from 'express'
+import { v4 as uuidv4 } from 'uuid'
+import { ChildProcess } from 'child_process'
+
+import { WithSecurityStrategy } from '../../security'
+import { WithConfig } from '../../app'
+import { Responses } from '../'
+import { writeSettingsFile } from '../../config/config'
+
+import {
+  ContainerJobConfig,
+  ContainerJobError,
+  ContainerJobResult,
+  ContainerRuntimeInfo
+} from '@signalk/server-api'
+
+import {
+  detectRuntime,
+  imageExists,
+  pullImage,
+  pruneImages,
+  executeContainer
+} from './runtime'
+
+export const CONTAINER_JOBS_API_PATH = `/signalk/v2/api/containerjobs`
+
+interface ContainerJobsApplication
+  extends IRouter, WithConfig, WithSecurityStrategy {}
+
+interface ContainerJobsSettings {
+  preferredRuntime: 'podman' | 'docker' | 'auto'
+  maxConcurrentJobs: number
+  completedJobRetention: number
+}
+
+export class ContainerJobsApi {
+  private app: ContainerJobsApplication
+  private settings!: ContainerJobsSettings
+  private runtimeInfo: ContainerRuntimeInfo | null = null
+  private jobs: Map<string, ContainerJobResult> = new Map()
+  private activeJobCount = 0
+  private activeChildren: Map<string, ChildProcess> = new Map()
+  private cleanupTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+
+  constructor(app: ContainerJobsApplication) {
+    this.app = app
+    this.parseSettings()
+    this.initRoutes()
+  }
+
+  async start(): Promise<void> {
+    this.runtimeInfo = await detectRuntime(this.settings.preferredRuntime)
+    if (this.runtimeInfo) {
+      debug(
+        `Container runtime: ${this.runtimeInfo.runtime} ${this.runtimeInfo.version}` +
+          (this.runtimeInfo.isPodmanDockerShim ? ' (podman-docker shim)' : '')
+      )
+    } else {
+      debug('No container runtime found (podman or docker)')
+    }
+  }
+
+  stop(): void {
+    for (const [jobId, child] of this.activeChildren) {
+      debug(`Killing container process for job ${jobId}`)
+      child.kill('SIGKILL')
+    }
+    this.activeChildren.clear()
+    for (const timer of this.cleanupTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.cleanupTimers.clear()
+  }
+
+  getRuntimeInfo(): ContainerRuntimeInfo | null {
+    return this.runtimeInfo
+  }
+
+  listJobs(label?: string): ContainerJobResult[] {
+    let jobs = Array.from(this.jobs.values())
+    if (label) {
+      jobs = jobs.filter((j) => j.label?.includes(label))
+    }
+    return jobs.map((job) => ({
+      ...job,
+      command: [...job.command],
+      log: [...job.log]
+    }))
+  }
+
+  async runJob(config: ContainerJobConfig): Promise<ContainerJobResult> {
+    if (!this.runtimeInfo) {
+      throw new ContainerJobError(
+        'No container runtime available (podman or docker not found)',
+        503
+      )
+    }
+
+    if (this.activeJobCount >= this.settings.maxConcurrentJobs) {
+      debug(
+        `Rejecting job: ${this.activeJobCount}/${this.settings.maxConcurrentJobs} concurrent jobs running`
+      )
+      throw new ContainerJobError(
+        `Too many concurrent container jobs (max ${this.settings.maxConcurrentJobs})`,
+        429
+      )
+    }
+
+    const jobConfig: ContainerJobConfig = {
+      ...config,
+      command: [...config.command],
+      inputs: config.inputs ? { ...config.inputs } : undefined,
+      outputs: config.outputs ? { ...config.outputs } : undefined,
+      env: config.env ? { ...config.env } : undefined
+    }
+
+    const totalTimeout = jobConfig.timeout ?? 600000
+    const deadline = Date.now() + totalTimeout
+
+    const jobId = uuidv4()
+    const jobLabel = jobConfig.label ? ` (${jobConfig.label})` : ''
+    debug(
+      `Job ${jobId}${jobLabel}: starting ${jobConfig.image} ${jobConfig.command.join(' ')}`
+    )
+    const job: ContainerJobResult = {
+      id: jobId,
+      status: 'pending',
+      image: jobConfig.image,
+      command: [...jobConfig.command],
+      label: jobConfig.label,
+      exitCode: null,
+      log: [],
+      createdAt: new Date().toISOString(),
+      runtime: this.runtimeInfo.runtime
+    }
+    this.jobs.set(jobId, job)
+    this.activeJobCount++
+
+    try {
+      job.status = 'pulling'
+      const exists = await imageExists(this.runtimeInfo, jobConfig.image)
+      if (!exists) {
+        debug(`Pulling image: ${jobConfig.image}`)
+        jobConfig.onProgress?.({
+          stream: 'stderr',
+          data: `Pulling image ${jobConfig.image}...\n`
+        })
+        const pullTimeout = Math.max(0, deadline - Date.now())
+        const pull = pullImage(this.runtimeInfo, jobConfig.image, pullTimeout)
+        this.activeChildren.set(jobId, pull.child)
+        await pull.promise
+        this.activeChildren.delete(jobId)
+        debug(`Image pulled: ${jobConfig.image}`)
+        pruneImages(this.runtimeInfo!).catch((err) =>
+          debug(`Image prune after pull failed: ${err.message}`)
+        )
+      }
+
+      job.status = 'running'
+      job.startedAt = new Date().toISOString()
+
+      const runTimeout = Math.max(0, deadline - Date.now())
+      const { promise, child } = executeContainer(
+        { ...jobConfig, timeout: runTimeout },
+        this.runtimeInfo,
+        job.log,
+        jobConfig.onProgress
+      )
+
+      this.activeChildren.set(jobId, child)
+
+      const result = await promise
+
+      this.activeChildren.delete(jobId)
+
+      job.exitCode = result.exitCode
+      job.status = result.exitCode === 0 ? 'completed' : 'failed'
+      job.completedAt = new Date().toISOString()
+      if (result.exitCode !== 0) {
+        job.error = `Container exited with code ${result.exitCode}`
+        debug(
+          `Job ${jobId}${jobLabel}: failed with exit code ${result.exitCode}`
+        )
+      } else {
+        debug(`Job ${jobId}${jobLabel}: completed successfully`)
+      }
+    } catch (err: any) {
+      this.activeChildren.delete(jobId)
+      job.status = 'failed'
+      job.error = err instanceof Error ? err.message : String(err)
+      job.completedAt = new Date().toISOString()
+      debug(`Job ${jobId}${jobLabel}: failed with error: ${job.error}`)
+    } finally {
+      this.activeJobCount--
+      this.scheduleCleanup(jobId)
+    }
+
+    return { ...job, command: [...job.command], log: [...job.log] }
+  }
+
+  private scheduleCleanup(jobId: string): void {
+    const timer = setTimeout(() => {
+      this.jobs.delete(jobId)
+      this.cleanupTimers.delete(jobId)
+    }, this.settings.completedJobRetention)
+    this.cleanupTimers.set(jobId, timer)
+  }
+
+  private parseSettings(): void {
+    const defaultSettings: ContainerJobsSettings = {
+      preferredRuntime: 'auto',
+      maxConcurrentJobs: 2,
+      completedJobRetention: 300000
+    }
+
+    const existing = (this.app.config.settings as any)['containerJobsApi']
+    if (!existing) {
+      debug('Applying default settings')
+      ;(this.app.config.settings as any)['containerJobsApi'] = defaultSettings
+    } else {
+      if (existing.preferredRuntime === undefined) {
+        existing.preferredRuntime = defaultSettings.preferredRuntime
+      }
+      if (existing.maxConcurrentJobs === undefined) {
+        existing.maxConcurrentJobs = defaultSettings.maxConcurrentJobs
+      }
+      if (existing.completedJobRetention === undefined) {
+        existing.completedJobRetention = defaultSettings.completedJobRetention
+      }
+    }
+    this.settings = (this.app.config.settings as any)['containerJobsApi']
+  }
+
+  saveSettings(): void {
+    writeSettingsFile(
+      this.app as any,
+      this.app.config.settings,
+      (err?: Error) => {
+        if (err) {
+          debug(`Failed to save settings: ${err.message}`)
+        } else {
+          debug('Settings saved')
+        }
+      }
+    )
+  }
+
+  private initRoutes(): void {
+    const writeAllowed = (req: Request): boolean =>
+      this.app.securityStrategy.shouldAllowPut(
+        req,
+        'vessels.self',
+        null,
+        'containerjobs'
+      )
+
+    this.app.get(
+      `${CONTAINER_JOBS_API_PATH}/runtime`,
+      (req: Request, res: Response) => {
+        if (!writeAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        if (this.runtimeInfo) {
+          res.json(this.runtimeInfo)
+        } else {
+          res.json({ runtime: null, message: 'No container runtime found' })
+        }
+      }
+    )
+
+    this.app.get(
+      `${CONTAINER_JOBS_API_PATH}/:jobId`,
+      (req: Request, res: Response) => {
+        if (!writeAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        const job = this.jobs.get(req.params.jobId)
+        if (job) {
+          res.json({ ...job, command: [...job.command], log: [...job.log] })
+        } else {
+          res.status(404).json(Responses.notFound)
+        }
+      }
+    )
+
+    this.app.get(
+      `${CONTAINER_JOBS_API_PATH}`,
+      (req: Request, res: Response) => {
+        if (!writeAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+        let jobs = Array.from(this.jobs.values())
+        const label = req.query.label as string | undefined
+        if (label) {
+          jobs = jobs.filter((j) => j.label?.includes(label))
+        }
+        res.json(
+          jobs.map((job) => ({
+            ...job,
+            command: [...job.command],
+            log: [...job.log]
+          }))
+        )
+      }
+    )
+
+    this.app.delete(
+      `${CONTAINER_JOBS_API_PATH}/:jobId`,
+      (req: Request, res: Response) => {
+        if (!writeAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+
+        const job = this.jobs.get(req.params.jobId)
+        if (!job) {
+          res.status(404).json(Responses.notFound)
+          return
+        }
+
+        if (job.status === 'running' || job.status === 'pulling') {
+          res.status(409).json({
+            state: 'FAILED',
+            statusCode: 409,
+            message: 'Cannot delete an active job'
+          })
+          return
+        }
+
+        this.jobs.delete(req.params.jobId)
+        const timer = this.cleanupTimers.get(req.params.jobId)
+        if (timer) {
+          clearTimeout(timer)
+          this.cleanupTimers.delete(req.params.jobId)
+        }
+        res.json(Responses.ok)
+      }
+    )
+
+    this.app.post(
+      `${CONTAINER_JOBS_API_PATH}/images/prune`,
+      async (req: Request, res: Response) => {
+        if (!writeAllowed(req)) {
+          res.status(403).json(Responses.unauthorised)
+          return
+        }
+
+        if (!this.runtimeInfo) {
+          res.status(503).json({
+            state: 'FAILED',
+            statusCode: 503,
+            message: 'No container runtime available'
+          })
+          return
+        }
+
+        try {
+          debug('Manual image prune requested')
+          const result = await pruneImages(this.runtimeInfo)
+          debug(`Image prune complete: ${result.imagesRemoved} images removed`)
+          res.json({
+            state: 'COMPLETED',
+            statusCode: 200,
+            ...result
+          })
+        } catch (err: any) {
+          debug(`Image prune failed: ${err.message}`)
+          res.status(500).json({
+            state: 'FAILED',
+            statusCode: 500,
+            message: err.message
+          })
+        }
+      }
+    )
+  }
+}

--- a/src/api/containerjobs/openApi.ts
+++ b/src/api/containerjobs/openApi.ts
@@ -1,0 +1,169 @@
+import { OpenApiDescription } from '../swagger'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const containerJobsApiDoc: any = {
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'Signal K Container Jobs API',
+    description:
+      'API for monitoring container jobs run by plugins via the server container runtime (Podman or Docker).'
+  },
+  paths: {
+    '/': {
+      get: {
+        summary: 'List all tracked container jobs',
+        parameters: [
+          {
+            name: 'label',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+            description: 'Filter jobs by label substring match'
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'Array of container job results',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/ContainerJobResult' }
+                }
+              }
+            }
+          },
+          '403': { description: 'Unauthorised' }
+        }
+      }
+    },
+    '/runtime': {
+      get: {
+        summary: 'Get detected container runtime information',
+        responses: {
+          '200': {
+            description: 'Container runtime info',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ContainerRuntimeInfo' }
+              }
+            }
+          },
+          '403': { description: 'Unauthorised' }
+        }
+      }
+    },
+    '/{jobId}': {
+      get: {
+        summary: 'Get a specific container job',
+        parameters: [
+          {
+            name: 'jobId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', format: 'uuid' }
+          }
+        ],
+        responses: {
+          '200': {
+            description: 'Container job result',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ContainerJobResult' }
+              }
+            }
+          },
+          '403': { description: 'Unauthorised' },
+          '404': { description: 'Job not found' }
+        }
+      },
+      delete: {
+        summary: 'Remove a completed or failed job from tracking',
+        parameters: [
+          {
+            name: 'jobId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', format: 'uuid' }
+          }
+        ],
+        responses: {
+          '200': { description: 'Job removed' },
+          '403': { description: 'Unauthorised' },
+          '404': { description: 'Job not found' },
+          '409': { description: 'Cannot delete an active job' }
+        }
+      }
+    },
+    '/images/prune': {
+      post: {
+        summary:
+          'Remove dangling (unused) container images to reclaim disk space',
+        responses: {
+          '200': {
+            description: 'Prune completed',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    state: { type: 'string' },
+                    statusCode: { type: 'integer' },
+                    imagesRemoved: { type: 'integer' },
+                    spaceReclaimed: { type: 'string' }
+                  }
+                }
+              }
+            }
+          },
+          '403': { description: 'Unauthorised' },
+          '503': { description: 'No container runtime available' }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      ContainerJobResult: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          status: {
+            type: 'string',
+            enum: ['pending', 'pulling', 'running', 'completed', 'failed']
+          },
+          image: { type: 'string' },
+          command: { type: 'array', items: { type: 'string' } },
+          label: { type: 'string' },
+          exitCode: { type: 'integer', nullable: true },
+          log: { type: 'array', items: { type: 'string' } },
+          error: { type: 'string' },
+          createdAt: { type: 'string', format: 'date-time' },
+          startedAt: { type: 'string', format: 'date-time' },
+          completedAt: { type: 'string', format: 'date-time' },
+          runtime: { type: 'string', enum: ['podman', 'docker'] }
+        }
+      },
+      ContainerRuntimeInfo: {
+        type: 'object',
+        properties: {
+          runtime: {
+            type: 'string',
+            enum: ['podman', 'docker'],
+            nullable: true
+          },
+          version: { type: 'string' },
+          isPodmanDockerShim: { type: 'boolean' },
+          message: { type: 'string' }
+        }
+      }
+    }
+  }
+}
+
+export const containerJobsApiRecord = {
+  name: 'containerjobs',
+  path: '/signalk/v2/api/containerjobs',
+  apiDoc: containerJobsApiDoc as OpenApiDescription
+}

--- a/src/api/containerjobs/runtime.ts
+++ b/src/api/containerjobs/runtime.ts
@@ -1,0 +1,285 @@
+import { execFile, spawn, ChildProcess } from 'child_process'
+import {
+  ContainerRuntimeInfo,
+  ContainerJobConfig,
+  ContainerJobProgress
+} from '@signalk/server-api'
+
+const DEFAULT_PULL_TIMEOUT = 600000
+const IMAGE_EXISTS_TIMEOUT = 30000
+const MAX_LOG_LINES = 100
+
+export function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  delete env.LISTEN_FDS
+  delete env.LISTEN_PID
+  delete env.LISTEN_FDNAMES
+  return env
+}
+
+function tryRuntime(
+  binary: string
+): Promise<{ available: boolean; version: string; output: string }> {
+  return new Promise((resolve) => {
+    execFile(binary, ['--version'], { env: cleanEnv() }, (error, stdout) => {
+      if (error) {
+        resolve({ available: false, version: '', output: '' })
+      } else {
+        resolve({
+          available: true,
+          version: stdout.trim(),
+          output: stdout.toLowerCase()
+        })
+      }
+    })
+  })
+}
+
+export async function detectRuntime(
+  preferred: 'podman' | 'docker' | 'auto'
+): Promise<ContainerRuntimeInfo | null> {
+  const order: Array<'podman' | 'docker'> =
+    preferred === 'docker' ? ['docker', 'podman'] : ['podman', 'docker']
+
+  for (const binary of order) {
+    const result = await tryRuntime(binary)
+    if (!result.available) {
+      continue
+    }
+
+    if (binary === 'docker' && result.output.includes('podman')) {
+      return {
+        runtime: 'podman',
+        version: result.version,
+        isPodmanDockerShim: true
+      }
+    }
+
+    return { runtime: binary, version: result.version }
+  }
+
+  return null
+}
+
+function isPodman(info: ContainerRuntimeInfo): boolean {
+  return info.runtime === 'podman' || info.isPodmanDockerShim === true
+}
+
+function runtimeBinary(info: ContainerRuntimeInfo): string {
+  return info.isPodmanDockerShim ? 'docker' : info.runtime
+}
+
+export function imageExists(
+  info: ContainerRuntimeInfo,
+  image: string
+): Promise<boolean> {
+  const binary = runtimeBinary(info)
+  const args = isPodman(info)
+    ? ['image', 'exists', image]
+    : ['image', 'inspect', image]
+
+  return new Promise((resolve) => {
+    execFile(
+      binary,
+      args,
+      { env: cleanEnv(), timeout: IMAGE_EXISTS_TIMEOUT },
+      (error) => {
+        resolve(!error)
+      }
+    )
+  })
+}
+
+export function pullImage(
+  info: ContainerRuntimeInfo,
+  image: string,
+  timeout: number = DEFAULT_PULL_TIMEOUT
+): { promise: Promise<void>; child: ChildProcess } {
+  const binary = runtimeBinary(info)
+  const child = spawn(binary, ['pull', image], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: cleanEnv()
+  })
+
+  let stderr = ''
+  child.stderr?.on('data', (data: Buffer) => {
+    stderr += data.toString()
+  })
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  const promise = new Promise<void>((resolve, reject) => {
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        child.kill('SIGKILL')
+        reject(new Error(`Image pull timed out after ${timeout}ms`))
+      }, timeout)
+    }
+
+    child.on('error', (err) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      reject(new Error(`Failed to pull ${image}: ${err.message}`))
+    })
+
+    child.on('close', (code) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      if (code !== 0) {
+        reject(
+          new Error(`Failed to pull ${image} (exit ${code}): ${stderr.trim()}`)
+        )
+      } else {
+        resolve()
+      }
+    })
+  })
+
+  return { promise, child }
+}
+
+export interface PruneResult {
+  imagesRemoved: number
+  spaceReclaimed: string
+}
+
+export function pruneImages(info: ContainerRuntimeInfo): Promise<PruneResult> {
+  const binary = runtimeBinary(info)
+  return new Promise((resolve, reject) => {
+    execFile(
+      binary,
+      ['image', 'prune', '-f'],
+      { timeout: 60000, env: cleanEnv() },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(
+            new Error(`Failed to prune images: ${stderr || error.message}`)
+          )
+        } else {
+          const lines = stdout
+            .trim()
+            .split(/\r?\n/)
+            .filter((l) => l.length > 0)
+          resolve({
+            imagesRemoved: lines.length,
+            spaceReclaimed: stdout.trim()
+          })
+        }
+      }
+    )
+  })
+}
+
+export function buildVolumeArgs(
+  config: ContainerJobConfig,
+  info: ContainerRuntimeInfo
+): string[] {
+  const args: string[] = []
+  const zFlag = isPodman(info) ? ',Z' : ''
+
+  if (config.inputs) {
+    for (const [containerPath, hostPath] of Object.entries(config.inputs)) {
+      args.push('-v', `${hostPath}:${containerPath}:ro${zFlag}`)
+    }
+  }
+
+  if (config.outputs) {
+    for (const [containerPath, hostPath] of Object.entries(config.outputs)) {
+      args.push('-v', `${hostPath}:${containerPath}${zFlag ? ':Z' : ''}`)
+    }
+  }
+
+  return args
+}
+
+function buildEnvArgs(env?: Record<string, string>): string[] {
+  if (!env) {
+    return []
+  }
+  const args: string[] = []
+  for (const [key, value] of Object.entries(env)) {
+    args.push('-e', `${key}=${value}`)
+  }
+  return args
+}
+
+export function appendToLog(log: string[], text: string): void {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0)
+  log.push(...lines)
+  if (log.length > MAX_LOG_LINES) {
+    log.splice(0, log.length - MAX_LOG_LINES)
+  }
+}
+
+export interface ContainerExecResult {
+  exitCode: number
+}
+
+export function executeContainer(
+  config: ContainerJobConfig,
+  info: ContainerRuntimeInfo,
+  log: string[],
+  onProgress?: (data: ContainerJobProgress) => void
+): { promise: Promise<ContainerExecResult>; child: ChildProcess } {
+  const binary = runtimeBinary(info)
+  const volumeArgs = buildVolumeArgs(config, info)
+  const envArgs = buildEnvArgs(config.env)
+
+  const args = [
+    'run',
+    '--rm',
+    '--init',
+    ...volumeArgs,
+    ...envArgs,
+    config.image,
+    ...config.command
+  ]
+
+  const child = spawn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: cleanEnv()
+  })
+
+  const handleData = (stream: 'stdout' | 'stderr') => (data: Buffer) => {
+    const text = data.toString()
+    appendToLog(log, text)
+    try {
+      onProgress?.({ stream, data: text })
+    } catch {
+      // plugin callback errors must not crash the process
+    }
+  }
+
+  child.stdout?.on('data', handleData('stdout'))
+  child.stderr?.on('data', handleData('stderr'))
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = config.timeout ?? DEFAULT_PULL_TIMEOUT
+
+  const promise = new Promise<ContainerExecResult>((resolve, reject) => {
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        child.kill('SIGKILL')
+        reject(new Error(`Container timed out after ${timeout}ms`))
+      }, timeout)
+    }
+
+    child.on('error', (err) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      reject(new Error(`Failed to start ${binary}: ${err.message}`))
+    })
+
+    child.on('close', (code) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      resolve({ exitCode: code ?? 1 })
+    })
+  })
+
+  return { promise, child }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,8 @@ import { RadarApi } from './radar'
 import { HistoryApiHttpRegistry } from './history'
 import { SignalKApiId, WithFeatures } from '@signalk/server-api'
 import { NotificationApi, NotificationApplication } from './notifications'
+import { ContainerJobsApi } from './containerjobs'
+import { ContainerJobConfig } from '@signalk/server-api'
 import { binaryStreamManager, initializeBinaryStreams } from './streams'
 
 export interface ApiResponse {
@@ -101,6 +103,23 @@ export const startApis = (
   ;(app as any).notificationApi = notificationApi
   apiList.push('notifications')
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const containerJobsApi = new ContainerJobsApi(app as any)
+  const containerJobsApiStarted = containerJobsApi.start()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).containerJobsApi = containerJobsApi
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).runContainerJob = async (config: ContainerJobConfig) => {
+    await containerJobsApiStarted
+    return containerJobsApi.runJob(config)
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).listContainerJobs = (label?: string) =>
+    containerJobsApi.listJobs(label)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).getContainerRuntime = () => containerJobsApi.getRuntimeInfo()
+  apiList.push('containerjobs')
+
   Promise.all([
     resourcesApi.start(),
     courseApi.start(),
@@ -109,7 +128,8 @@ export const startApis = (
     autopilotApi.start(),
     radarApi.start(),
     historyApiHttpRegistry.start(),
-    notificationApi.start()
+    notificationApi.start(),
+    containerJobsApiStarted
   ])
   return apiList
 }

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -12,6 +12,7 @@ import { weatherApiRecord } from './weather/openApi'
 import { appsApiRecord } from './apps/openApi'
 import { historyApiRecord } from './history/openApi'
 import { radarApiRecord } from './radar/openApi'
+import { containerJobsApiRecord } from './containerjobs/openApi'
 import { PluginId, PluginManager } from '../interfaces/plugins'
 import { Brand } from '@signalk/server-api'
 
@@ -37,7 +38,8 @@ const apiDocs = [
   weatherApiRecord,
   securityApiRecord,
   historyApiRecord,
-  radarApiRecord
+  radarApiRecord,
+  containerJobsApiRecord
 ].reduce<ApiRecords>((acc, apiRecord: OpenApiRecord) => {
   acc[apiRecord.name] = apiRecord
   return acc

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -89,6 +89,11 @@ export interface Config {
     courseApi?: {
       apiOnly?: boolean
     }
+    containerJobsApi?: {
+      preferredRuntime?: 'podman' | 'docker' | 'auto'
+      maxConcurrentJobs?: number
+      completedJobRetention?: number
+    }
   }
   defaults: object
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -565,6 +565,7 @@ class Server {
           intf.stop()
         }
       })
+      ;(this.app as any).containerJobsApi?.stop()
 
       this.app.intervals.forEach((interval) => {
         clearInterval(interval)

--- a/test/containerjobs.ts
+++ b/test/containerjobs.ts
@@ -1,0 +1,294 @@
+import { expect } from 'chai'
+import { ContainerJobsApi } from '../dist/api/containerjobs/index.js'
+import { ContainerJobError } from '@signalk/server-api'
+import {
+  cleanEnv,
+  detectRuntime,
+  buildVolumeArgs,
+  appendToLog,
+  imageExists
+} from '../dist/api/containerjobs/runtime.js'
+import type {
+  ContainerJobConfig,
+  ContainerRuntimeInfo
+} from '@signalk/server-api'
+
+describe('Container Jobs API - runtime utilities', () => {
+  describe('cleanEnv', () => {
+    it('strips systemd socket activation variables', () => {
+      const original = { ...process.env }
+      process.env.LISTEN_FDS = '1'
+      process.env.LISTEN_PID = '1234'
+      process.env.LISTEN_FDNAMES = 'test'
+      process.env.HOME = '/home/test'
+
+      try {
+        const env = cleanEnv()
+
+        expect(env.LISTEN_FDS).to.be.undefined
+        expect(env.LISTEN_PID).to.be.undefined
+        expect(env.LISTEN_FDNAMES).to.be.undefined
+        expect(env.HOME).to.equal('/home/test')
+      } finally {
+        delete process.env.LISTEN_FDS
+        delete process.env.LISTEN_PID
+        delete process.env.LISTEN_FDNAMES
+        Object.assign(process.env, original)
+      }
+    })
+  })
+
+  describe('buildVolumeArgs', () => {
+    const podmanInfo: ContainerRuntimeInfo = {
+      runtime: 'podman',
+      version: 'podman version 5.0.0'
+    }
+    const dockerInfo: ContainerRuntimeInfo = {
+      runtime: 'docker',
+      version: 'Docker version 27.0.0'
+    }
+    const shimInfo: ContainerRuntimeInfo = {
+      runtime: 'podman',
+      version: 'podman version 5.0.0',
+      isPodmanDockerShim: true
+    }
+
+    it('generates read-only volume args with :Z for podman inputs', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        inputs: { '/input': '/host/source' }
+      }
+      const args = buildVolumeArgs(config, podmanInfo)
+      expect(args).to.deep.equal(['-v', '/host/source:/input:ro,Z'])
+    })
+
+    it('generates read-write volume args with :Z for podman outputs', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        outputs: { '/output': '/host/dest' }
+      }
+      const args = buildVolumeArgs(config, podmanInfo)
+      expect(args).to.deep.equal(['-v', '/host/dest:/output:Z'])
+    })
+
+    it('omits :Z for docker inputs', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        inputs: { '/input': '/host/source' }
+      }
+      const args = buildVolumeArgs(config, dockerInfo)
+      expect(args).to.deep.equal(['-v', '/host/source:/input:ro'])
+    })
+
+    it('omits :Z for docker outputs', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        outputs: { '/output': '/host/dest' }
+      }
+      const args = buildVolumeArgs(config, dockerInfo)
+      expect(args).to.deep.equal(['-v', '/host/dest:/output'])
+    })
+
+    it('uses :Z for podman-docker shim', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        inputs: { '/input': '/host/source' },
+        outputs: { '/output': '/host/dest' }
+      }
+      const args = buildVolumeArgs(config, shimInfo)
+      expect(args).to.deep.equal([
+        '-v',
+        '/host/source:/input:ro,Z',
+        '-v',
+        '/host/dest:/output:Z'
+      ])
+    })
+
+    it('handles multiple inputs and outputs', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo'],
+        inputs: { '/in1': '/host/a', '/in2': '/host/b' },
+        outputs: { '/out1': '/host/c' }
+      }
+      const args = buildVolumeArgs(config, podmanInfo)
+      expect(args).to.have.lengthOf(6)
+      expect(args).to.include('-v')
+    })
+
+    it('returns empty array when no volumes specified', () => {
+      const config: ContainerJobConfig = {
+        image: 'test',
+        command: ['echo']
+      }
+      const args = buildVolumeArgs(config, podmanInfo)
+      expect(args).to.deep.equal([])
+    })
+  })
+
+  describe('appendToLog', () => {
+    it('appends lines to log buffer', () => {
+      const log: string[] = []
+      appendToLog(log, 'line1\nline2\n')
+      expect(log).to.deep.equal(['line1', 'line2'])
+    })
+
+    it('respects max log lines limit', () => {
+      const log: string[] = []
+      for (let i = 0; i < 120; i++) {
+        appendToLog(log, `line${i}`)
+      }
+      expect(log.length).to.be.at.most(100)
+      expect(log[log.length - 1]).to.equal('line119')
+    })
+
+    it('filters empty lines', () => {
+      const log: string[] = []
+      appendToLog(log, 'line1\n\n\nline2')
+      expect(log).to.deep.equal(['line1', 'line2'])
+    })
+  })
+})
+
+describe('Container Jobs API - ContainerJobsApi', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type RouteHandler = (...args: any[]) => void
+  function createMockApp(settingsOverride?: object) {
+    const routes: Record<string, RouteHandler> = {}
+    return {
+      config: {
+        settings: {
+          containerJobsApi: settingsOverride
+        },
+        configPath: '/tmp/test'
+      },
+      securityStrategy: {
+        shouldAllowPut: () => true
+      },
+      get: (path: string, handler: RouteHandler) => {
+        routes[`GET ${path}`] = handler
+      },
+      post: (path: string, handler: RouteHandler) => {
+        routes[`POST ${path}`] = handler
+      },
+      put: (path: string, handler: RouteHandler) => {
+        routes[`PUT ${path}`] = handler
+      },
+      delete: (path: string, handler: RouteHandler) => {
+        routes[`DELETE ${path}`] = handler
+      },
+      _routes: routes
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+  }
+
+  it('creates with default settings when none provided', () => {
+    const app = createMockApp()
+    new ContainerJobsApi(app)
+    expect(app.config.settings.containerJobsApi).to.deep.include({
+      preferredRuntime: 'auto',
+      maxConcurrentJobs: 2,
+      completedJobRetention: 300000
+    })
+  })
+
+  it('preserves existing settings', () => {
+    const app = createMockApp({
+      preferredRuntime: 'podman',
+      maxConcurrentJobs: 4,
+      completedJobRetention: 60000
+    })
+    new ContainerJobsApi(app)
+    expect(app.config.settings.containerJobsApi.preferredRuntime).to.equal(
+      'podman'
+    )
+    expect(app.config.settings.containerJobsApi.maxConcurrentJobs).to.equal(4)
+  })
+
+  it('fills in missing settings with defaults', () => {
+    const app = createMockApp({ preferredRuntime: 'docker' })
+    new ContainerJobsApi(app)
+    expect(app.config.settings.containerJobsApi.preferredRuntime).to.equal(
+      'docker'
+    )
+    expect(app.config.settings.containerJobsApi.maxConcurrentJobs).to.equal(2)
+    expect(app.config.settings.containerJobsApi.completedJobRetention).to.equal(
+      300000
+    )
+  })
+
+  it('getRuntimeInfo returns null before start', () => {
+    const app = createMockApp()
+    const api = new ContainerJobsApi(app)
+    expect(api.getRuntimeInfo()).to.be.null
+  })
+
+  it('throws 503 when no runtime available', async () => {
+    const app = createMockApp()
+    const api = new ContainerJobsApi(app)
+    try {
+      await api.runJob({
+        image: 'alpine',
+        command: ['echo', 'hello']
+      })
+      expect.fail('Should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(ContainerJobError)
+      expect((err as ContainerJobError).statusCode).to.equal(503)
+    }
+  })
+
+  it('registers REST routes', () => {
+    const app = createMockApp()
+    new ContainerJobsApi(app)
+    expect(app._routes['GET /signalk/v2/api/containerjobs']).to.be.a('function')
+    expect(app._routes['GET /signalk/v2/api/containerjobs/runtime']).to.be.a(
+      'function'
+    )
+    expect(app._routes['GET /signalk/v2/api/containerjobs/:jobId']).to.be.a(
+      'function'
+    )
+    expect(app._routes['DELETE /signalk/v2/api/containerjobs/:jobId']).to.be.a(
+      'function'
+    )
+    expect(
+      app._routes['POST /signalk/v2/api/containerjobs/images/prune']
+    ).to.be.a('function')
+  })
+
+  it('stop cleans up timers', () => {
+    const app = createMockApp()
+    const api = new ContainerJobsApi(app)
+    api.stop()
+  })
+})
+
+describe('Container Jobs API - runtime detection', () => {
+  it('detectRuntime returns info when podman is available', async function () {
+    this.timeout(10000)
+    const result = await detectRuntime('auto')
+    if (result) {
+      expect(result.runtime).to.be.oneOf(['podman', 'docker'])
+      expect(result.version).to.be.a('string').that.is.not.empty
+    }
+  })
+
+  it('imageExists returns false for non-existent image', async function () {
+    this.timeout(10000)
+    const runtimeInfo = await detectRuntime('auto')
+    if (!runtimeInfo) {
+      this.skip()
+      return
+    }
+    const exists = await imageExists(
+      runtimeInfo,
+      'nonexistent-image-that-does-not-exist:never'
+    )
+    expect(exists).to.be.false
+  })
+})


### PR DESCRIPTION
## Summary

Adds a server-level container job API so plugins can run containers (podman/docker) without managing runtimes themselves. Closes #2477.

- Automatic runtime detection: podman-first with docker fallback, including podman-docker shim detection
- `app.runContainerJob()` for plugins: image pulling, SELinux volume flags, deadline-based timeouts, progress streaming via callback, concurrency control
- REST endpoints at `/signalk/v2/api/containerjobs/` for runtime info, job listing, job details, deletion, and image pruning — all gated by `containerJobs` feature permission
- Dangling image pruning after pulls and via `POST /images/prune` endpoint
- Shutdown cleanup: active containers are killed and timers cleared
- OpenAPI documentation for all endpoints

## Tested with

End-to-end tested with [signalk-charts-provider-simple `use-server-job-api` branch](https://github.com/dirkwa/signalk-charts-provider-simple/tree/use-server-job-api), which drops ~300 lines of container boilerplate by switching to this API. Successfully downloaded and converted S-57 ENC charts through the full pipeline: download → GDAL export → tippecanoe tiling → chart available in Signal K resources.