### PR TITLE
fix(subscriptions): coerce period and minPeriod to number

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -221,11 +221,16 @@ function handleSubscribeRow(
             `minPeriod assumes policy 'instant', ignoring policy ${subscribeRow.policy}`
           )
         }
+        const minPeriodValue = Number(subscribeRow.minPeriod)
         debug('minPeriod:' + subscribeRow.minPeriod)
-        if (key !== '') {
+        if (isNaN(minPeriodValue)) {
+          errorCallback(
+            `invalid minPeriod value '${subscribeRow.minPeriod}', ignoring`
+          )
+        } else if (key !== '') {
           // we can not apply minPeriod for empty path subscriptions
           debug('debouncing')
-          filteredBus = filteredBus.debounceImmediate(subscribeRow.minPeriod)
+          filteredBus = filteredBus.debounceImmediate(minPeriodValue)
         }
       } else if (
         subscribeRow.period ||
@@ -237,7 +242,7 @@ function handleSubscribeRow(
           )
         } else if (key !== '') {
           // we can not apply period for empty path subscriptions
-          const interval = subscribeRow.period || 1000
+          const interval = Number(subscribeRow.period) || 1000
           filteredBus = filteredBus
             .bufferWithTime(interval)
             .flatMapLatest((bufferedValues: any) => {

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -600,6 +600,123 @@ describe('Subscriptions', (_) => {
       })
   })
 
+  it('JSON subscription with string period works', async function () {
+    await serverP
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+
+    const self = JSON.parse(await wsPromiser.nthMessage(1)).self
+
+    await wsPromiser.send({
+      context: 'vessels.*',
+      subscribe: [
+        {
+          path: 'navigation.logTrip',
+          policy: 'fixed',
+          period: '500'
+        }
+      ]
+    })
+
+    await sendDelta(getDelta({ context: self }), deltaUrl)
+    await new Promise((resolve) => setTimeout(resolve, 600))
+
+    const messages = wsPromiser.parsedMessages().slice(1)
+    const logTripMessages = messages.filter(
+      (d) =>
+        d.updates &&
+        d.updates.some(
+          (u) =>
+            u.values && u.values.some((v) => v.path === 'navigation.logTrip')
+        )
+    )
+    assert(
+      logTripMessages.length > 0,
+      'Should receive logTrip delta with string period'
+    )
+  })
+
+  it('JSON subscription with string minPeriod works', async function () {
+    await serverP
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+
+    const self = JSON.parse(await wsPromiser.nthMessage(1)).self
+
+    await wsPromiser.send({
+      context: 'vessels.*',
+      subscribe: [
+        {
+          path: 'navigation.courseOverGroundTrue',
+          minPeriod: '200'
+        }
+      ]
+    })
+
+    await sendDelta(getDelta({ context: self }), deltaUrl)
+    await sendDelta(getDelta({ context: self }), deltaUrl)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    const messages = wsPromiser.parsedMessages().slice(1)
+    const cogMessages = messages.filter(
+      (d) =>
+        d.updates &&
+        d.updates.some(
+          (u) =>
+            u.values &&
+            u.values.some((v) => v.path === 'navigation.courseOverGroundTrue')
+        )
+    )
+    assert(
+      cogMessages.length > 0,
+      'Should receive COG delta with string minPeriod'
+    )
+  })
+
+  it('JSON subscription with invalid minPeriod warns and delivers deltas', function () {
+    let self, wsPromiser
+
+    return serverP
+      .then((_) => {
+        wsPromiser = new WsPromiser(
+          'ws://localhost:' +
+            port +
+            '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+        )
+        return wsPromiser.nextMsg()
+      })
+      .then((wsHello) => {
+        self = JSON.parse(wsHello).self
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getDelta({ context: self }), deltaUrl)
+        ])
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          wsPromiser.send({
+            context: '*',
+            subscribe: [
+              {
+                path: 'navigation.courseOverGroundTrue',
+                minPeriod: 'abc'
+              }
+            ]
+          })
+        ])
+      })
+      .then(([response]) => {
+        assert.equal(response, '"invalid minPeriod value \'abc\', ignoring"')
+      })
+  })
+
   it('announceNewPaths sends existing paths once and announces new paths', async function () {
     await serverP
     const wsPromiser = new WsPromiser(


### PR DESCRIPTION
## Summary

Fixes the `TypeError: delay is not a function` crash reported in #2521.

BaconJS 3.x's internal `toDelayFunction` only recognizes `number` and `function` types. When `period` arrives as a string (e.g. from a WebSocket subscription message or plugin `subscribe()` call), it falls through to `return delay` — returning the raw string. This passes the `delayFunc !== undefined` guard in `flushOrSchedule` but crashes when `Buffer.schedule` tries to invoke it as a function.

The fix coerces both `period` and `minPeriod` with `Number()` at the point of use in `subscriptionmanager.ts`, since these values come from untrusted external input.

Fixes: #2521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription period handling so numeric interval values are interpreted correctly for both regular and minimum update intervals.

* **Tests**
  * Added tests verifying subscriptions accept period and minPeriod values when provided as strings and still deliver timely updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->