### PR TITLE
feat(security): device manager with identity, tracking and scoped storage

### DIFF
--- a/packages/server-admin-ui/src/hooks/useWebSocket.ts
+++ b/packages/server-admin-ui/src/hooks/useWebSocket.ts
@@ -2,7 +2,9 @@ import { useSyncExternalStore, useCallback, useEffect, useRef } from 'react'
 import { webSocketService } from '../services/WebSocketService'
 import type {
   WebSocketStatus,
-  DeltaMessageHandler
+  DeltaMessageHandler,
+  ServerEventHandler,
+  ServerEventType
 } from '../services/WebSocketService'
 
 interface WebSocketState {
@@ -58,6 +60,24 @@ export function useDeltaMessages(handler: DeltaMessageHandler): void {
     }
     return webSocketService.addDeltaHandler(wrappedHandler)
   }, [])
+}
+
+export function useServerEvent(
+  eventType: ServerEventType,
+  handler: ServerEventHandler
+): void {
+  const handlerRef = useRef(handler)
+
+  useEffect(() => {
+    handlerRef.current = handler
+  })
+
+  useEffect(() => {
+    const wrappedHandler: ServerEventHandler = (data) => {
+      handlerRef.current(data)
+    }
+    return webSocketService.addServerEventHandler(eventType, wrappedHandler)
+  }, [eventType])
 }
 
 export function useWebSocketActions() {

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -6,6 +6,35 @@ export type WebSocketStatus =
 
 export type DeltaMessageHandler = (message: unknown) => void
 export type StatusChangeHandler = (status: WebSocketStatus) => void
+export type ServerEventHandler = (data: unknown) => void
+
+// Known server event names: the handleServerEvent switch cases plus
+// events delivered only through addServerEventHandler subscriptions.
+export type ServerEventType =
+  | 'SERVERSTATISTICS'
+  | 'PROVIDERSTATUS'
+  | 'DEBUG_SETTINGS'
+  | 'LOG'
+  | 'ACCESS_REQUEST'
+  | 'RECEIVE_LOGIN_STATUS'
+  | 'DISCOVERY_CHANGED'
+  | 'PRIORITYOVERRIDES'
+  | 'PRIORITYGROUPS'
+  | 'PRIORITYDEFAULTS'
+  | 'SOURCEALIASES'
+  | 'MULTISOURCEPATHS'
+  | 'RECONCILEDGROUPS'
+  | 'LIVEPREFERREDSOURCES'
+  | 'SOURCEEVICTED'
+  | 'SOURCESTATUS'
+  | 'N2KDEVICESTATUS'
+  | 'RESTORESTATUS'
+  | 'VESSEL_INFO'
+  | 'SOURCEPRIORITIES'
+  | 'RECEIVE_APPSTORE_LIST'
+  | 'APP_STORE_CHANGED'
+  | 'PLUGINS_CHANGED'
+  | 'DEVICE_STATUS_CHANGE'
 
 interface WebSocketServiceState {
   status: WebSocketStatus
@@ -29,6 +58,10 @@ export class WebSocketService {
   private listeners = new Set<Listener>()
   private deltaHandlers = new Set<DeltaMessageHandler>()
   private statusHandlers = new Set<StatusChangeHandler>()
+  private serverEventHandlers = new Map<
+    ServerEventType,
+    Set<ServerEventHandler>
+  >()
   private reconnectTimer: ReturnType<typeof setInterval> | null = null
   private reconnectAttempts = 0
   private maxReconnectAttempts = Infinity
@@ -153,6 +186,27 @@ export class WebSocketService {
     this.statusHandlers.add(handler)
     return () => {
       this.statusHandlers.delete(handler)
+    }
+  }
+
+  addServerEventHandler(
+    eventType: ServerEventType,
+    handler: ServerEventHandler
+  ): () => void {
+    let handlers = this.serverEventHandlers.get(eventType)
+    if (!handlers) {
+      handlers = new Set()
+      this.serverEventHandlers.set(eventType, handlers)
+    }
+    handlers.add(handler)
+    return () => {
+      const current = this.serverEventHandlers.get(eventType)
+      if (current) {
+        current.delete(handler)
+        if (current.size === 0) {
+          this.serverEventHandlers.delete(eventType)
+        }
+      }
     }
   }
 
@@ -382,6 +436,19 @@ export class WebSocketService {
         break
       default:
         console.debug('Unhandled server event:', eventType)
+    }
+
+    // eventType is an arbitrary wire string here; unknown names simply
+    // find no subscription.
+    const handlers = this.serverEventHandlers.get(eventType as ServerEventType)
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(data)
+        } catch (e) {
+          console.error('Server event handler error:', e)
+        }
+      })
     }
   }
 

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -7,6 +7,38 @@ export type WebSocketStatus =
 
 export type DeltaMessageHandler = (message: unknown) => void
 export type StatusChangeHandler = (status: WebSocketStatus) => void
