### PR TITLE
fix(security): validate from field in JSON patch prototype pollution guard

### DIFF
--- a/src/interfaces/applicationData.js
+++ b/src/interfaces/applicationData.js
@@ -52,7 +52,9 @@ function isPrototypePollutionPath(pathString) {
 
 function hasPrototypePollutionPatch(patches) {
   return patches.some(
-    (patch) => patch.path && isPrototypePollutionPath(patch.path)
+    (patch) =>
+      (patch.path && isPrototypePollutionPath(patch.path)) ||
+      (patch.from && isPrototypePollutionPath(patch.from))
   )
 }
 

--- a/test/applicationData.ts
+++ b/test/applicationData.ts
@@ -229,4 +229,55 @@ describe('Application Data', () => {
       data.should.equal(test.settings.something)
     }
   })
+
+  it('rejects prototype pollution via path in add', async function () {
+    const result = await fetch(
+      `${url}/signalk/v1/applicationData/global/${APP_ID}/${APP_VERSION}`,
+      {
+        method: 'POST',
+        headers: {
+          ...adminHeaders,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify([
+          { op: 'add', path: '/__proto__/polluted', value: 'hacked' }
+        ])
+      }
+    )
+    result.status.should.equal(400)
+  })
+
+  it('rejects prototype read via from in copy', async function () {
+    const result = await fetch(
+      `${url}/signalk/v1/applicationData/global/${APP_ID}/${APP_VERSION}`,
+      {
+        method: 'POST',
+        headers: {
+          ...adminHeaders,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify([
+          { op: 'copy', from: '/__proto__/toString', path: '/stolen' }
+        ])
+      }
+    )
+    result.status.should.equal(400)
+  })
+
+  it('rejects prototype read via from in move', async function () {
+    const result = await fetch(
+      `${url}/signalk/v1/applicationData/global/${APP_ID}/${APP_VERSION}`,
+      {
+        method: 'POST',
+        headers: {
+          ...adminHeaders,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify([
+          { op: 'move', from: '/__proto__/constructor', path: '/stolen' }
+        ])
+      }
+    )
+    result.status.should.equal(400)
+  })
 })


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>The <code>hasPrototypePollutionPatch</code> guard in the applicationData endpoint only inspected the <code>path</code> property of incoming JSON Patch operations. The <code>from</code> property, used by RFC 6902 <code>copy</code> and <code>move</code> operations, was not checked. This allowed an authenticated user to bypass the prototype pollution guard and read internal prototype properties into their application data.</p>
<p>GHSA-qh3j-mrg8-f234</p>
<h2 data-heading="Fix">Fix</h2>
<p>Added validation of <code>patch.from</code> alongside <code>patch.path</code> in <code>hasPrototypePollutionPatch()</code>.</p>
<h2 data-heading="Manual test results">Manual test results</h2>
<p>Tested against a running server on port 4000 with an admin bearer token:</p>

Test | Payload | Expected | Result
-- | -- | -- | --
add with __proto__ in path | [{"op":"add","path":"/__proto__/polluted","value":"hacked"}] | 400 | 400
copy with __proto__ in from | [{"op":"copy","from":"/__proto__/toString","path":"/stolen"}] | 400 | 400
move with __proto__ in from | [{"op":"move","from":"/__proto__/constructor","path":"/stolen"}] | 400 | 400
Legitimate add patch | [{"op":"add","path":"/legit","value":"works"}] | 200 | 200

<!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened JSON Patch validation to reject operations containing unsafe source location references, complementing existing protections against unsafe target paths. This comprehensive approach prevents prototype pollution attacks.

* **Tests**
  * Added test cases confirming proper rejection of JSON Patch operations targeting prototype pollution security vectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->