### PR TITLE
fix(streams): set provider error status on tcp disconnect

### DIFF
--- a/packages/streams/src/tcp.ts
+++ b/packages/streams/src/tcp.ts
@@ -109,7 +109,9 @@ export default class TcpStream extends Transform {
       })
       .on('disconnect', () => {
         this.tcpStream = undefined
-        this.debug(`Disconnected ${this.options.host} ${this.options.port}`)
+        const msg = `Disconnected ${this.options.host} ${this.options.port}`
+        this.options.app.setProviderError(this.options.providerId, msg)
+        this.debug(msg)
       })
       .on('error', (err: Error & { errors?: string[] }) => {
         let msg: string


### PR DESCRIPTION
## Summary

Set `setProviderError()` on TCP stream disconnect so the dashboard reflects the actual connection state. Previously, the last status remained "Connected to ..." during outages until the next successful reconnect, leaving users with stale/misleading status.

## Context

Spotted while working on #2503 (GPSD stream rewrite), where the same gap was fixed for the new GPSD implementation. This applies the identical fix to the TCP stream provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TCP disconnect events now properly report connection errors to the application, improving visibility into connection state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->