+export type ServerEventHandler = (data: unknown) => void
+
+// Known server event names: the handleServerEvent switch cases plus
+// events delivered only through addServerEventHandler subscriptions.
+export type ServerEventType =
+  | 'SERVERSTATISTICS'
+  | 'PROVIDERSTATUS'
+  | 'DEBUG_SETTINGS'
+  | 'LOG'
+  | 'ACCESS_REQUEST'
+  | 'RECEIVE_LOGIN_STATUS'
+  | 'DISCOVERY_CHANGED'
+  | 'PRIORITYOVERRIDES'
+  | 'PRIORITYGROUPS'
+  | 'PRIORITYDEFAULTS'
+  | 'SOURCEALIASES'
+  | 'MULTISOURCEPATHS'
+  | 'RECONCILEDGROUPS'
+  | 'LIVEPREFERREDSOURCES'
+  | 'SOURCEEVICTED'
+  | 'SOURCESTATUS'
+  | 'HISTORYPROVIDERS'
+  | 'N2KDEVICESTATUS'
+  | 'POSITION_SOURCES'
+  | 'GNSS_SENSORS'
+  | 'RESTORESTATUS'
+  | 'VESSEL_INFO'
+  | 'SOURCEPRIORITIES'
+  | 'RECEIVE_APPSTORE_LIST'
+  | 'APP_STORE_CHANGED'
+  | 'PLUGINS_CHANGED'
+  | 'DEVICE_STATUS_CHANGE'
 
 interface WebSocketServiceState {
   status: WebSocketStatus
@@ -30,6 +62,10 @@ export class WebSocketService {
   private listeners = new Set<Listener>()
   private deltaHandlers = new Set<DeltaMessageHandler>()
   private statusHandlers = new Set<StatusChangeHandler>()
+  private serverEventHandlers = new Map<
+    ServerEventType,
+    Set<ServerEventHandler>
+  >()
   private reconnectTimer: ReturnType<typeof setInterval> | null = null
   private reconnectAttempts = 0
   private maxReconnectAttempts = Infinity
@@ -157,6 +193,27 @@ export class WebSocketService {
     }
   }
 
+  addServerEventHandler(
+    eventType: ServerEventType,
+    handler: ServerEventHandler
+  ): () => void {
+    let handlers = this.serverEventHandlers.get(eventType)
+    if (!handlers) {
+      handlers = new Set()
+      this.serverEventHandlers.set(eventType, handlers)
+    }
+    handlers.add(handler)
+    return () => {
+      const current = this.serverEventHandlers.get(eventType)
+      if (current) {
+        current.delete(handler)
+        if (current.size === 0) {
+          this.serverEventHandlers.delete(eventType)
+        }
+      }
+    }
+  }
+
   private handleMessage(message: unknown): void {
     const msg = message as Record<string, unknown>
 
@@ -225,10 +282,25 @@ export class WebSocketService {
   }
 
   private handleServerEvent(msg: Record<string, unknown>): void {
-    if (!this.zustandSetState) return
-
     const eventType = msg.type as string
     const data = msg.data as Record<string, unknown> | undefined
+
+    // Dispatch to addServerEventHandler subscriptions before the store
+    // guard so they receive events even when zustand is not wired yet.
+    // eventType is an arbitrary wire string here; unknown names simply
+    // find no subscription.
+    const handlers = this.serverEventHandlers.get(eventType as ServerEventType)
+    if (handlers) {
+      handlers.forEach((handler) => {
+        try {
+          handler(data)
+        } catch (e) {
+          console.error('Server event handler error:', e)
+        }
+      })
+    }
+
+    if (!this.zustandSetState) return
 
     switch (eventType) {
       case 'SERVERSTATISTICS':

--- a/packages/server-admin-ui/src/views/security/Devices.tsx
+++ b/packages/server-admin-ui/src/views/security/Devices.tsx
@@ -7,37 +7,62 @@ import {
   FormEvent
 } from 'react'
 import { useLoginStatus } from '../../store'
+import { useServerEvent } from '../../hooks/useWebSocket'
 import Badge from 'react-bootstrap/Badge'
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
 import Form from 'react-bootstrap/Form'
+import Modal from 'react-bootstrap/Modal'
 import Row from 'react-bootstrap/Row'
 import Table from 'react-bootstrap/Table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify'
 import { faBan } from '@fortawesome/free-solid-svg-icons/faBan'
+import { faCircle } from '@fortawesome/free-solid-svg-icons/faCircle'
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import EnableSecurity from './EnableSecurity'
 
 type PermissionType = 'readonly' | 'readwrite' | 'admin'
 
+interface DeviceDashboard {
+  mode: 'redirect' | 'metadata'
+  url?: string
+  metadata?: Record<string, unknown>
+}
+
 interface Device {
   clientId: string
   description?: string
+  displayName?: string
   permissions?: PermissionType
   requestedPermissions?: string
   tokenExpiry?: number
+  createdAt?: string
+  registrationInfo?: {
+    sourceIp?: string
+    deviceId?: string
+    firmwareVersion?: string
+    userAgent?: string
+  }
+  dashboard?: DeviceDashboard
+  isConnected?: boolean
+  lastSeen?: string
+  lastIp?: string
+  pluginData?: Record<string, Record<string, unknown>>
+}
+
+interface NewDeviceForm {
+  displayName: string
+  permissions: PermissionType
+  dashboardUrl: string
 }
 
 function convertPermissions(type: PermissionType | undefined): string {
-  if (type === 'readonly') {
-    return 'Read Only'
-  } else if (type === 'readwrite') {
-    return 'Read/Write'
-  } else if (type === 'admin') {
-    return 'Admin'
-  }
+  if (type === 'readonly') return 'Read Only'
+  if (type === 'readwrite') return 'Read/Write'
+  if (type === 'admin') return 'Admin'
   return ''
 }
 
@@ -46,58 +71,146 @@ function isExpired(device: Device): boolean {
 }
 
 function formatExpiry(device: Device): string {
-  if (!device.tokenExpiry) {
-    return 'NEVER'
-  }
+  if (!device.tokenExpiry) return 'NEVER'
   const expiryMs = device.tokenExpiry * 1000
   const nowMs = Date.now()
-  if (expiryMs < nowMs) {
-    return 'Expired'
-  }
+  if (expiryMs < nowMs) return 'Expired'
   const diffMs = expiryMs - nowMs
   const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
   const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
-  if (days > 0) {
-    return `${days}d ${hours}h remaining`
-  }
+  if (days > 0) return `${days}d ${hours}h remaining`
   const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
-  if (hours > 0) {
-    return `${hours}h ${minutes}m remaining`
-  }
+  if (hours > 0) return `${hours}h ${minutes}m remaining`
   return `${minutes}m remaining`
+}
+
+function formatLastSeen(lastSeen?: string): string {
+  if (!lastSeen) return ''
+  const diff = Date.now() - new Date(lastSeen).getTime()
+  if (diff < 60_000) return 'Just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}
+
+function getDeviceName(device: Device): string {
+  return device.displayName || device.description || device.clientId
+}
+
+function getDeviceCategory(device: Device): 'display' | 'sensor' | 'server' {
+  if (device.description?.toLowerCase().includes('server')) return 'server'
+  if (device.dashboard) return 'display'
+  return 'sensor'
+}
+
+function ConnectionDot({ connected }: { connected?: boolean }) {
+  return (
+    <FontAwesomeIcon
+      icon={faCircle}
+      style={{
+        color: connected ? '#28a745' : '#999',
+        fontSize: '0.6em',
+        marginRight: '0.5em'
+      }}
+    />
+  )
+}
+
+function DeviceTable({
+  devices,
+  onDeviceClick
+}: {
+  devices: Device[]
+  onDeviceClick: (device: Device) => void
+}) {
+  if (devices.length === 0) return null
+  return (
+    <Table hover responsive bordered striped size="sm">
+      <thead>
+        <tr>
+          <th style={{ width: '2em' }}></th>
+          <th>Name</th>
+          <th>Permissions</th>
+          <th>Last Seen</th>
+          <th>IP</th>
+          <th>Token Expiry</th>
+        </tr>
+      </thead>
+      <tbody>
+        {devices.map((device) => (
+          <tr
+            key={device.clientId}
+            onClick={() => onDeviceClick(device)}
+            style={{ cursor: 'pointer' }}
+          >
+            <td style={{ textAlign: 'center' }}>
+              <ConnectionDot connected={device.isConnected} />
+            </td>
+            <td>{getDeviceName(device)}</td>
+            <td>{convertPermissions(device.permissions)}</td>
+            <td>
+              {device.isConnected ? (
+                <Badge bg="success">Online</Badge>
+              ) : (
+                formatLastSeen(device.lastSeen)
+              )}
+            </td>
+            <td>
+              <small>{device.lastIp || ''}</small>
+            </td>
+            <td>
+              {isExpired(device) ? (
+                <Badge bg="danger">Expired</Badge>
+              ) : (
+                formatExpiry(device)
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
 export default function Devices() {
   const loginStatus = useLoginStatus()
   const [devices, setDevices] = useState<Device[]>([])
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null)
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [newDevice, setNewDevice] = useState<NewDeviceForm>({
+    displayName: '',
+    permissions: 'readonly',
+    dashboardUrl: ''
+  })
+  const [createdToken, setCreatedToken] = useState<{
+    clientId: string
+    token: string
+  } | null>(null)
+  const [deviceToken, setDeviceToken] = useState<string | null>(null)
   const selectedDeviceRef = useRef<HTMLDivElement>(null)
 
   const loadDevices = useCallback(async (): Promise<Device[]> => {
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices`,
-      {
-        credentials: 'include'
-      }
+      { credentials: 'include' }
     )
     return response.json()
   }, [])
 
   const refreshDevices = useCallback(() => {
-    loadDevices().then((data) => {
-      setDevices(data)
-    })
+    loadDevices().then(setDevices)
   }, [loadDevices])
 
   useEffect(() => {
     if (loginStatus.authenticationRequired) {
-      loadDevices().then((data) => {
-        setDevices(data)
-      })
+      loadDevices().then(setDevices)
     }
   }, [loginStatus.authenticationRequired, loadDevices])
 
-  const handleDeviceChange = (event: ChangeEvent<HTMLInputElement>) => {
+  useServerEvent('DEVICE_STATUS_CHANGE', refreshDevices)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleDeviceChange = (event: any) => {
     const value =
       event.target.type === 'checkbox'
         ? event.target.checked
@@ -107,23 +220,37 @@ export default function Devices() {
     )
   }
 
+  const handleDashboardUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSelectedDevice((prev) => {
+      if (!prev) return null
+      const url = event.target.value
+      if (!url) {
+        const { dashboard: _, ...rest } = prev
+        return rest as Device
+      }
+      return {
+        ...prev,
+        dashboard: { mode: 'redirect' as const, url }
+      }
+    })
+  }
+
   const handleApply = async (event: FormEvent) => {
     event.preventDefault()
-
     if (!selectedDevice) return
 
-    const payload = {
+    const payload: Record<string, unknown> = {
       permissions: selectedDevice.permissions || 'readonly',
-      description: selectedDevice.description
+      description: selectedDevice.description,
+      displayName: selectedDevice.displayName,
+      dashboard: selectedDevice.dashboard ?? null
     }
 
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}`,
       {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
         credentials: 'include'
       }
@@ -136,14 +263,11 @@ export default function Devices() {
 
   const deleteDevice = async () => {
     if (!selectedDevice) return
-
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}`,
       {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include'
       }
     )
@@ -155,6 +279,7 @@ export default function Devices() {
 
   const deviceClicked = (device: Device) => {
     setSelectedDevice(structuredClone(device))
+    setDeviceToken(null)
     setTimeout(() => {
       selectedDeviceRef.current?.scrollIntoView()
     }, 0)
@@ -162,88 +287,229 @@ export default function Devices() {
 
   const handleCancel = () => {
     setSelectedDevice(null)
+    setDeviceToken(null)
   }
+
+  const handleShowToken = async () => {
+    if (!selectedDevice) return
+    const response = await fetch(
+      `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}/token`,
+      {
+        method: 'POST',
+        credentials: 'include'
+      }
+    )
+    if (response.ok) {
+      const result = await response.json()
+      setDeviceToken(result.token)
+    } else {
+      alert('Failed to retrieve token')
+    }
+  }
+
+  const handleCreateDevice = async () => {
+    const payload: Record<string, unknown> = {
+      displayName: newDevice.displayName,
+      permissions: newDevice.permissions
+    }
+    if (newDevice.dashboardUrl) {
+      payload.dashboard = { mode: 'redirect', url: newDevice.dashboardUrl }
+    }
+    const response = await fetch(
+      `${window.serverRoutesPrefix}/security/devices`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        credentials: 'include'
+      }
+    )
+    if (response.ok) {
+      const result = await response.json()
+      setCreatedToken(result)
+      setShowAddModal(false)
+      setNewDevice({
+        displayName: '',
+        permissions: 'readonly',
+        dashboardUrl: ''
+      })
+      refreshDevices()
+    } else {
+      const text = await response.text()
+      alert('Failed to create device: ' + text)
+    }
+  }
+
+  const getTokenUrl = (token: string) => {
+    return `${window.location.origin}/?token=${token}`
+  }
+
+  // navigator.clipboard is undefined outside secure contexts (plain-HTTP LAN),
+  // where writeText would throw synchronously before any .catch().
+  const copyTokenUrl = (token: string) => {
+    if (!navigator.clipboard) {
+      alert('Clipboard unavailable (requires HTTPS)')
+      return
+    }
+    navigator.clipboard
+      .writeText(getTokenUrl(token))
+      .catch(() => alert('Failed to copy to clipboard'))
+  }
+
+  const displays = devices.filter((d) => getDeviceCategory(d) === 'display')
+  const sensors = devices.filter((d) => getDeviceCategory(d) === 'sensor')
+  const servers = devices.filter((d) => getDeviceCategory(d) === 'server')
 
   return (
     <div className="animated fadeIn">
       {loginStatus.authenticationRequired === false && <EnableSecurity />}
       {loginStatus.authenticationRequired && (
         <div>
-          <Card>
-            <Card.Header>
-              <FontAwesomeIcon icon={faAlignJustify} /> Devices
+          {createdToken && (
+            <Card className="mb-3 border-success">
+              <Card.Header className="bg-success text-white">
+                Device Created
+              </Card.Header>
+              <Card.Body>
+                <p>
+                  <strong>Client ID:</strong> {createdToken.clientId}
+                </p>
+                <Form.Group as={Row} className="mb-2">
+                  <Col md="2">
+                    <Form.Label>Token URL</Form.Label>
+                  </Col>
+                  <Col xs="12" md="10">
+                    <Form.Control
+                      type="text"
+                      readOnly
+                      value={getTokenUrl(createdToken.token)}
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                  </Col>
+                </Form.Group>
+                <p className="text-muted small mb-0">
+                  Copy this URL and use it to access the server from the device.
+                  This token will not be shown again.
+                </p>
+              </Card.Body>
+              <Card.Footer>
+                <Button
+                  size="sm"
+                  variant="outline-success"
+                  onClick={() => copyTokenUrl(createdToken.token)}
+                >
+                  Copy URL
+                </Button>{' '}
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setCreatedToken(null)}
+                >
+                  Dismiss
+                </Button>
+              </Card.Footer>
+            </Card>
+          )}
+
+          <Card className="mb-3">
+            <Card.Header className="d-flex justify-content-between align-items-center">
+              <span>
+                <FontAwesomeIcon icon={faAlignJustify} /> Displays & Apps
+              </span>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => setShowAddModal(true)}
+              >
+                <FontAwesomeIcon icon={faPlus} /> Add Device
+              </Button>
             </Card.Header>
             <Card.Body>
-              <Table hover responsive bordered striped size="sm">
-                <thead>
-                  <tr>
-                    <th>Client ID</th>
-                    <th>Description</th>
-                    <th>Type</th>
-                    <th>Token Expiry</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(devices || []).map((device) => {
-                    return (
-                      <tr
-                        key={device.clientId}
-                        onClick={() => deviceClicked(device)}
-                      >
-                        <td>{device.clientId}</td>
-                        <td>{device.description}</td>
-                        <td>{convertPermissions(device.permissions)}</td>
-                        <td>
-                          {isExpired(device) ? (
-                            <Badge bg="danger">Expired</Badge>
-                          ) : (
-                            formatExpiry(device)
-                          )}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </Table>
+              {displays.length === 0 ? (
+                <p className="text-muted mb-0">
+                  No display devices. Click "Add Device" to create one.
+                </p>
+              ) : (
+                <DeviceTable devices={displays} onDeviceClick={deviceClicked} />
+              )}
             </Card.Body>
-            <Card.Footer></Card.Footer>
           </Card>
+
+          {sensors.length > 0 && (
+            <Card className="mb-3">
+              <Card.Header>
+                <FontAwesomeIcon icon={faAlignJustify} /> Sensors & Bridges
+              </Card.Header>
+              <Card.Body>
+                <DeviceTable devices={sensors} onDeviceClick={deviceClicked} />
+              </Card.Body>
+            </Card>
+          )}
+
+          {servers.length > 0 && (
+            <Card className="mb-3">
+              <Card.Header>
+                <FontAwesomeIcon icon={faAlignJustify} /> Remote Servers
+              </Card.Header>
+              <Card.Body>
+                <DeviceTable devices={servers} onDeviceClick={deviceClicked} />
+              </Card.Body>
+            </Card>
+          )}
 
           {selectedDevice && (
             <div ref={selectedDeviceRef}>
               <Card>
                 <Card.Header>
-                  <FontAwesomeIcon icon={faAlignJustify} /> Device
+                  <FontAwesomeIcon icon={faAlignJustify} />{' '}
+                  {getDeviceName(selectedDevice)}
                 </Card.Header>
                 <Card.Body>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label>Client ID</Form.Label>
                     </Col>
                     <Col xs="12" md="9">
                       <span className="form-control-plaintext">
-                        {selectedDevice.clientId}
+                        <code>{selectedDevice.clientId}</code>
                       </span>
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label htmlFor="displayName">
+                        Display Name
+                      </Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <Form.Control
+                        type="text"
+                        id="displayName"
+                        name="displayName"
+                        autoComplete="off"
+                        style={{ width: 'auto' }}
+                        onChange={handleDeviceChange}
+                        value={selectedDevice.displayName || ''}
+                      />
+                    </Col>
+                  </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label htmlFor="description">Description</Form.Label>
                     </Col>
                     <Col xs="12" md="9">
                       <Form.Control
-                        size={60}
-                        style={{ width: 'auto' }}
                         type="text"
                         id="description"
                         name="description"
                         autoComplete="off"
+                        style={{ width: 'auto' }}
                         onChange={handleDeviceChange}
                         value={selectedDevice.description || ''}
                       />
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label htmlFor="permissions">Permissions</Form.Label>
                     </Col>
@@ -267,7 +533,29 @@ export default function Devices() {
                       )}
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label htmlFor="dashboardUrl">
+                        Dashboard URL
+                      </Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <Form.Control
+                        type="text"
+                        id="dashboardUrl"
+                        name="dashboardUrl"
+                        autoComplete="off"
+                        style={{ width: 'auto' }}
+                        placeholder="e.g. /@signalk/freeboard-sk/"
+                        onChange={handleDashboardUrlChange}
+                        value={selectedDevice.dashboard?.url || ''}
+                      />
+                      <Form.Text className="text-muted">
+                        Optional. Assign a webapp for this device to display.
+                      </Form.Text>
+                    </Col>
+                  </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label>Token Expiry</Form.Label>
                     </Col>
@@ -281,6 +569,56 @@ export default function Devices() {
                       </span>
                     </Col>
                   </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label>Status</Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <span className="form-control-plaintext">
+                        <ConnectionDot connected={selectedDevice.isConnected} />
+                        {selectedDevice.isConnected ? 'Online' : 'Offline'}
+                        {selectedDevice.lastIp && (
+                          <small className="ms-2 text-muted">
+                            ({selectedDevice.lastIp})
+                          </small>
+                        )}
+                        {selectedDevice.lastSeen && (
+                          <small className="ms-2 text-muted">
+                            Last seen: {formatLastSeen(selectedDevice.lastSeen)}
+                          </small>
+                        )}
+                      </span>
+                    </Col>
+                  </Form.Group>
+                  {selectedDevice.createdAt && (
+                    <Form.Group as={Row} className="mb-2">
+                      <Col md="2">
+                        <Form.Label>Created</Form.Label>
+                      </Col>
+                      <Col xs="12" md="9">
+                        <span className="form-control-plaintext">
+                          {new Date(selectedDevice.createdAt).toLocaleString()}
+                        </span>
+                      </Col>
+                    </Form.Group>
+                  )}
+                  {selectedDevice.registrationInfo && (
+                    <Form.Group as={Row} className="mb-2">
+                      <Col md="2">
+                        <Form.Label>Registration</Form.Label>
+                      </Col>
+                      <Col xs="12" md="9">
+                        <span className="form-control-plaintext">
+                          <small className="text-muted">
+                            {selectedDevice.registrationInfo.sourceIp &&
+                              `IP: ${selectedDevice.registrationInfo.sourceIp}`}
+                            {selectedDevice.registrationInfo.firmwareVersion &&
+                              ` | FW: ${selectedDevice.registrationInfo.firmwareVersion}`}
+                          </small>
+                        </span>
+                      </Col>
+                    </Form.Group>
+                  )}
                 </Card.Body>
                 <Card.Footer>
                   <div className="d-flex flex-wrap gap-2">
@@ -296,6 +634,13 @@ export default function Devices() {
                     </Button>
                     <Button
                       size="sm"
+                      variant="outline-info"
+                      onClick={handleShowToken}
+                    >
+                      Show Token URL
+                    </Button>
+                    <Button
+                      size="sm"
                       variant="danger"
                       className="ms-auto"
                       onClick={deleteDevice}
@@ -303,10 +648,99 @@ export default function Devices() {
                       <FontAwesomeIcon icon={faBan} /> Delete
                     </Button>
                   </div>
+                  {deviceToken && (
+                    <div className="mt-2">
+                      <Form.Control
+                        type="text"
+                        readOnly
+                        value={getTokenUrl(deviceToken)}
+                        onClick={(e) => (e.target as HTMLInputElement).select()}
+                      />
+                      <div className="mt-1">
+                        <Button
+                          size="sm"
+                          variant="outline-success"
+                          onClick={() => copyTokenUrl(deviceToken)}
+                        >
+                          Copy URL
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                 </Card.Footer>
               </Card>
             </div>
           )}
+
+          <Modal show={showAddModal} onHide={() => setShowAddModal(false)}>
+            <Modal.Header closeButton>
+              <Modal.Title>Add Device</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <Form.Group className="mb-3">
+                <Form.Label>Device Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="e.g. iPad Helm, SenseESP Engine"
+                  value={newDevice.displayName}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      displayName: e.target.value
+                    }))
+                  }
+                />
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Label>Permissions</Form.Label>
+                <Form.Select
+                  value={newDevice.permissions}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      permissions: e.target.value as PermissionType
+                    }))
+                  }
+                >
+                  <option value="readonly">Read Only</option>
+                  <option value="readwrite">Read/Write</option>
+                  <option value="admin">Admin</option>
+                </Form.Select>
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Label>Dashboard URL (optional)</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="e.g. /@signalk/freeboard-sk/"
+                  value={newDevice.dashboardUrl}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      dashboardUrl: e.target.value
+                    }))
+                  }
+                />
+                <Form.Text className="text-muted">
+                  If set, the device will be categorized as a Display.
+                </Form.Text>
+              </Form.Group>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                variant="secondary"
+                onClick={() => setShowAddModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleCreateDevice}
+                disabled={!newDevice.displayName.trim()}
+              >
+                Create Device
+              </Button>
+            </Modal.Footer>
+          </Modal>
         </div>
       )}
     </div>

--- a/packages/server-admin-ui/src/views/security/Devices.tsx
+++ b/packages/server-admin-ui/src/views/security/Devices.tsx
@@ -7,37 +7,62 @@ import {
   FormEvent
 } from 'react'
 import { useLoginStatus } from '../../store'
+import { useServerEvent } from '../../hooks/useWebSocket'
 import Badge from 'react-bootstrap/Badge'
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
 import Form from 'react-bootstrap/Form'
+import Modal from 'react-bootstrap/Modal'
 import Row from 'react-bootstrap/Row'
 import Table from 'react-bootstrap/Table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify'
 import { faBan } from '@fortawesome/free-solid-svg-icons/faBan'
+import { faCircle } from '@fortawesome/free-solid-svg-icons/faCircle'
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import EnableSecurity from './EnableSecurity'
 
 type PermissionType = 'readonly' | 'readwrite' | 'admin'
 
+interface DeviceDashboard {
+  mode: 'redirect' | 'metadata'
+  url?: string
+  metadata?: Record<string, unknown>
+}
+
 interface Device {
   clientId: string
   description?: string
+  displayName?: string
   permissions?: PermissionType
   requestedPermissions?: string
   tokenExpiry?: number
+  createdAt?: string
+  registrationInfo?: {
+    sourceIp?: string
+    deviceId?: string
+    firmwareVersion?: string
+    userAgent?: string
+  }
+  dashboard?: DeviceDashboard
+  isConnected?: boolean
+  lastSeen?: string
+  lastIp?: string
+  pluginData?: Record<string, Record<string, unknown>>
+}
+
+interface NewDeviceForm {
+  displayName: string
+  permissions: PermissionType
+  dashboardUrl: string
 }
 
 function convertPermissions(type: PermissionType | undefined): string {
-  if (type === 'readonly') {
-    return 'Read Only'
-  } else if (type === 'readwrite') {
-    return 'Read/Write'
-  } else if (type === 'admin') {
-    return 'Admin'
-  }
+  if (type === 'readonly') return 'Read Only'
+  if (type === 'readwrite') return 'Read/Write'
+  if (type === 'admin') return 'Admin'
   return ''
 }
 
@@ -46,84 +71,196 @@ function isExpired(device: Device): boolean {
 }
 
 function formatExpiry(device: Device): string {
-  if (!device.tokenExpiry) {
-    return 'NEVER'
-  }
+  if (!device.tokenExpiry) return 'NEVER'
   const expiryMs = device.tokenExpiry * 1000
   const nowMs = Date.now()
-  if (expiryMs < nowMs) {
-    return 'Expired'
-  }
+  if (expiryMs < nowMs) return 'Expired'
   const diffMs = expiryMs - nowMs
   const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
   const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
-  if (days > 0) {
-    return `${days}d ${hours}h remaining`
-  }
+  if (days > 0) return `${days}d ${hours}h remaining`
   const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
-  if (hours > 0) {
-    return `${hours}h ${minutes}m remaining`
-  }
+  if (hours > 0) return `${hours}h ${minutes}m remaining`
   return `${minutes}m remaining`
+}
+
+function formatLastSeen(lastSeen?: string): string {
+  if (!lastSeen) return ''
+  const diff = Date.now() - new Date(lastSeen).getTime()
+  if (diff < 60_000) return 'Just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  return `${Math.floor(diff / 86_400_000)}d ago`
+}
+
+function getDeviceName(device: Device): string {
+  return device.displayName || device.description || device.clientId
+}
+
+function getDeviceCategory(device: Device): 'display' | 'sensor' | 'server' {
+  if (device.description?.toLowerCase().includes('server')) return 'server'
+  if (device.dashboard) return 'display'
+  return 'sensor'
+}
+
+function ConnectionDot({ connected }: { connected?: boolean }) {
+  return (
+    <FontAwesomeIcon
+      icon={faCircle}
+      style={{
+        color: connected ? '#28a745' : '#999',
+        fontSize: '0.6em',
+        marginRight: '0.5em'
+      }}
+    />
+  )
+}
+
+function DeviceTable({
+  devices,
+  onDeviceClick
+}: {
+  devices: Device[]
+  onDeviceClick: (device: Device) => void
+}) {
+  if (devices.length === 0) return null
+  return (
+    <Table hover responsive bordered striped size="sm">
+      <thead>
+        <tr>
+          <th style={{ width: '2em' }}></th>
+          <th>Name</th>
+          <th>Permissions</th>
+          <th>Last Seen</th>
+          <th>IP</th>
+          <th>Token Expiry</th>
+        </tr>
+      </thead>
+      <tbody>
+        {devices.map((device) => (
+          <tr
+            key={device.clientId}
+            onClick={() => onDeviceClick(device)}
+            style={{ cursor: 'pointer' }}
+          >
+            <td style={{ textAlign: 'center' }}>
+              <ConnectionDot connected={device.isConnected} />
+            </td>
+            <td>{getDeviceName(device)}</td>
+            <td>{convertPermissions(device.permissions)}</td>
+            <td>
+              {device.isConnected ? (
+                <Badge bg="success">Online</Badge>
+              ) : (
+                formatLastSeen(device.lastSeen)
+              )}
+            </td>
+            <td>
+              <small>{device.lastIp || ''}</small>
+            </td>
+            <td>
+              {isExpired(device) ? (
+                <Badge bg="danger">Expired</Badge>
+              ) : (
+                formatExpiry(device)
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
 }
 
 export default function Devices() {
   const loginStatus = useLoginStatus()
   const [devices, setDevices] = useState<Device[]>([])
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null)
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [newDevice, setNewDevice] = useState<NewDeviceForm>({
+    displayName: '',
+    permissions: 'readonly',
+    dashboardUrl: ''
+  })
+  const [createdToken, setCreatedToken] = useState<{
+    clientId: string
+    token: string
+  } | null>(null)
+  const [deviceToken, setDeviceToken] = useState<string | null>(null)
   const selectedDeviceRef = useRef<HTMLDivElement>(null)
 
   const loadDevices = useCallback(async (): Promise<Device[]> => {
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices`,
-      {
-        credentials: 'include'
-      }
+      { credentials: 'include' }
     )
-    return response.json()
+    if (!response.ok) {
+      return []
+    }
+    const data = await response.json()
+    return Array.isArray(data) ? data : []
   }, [])
 
   const refreshDevices = useCallback(() => {
-    loadDevices().then((data) => {
-      setDevices(data)
-    })
+    loadDevices().then(setDevices)
   }, [loadDevices])
 
   useEffect(() => {
     if (loginStatus.authenticationRequired) {
-      loadDevices().then((data) => {
-        setDevices(data)
-      })
+      loadDevices().then(setDevices)
     }
   }, [loginStatus.authenticationRequired, loadDevices])
 
-  const handleDeviceChange = (event: ChangeEvent<HTMLInputElement>) => {
+  useServerEvent('DEVICE_STATUS_CHANGE', refreshDevices)
+
+  const handleDeviceChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const target = event.target
     const value =
-      event.target.type === 'checkbox'
-        ? event.target.checked
-        : event.target.value
+      target instanceof HTMLInputElement && target.type === 'checkbox'
+        ? target.checked
+        : target.value
     setSelectedDevice((prev) =>
-      prev ? { ...prev, [event.target.name]: value } : null
+      prev ? { ...prev, [target.name]: value } : null
     )
+  }
+
+  const handleDashboardUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSelectedDevice((prev) => {
+      if (!prev) return null
+      const url = event.target.value
+      if (!url) {
+        const { dashboard: _, ...rest } = prev
+        return rest as Device
+      }
+      return {
+        ...prev,
+        dashboard: {
+          ...prev.dashboard,
+          mode: prev.dashboard?.mode ?? 'redirect',
+          url
+        }
+      }
+    })
   }
 
   const handleApply = async (event: FormEvent) => {
     event.preventDefault()
-
     if (!selectedDevice) return
 
-    const payload = {
+    const payload: Record<string, unknown> = {
       permissions: selectedDevice.permissions || 'readonly',
-      description: selectedDevice.description
+      description: selectedDevice.description,
+      displayName: selectedDevice.displayName,
+      dashboard: selectedDevice.dashboard ?? null
     }
 
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}`,
       {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
         credentials: 'include'
       }
@@ -136,14 +273,11 @@ export default function Devices() {
 
   const deleteDevice = async () => {
     if (!selectedDevice) return
-
     const response = await fetch(
       `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}`,
       {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include'
       }
     )
@@ -155,6 +289,7 @@ export default function Devices() {
 
   const deviceClicked = (device: Device) => {
     setSelectedDevice(structuredClone(device))
+    setDeviceToken(null)
     setTimeout(() => {
       selectedDeviceRef.current?.scrollIntoView()
     }, 0)
@@ -162,88 +297,230 @@ export default function Devices() {
 
   const handleCancel = () => {
     setSelectedDevice(null)
+    setDeviceToken(null)
   }
+
+  const handleShowToken = async () => {
+    if (!selectedDevice) return
+    const response = await fetch(
+      `${window.serverRoutesPrefix}/security/devices/${selectedDevice.clientId}/token`,
+      {
+        method: 'POST',
+        credentials: 'include'
+      }
+    )
+    if (response.ok) {
+      const result = await response.json()
+      setDeviceToken(result.token)
+    } else {
+      alert('Failed to retrieve token')
+    }
+  }
+
+  const handleCreateDevice = async () => {
+    const payload: Record<string, unknown> = {
+      displayName: newDevice.displayName,
+      permissions: newDevice.permissions
+    }
+    if (newDevice.dashboardUrl) {
+      payload.dashboard = { mode: 'redirect', url: newDevice.dashboardUrl }
+    }
+    const response = await fetch(
+      `${window.serverRoutesPrefix}/security/devices`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        credentials: 'include'
+      }
+    )
+    if (response.ok) {
+      const result = await response.json()
+      setCreatedToken(result)
+      setShowAddModal(false)
+      setNewDevice({
+        displayName: '',
+        permissions: 'readonly',
+        dashboardUrl: ''
+      })
+      refreshDevices()
+    } else {
+      const text = await response.text()
+      alert('Failed to create device: ' + text)
+    }
+  }
+
+  const getTokenUrl = (token: string) => {
+    return `${window.location.origin}/?token=${token}`
+  }
+
+  // navigator.clipboard is undefined outside secure contexts (plain-HTTP LAN),
+  // where writeText would throw synchronously before any .catch().
+  const copyTokenUrl = (token: string) => {
+    if (!navigator.clipboard) {
+      alert('Clipboard unavailable (requires HTTPS)')
+      return
+    }
+    navigator.clipboard
+      .writeText(getTokenUrl(token))
+      .catch(() => alert('Failed to copy to clipboard'))
+  }
+
+  const displays = devices.filter((d) => getDeviceCategory(d) === 'display')
+  const sensors = devices.filter((d) => getDeviceCategory(d) === 'sensor')
+  const servers = devices.filter((d) => getDeviceCategory(d) === 'server')
 
   return (
     <div className="animated fadeIn">
       {loginStatus.authenticationRequired === false && <EnableSecurity />}
       {loginStatus.authenticationRequired && (
         <div>
-          <Card>
-            <Card.Header>
-              <FontAwesomeIcon icon={faAlignJustify} /> Devices
+          {createdToken && (
+            <Card className="mb-3 border-success">
+              <Card.Header className="bg-success text-white">
+                Device Created
+              </Card.Header>
+              <Card.Body>
+                <p>
+                  <strong>Client ID:</strong> {createdToken.clientId}
+                </p>
+                <Form.Group as={Row} className="mb-2">
+                  <Col md="2">
+                    <Form.Label>Token URL</Form.Label>
+                  </Col>
+                  <Col xs="12" md="10">
+                    <Form.Control
+                      type="text"
+                      readOnly
+                      value={getTokenUrl(createdToken.token)}
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                  </Col>
+                </Form.Group>
+                <p className="text-muted small mb-0">
+                  Copy this URL and use it to access the server from the device.
+                  This token will not be shown again.
+                </p>
+              </Card.Body>
+              <Card.Footer>
+                <Button
+                  size="sm"
+                  variant="outline-success"
+                  onClick={() => copyTokenUrl(createdToken.token)}
+                >
+                  Copy URL
+                </Button>{' '}
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
+                  onClick={() => setCreatedToken(null)}
+                >
+                  Dismiss
+                </Button>
+              </Card.Footer>
+            </Card>
+          )}
+
+          <Card className="mb-3">
+            <Card.Header className="d-flex justify-content-between align-items-center">
+              <span>
+                <FontAwesomeIcon icon={faAlignJustify} /> Displays & Apps
+              </span>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => setShowAddModal(true)}
+              >
+                <FontAwesomeIcon icon={faPlus} /> Add Device
+              </Button>
             </Card.Header>
             <Card.Body>
-              <Table hover responsive bordered striped size="sm">
-                <thead>
-                  <tr>
-                    <th>Client ID</th>
-                    <th>Description</th>
-                    <th>Type</th>
-                    <th>Token Expiry</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(devices || []).map((device) => {
-                    return (
-                      <tr
-                        key={device.clientId}
-                        onClick={() => deviceClicked(device)}
-                      >
-                        <td>{device.clientId}</td>
-                        <td>{device.description}</td>
-                        <td>{convertPermissions(device.permissions)}</td>
-                        <td>
-                          {isExpired(device) ? (
-                            <Badge bg="danger">Expired</Badge>
-                          ) : (
-                            formatExpiry(device)
-                          )}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </Table>
+              {displays.length === 0 ? (
+                <p className="text-muted mb-0">
+                  No display devices. Click &ldquo;Add Device&rdquo; to create
+                  one.
+                </p>
+              ) : (
+                <DeviceTable devices={displays} onDeviceClick={deviceClicked} />
+              )}
             </Card.Body>
-            <Card.Footer></Card.Footer>
           </Card>
+
+          {sensors.length > 0 && (
+            <Card className="mb-3">
+              <Card.Header>
+                <FontAwesomeIcon icon={faAlignJustify} /> Sensors & Bridges
+              </Card.Header>
+              <Card.Body>
+                <DeviceTable devices={sensors} onDeviceClick={deviceClicked} />
+              </Card.Body>
+            </Card>
+          )}
+
+          {servers.length > 0 && (
+            <Card className="mb-3">
+              <Card.Header>
+                <FontAwesomeIcon icon={faAlignJustify} /> Remote Servers
+              </Card.Header>
+              <Card.Body>
+                <DeviceTable devices={servers} onDeviceClick={deviceClicked} />
+              </Card.Body>
+            </Card>
+          )}
 
           {selectedDevice && (
             <div ref={selectedDeviceRef}>
               <Card>
                 <Card.Header>
-                  <FontAwesomeIcon icon={faAlignJustify} /> Device
+                  <FontAwesomeIcon icon={faAlignJustify} />{' '}
+                  {getDeviceName(selectedDevice)}
                 </Card.Header>
                 <Card.Body>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label>Client ID</Form.Label>
                     </Col>
                     <Col xs="12" md="9">
                       <span className="form-control-plaintext">
-                        {selectedDevice.clientId}
+                        <code>{selectedDevice.clientId}</code>
                       </span>
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label htmlFor="displayName">
+                        Display Name
+                      </Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <Form.Control
+                        type="text"
+                        id="displayName"
+                        name="displayName"
+                        autoComplete="off"
+                        style={{ width: 'auto' }}
+                        onChange={handleDeviceChange}
+                        value={selectedDevice.displayName || ''}
+                      />
+                    </Col>
+                  </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label htmlFor="description">Description</Form.Label>
                     </Col>
                     <Col xs="12" md="9">
                       <Form.Control
-                        size={60}
-                        style={{ width: 'auto' }}
                         type="text"
                         id="description"
                         name="description"
                         autoComplete="off"
+                        style={{ width: 'auto' }}
                         onChange={handleDeviceChange}
                         value={selectedDevice.description || ''}
                       />
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label htmlFor="permissions">Permissions</Form.Label>
                     </Col>
@@ -267,7 +544,29 @@ export default function Devices() {
                       )}
                     </Col>
                   </Form.Group>
-                  <Form.Group as={Row}>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label htmlFor="dashboardUrl">
+                        Dashboard URL
+                      </Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <Form.Control
+                        type="text"
+                        id="dashboardUrl"
+                        name="dashboardUrl"
+                        autoComplete="off"
+                        style={{ width: 'auto' }}
+                        placeholder="e.g. /@signalk/freeboard-sk/"
+                        onChange={handleDashboardUrlChange}
+                        value={selectedDevice.dashboard?.url || ''}
+                      />
+                      <Form.Text className="text-muted">
+                        Optional. Assign a webapp for this device to display.
+                      </Form.Text>
+                    </Col>
+                  </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
                     <Col md="2">
                       <Form.Label>Token Expiry</Form.Label>
                     </Col>
@@ -281,6 +580,56 @@ export default function Devices() {
                       </span>
                     </Col>
                   </Form.Group>
+                  <Form.Group as={Row} className="mb-2">
+                    <Col md="2">
+                      <Form.Label>Status</Form.Label>
+                    </Col>
+                    <Col xs="12" md="9">
+                      <span className="form-control-plaintext">
+                        <ConnectionDot connected={selectedDevice.isConnected} />
+                        {selectedDevice.isConnected ? 'Online' : 'Offline'}
+                        {selectedDevice.lastIp && (
+                          <small className="ms-2 text-muted">
+                            ({selectedDevice.lastIp})
+                          </small>
+                        )}
+                        {selectedDevice.lastSeen && (
+                          <small className="ms-2 text-muted">
+                            Last seen: {formatLastSeen(selectedDevice.lastSeen)}
+                          </small>
+                        )}
+                      </span>
+                    </Col>
+                  </Form.Group>
+                  {selectedDevice.createdAt && (
+                    <Form.Group as={Row} className="mb-2">
+                      <Col md="2">
+                        <Form.Label>Created</Form.Label>
+                      </Col>
+                      <Col xs="12" md="9">
+                        <span className="form-control-plaintext">
+                          {new Date(selectedDevice.createdAt).toLocaleString()}
+                        </span>
+                      </Col>
+                    </Form.Group>
+                  )}
+                  {selectedDevice.registrationInfo && (
+                    <Form.Group as={Row} className="mb-2">
+                      <Col md="2">
+                        <Form.Label>Registration</Form.Label>
+                      </Col>
+                      <Col xs="12" md="9">
+                        <span className="form-control-plaintext">
+                          <small className="text-muted">
+                            {selectedDevice.registrationInfo.sourceIp &&
+                              `IP: ${selectedDevice.registrationInfo.sourceIp}`}
+                            {selectedDevice.registrationInfo.firmwareVersion &&
+                              ` | FW: ${selectedDevice.registrationInfo.firmwareVersion}`}
+                          </small>
+                        </span>
+                      </Col>
+                    </Form.Group>
+                  )}
                 </Card.Body>
                 <Card.Footer>
                   <div className="d-flex flex-wrap gap-2">
@@ -296,6 +645,13 @@ export default function Devices() {
                     </Button>
                     <Button
                       size="sm"
+                      variant="outline-info"
+                      onClick={handleShowToken}
+                    >
+                      Show Token URL
+                    </Button>
+                    <Button
+                      size="sm"
                       variant="danger"
                       className="ms-auto"
                       onClick={deleteDevice}
@@ -303,10 +659,99 @@ export default function Devices() {
                       <FontAwesomeIcon icon={faBan} /> Delete
                     </Button>
                   </div>
+                  {deviceToken && (
+                    <div className="mt-2">
+                      <Form.Control
+                        type="text"
+                        readOnly
+                        value={getTokenUrl(deviceToken)}
+                        onClick={(e) => (e.target as HTMLInputElement).select()}
+                      />
+                      <div className="mt-1">
+                        <Button
+                          size="sm"
+                          variant="outline-success"
+                          onClick={() => copyTokenUrl(deviceToken)}
+                        >
+                          Copy URL
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                 </Card.Footer>
               </Card>
             </div>
           )}
+
+          <Modal show={showAddModal} onHide={() => setShowAddModal(false)}>
+            <Modal.Header closeButton>
+              <Modal.Title>Add Device</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <Form.Group className="mb-3">
+                <Form.Label>Device Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="e.g. iPad Helm, SenseESP Engine"
+                  value={newDevice.displayName}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      displayName: e.target.value
+                    }))
+                  }
+                />
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Label>Permissions</Form.Label>
+                <Form.Select
+                  value={newDevice.permissions}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      permissions: e.target.value as PermissionType
+                    }))
+                  }
+                >
+                  <option value="readonly">Read Only</option>
+                  <option value="readwrite">Read/Write</option>
+                  <option value="admin">Admin</option>
+                </Form.Select>
+              </Form.Group>
+              <Form.Group className="mb-3">
+                <Form.Label>Dashboard URL (optional)</Form.Label>
+                <Form.Control
+                  type="text"
+                  placeholder="e.g. /@signalk/freeboard-sk/"
+                  value={newDevice.dashboardUrl}
+                  onChange={(e) =>
+                    setNewDevice((prev) => ({
+                      ...prev,
+                      dashboardUrl: e.target.value
+                    }))
+                  }
+                />
+                <Form.Text className="text-muted">
+                  If set, the device will be categorized as a Display.
+                </Form.Text>
+              </Form.Group>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button
+                variant="secondary"
+                onClick={() => setShowAddModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleCreateDevice}
+                disabled={!newDevice.displayName.trim()}
+              >
+                Create Device
+              </Button>
+            </Modal.Footer>
+          </Modal>
         </div>
       )}
     </div>

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -484,6 +484,36 @@ export interface ServerAPI
    * @category Status and Debugging
    */
   reportOutputMessages(count?: number): void
+
+  /**
+   * Store plugin-specific metadata for a device. This data is merged into
+   * the device list API response and is available to the admin UI.
+   *
+   * @param clientId - The device's clientId
+   * @param metadata - Key-value metadata to store
+   * @category Device API
+   */
+  setDevicePluginData(clientId: string, metadata: Record<string, unknown>): void
+
+  /**
+   * Retrieve plugin-specific metadata previously stored for a device.
+   *
+   * @param clientId - The device's clientId
+   * @returns The stored metadata, or undefined if none
+   * @category Device API
+   */
+  getDevicePluginData(clientId: string): Record<string, unknown> | undefined
+
+  /**
+   * Register a callback for device connection state changes (connect/disconnect).
+   *
+   * @param callback - Called with event data when a device connects or disconnects
+   * @returns A function to unsubscribe
+   * @category Device API
+   */
+  onDeviceStateChange(
+    callback: (event: DeviceStateChangeEvent) => void
+  ): () => void
 }
 
 /**
@@ -541,4 +571,15 @@ export interface ActionResult {
   statusCode?: number
   message?: string
   timestamp?: string
+}
+
+/**
+ * Event emitted when a device's connection state changes.
+ * @category Device API
+ */
+export interface DeviceStateChangeEvent {
+  clientId: string
+  connected: boolean
+  ip?: string
+  connectionType?: 'websocket' | 'http'
 }

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -566,6 +566,36 @@ export interface ServerAPI
    * @category Status and Debugging
    */
   reportOutputMessages(count?: number): void
+
+  /**
+   * Store plugin-specific metadata for a device. This data is merged into
+   * the device list API response and is available to the admin UI.
+   *
+   * @param clientId - The device's clientId
+   * @param metadata - Key-value metadata to store
+   * @category Device API
+   */
+  setDevicePluginData(clientId: string, metadata: Record<string, unknown>): void
+
+  /**
+   * Retrieve plugin-specific metadata previously stored for a device.
+   *
+   * @param clientId - The device's clientId
+   * @returns The stored metadata, or undefined if none
+   * @category Device API
+   */
+  getDevicePluginData(clientId: string): Record<string, unknown> | undefined
+
+  /**
+   * Register a callback for device connection state changes (connect/disconnect).
+   *
+   * @param callback - Called with event data when a device connects or disconnects
+   * @returns A function to unsubscribe
+   * @category Device API
+   */
+  onDeviceStateChange(
+    callback: (event: DeviceStateChangeEvent) => void
+  ): () => void
 }
 
 /**
@@ -623,4 +653,15 @@ export interface ActionResult {
   statusCode?: number
   message?: string
   timestamp?: string
+}
+
+/**
+ * Event emitted when a device's connection state changes.
+ * @category Device API
+ */
+export interface DeviceStateChangeEvent {
+  clientId: string
+  connected: boolean
+  ip?: string
+  connectionType?: 'websocket' | 'http'
 }

--- a/src/deviceTracker.ts
+++ b/src/deviceTracker.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from 'events'
+import { createDebug } from './debug'
+
+const debug = createDebug('signalk-server:deviceTracker')
+
+const HTTP_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000
+
+export interface DeviceRuntimeState {
+  clientId: string
+  isConnected: boolean
+  connectionCount: number
+  lastSeen: string
+  lastIp?: string
+  pluginData?: Record<string, Record<string, unknown>>
+}
+
+export interface DeviceStateEvent {
+  clientId: string
+  connected: boolean
+  ip?: string
+  connectionType?: 'websocket' | 'http'
+}
+
+export class DeviceTracker extends EventEmitter {
+  private devices = new Map<string, DeviceRuntimeState>()
+  private httpTimer: NodeJS.Timeout | undefined
+
+  constructor(private emitAdminEvent: (event: unknown) => void) {
+    super()
+    this.httpTimer = setInterval(
+      () => this.pruneHttpDevices(),
+      HTTP_ACTIVITY_TIMEOUT_MS
+    )
+    this.httpTimer.unref?.()
+  }
+
+  onConnect(clientId: string, ip?: string): void {
+    const state = this.getOrCreate(clientId)
+    const wasConnected = state.isConnected
+    state.connectionCount++
+    state.isConnected = true
+    state.lastSeen = new Date().toISOString()
+    if (ip) {
+      state.lastIp = ip
+    }
+    debug(
+      'device connected: %s (connections: %d)',
+      clientId,
+      state.connectionCount
+    )
+    if (!wasConnected) {
+      this.emitChange({
+        clientId,
+        connected: true,
+        ip,
+        connectionType: 'websocket'
+      })
+    }
+  }
+
+  onDisconnect(clientId: string): void {
+    const state = this.devices.get(clientId)
+    if (!state) return
+    state.connectionCount = Math.max(0, state.connectionCount - 1)
+    state.isConnected = state.connectionCount > 0
+    state.lastSeen = new Date().toISOString()
+    debug(
+      'device disconnected: %s (connections: %d)',
+      clientId,
+      state.connectionCount
+    )
+    if (!state.isConnected) {
+      this.emitChange({
+        clientId,
+        connected: false,
+        connectionType: 'websocket'
+      })
+    }
+  }
+
+  onActivity(clientId: string, ip?: string): void {
+    const state = this.getOrCreate(clientId)
+    state.lastSeen = new Date().toISOString()
+    if (ip) {
+      state.lastIp = ip
+    }
+    if (!state.isConnected) {
+      state.isConnected = true
+      this.emitChange({ clientId, connected: true, ip, connectionType: 'http' })
+    }
+  }
+
+  onDeviceRemoved(clientId: string): void {
+    this.devices.delete(clientId)
+  }
+
+  getState(clientId: string): DeviceRuntimeState | undefined {
+    return this.devices.get(clientId)
+  }
+
+  getAllStates(): ReadonlyMap<string, DeviceRuntimeState> {
+    return new Map(this.devices)
+  }
+
+  setPluginData(
+    pluginId: string,
+    clientId: string,
+    metadata: Record<string, unknown>
+  ): void {
+    const state = this.getOrCreate(clientId)
+    if (!state.pluginData) {
+      state.pluginData = {}
+    }
+    state.pluginData[pluginId] = metadata
+    this.emitAdminEvent({
+      type: 'DEVICE_STATUS_CHANGE',
+      data: { clientId }
+    })
+  }
+
+  getPluginData(
+    pluginId: string,
+    clientId: string
+  ): Record<string, unknown> | undefined {
+    return this.devices.get(clientId)?.pluginData?.[pluginId]
+  }
+
+  destroy(): void {
+    if (this.httpTimer) {
+      clearInterval(this.httpTimer)
+      this.httpTimer = undefined
+    }
+  }
+
+  private getOrCreate(clientId: string): DeviceRuntimeState {
+    let state = this.devices.get(clientId)
+    if (!state) {
+      state = {
+        clientId,
+        isConnected: false,
+        connectionCount: 0,
+        lastSeen: new Date().toISOString()
+      }
+      this.devices.set(clientId, state)
+    }
+    return state
+  }
+
+  private emitChange(event: DeviceStateEvent): void {
+    this.emit('deviceStateChange', event)
+    this.emitAdminEvent({
+      type: 'DEVICE_STATUS_CHANGE',
+      data: event
+    })
+  }
+
+  private pruneHttpDevices(): void {
+    const cutoff = Date.now() - HTTP_ACTIVITY_TIMEOUT_MS
+    for (const [, state] of this.devices) {
+      if (
+        state.isConnected &&
+        state.connectionCount === 0 &&
+        new Date(state.lastSeen).getTime() < cutoff
+      ) {
+        state.isConnected = false
+        debug('device http timeout: %s', state.clientId)
+        this.emitChange({
+          clientId: state.clientId,
+          connected: false,
+          connectionType: 'http'
+        })
+      }
+    }
+  }
+}

--- a/src/interfaces/applicationData.js
+++ b/src/interfaces/applicationData.js
@@ -75,6 +75,11 @@ const userApplicationDataUrls = [
   `${prefix}/user/:appid/:version`
 ]
 
+const deviceApplicationDataUrls = [
+  `${prefix}/device/:deviceId/:appid/:version/*`,
+  `${prefix}/device/:deviceId/:appid/:version`
+]
+
 module.exports = function (app) {
   if (app.securityStrategy.isDummy()) {
     debug('ApplicationData disabled because security is off')
@@ -114,6 +119,40 @@ module.exports = function (app) {
     postApplicationData(req, res, false)
   })
 
+  function deviceAuthMiddleware(req, res, next) {
+    if (!req.skPrincipal) {
+      res.status(401).send('Unauthorized')
+      return
+    }
+    const isAdmin = req.skPrincipal.permissions === 'admin'
+    const isOwnDevice = req.skPrincipal.identifier === req.params.deviceId
+    if (!isAdmin && !isOwnDevice) {
+      res.status(403).send('Forbidden')
+      return
+    }
+    next()
+  }
+
+  deviceApplicationDataUrls.forEach((url) => {
+    app.use(url, deviceAuthMiddleware)
+  })
+
+  app.get(deviceApplicationDataUrls, (req, res) => {
+    getApplicationData(req, res, false, req.params.deviceId)
+  })
+
+  app.post(deviceApplicationDataUrls, (req, res) => {
+    postApplicationData(req, res, false, req.params.deviceId)
+  })
+
+  app.get(
+    `${prefix}/device/:deviceId/:appid`,
+    deviceAuthMiddleware,
+    (req, res) => {
+      listVersions(req, res, false, req.params.deviceId)
+    }
+  )
+
   app.get(`${prefix}/global/:appid`, (req, res) => {
     listVersions(req, res, false)
   })
@@ -122,7 +161,7 @@ module.exports = function (app) {
     listVersions(req, res, true)
   })
 
-  function listVersions(req, res, isUser) {
+  function listVersions(req, res, isUser, deviceId) {
     const appid = validateAppId(req.params.appid)
 
     if (!appid) {
@@ -130,7 +169,7 @@ module.exports = function (app) {
       return
     }
 
-    const dir = dirForApplicationData(req, appid, isUser)
+    const dir = dirForApplicationData(req, appid, isUser, deviceId)
 
     if (!fs.existsSync(dir)) {
       res.sendStatus(404)
@@ -140,7 +179,7 @@ module.exports = function (app) {
     res.json(fs.readdirSync(dir).map((file) => file.slice(0, -5)))
   }
 
-  function getApplicationData(req, res, isUser) {
+  function getApplicationData(req, res, isUser, deviceId) {
     const appid = validateAppId(req.params.appid)
     const version = validateVersion(req.params.version)
 
@@ -154,7 +193,13 @@ module.exports = function (app) {
       return
     }
 
-    let applicationData = readApplicationData(req, appid, version, isUser)
+    let applicationData = readApplicationData(
+      req,
+      appid,
+      version,
+      isUser,
+      deviceId
+    )
 
     let data = applicationData
     if (req.params[0] && req.params[0].length !== 0) {
@@ -178,7 +223,7 @@ module.exports = function (app) {
     res.json(data)
   }
 
-  async function postApplicationData(req, res, isUser) {
+  async function postApplicationData(req, res, isUser, deviceId) {
     const appid = validateAppId(req.params.appid)
     const version = validateVersion(req.params.version)
 
@@ -206,7 +251,8 @@ module.exports = function (app) {
       req,
       isUnitprefs ? UNITPREFS_APPID : appid,
       version,
-      isUser
+      isUser,
+      deviceId
     )
 
     try {
@@ -216,7 +262,8 @@ module.exports = function (app) {
           req,
           isUnitprefs ? UNITPREFS_APPID : appid,
           version,
-          isUser
+          isUser,
+          deviceId
         )
 
         if (req.params[0] && req.params[0].length !== 0) {
@@ -247,7 +294,8 @@ module.exports = function (app) {
             appid,
             version,
             isUser,
-            applicationData
+            applicationData,
+            deviceId
           )
         }
         res.json('ApplicationData saved')
@@ -268,11 +316,11 @@ module.exports = function (app) {
     }
   }
 
-  function readApplicationData(req, appid, version, isUser) {
+  function readApplicationData(req, appid, version, isUser, deviceId) {
     let applicationDataString = '{}'
     try {
       applicationDataString = fs.readFileSync(
-        pathForApplicationData(req, appid, version, isUser),
+        pathForApplicationData(req, appid, version, isUser, deviceId),
         'utf8'
       )
     } catch (_) {
@@ -282,7 +330,7 @@ module.exports = function (app) {
       const applicationData = JSON.parse(applicationDataString)
       return applicationData
     } catch (e) {
-      let filePath = dirForApplicationData(req, appid, isUser)
+      let filePath = dirForApplicationData(req, appid, isUser, deviceId)
       console.error(
         'Could not parse applicationData for "%s": %s',
         filePath,
@@ -304,19 +352,26 @@ module.exports = function (app) {
     return semver.valid(semver.coerce(version))
   }
 
-  function dirForApplicationData(req, appid, isUser) {
-    let location = path.join(
-      app.config.configPath,
-      'applicationData',
-      isUser ? `users/${req.skPrincipal.identifier}` : 'global'
-    )
+  function dirForApplicationData(req, appid, isUser, deviceId) {
+    let scope
+    if (deviceId) {
+      scope = `devices/${deviceId}`
+    } else if (isUser) {
+      scope = `users/${req.skPrincipal.identifier}`
+    } else {
+      scope = 'global'
+    }
+    let location = path.join(app.config.configPath, 'applicationData', scope)
 
     return path.join(location, appid)
   }
 
-  function pathForApplicationData(req, appid, version, isUser) {
+  function pathForApplicationData(req, appid, version, isUser, deviceId) {
     const filePath = path.normalize(
-      path.join(dirForApplicationData(req, appid, isUser), `${version}.json`)
+      path.join(
+        dirForApplicationData(req, appid, isUser, deviceId),
+        `${version}.json`
+      )
     )
     const configPath = path.resolve(app.config.configPath)
     const resolvedPath = path.resolve(filePath)
@@ -328,19 +383,38 @@ module.exports = function (app) {
     return filePath
   }
 
-  async function saveApplicationData(req, appid, version, isUser, data) {
+  async function saveApplicationData(
+    req,
+    appid,
+    version,
+    isUser,
+    data,
+    deviceId
+  ) {
     const applicationDataDir = path.join(
       app.config.configPath,
       'applicationData'
     )
-    const usersDir = path.join(applicationDataDir, 'users')
-    const globalDir = path.join(applicationDataDir, 'global')
 
     if (!fs.existsSync(applicationDataDir)) {
       fs.mkdirSync(applicationDataDir)
     }
 
-    if (isUser) {
+    if (deviceId) {
+      const devicesDir = path.join(applicationDataDir, 'devices')
+      if (!fs.existsSync(devicesDir)) {
+        fs.mkdirSync(devicesDir)
+      }
+      const deviceDir = path.join(devicesDir, deviceId)
+      if (!fs.existsSync(deviceDir)) {
+        fs.mkdirSync(deviceDir)
+      }
+      const appDir = path.join(deviceDir, appid)
+      if (!fs.existsSync(appDir)) {
+        fs.mkdirSync(appDir)
+      }
+    } else if (isUser) {
+      const usersDir = path.join(applicationDataDir, 'users')
       if (!fs.existsSync(usersDir)) {
         fs.mkdirSync(usersDir)
       }
@@ -353,6 +427,7 @@ module.exports = function (app) {
         fs.mkdirSync(appDir)
       }
     } else {
+      const globalDir = path.join(applicationDataDir, 'global')
       if (!fs.existsSync(globalDir)) {
         fs.mkdirSync(globalDir)
       }
@@ -363,7 +438,7 @@ module.exports = function (app) {
     }
 
     await atomicWriteFile(
-      pathForApplicationData(req, appid, version, isUser),
+      pathForApplicationData(req, appid, version, isUser, deviceId),
       JSON.stringify(data, null, 2)
     )
   }

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -45,7 +45,8 @@ import {
   AccessScopedRouter,
   PluginRouter,
   RouteAccessLevel,
-  RoutePermission
+  RoutePermission,
+  DeviceStateChangeEvent
 } from '@signalk/server-api'
 import { getLogger } from '@signalk/streams/logging'
 import express, { IRouter, Request, RequestHandler, Response } from 'express'
@@ -947,6 +948,33 @@ module.exports = (theApp: any) => {
       return getPluginOptions(plugin.id)
     }
     appCopy.getDataDirPath = () => dirForPluginId(plugin.id)
+
+    appCopy.setDevicePluginData = (
+      clientId: string,
+      metadata: Record<string, unknown>
+    ) => {
+      if (app.deviceTracker) {
+        app.deviceTracker.setPluginData(plugin.id, clientId, metadata)
+      }
+    }
+    appCopy.getDevicePluginData = (
+      clientId: string
+    ): Record<string, unknown> | undefined => {
+      return app.deviceTracker?.getPluginData(plugin.id, clientId)
+    }
+    appCopy.onDeviceStateChange = (
+      callback: (event: DeviceStateChangeEvent) => void
+    ): (() => void) => {
+      if (app.deviceTracker) {
+        app.deviceTracker.on('deviceStateChange', callback)
+        const cleanup = () => {
+          app.deviceTracker?.removeListener('deviceStateChange', callback)
+        }
+        onStopHandlers[plugin.id].push(cleanup)
+        return cleanup
+      }
+      return () => {}
+    }
 
     appCopy.registerPutHandler = (context, aPath, callback, source) => {
       appCopy.handleMessage(plugin.id, {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -47,7 +47,8 @@ import {
   PluginRouter,
   RouteAccessLevel,
   RoutePermission,
-  PluginWebSocketServer
+  PluginWebSocketServer,
+  DeviceStateChangeEvent
 } from '@signalk/server-api'
 import { getLogger } from '@signalk/streams/logging'
 import express, { IRouter, Request, RequestHandler, Response } from 'express'
@@ -1084,6 +1085,33 @@ module.exports = (theApp: any) => {
       return getPluginOptions(plugin.id)
     }
     appCopy.getDataDirPath = () => dirForPluginId(plugin.id)
+
+    appCopy.setDevicePluginData = (
+      clientId: string,
+      metadata: Record<string, unknown>
+    ) => {
+      if (app.deviceTracker) {
+        app.deviceTracker.setPluginData(plugin.id, clientId, metadata)
+      }
+    }
+    appCopy.getDevicePluginData = (
+      clientId: string
+    ): Record<string, unknown> | undefined => {
+      return app.deviceTracker?.getPluginData(plugin.id, clientId)
+    }
+    appCopy.onDeviceStateChange = (
+      callback: (event: DeviceStateChangeEvent) => void
+    ): (() => void) => {
+      if (app.deviceTracker) {
+        app.deviceTracker.on('deviceStateChange', callback)
+        const cleanup = () => {
+          app.deviceTracker?.removeListener('deviceStateChange', callback)
+        }
+        onStopHandlers[plugin.id].push(cleanup)
+        return cleanup
+      }
+      return () => {}
+    }
 
     appCopy.registerPutHandler = (context, aPath, callback, source) => {
       appCopy.handleMessage(plugin.id, {

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -39,6 +39,7 @@ import {
   UpdateOptions
 } from '../requestResponse'
 import { putPath, deletePath } from '../put'
+import type { DeviceTracker } from '../deviceTracker'
 import { createDebug } from '../debug'
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { startEvents, startServerEvents } from '../events'
@@ -290,6 +291,7 @@ interface WsApp {
   handleMessage: (source: string, msg: WsMessage) => void
   setProviderError: (provider: string, message: string) => void
   getHello: () => Record<string, unknown>
+  deviceTracker?: DeviceTracker
 }
 
 interface WsApi {
@@ -533,6 +535,10 @@ function wsInterface(app: WsApp): WsApi {
             `${spark.id} connected ${JSON.stringify(spark.query)} ${spark.request._resolvedIp}:${principalId} (ip connections: ${ipConnectionCounts.get(spark.request._resolvedIp) ?? '?'})`
           )
 
+          if (principalId && app.deviceTracker) {
+            app.deviceTracker.onConnect(principalId, sparkIp)
+          }
+
           spark.sendMetaDeltas = spark.query.sendMeta === 'all'
           spark.sourcePolicy = spark.query.sourcePolicy || 'preferred'
           spark.sentMetaData = {}
@@ -671,6 +677,10 @@ function wsInterface(app: WsApp): WsApi {
             debugConnection(
               `${spark.id} end ${JSON.stringify(spark.query)} ${spark.request._resolvedIp}:${principalId}`
             )
+
+            if (principalId && app.deviceTracker) {
+              app.deviceTracker.onDisconnect(principalId)
+            }
 
             unsubscribes.forEach((unsubscribe) => unsubscribe())
 

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -39,6 +39,7 @@ import {
   UpdateOptions
 } from '../requestResponse'
 import { putPath, deletePath } from '../put'
+import type { DeviceTracker } from '../deviceTracker'
 import { createDebug } from '../debug'
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { startEvents, startServerEvents } from '../events'
@@ -113,6 +114,7 @@ interface Spark {
   sentMetaData: Record<string, boolean>
   backpressureManager?: BackpressureManager
   skPendingAccessRequest?: boolean
+  skTrackedDeviceId?: string
   logUnsubscribe?: () => void
   onDisconnects: Array<() => void>
   hasServerEvents?: boolean
@@ -291,6 +293,7 @@ interface WsApp {
   handleMessage: (source: string, msg: WsMessage) => void
   setProviderError: (provider: string, message: string) => void
   getHello: () => Record<string, unknown>
+  deviceTracker?: DeviceTracker
 }
 
 interface WsApi {
@@ -534,6 +537,8 @@ function wsInterface(app: WsApp): WsApi {
             `${spark.id} connected ${JSON.stringify(spark.query)} ${spark.request._resolvedIp}:${principalId} (ip connections: ${ipConnectionCounts.get(spark.request._resolvedIp) ?? '?'})`
           )
 
+          trackDeviceConnect(app, spark)
+
           spark.sendMetaDeltas = spark.query.sendMeta === 'all'
           spark.sourcePolicy = spark.query.sourcePolicy || 'preferred'
           spark.sentMetaData = {}
@@ -672,6 +677,10 @@ function wsInterface(app: WsApp): WsApi {
             debugConnection(
               `${spark.id} end ${JSON.stringify(spark.query)} ${spark.request._resolvedIp}:${principalId}`
             )
+
+            if (spark.skTrackedDeviceId && app.deviceTracker) {
+              app.deviceTracker.onDisconnect(spark.skTrackedDeviceId)
+            }
 
             unsubscribes.forEach((unsubscribe) => unsubscribe())
 
@@ -813,6 +822,7 @@ function wsInterface(app: WsApp): WsApi {
               spark.request.source =
                 'ws.' +
                 spark.request.skPrincipal!.identifier.replace(/\./g, '_')
+              trackDeviceConnect(app, spark)
             }
           }
           spark.write(res)
@@ -856,6 +866,7 @@ function wsInterface(app: WsApp): WsApi {
         if (reply.token) {
           spark.request.token = reply.token
           app.securityStrategy.authorizeWS(spark.request)
+          trackDeviceConnect(app, spark)
         }
         spark.write({
           requestId: msg.requestId,
@@ -1218,6 +1229,26 @@ function processUnsubscribe(
 
 const isSelfSubscription = (query: Spark['query']): boolean =>
   !query.subscribe || query.subscribe === 'self'
+
+// A connection may authenticate after the upgrade (login or access-request
+// messages), so device tracking keys on the spark, not on the principal
+// captured at connect time. The anonymous allow_readonly principal (AUTO)
+// is not a device identity: it is skipped, and a later real authentication
+// on the same socket re-keys the tracked connection.
+function trackDeviceConnect(app: WsApp, spark: Spark): void {
+  const principalId = spark.request.skPrincipal?.identifier
+  if (!principalId || principalId === 'AUTO' || !app.deviceTracker) {
+    return
+  }
+  if (spark.skTrackedDeviceId === principalId) {
+    return
+  }
+  if (spark.skTrackedDeviceId) {
+    app.deviceTracker.onDisconnect(spark.skTrackedDeviceId)
+  }
+  spark.skTrackedDeviceId = principalId
+  app.deviceTracker.onConnect(principalId, spark.request._resolvedIp)
+}
 
 function handleVerifyWSError(spark: Spark, error: Error): void {
   if (!spark.skPendingAccessRequest) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -18,6 +18,7 @@
 import { RoutePermission } from '@signalk/server-api'
 import { Request, Response } from 'express'
 import { PartialOIDCConfig } from './oidc/types'
+import { DeviceTracker } from './deviceTracker'
 import {
   chmodSync,
   existsSync,
@@ -50,6 +51,10 @@ export interface LoginStatusResponse {
   allowDeviceAccessRequests?: boolean
   userLevel?: any
   username?: string
+  principalType?: 'user' | 'device'
+  deviceId?: string
+  deviceName?: string
+  deviceDashboard?: DeviceDashboard
 }
 
 export interface ACL {
@@ -106,6 +111,19 @@ export interface UserWithPassword {
   password: string
 }
 
+export interface DeviceRegistrationInfo {
+  sourceIp?: string
+  deviceId?: string
+  firmwareVersion?: string
+  userAgent?: string
+}
+
+export interface DeviceDashboard {
+  mode: 'redirect' | 'metadata'
+  url?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface Device {
   clientId: string
   permissions: string
@@ -113,11 +131,17 @@ export interface Device {
   description: string
   requestedPermissions: string
   tokenExpiry?: number
+  displayName?: string
+  createdAt?: string
+  registrationInfo?: DeviceRegistrationInfo
+  dashboard?: DeviceDashboard
 }
 
 export interface DeviceDataUpdate {
   permissions?: string
   description?: string
+  displayName?: string
+  dashboard?: DeviceDashboard
 }
 
 export interface OIDCSecurityConfig {
@@ -190,6 +214,26 @@ export interface SecurityStrategy {
     clientId: string,
     cb: ICallback<SecurityConfig>
   ) => void
+
+  createDevice: (
+    theConfig: SecurityConfig,
+    device: {
+      displayName: string
+      permissions: string
+      expiration?: string
+      dashboard?: DeviceDashboard
+    },
+    cb: (
+      err: Error | null,
+      config?: SecurityConfig,
+      result?: { clientId: string; token: string }
+    ) => void
+  ) => void
+
+  generateDeviceToken: (
+    theConfig: SecurityConfig,
+    clientId: string
+  ) => string | null
 
   generateToken: (
     req: Request,
@@ -289,6 +333,14 @@ export function startSecurity(
       app.securityStrategy.configFromArguments = true
       app.securityStrategy.securityConfig = securityConfig
     }
+
+    const appWithTracker = app as WithSecurityStrategy &
+      WithConfig & { deviceTracker?: DeviceTracker }
+    appWithTracker.deviceTracker = new DeviceTracker((event) => {
+      if (typeof (app as any).emit === 'function') {
+        ;(app as any).emit('serverAdminEvent', event)
+      }
+    })
   } else {
     app.securityStrategy = dummysecurity()
   }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -57,6 +57,7 @@ import { getAuthor, Package, restoreModules } from './modules'
 import { getHttpPort, getSslPort } from './ports'
 import { queryRequest } from './requestResponse'
 import {
+  Device,
   getRateLimitValidationOptions,
   pathForSecurityConfig,
   SecurityConfig,
@@ -66,6 +67,7 @@ import {
   User,
   WithSecurityStrategy
 } from './security'
+import { DeviceTracker } from './deviceTracker'
 import { listAllSerialPorts } from './serialports'
 import { StreamBundle } from './streambundle'
 import { WithWrappedEmitter } from './events'
@@ -288,6 +290,7 @@ interface App
   }
   activateSourcePriorities: () => void
   streambundle: StreamBundle
+  deviceTracker?: DeviceTracker
 }
 
 interface ModuleInfo {
@@ -446,6 +449,32 @@ module.exports = function (
   app.use('/admin', express.static(adminUiPath))
 
   app.get('/', (req: Request, res: Response) => {
+    const queryToken = req.query?.token as string | undefined
+    if (queryToken) {
+      try {
+        const payload = JSON.parse(
+          Buffer.from(queryToken.split('.')[1], 'base64url').toString()
+        )
+        if (payload.device) {
+          const config = getSecurityConfig(app)
+          const device = config.devices?.find(
+            (d: Device) => d.clientId === payload.device
+          )
+          if (device?.dashboard?.mode === 'redirect' && device.dashboard.url) {
+            const rawUrl = device.dashboard.url.trim()
+            const dashUrl = rawUrl.startsWith('/') ? rawUrl : `/${rawUrl}`
+            if (!dashUrl.startsWith('//')) {
+              const separator = dashUrl.includes('?') ? '&' : '?'
+              res.redirect(`${dashUrl}${separator}token=${queryToken}`)
+              return
+            }
+          }
+        }
+      } catch (_) {
+        // invalid token, fall through to default landing page
+      }
+    }
+
     let landingPage = '/admin/'
 
     // if accessed with hostname that starts with a webapp's displayName redirect there
@@ -588,7 +617,66 @@ module.exports = function (
     (req: Request, res: Response) => {
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)
-        res.json(app.securityStrategy.getDevices(config))
+        const devices = app.securityStrategy.getDevices(config)
+        if (app.deviceTracker) {
+          const runtimeStates = app.deviceTracker.getAllStates()
+          res.json(
+            devices.map((device: Device) => {
+              const state = runtimeStates.get(device.clientId)
+              if (state) {
+                return {
+                  ...device,
+                  isConnected: state.isConnected,
+                  lastSeen: state.lastSeen,
+                  lastIp: state.lastIp,
+                  pluginData: state.pluginData
+                }
+              }
+              return { ...device, isConnected: false }
+            })
+          )
+        } else {
+          res.json(devices)
+        }
+      }
+    }
+  )
+
+  app.post(
+    `${SERVERROUTESPREFIX}/security/devices`,
+    (req: Request, res: Response) => {
+      if (checkAllowConfigure(req, res)) {
+        const { displayName, permissions } = req.body
+        if (typeof displayName !== 'string' || !displayName.trim()) {
+          res.status(400).json({ error: 'displayName is required' })
+          return
+        }
+        if (!['readonly', 'readwrite', 'admin'].includes(permissions)) {
+          res.status(400).json({ error: 'Invalid permissions value' })
+          return
+        }
+        const config = getSecurityConfig(app)
+        app.securityStrategy.createDevice(
+          config,
+          req.body,
+          (err, updatedConfig, result) => {
+            if (err) {
+              console.log(err)
+              res.status(500).json({ error: 'Unable to create device' })
+            } else if (updatedConfig) {
+              saveSecurityConfig(app, updatedConfig, (saveErr) => {
+                if (saveErr) {
+                  console.log(saveErr)
+                  res
+                    .status(500)
+                    .json({ error: 'Unable to save configuration' })
+                  return
+                }
+                res.json(result)
+              })
+            }
+          }
+        )
       }
     }
   )
@@ -617,15 +705,47 @@ module.exports = function (
     (req: Request, res: Response) => {
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)
+        const clientId = req.params.uuid
         app.securityStrategy.deleteDevice(
           config,
-          req.params.uuid,
-          getConfigSavingCallback(
-            'Device deleted',
-            'Unable to delete device',
-            res
-          )
+          clientId,
+          (err, updatedConfig) => {
+            if (err) {
+              console.log(err)
+              res.status(500).type('text/plain').send('Unable to delete device')
+            } else if (updatedConfig) {
+              saveSecurityConfig(app, updatedConfig, (saveErr) => {
+                if (saveErr) {
+                  console.log(saveErr)
+                  res.status(500).send('Unable to save configuration change')
+                  return
+                }
+                app.deviceTracker?.onDeviceRemoved(clientId)
+                res.type('text/plain').send('Device deleted')
+              })
+            } else {
+              res.type('text/plain').send('Device deleted')
+            }
+          }
         )
+      }
+    }
+  )
+
+  app.post(
+    `${SERVERROUTESPREFIX}/security/devices/:uuid/token`,
+    (req: Request, res: Response) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        const token = app.securityStrategy.generateDeviceToken(
+          config,
+          req.params.uuid
+        )
+        if (token) {
+          res.json({ token })
+        } else {
+          res.status(404).json({ error: 'Device not found' })
+        }
       }
     }
   )

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -59,6 +59,7 @@ import { getAuthor, Package, restoreModules } from './modules'
 import { getHttpPort, getSslPort } from './ports'
 import { queryRequest } from './requestResponse'
 import {
+  Device,
   getRateLimitValidationOptions,
   pathForSecurityConfig,
   SecurityConfig,
@@ -68,6 +69,7 @@ import {
   User,
   WithSecurityStrategy
 } from './security'
+import { DeviceTracker } from './deviceTracker'
 import { listAllSerialPorts } from './serialports'
 import { StreamBundle } from './streambundle'
 import { WithWrappedEmitter } from './events'
@@ -325,6 +327,7 @@ interface App
   }
   activateSourcePriorities: () => void
   streambundle: StreamBundle
+  deviceTracker?: DeviceTracker
 }
 
 interface ModuleInfo {
@@ -483,6 +486,44 @@ module.exports = function (
   app.use('/admin', serveStaticFiles(adminUiPath))
 
   app.get('/', (req: Request, res: Response) => {
+    const queryToken =
+      typeof req.query?.token === 'string' ? req.query.token : undefined
+    if (queryToken) {
+      try {
+        const payload: unknown = JSON.parse(
+          Buffer.from(queryToken.split('.')[1], 'base64url').toString()
+        )
+        const deviceId = (payload as { device?: unknown } | null)?.device
+        if (typeof deviceId === 'string') {
+          const config = getSecurityConfig(app)
+          const device = config.devices?.find(
+            (d: Device) => d.clientId === deviceId
+          )
+          if (device?.dashboard?.mode === 'redirect' && device.dashboard.url) {
+            const rawUrl = device.dashboard.url.trim()
+            const dashUrl = rawUrl.startsWith('/') ? rawUrl : `/${rawUrl}`
+            // Browsers normalize backslashes to slashes, so /\evil.example
+            // would become a protocol-relative redirect leaking the token.
+            if (!dashUrl.startsWith('//') && !dashUrl.includes('\\')) {
+              // Keep the token in the query string: appending it after a
+              // #fragment would hide it from the dashboard's location.search.
+              const [pathAndQuery, ...fragmentParts] = dashUrl.split('#')
+              const fragment = fragmentParts.length
+                ? `#${fragmentParts.join('#')}`
+                : ''
+              const separator = pathAndQuery.includes('?') ? '&' : '?'
+              res.redirect(
+                `${pathAndQuery}${separator}token=${encodeURIComponent(queryToken)}${fragment}`
+              )
+              return
+            }
+          }
+        }
+      } catch (_) {
+        // invalid token, fall through to default landing page
+      }
+    }
+
     let landingPage = '/admin/'
 
     // if accessed with hostname that starts with a webapp's displayName redirect there
@@ -625,7 +666,68 @@ module.exports = function (
     (req: Request, res: Response) => {
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)
-        res.json(app.securityStrategy.getDevices(config))
+        const devices = app.securityStrategy.getDevices(config)
+        if (app.deviceTracker) {
+          const runtimeStates = app.deviceTracker.getAllStates()
+          res.json(
+            devices.map((device: Device) => {
+              const state = runtimeStates.get(device.clientId)
+              if (state) {
+                return {
+                  ...device,
+                  isConnected: state.isConnected,
+                  lastSeen: state.lastSeen,
+                  lastIp: state.lastIp,
+                  pluginData: state.pluginData
+                }
+              }
+              return { ...device, isConnected: false }
+            })
+          )
+        } else {
+          res.json(devices)
+        }
+      }
+    }
+  )
+
+  app.post(
+    `${SERVERROUTESPREFIX}/security/devices`,
+    (req: Request, res: Response) => {
+      if (checkAllowConfigure(req, res)) {
+        const { displayName, permissions } = req.body
+        if (typeof displayName !== 'string' || !displayName.trim()) {
+          res.status(400).json({ error: 'displayName is required' })
+          return
+        }
+        if (!['readonly', 'readwrite', 'admin'].includes(permissions)) {
+          res.status(400).json({ error: 'Invalid permissions value' })
+          return
+        }
+        const config = getSecurityConfig(app)
+        app.securityStrategy.createDevice(
+          config,
+          req.body,
+          (err, updatedConfig, result) => {
+            if (err) {
+              console.log(err)
+              res.status(500).json({ error: 'Unable to create device' })
+            } else if (updatedConfig) {
+              saveSecurityConfig(app, updatedConfig, (saveErr) => {
+                if (saveErr) {
+                  console.log(saveErr)
+                  res
+                    .status(500)
+                    .json({ error: 'Unable to save configuration' })
+                  return
+                }
+                res.json(result)
+              })
+            } else {
+              res.status(500).json({ error: 'Unable to create device' })
+            }
+          }
+        )
       }
     }
   )
@@ -654,15 +756,47 @@ module.exports = function (
     (req: Request, res: Response) => {
       if (checkAllowConfigure(req, res)) {
         const config = getSecurityConfig(app)
+        const clientId = req.params.uuid
         app.securityStrategy.deleteDevice(
           config,
-          req.params.uuid,
-          getConfigSavingCallback(
-            'Device deleted',
-            'Unable to delete device',
-            res
-          )
+          clientId,
+          (err, updatedConfig) => {
+            if (err) {
+              console.log(err)
+              res.status(500).type('text/plain').send('Unable to delete device')
+            } else if (updatedConfig) {
+              saveSecurityConfig(app, updatedConfig, (saveErr) => {
+                if (saveErr) {
+                  console.log(saveErr)
+                  res.status(500).send('Unable to save configuration change')
+                  return
+                }
+                app.deviceTracker?.onDeviceRemoved(clientId)
+                res.type('text/plain').send('Device deleted')
+              })
+            } else {
+              res.type('text/plain').send('Device deleted')
+            }
+          }
         )
+      }
+    }
+  )
+
+  app.post(
+    `${SERVERROUTESPREFIX}/security/devices/:uuid/token`,
+    (req: Request, res: Response) => {
+      if (checkAllowConfigure(req, res)) {
+        const config = getSecurityConfig(app)
+        const token = app.securityStrategy.generateDeviceToken(
+          config,
+          req.params.uuid
+        )
+        if (token) {
+          res.json({ token })
+        } else {
+          res.status(404).json({ error: 'Device not found' })
+        }
       }
     }
   )

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -35,6 +35,7 @@ import { createHash, randomBytes } from 'crypto'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pathToRegexp: (path: string) => RegExp = require('path-to-regexp')
 import { createDebug } from './debug'
+import type { DeviceTracker as DeviceTrackerType } from './deviceTracker'
 import {
   createLoginRateLimiter,
   LOGIN_RATE_LIMIT_MESSAGE
@@ -44,6 +45,7 @@ import {
   SecurityConfig,
   User,
   Device,
+  DeviceDashboard,
   UserData,
   UserDataUpdate,
   DeviceDataUpdate,
@@ -1016,6 +1018,18 @@ function tokenSecurityFactory(
     if (skReq.skIsAuthenticated && skReq.skPrincipal) {
       result.userLevel = skReq.skPrincipal.permissions
       result.username = skReq.skPrincipal.identifier
+
+      const device = options.devices?.find(
+        (d) => d.clientId === skReq.skPrincipal!.identifier
+      )
+      if (device) {
+        result.principalType = 'device'
+        result.deviceId = device.clientId
+        result.deviceName = device.displayName || device.description
+        if (device.dashboard) {
+          result.deviceDashboard = device.dashboard
+        }
+      }
     }
     if (configuration.users.length === 0) {
       result.noUsers = true
@@ -1250,6 +1264,69 @@ function tokenSecurityFactory(
     callback(null, theConfig)
   }
 
+  strategy.createDevice = (
+    theConfig: SecurityConfig,
+    device: {
+      displayName: string
+      permissions: string
+      expiration?: string
+      dashboard?: DeviceDashboard
+    },
+    cb: (
+      err: Error | null,
+      config?: SecurityConfig,
+      result?: { clientId: string; token: string }
+    ) => void
+  ): void => {
+    assertConfigImmutability()
+    const clientId = crypto.randomUUID()
+    const payload: JWTPayload = { device: clientId }
+    const jwtOptions: SignOptions = {}
+
+    const expiresIn = device.expiration || theConfig.expiration
+    if (!isNever(expiresIn)) {
+      jwtOptions.expiresIn = expiresIn as StringValue
+    }
+
+    const token = jwt.sign(payload, theConfig.secretKey, jwtOptions)
+    const decoded = jwt.decode(token) as JWTPayload
+
+    if (!theConfig.devices) {
+      theConfig.devices = []
+    }
+
+    theConfig.devices.push({
+      clientId,
+      permissions: device.permissions,
+      config: {},
+      description: device.displayName,
+      displayName: device.displayName,
+      requestedPermissions: '',
+      tokenExpiry: decoded?.exp,
+      createdAt: new Date().toISOString(),
+      dashboard: device.dashboard
+    })
+
+    options = theConfig as TokenSecurityOptions
+    cb(null, theConfig, { clientId, token })
+  }
+
+  strategy.generateDeviceToken = (
+    theConfig: SecurityConfig,
+    clientId: string
+  ): string | null => {
+    const device = theConfig.devices?.find((d) => d.clientId === clientId)
+    if (!device) return null
+    const payload: JWTPayload = { device: clientId }
+    const jwtOptions: SignOptions = {}
+    if (device.tokenExpiry) {
+      const remaining = device.tokenExpiry - Math.floor(Date.now() / 1000)
+      if (remaining <= 0) return null
+      jwtOptions.expiresIn = remaining
+    }
+    return jwt.sign(payload, theConfig.secretKey, jwtOptions)
+  }
+
   strategy.updateDevice = (
     theConfig: SecurityConfig,
     clientId: string,
@@ -1270,6 +1347,14 @@ function tokenSecurityFactory(
 
     if (updates.description) {
       device.description = updates.description
+    }
+
+    if (updates.displayName !== undefined) {
+      device.displayName = updates.displayName
+    }
+
+    if (updates.dashboard !== undefined) {
+      device.dashboard = updates.dashboard || undefined
     }
 
     callback(null, theConfig)
@@ -1710,6 +1795,10 @@ function tokenSecurityFactory(
         token = getAuthorizationFromHeaders(req)
       }
 
+      if (!token && req.query?.token) {
+        token = req.query.token as string
+      }
+
       if (token) {
         jwt.verify(
           token,
@@ -1717,7 +1806,8 @@ function tokenSecurityFactory(
           function (err: Error | null, decoded: unknown) {
             debug('verify')
             if (!err) {
-              const principal = getPrincipal(decoded as JWTPayload)
+              const jwtData = decoded as JWTPayload
+              const principal = getPrincipal(jwtData)
               if (principal) {
                 debug('authorized')
                 skReq.skPrincipal = principal
@@ -1740,6 +1830,15 @@ function tokenSecurityFactory(
                     rememberMe: jwtPayload.rememberMe
                   })
                   debug('token refreshed for %s', jwtPayload.id)
+                }
+                if (
+                  jwtData.device &&
+                  (app as unknown as { deviceTracker?: DeviceTrackerType })
+                    .deviceTracker
+                ) {
+                  ;(
+                    app as unknown as { deviceTracker: DeviceTrackerType }
+                  ).deviceTracker.onActivity(principal.identifier, req.ip)
                 }
                 next()
                 return
@@ -1866,6 +1965,10 @@ function tokenSecurityFactory(
           (d) => d.clientId !== identifier
         )
 
+        const accessReq = request.clientRequest.accessRequest as Record<
+          string,
+          unknown
+        >
         theConfig.devices.push({
           clientId: request.accessIdentifier,
           permissions: !request.clientRequest.requestedPermissions
@@ -1876,7 +1979,19 @@ function tokenSecurityFactory(
           requestedPermissions: request.clientRequest.requestedPermissions
             ? 'true'
             : '',
-          tokenExpiry: decoded?.exp
+          tokenExpiry: decoded?.exp,
+          createdAt: new Date().toISOString(),
+          registrationInfo: {
+            sourceIp: request.ip,
+            deviceId:
+              typeof accessReq.deviceId === 'string'
+                ? accessReq.deviceId
+                : undefined,
+            firmwareVersion:
+              typeof accessReq.firmwareVersion === 'string'
+                ? accessReq.firmwareVersion
+                : undefined
+          }
         })
         request.token = token
       } else {

--- a/test/device-manager.ts
+++ b/test/device-manager.ts
@@ -1,0 +1,669 @@
+import chai from 'chai'
+import jwt from 'jsonwebtoken'
+import type { StringValue } from 'ms'
+import path from 'path'
+import { rimraf } from 'rimraf'
+import { freeport } from './ts-servertestutilities'
+import {
+  startServerP,
+  getAdminToken,
+  getReadOnlyToken,
+  serverTestConfigDirectory
+} from './servertestutilities'
+
+const expect = chai.expect
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(chai as any).Should()
+
+describe('Device Manager', function () {
+  let url: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let adminToken: string
+  let readToken: string
+  let secretKey: string
+
+  function adminHeaders() {
+    return {
+      Cookie: `JAUTHENTICATION=${adminToken}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  function tokenHeaders(token: string) {
+    return {
+      Cookie: `JAUTHENTICATION=${token}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  function createDeviceToken(
+    clientId: string,
+    opts?: { expiresIn?: string }
+  ): string {
+    const jwtOpts: jwt.SignOptions = {}
+    if (opts?.expiresIn) {
+      jwtOpts.expiresIn = opts.expiresIn as StringValue
+    }
+    return jwt.sign({ device: clientId }, secretKey, jwtOpts)
+  }
+
+  before(async function () {
+    this.timeout(60000)
+    const port = await freeport()
+    url = `http://0.0.0.0:${port}`
+    server = await startServerP(port, true)
+    adminToken = await getAdminToken(server)
+    readToken = await getReadOnlyToken(server)
+    secretKey = server.app.securityStrategy.securityConfig.secretKey
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  describe('?token= HTTP auth', function () {
+    afterEach(function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = (config.devices || []).filter(
+        (d: { clientId: string }) => d.clientId !== 'token-auth-test-device'
+      )
+    })
+
+    it('authenticates via query parameter', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${adminToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+    })
+
+    it('rejects invalid token in query parameter', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=invalid.jwt.token`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('notLoggedIn')
+    })
+
+    it('authenticates device token via query parameter', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      config.devices.push({
+        clientId: 'token-auth-test-device',
+        permissions: 'readonly',
+        config: {},
+        description: 'token auth test',
+        requestedPermissions: ''
+      })
+
+      const deviceToken = createDeviceToken('token-auth-test-device')
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${deviceToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+      expect(body.userLevel).to.equal('readonly')
+    })
+  })
+
+  describe('Device CRUD', function () {
+    it('rejects unauthenticated device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`)
+      expect(result.status).to.equal(401)
+    })
+
+    it('rejects non-admin device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        headers: tokenHeaders(readToken)
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('returns empty device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      expect(result.status).to.equal(200)
+      const devices = await result.json()
+      expect(devices).to.be.an('array')
+    })
+
+    it('creates a device', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Test Helm Display',
+          permissions: 'readonly'
+        })
+      })
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.clientId).to.be.a('string')
+      expect(body.token).to.be.a('string')
+
+      const decoded = jwt.decode(body.token) as { device: string }
+      expect(decoded.device).to.equal(body.clientId)
+    })
+
+    it('creates a device with dashboard', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Nav iPad',
+          permissions: 'readonly',
+          dashboard: { mode: 'redirect', url: '/@signalk/freeboard-sk/' }
+        })
+      })
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      const device = devices.find(
+        (d: { clientId: string }) => d.clientId === body.clientId
+      )
+      expect(device).to.exist
+      expect(device.displayName).to.equal('Nav iPad')
+      expect(device.dashboard.mode).to.equal('redirect')
+      expect(device.dashboard.url).to.equal('/@signalk/freeboard-sk/')
+    })
+
+    it('updates a device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Before Update',
+          permissions: 'readonly'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const updateResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}`,
+        {
+          method: 'PUT',
+          headers: adminHeaders(),
+          body: JSON.stringify({
+            displayName: 'After Update',
+            permissions: 'readwrite',
+            dashboard: { mode: 'metadata', metadata: { layout: 'helm' } }
+          })
+        }
+      )
+      expect(updateResult.status).to.equal(200)
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      const device = devices.find(
+        (d: { clientId: string }) => d.clientId === clientId
+      )
+      expect(device.displayName).to.equal('After Update')
+      expect(device.permissions).to.equal('readwrite')
+      expect(device.dashboard.mode).to.equal('metadata')
+    })
+
+    it('deletes a device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'To Delete',
+          permissions: 'readonly'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const deleteResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}`,
+        {
+          method: 'DELETE',
+          headers: adminHeaders()
+        }
+      )
+      expect(deleteResult.status).to.equal(200)
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      expect(devices.find((d: { clientId: string }) => d.clientId === clientId))
+        .to.be.undefined
+    })
+  })
+
+  describe('Token regeneration', function () {
+    it('regenerates a valid token for an existing device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Token Regen Test',
+          permissions: 'readwrite'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const regenResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}/token`,
+        {
+          method: 'POST',
+          headers: adminHeaders()
+        }
+      )
+      expect(regenResult.status).to.equal(200)
+      const { token } = await regenResult.json()
+      expect(token).to.be.a('string')
+
+      const decoded = jwt.decode(token) as { device: string }
+      expect(decoded.device).to.equal(clientId)
+
+      const statusResult = await fetch(
+        `${url}/skServer/loginStatus?token=${token}`
+      )
+      const status = await statusResult.json()
+      expect(status.status).to.equal('loggedIn')
+    })
+
+    it('returns 404 for nonexistent device', async function () {
+      const result = await fetch(
+        `${url}/skServer/security/devices/nonexistent-id/token`,
+        {
+          method: 'POST',
+          headers: adminHeaders()
+        }
+      )
+      expect(result.status).to.equal(404)
+    })
+
+    it('rejects non-admin request', async function () {
+      const result = await fetch(
+        `${url}/skServer/security/devices/any-id/token`,
+        {
+          method: 'POST',
+          headers: tokenHeaders(readToken)
+        }
+      )
+      expect(result.status).to.equal(401)
+    })
+  })
+
+  describe('loginStatus device identity', function () {
+    let deviceClientId: string
+    let deviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'LoginStatus Test Device',
+          permissions: 'readonly',
+          dashboard: {
+            mode: 'metadata',
+            metadata: { layout: 'helm', theme: 'dark' }
+          }
+        })
+      })
+      const body = await result.json()
+      deviceClientId = body.clientId
+      deviceToken = body.token
+    })
+
+    it('returns device identity in loginStatus', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${deviceToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+      expect(body.principalType).to.equal('device')
+      expect(body.deviceId).to.equal(deviceClientId)
+      expect(body.deviceName).to.equal('LoginStatus Test Device')
+      expect(body.deviceDashboard).to.deep.include({ mode: 'metadata' })
+      expect(body.deviceDashboard.metadata).to.deep.equal({
+        layout: 'helm',
+        theme: 'dark'
+      })
+    })
+  })
+
+  describe('Dashboard redirect', function () {
+    let redirectDeviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Redirect Test',
+          permissions: 'readonly',
+          dashboard: { mode: 'redirect', url: '@signalk/freeboard-sk/' }
+        })
+      })
+      const body = await result.json()
+      redirectDeviceToken = body.token
+    })
+
+    it('redirects device with dashboard to assigned URL', async function () {
+      const result = await fetch(`${url}/?token=${redirectDeviceToken}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.include('/@signalk/freeboard-sk/')
+      expect(location).to.include(`token=${redirectDeviceToken}`)
+    })
+
+    it('redirects device without dashboard to default location', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'No Dashboard',
+          permissions: 'readonly'
+        })
+      })
+      const { token } = await createResult.json()
+
+      const result = await fetch(`${url}/?token=${token}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.not.include('freeboard')
+    })
+
+    it('redirects user tokens to default location', async function () {
+      const result = await fetch(`${url}/?token=${adminToken}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.not.include('freeboard')
+    })
+  })
+
+  describe('Device-scoped applicationData', function () {
+    let deviceClientId: string
+    let deviceToken: string
+    let otherDeviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'AppData Device',
+          permissions: 'readwrite'
+        })
+      })
+      const body = await result.json()
+      deviceClientId = body.clientId
+      deviceToken = body.token
+
+      const result2 = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Other Device',
+          permissions: 'readwrite'
+        })
+      })
+      const body2 = await result2.json()
+      otherDeviceToken = body2.token
+    })
+
+    beforeEach(async function () {
+      await rimraf(
+        path.join(serverTestConfigDirectory(), 'applicationData', 'devices')
+      )
+    })
+
+    it('device can write and read own applicationData', async function () {
+      const data = { dashboard: 'helm', gauges: [1, 2, 3] }
+      const postResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        {
+          method: 'POST',
+          headers: tokenHeaders(deviceToken),
+          body: JSON.stringify(data)
+        }
+      )
+      expect(postResult.status).to.equal(200)
+
+      const getResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: tokenHeaders(deviceToken) }
+      )
+      expect(getResult.status).to.equal(200)
+      const body = await getResult.json()
+      expect(body).to.deep.equal(data)
+    })
+
+    it('device cannot access another device scope', async function () {
+      const result = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: tokenHeaders(otherDeviceToken) }
+      )
+      expect(result.status).to.equal(403)
+    })
+
+    it('admin can access any device scope', async function () {
+      const data = { config: 'admin-written' }
+      const postResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        {
+          method: 'POST',
+          headers: adminHeaders(),
+          body: JSON.stringify(data)
+        }
+      )
+      expect(postResult.status).to.equal(200)
+
+      const getResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: adminHeaders() }
+      )
+      expect(getResult.status).to.equal(200)
+      const body = await getResult.json()
+      expect(body).to.deep.equal(data)
+    })
+
+    it('unauthenticated request is rejected', async function () {
+      const result = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`
+      )
+      expect(result.status).to.equal(401)
+    })
+  })
+
+  describe('Plugin route permissions', function () {
+    it('registers and enforces route permissions', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      const clientId = 'route-perm-test-device'
+      config.devices.push({
+        clientId,
+        permissions: 'readwrite',
+        config: {},
+        description: 'route perm test',
+        requestedPermissions: ''
+      })
+
+      server.app.securityStrategy.registerPluginRoutePermissions(
+        'test-plugin',
+        [
+          { method: 'GET', path: '/status', permission: 'readonly' },
+          { method: 'POST', path: '/data', permission: 'readwrite' }
+        ]
+      )
+
+      const rwToken = createDeviceToken(clientId)
+
+      const statusResult = await fetch(
+        `${url}/plugins/test-plugin/status?token=${rwToken}`
+      )
+      expect(statusResult.status).to.not.equal(401)
+
+      const dataResult = await fetch(
+        `${url}/plugins/test-plugin/data?token=${rwToken}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      )
+      expect(dataResult.status).to.not.equal(401)
+
+      config.devices = config.devices.filter(
+        (d: { clientId: string }) => d.clientId !== clientId
+      )
+    })
+
+    it('denies readonly device access to readwrite routes', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      const clientId = 'route-perm-ro-device'
+      config.devices.push({
+        clientId,
+        permissions: 'readonly',
+        config: {},
+        description: 'readonly device',
+        requestedPermissions: ''
+      })
+
+      server.app.securityStrategy.registerPluginRoutePermissions(
+        'test-plugin-rw',
+        [{ method: 'POST', path: '/data', permission: 'readwrite' }]
+      )
+
+      const roToken = createDeviceToken(clientId)
+
+      const result = await fetch(
+        `${url}/plugins/test-plugin-rw/data?token=${roToken}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      )
+      expect(result.status).to.equal(401)
+
+      config.devices = config.devices.filter(
+        (d: { clientId: string }) => d.clientId !== clientId
+      )
+    })
+  })
+})
+
+describe('DeviceTracker', function () {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+  const DeviceTracker = (require('../dist/deviceTracker') as any).DeviceTracker
+
+  it('tracks connect and disconnect', function () {
+    const events: unknown[] = []
+    const tracker = new DeviceTracker((e: unknown) => events.push(e))
+
+    tracker.onConnect('device-1', '10.0.0.1')
+    let state = tracker.getState('device-1')
+    expect(state.isConnected).to.be.true
+    expect(state.connectionCount).to.equal(1)
+    expect(state.lastIp).to.equal('10.0.0.1')
+
+    tracker.onDisconnect('device-1')
+    state = tracker.getState('device-1')
+    expect(state.isConnected).to.be.false
+    expect(state.connectionCount).to.equal(0)
+
+    tracker.destroy()
+  })
+
+  it('tracks multiple connections', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onConnect('device-2', '10.0.0.1')
+    tracker.onConnect('device-2', '10.0.0.1')
+    let state = tracker.getState('device-2')
+    expect(state.connectionCount).to.equal(2)
+    expect(state.isConnected).to.be.true
+
+    tracker.onDisconnect('device-2')
+    state = tracker.getState('device-2')
+    expect(state.connectionCount).to.equal(1)
+    expect(state.isConnected).to.be.true
+
+    tracker.onDisconnect('device-2')
+    state = tracker.getState('device-2')
+    expect(state.connectionCount).to.equal(0)
+    expect(state.isConnected).to.be.false
+
+    tracker.destroy()
+  })
+
+  it('tracks HTTP activity', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onActivity('device-3', '10.0.0.5')
+    const state = tracker.getState('device-3')
+    expect(state.isConnected).to.be.true
+    expect(state.connectionCount).to.equal(0)
+    expect(state.lastIp).to.equal('10.0.0.5')
+
+    tracker.destroy()
+  })
+
+  it('removes device state', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onConnect('device-4', '10.0.0.1')
+    expect(tracker.getState('device-4')).to.exist
+
+    tracker.onDeviceRemoved('device-4')
+    expect(tracker.getState('device-4')).to.be.undefined
+
+    tracker.destroy()
+  })
+
+  it('stores and retrieves plugin data', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onConnect('device-5', '10.0.0.1')
+    tracker.setPluginData('my-plugin', 'device-5', {
+      firmware: '2.1.0',
+      board: 'esp32'
+    })
+
+    const data = tracker.getPluginData('my-plugin', 'device-5')
+    expect(data).to.deep.equal({ firmware: '2.1.0', board: 'esp32' })
+
+    expect(tracker.getPluginData('other-plugin', 'device-5')).to.be.undefined
+
+    tracker.destroy()
+  })
+
+  it('emits state change events', function () {
+    const events: unknown[] = []
+    const tracker = new DeviceTracker((e: unknown) => events.push(e))
+
+    tracker.onConnect('device-6', '10.0.0.1')
+    expect(events).to.have.lengthOf(1)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const connectEvent = events[0] as any
+    expect(connectEvent.type).to.equal('DEVICE_STATUS_CHANGE')
+    expect(connectEvent.data.clientId).to.equal('device-6')
+    expect(connectEvent.data.connected).to.be.true
+
+    tracker.onDisconnect('device-6')
+    expect(events).to.have.lengthOf(2)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const disconnectEvent = events[1] as any
+    expect(disconnectEvent.type).to.equal('DEVICE_STATUS_CHANGE')
+    expect(disconnectEvent.data.clientId).to.equal('device-6')
+    expect(disconnectEvent.data.connected).to.be.false
+
+    tracker.destroy()
+  })
+})

--- a/test/device-manager.ts
+++ b/test/device-manager.ts
@@ -1,0 +1,731 @@
+import chai from 'chai'
+import jwt from 'jsonwebtoken'
+import path from 'path'
+import { rimraf } from 'rimraf'
+import { freeport, SERVER_START_TIMEOUT } from './ts-servertestutilities'
+import {
+  startServerP,
+  getAdminToken,
+  getReadOnlyToken,
+  serverTestConfigDirectory
+} from './servertestutilities'
+import type { DeviceStateEvent } from '../src/deviceTracker'
+
+const expect = chai.expect
+
+interface TestServer {
+  app: {
+    securityStrategy: {
+      securityConfig: {
+        secretKey: string
+        devices: Array<{ clientId: string } & Record<string, unknown>>
+      }
+      registerPluginRoutePermissions: (
+        pluginId: string,
+        permissions: Array<{ method: string; path: string; permission: string }>
+      ) => void
+    }
+  }
+  stop: () => Promise<void>
+}
+
+describe('Device Manager', function () {
+  let url: string
+  let server: TestServer
+  let adminToken: string
+  let readToken: string
+  let secretKey: string
+
+  function adminHeaders() {
+    return {
+      Cookie: `JAUTHENTICATION=${adminToken}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  function tokenHeaders(token: string) {
+    return {
+      Cookie: `JAUTHENTICATION=${token}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  function createDeviceToken(clientId: string): string {
+    return jwt.sign({ device: clientId }, secretKey)
+  }
+
+  before(async function () {
+    this.timeout(SERVER_START_TIMEOUT)
+    const port = await freeport()
+    url = `http://0.0.0.0:${port}`
+    server = await startServerP(port, true)
+    adminToken = await getAdminToken(server)
+    readToken = await getReadOnlyToken(server)
+    secretKey = server.app.securityStrategy.securityConfig.secretKey
+  })
+
+  after(async function () {
+    // Remove devices created through the API so no device state persists in
+    // the shared test security config beyond this suite.
+    const res = await fetch(`${url}/skServer/security/devices`, {
+      headers: adminHeaders()
+    })
+    if (res.ok) {
+      const devices = await res.json()
+      for (const d of devices) {
+        await fetch(`${url}/skServer/security/devices/${d.clientId}`, {
+          method: 'DELETE',
+          headers: adminHeaders()
+        })
+      }
+    }
+    await server.stop()
+  })
+
+  describe('?token= HTTP auth', function () {
+    afterEach(function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = (config.devices || []).filter(
+        (d: { clientId: string }) => d.clientId !== 'token-auth-test-device'
+      )
+    })
+
+    it('authenticates via query parameter', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${adminToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+    })
+
+    it('rejects invalid token in query parameter', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=invalid.jwt.token`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('notLoggedIn')
+    })
+
+    it('authenticates device token via query parameter', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      config.devices.push({
+        clientId: 'token-auth-test-device',
+        permissions: 'readonly',
+        config: {},
+        description: 'token auth test',
+        requestedPermissions: ''
+      })
+
+      const deviceToken = createDeviceToken('token-auth-test-device')
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${deviceToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+      expect(body.userLevel).to.equal('readonly')
+    })
+  })
+
+  describe('Device CRUD', function () {
+    it('rejects unauthenticated device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`)
+      expect(result.status).to.equal(401)
+    })
+
+    it('rejects non-admin device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        headers: tokenHeaders(readToken)
+      })
+      expect(result.status).to.equal(401)
+    })
+
+    it('returns empty device list', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      expect(result.status).to.equal(200)
+      const devices = await result.json()
+      expect(devices).to.be.an('array').that.is.empty
+    })
+
+    it('creates a device', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Test Helm Display',
+          permissions: 'readonly'
+        })
+      })
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.clientId).to.be.a('string')
+      expect(body.token).to.be.a('string')
+
+      const decoded = jwt.decode(body.token) as { device: string }
+      expect(decoded.device).to.equal(body.clientId)
+    })
+
+    it('creates a device with dashboard', async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Nav iPad',
+          permissions: 'readonly',
+          dashboard: { mode: 'redirect', url: '/@signalk/freeboard-sk/' }
+        })
+      })
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      const device = devices.find(
+        (d: { clientId: string }) => d.clientId === body.clientId
+      )
+      expect(device).to.exist
+      expect(device.displayName).to.equal('Nav iPad')
+      expect(device.dashboard.mode).to.equal('redirect')
+      expect(device.dashboard.url).to.equal('/@signalk/freeboard-sk/')
+    })
+
+    it('updates a device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Before Update',
+          permissions: 'readonly'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const updateResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}`,
+        {
+          method: 'PUT',
+          headers: adminHeaders(),
+          body: JSON.stringify({
+            displayName: 'After Update',
+            permissions: 'readwrite',
+            dashboard: { mode: 'metadata', metadata: { layout: 'helm' } }
+          })
+        }
+      )
+      expect(updateResult.status).to.equal(200)
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      const device = devices.find(
+        (d: { clientId: string }) => d.clientId === clientId
+      )
+      expect(device.displayName).to.equal('After Update')
+      expect(device.permissions).to.equal('readwrite')
+      expect(device.dashboard.mode).to.equal('metadata')
+    })
+
+    it('deletes a device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'To Delete',
+          permissions: 'readonly'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const deleteResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}`,
+        {
+          method: 'DELETE',
+          headers: adminHeaders()
+        }
+      )
+      expect(deleteResult.status).to.equal(200)
+
+      const listResult = await fetch(`${url}/skServer/security/devices`, {
+        headers: adminHeaders()
+      })
+      const devices = await listResult.json()
+      expect(devices.find((d: { clientId: string }) => d.clientId === clientId))
+        .to.be.undefined
+    })
+  })
+
+  describe('Token regeneration', function () {
+    it('regenerates a valid token for an existing device', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Token Regen Test',
+          permissions: 'readwrite'
+        })
+      })
+      const { clientId } = await createResult.json()
+
+      const regenResult = await fetch(
+        `${url}/skServer/security/devices/${clientId}/token`,
+        {
+          method: 'POST',
+          headers: adminHeaders()
+        }
+      )
+      expect(regenResult.status).to.equal(200)
+      const { token } = await regenResult.json()
+      expect(token).to.be.a('string')
+
+      const decoded = jwt.decode(token) as { device: string }
+      expect(decoded.device).to.equal(clientId)
+
+      const statusResult = await fetch(
+        `${url}/skServer/loginStatus?token=${token}`
+      )
+      const status = await statusResult.json()
+      expect(status.status).to.equal('loggedIn')
+    })
+
+    it('returns 404 for nonexistent device', async function () {
+      const result = await fetch(
+        `${url}/skServer/security/devices/nonexistent-id/token`,
+        {
+          method: 'POST',
+          headers: adminHeaders()
+        }
+      )
+      expect(result.status).to.equal(404)
+    })
+
+    it('rejects non-admin request', async function () {
+      const result = await fetch(
+        `${url}/skServer/security/devices/any-id/token`,
+        {
+          method: 'POST',
+          headers: tokenHeaders(readToken)
+        }
+      )
+      expect(result.status).to.equal(401)
+    })
+  })
+
+  describe('loginStatus device identity', function () {
+    let deviceClientId: string
+    let deviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'LoginStatus Test Device',
+          permissions: 'readonly',
+          dashboard: {
+            mode: 'metadata',
+            metadata: { layout: 'helm', theme: 'dark' }
+          }
+        })
+      })
+      const body = await result.json()
+      deviceClientId = body.clientId
+      deviceToken = body.token
+    })
+
+    it('returns device identity in loginStatus', async function () {
+      const result = await fetch(
+        `${url}/skServer/loginStatus?token=${deviceToken}`
+      )
+      expect(result.status).to.equal(200)
+      const body = await result.json()
+      expect(body.status).to.equal('loggedIn')
+      expect(body.principalType).to.equal('device')
+      expect(body.deviceId).to.equal(deviceClientId)
+      expect(body.deviceName).to.equal('LoginStatus Test Device')
+      expect(body.deviceDashboard).to.deep.include({ mode: 'metadata' })
+      expect(body.deviceDashboard.metadata).to.deep.equal({
+        layout: 'helm',
+        theme: 'dark'
+      })
+    })
+  })
+
+  describe('Dashboard redirect', function () {
+    let redirectDeviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Redirect Test',
+          permissions: 'readonly',
+          dashboard: { mode: 'redirect', url: '@signalk/freeboard-sk/' }
+        })
+      })
+      const body = await result.json()
+      redirectDeviceToken = body.token
+    })
+
+    it('redirects device with dashboard to assigned URL', async function () {
+      const result = await fetch(`${url}/?token=${redirectDeviceToken}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.include('/@signalk/freeboard-sk/')
+      expect(location).to.include(`token=${redirectDeviceToken}`)
+    })
+
+    it('redirects device without dashboard to default location', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'No Dashboard',
+          permissions: 'readonly'
+        })
+      })
+      const { token } = await createResult.json()
+
+      const result = await fetch(`${url}/?token=${token}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.not.include('freeboard')
+    })
+
+    it('does not redirect to a backslash protocol-relative URL', async function () {
+      const createResult = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Backslash Dashboard',
+          permissions: 'readonly',
+          dashboard: { mode: 'redirect', url: '/\\evil.example' }
+        })
+      })
+      const { token } = await createResult.json()
+
+      const result = await fetch(`${url}/?token=${token}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.not.include('evil.example')
+    })
+
+    it('redirects user tokens to default location', async function () {
+      const result = await fetch(`${url}/?token=${adminToken}`, {
+        redirect: 'manual'
+      })
+      expect(result.status).to.equal(302)
+      const location = result.headers.get('location')
+      expect(location).to.not.include('freeboard')
+    })
+  })
+
+  describe('Device-scoped applicationData', function () {
+    let deviceClientId: string
+    let deviceToken: string
+    let otherDeviceToken: string
+
+    before(async function () {
+      const result = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'AppData Device',
+          permissions: 'readwrite'
+        })
+      })
+      const body = await result.json()
+      deviceClientId = body.clientId
+      deviceToken = body.token
+
+      const result2 = await fetch(`${url}/skServer/security/devices`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          displayName: 'Other Device',
+          permissions: 'readwrite'
+        })
+      })
+      const body2 = await result2.json()
+      otherDeviceToken = body2.token
+    })
+
+    beforeEach(async function () {
+      await rimraf(
+        path.join(serverTestConfigDirectory(), 'applicationData', 'devices')
+      )
+    })
+
+    it('device can write and read own applicationData', async function () {
+      const data = { dashboard: 'helm', gauges: [1, 2, 3] }
+      const postResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        {
+          method: 'POST',
+          headers: tokenHeaders(deviceToken),
+          body: JSON.stringify(data)
+        }
+      )
+      expect(postResult.status).to.equal(200)
+
+      const getResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: tokenHeaders(deviceToken) }
+      )
+      expect(getResult.status).to.equal(200)
+      const body = await getResult.json()
+      expect(body).to.deep.equal(data)
+    })
+
+    it('device cannot access another device scope', async function () {
+      const result = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: tokenHeaders(otherDeviceToken) }
+      )
+      expect(result.status).to.equal(403)
+    })
+
+    it('admin can access any device scope', async function () {
+      const data = { config: 'admin-written' }
+      const postResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        {
+          method: 'POST',
+          headers: adminHeaders(),
+          body: JSON.stringify(data)
+        }
+      )
+      expect(postResult.status).to.equal(200)
+
+      const getResult = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`,
+        { headers: adminHeaders() }
+      )
+      expect(getResult.status).to.equal(200)
+      const body = await getResult.json()
+      expect(body).to.deep.equal(data)
+    })
+
+    it('unauthenticated request is rejected', async function () {
+      const result = await fetch(
+        `${url}/signalk/v1/applicationData/device/${deviceClientId}/testapp/1.0.0`
+      )
+      expect(result.status).to.equal(401)
+    })
+  })
+
+  describe('Plugin route permissions', function () {
+    const createdDeviceIds: string[] = []
+
+    afterEach(function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = (config.devices || []).filter(
+        (d: { clientId: string }) => !createdDeviceIds.includes(d.clientId)
+      )
+      createdDeviceIds.length = 0
+    })
+
+    it('registers and enforces route permissions', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      const clientId = 'route-perm-test-device'
+      createdDeviceIds.push(clientId)
+      config.devices.push({
+        clientId,
+        permissions: 'readwrite',
+        config: {},
+        description: 'route perm test',
+        requestedPermissions: ''
+      })
+
+      server.app.securityStrategy.registerPluginRoutePermissions(
+        'test-plugin',
+        [
+          { method: 'GET', path: '/status', permission: 'readonly' },
+          { method: 'POST', path: '/data', permission: 'readwrite' }
+        ]
+      )
+
+      const rwToken = createDeviceToken(clientId)
+
+      const statusResult = await fetch(
+        `${url}/plugins/test-plugin/status?token=${rwToken}`
+      )
+      expect(statusResult.status).to.not.equal(401)
+
+      const dataResult = await fetch(
+        `${url}/plugins/test-plugin/data?token=${rwToken}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      )
+      expect(dataResult.status).to.not.equal(401)
+    })
+
+    it('denies readonly device access to readwrite routes', async function () {
+      const config = server.app.securityStrategy.securityConfig
+      config.devices = config.devices || []
+      const clientId = 'route-perm-ro-device'
+      createdDeviceIds.push(clientId)
+      config.devices.push({
+        clientId,
+        permissions: 'readonly',
+        config: {},
+        description: 'readonly device',
+        requestedPermissions: ''
+      })
+
+      server.app.securityStrategy.registerPluginRoutePermissions(
+        'test-plugin-rw',
+        [{ method: 'POST', path: '/data', permission: 'readwrite' }]
+      )
+
+      const roToken = createDeviceToken(clientId)
+
+      const result = await fetch(
+        `${url}/plugins/test-plugin-rw/data?token=${roToken}`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+      )
+      expect(result.status).to.equal(401)
+    })
+  })
+})
+
+describe('DeviceTracker', function () {
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { DeviceTracker } =
+    require('../dist/deviceTracker') as typeof import('../src/deviceTracker')
+  /* eslint-enable @typescript-eslint/no-require-imports */
+
+  interface AdminDeviceEvent {
+    type: string
+    data: Partial<DeviceStateEvent>
+  }
+
+  it('tracks connect and disconnect', function () {
+    const events: AdminDeviceEvent[] = []
+    const tracker = new DeviceTracker((e) => events.push(e as AdminDeviceEvent))
+
+    tracker.onConnect('device-1', '10.0.0.1')
+    let state = tracker.getState('device-1')!
+    expect(state.isConnected).to.be.true
+    expect(state.connectionCount).to.equal(1)
+    expect(state.lastIp).to.equal('10.0.0.1')
+
+    tracker.onDisconnect('device-1')
+    state = tracker.getState('device-1')!
+    expect(state.isConnected).to.be.false
+    expect(state.connectionCount).to.equal(0)
+
+    tracker.destroy()
+  })
+
+  it('tracks multiple connections', function () {
+    const events: AdminDeviceEvent[] = []
+    const tracker = new DeviceTracker((e) => events.push(e as AdminDeviceEvent))
+
+    tracker.onConnect('device-2', '10.0.0.1')
+    tracker.onConnect('device-2', '10.0.0.1')
+    let state = tracker.getState('device-2')!
+    expect(state.connectionCount).to.equal(2)
+    expect(state.isConnected).to.be.true
+    expect(events, 'second connection emits no extra event').to.have.lengthOf(1)
+
+    tracker.onDisconnect('device-2')
+    state = tracker.getState('device-2')!
+    expect(state.connectionCount).to.equal(1)
+    expect(state.isConnected).to.be.true
+    expect(
+      events,
+      'intermediate disconnect emits no disconnected event'
+    ).to.have.lengthOf(1)
+
+    tracker.onDisconnect('device-2')
+    state = tracker.getState('device-2')!
+    expect(state.connectionCount).to.equal(0)
+    expect(state.isConnected).to.be.false
+    expect(events).to.have.lengthOf(2)
+    expect(events[1].data.connected).to.be.false
+
+    tracker.destroy()
+  })
+
+  it('tracks HTTP activity', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onActivity('device-3', '10.0.0.5')
+    const state = tracker.getState('device-3')!
+    expect(state.isConnected).to.be.true
+    expect(state.connectionCount).to.equal(0)
+    expect(state.lastIp).to.equal('10.0.0.5')
+
+    tracker.destroy()
+  })
+
+  it('removes device state', function () {
+    const tracker = new DeviceTracker(() => {})
+
+    tracker.onConnect('device-4', '10.0.0.1')
+    expect(tracker.getState('device-4')).to.exist
+
+    tracker.onDeviceRemoved('device-4')
+    expect(tracker.getState('device-4')).to.be.undefined
+
+    tracker.destroy()
+  })
+
+  it('stores and retrieves plugin data', function () {
+    const events: AdminDeviceEvent[] = []
+    const tracker = new DeviceTracker((e) => events.push(e as AdminDeviceEvent))
+
+    tracker.onConnect('device-5', '10.0.0.1')
+    tracker.setPluginData('my-plugin', 'device-5', {
+      firmware: '2.1.0',
+      board: 'esp32'
+    })
+
+    const data = tracker.getPluginData('my-plugin', 'device-5')
+    expect(data).to.deep.equal({ firmware: '2.1.0', board: 'esp32' })
+
+    expect(tracker.getPluginData('other-plugin', 'device-5')).to.be.undefined
+
+    expect(events, 'setPluginData emits a status change').to.have.lengthOf(2)
+    expect(events[1].type).to.equal('DEVICE_STATUS_CHANGE')
+    expect(events[1].data.clientId).to.equal('device-5')
+
+    tracker.destroy()
+  })
+
+  it('emits state change events', function () {
+    const events: AdminDeviceEvent[] = []
+    const tracker = new DeviceTracker((e) => events.push(e as AdminDeviceEvent))
+
+    tracker.onConnect('device-6', '10.0.0.1')
+    expect(events).to.have.lengthOf(1)
+    const connectEvent = events[0]
+    expect(connectEvent.type).to.equal('DEVICE_STATUS_CHANGE')
+    expect(connectEvent.data.clientId).to.equal('device-6')
+    expect(connectEvent.data.connected).to.be.true
+
+    tracker.onDisconnect('device-6')
+    expect(events).to.have.lengthOf(2)
+    const disconnectEvent = events[1]
+    expect(disconnectEvent.type).to.equal('DEVICE_STATUS_CHANGE')
+    expect(disconnectEvent.data.clientId).to.equal('device-6')
+    expect(disconnectEvent.data.connected).to.be.false
+
+    tracker.destroy()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the Device Manager RFC. Devices get proper names, connection tracking, dashboard assignment, device-scoped applicationData, and plugin integration. The admin UI Devices page becomes a real device manager.

closes #2508

## What changed

**Token authentication** — `?token=` query parameter now authenticates all HTTP requests (was WebSocket-only). Resolution order for HTTP: cookie, header, query parameter.

**Enhanced device model** — `displayName`, `dashboard` (redirect or metadata mode), `registrationInfo` (captured at access request approval), `createdAt`.

**Admin-created devices** — POST /security/devices generates a JWT and returns a copyable token URL. "Show Token URL" button regenerates it later.

**Connection tracking** — DeviceTracker tracks online/offline in real time. WebSocket connections get immediate connect/disconnect. HTTP-only devices use a 5-minute activity timeout. The admin UI refreshes automatically via server-pushed WebSocket events.

**Device-scoped applicationData** — `/signalk/v1/applicationData/device/{deviceId}/{appId}/{version}` with strict isolation: a device token can only access its own scope, admins can access any. Existing global and user scopes unchanged.

**Plugin route permissions** — Plugins declare `getRoutePermissions()` to open specific routes to non-admin principals (e.g. a sensor bridge POSTing data with a readwrite token).

**Plugin device metadata API** — `setDevicePluginData`, `getDevicePluginData`, `onDeviceStateChange` on ServerAPI for plugins to attach metadata and react to device events.

**Dashboard redirect** — Devices with `dashboard.mode === 'redirect'` get 302-redirected from `/?token=` to the assigned webapp URL. Works correctly even when a browser admin cookie is present.

**loginStatus enrichment** — Returns `principalType`, `deviceId`, `deviceName`, `deviceDashboard` for device tokens, enabling metadata-mode dashboard integration.

**Admin UI** — Devices page groups devices into Displays & Apps, Sensors & Bridges, Remote Servers. Shows connection status, last seen, IP, token expiry. Detail card for editing. Live refresh via DEVICE_STATUS_CHANGE WebSocket events.

## Test plan

29 tests in `test/device-manager.ts` covering:

- `?token=` HTTP authentication (valid, invalid, device tokens)
- Device CRUD API (create, read, update, delete, auth enforcement)
- Token regeneration endpoint
- loginStatus device identity and dashboard metadata
- Dashboard redirect (with/without dashboard, user tokens)
- Device-scoped applicationData isolation (own scope, cross-device denied, admin access)
- Plugin route permissions (readwrite pass, readonly denied)
- DeviceTracker unit tests (connect, disconnect, multi-connection, HTTP activity, removal, plugin data, events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements the Device Manager RFC.

- Adds device identity, metadata, permissions, JWT lifecycle management, and dashboard assignments.
- Supports `?token=` authentication for HTTP requests.
- Tracks WebSocket and HTTP device activity, connections, IP addresses, and last-seen times.
- Adds device-scoped `applicationData` with access control.
- Adds plugin APIs for device metadata, state-change events, and route permissions.
- Adds dashboard redirect and metadata modes with device details in `loginStatus`.
- Adds an admin Devices page with device creation, token URLs, connection details, and live status updates.
- Adds `DeviceTracker` APIs with defensive state snapshots and plugin data storage.
- Adds integration coverage for authentication, device CRUD, token regeneration, dashboards, application data, plugin permissions, and connection tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->