### PR TITLE
refactor(interfaces): migrate nmea-tcp to TypeScript

### DIFF
--- a/src/interfaces/nmea-tcp.ts
+++ b/src/interfaces/nmea-tcp.ts
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-const _ = require('lodash')
-
+import { createServer, Server, Socket } from 'net'
 import { createDebug } from '../debug'
+import { Interface, SignalKServer } from '../types'
+
 const debug = createDebug('signalk-server:interfaces:tcp:nmea0183')
 
 const BUFFER_LIMIT = process.env.BACKPRESSURE_ENTER
@@ -28,41 +29,50 @@ const MAX_BUFFER_TIME = process.env.MAXSENDBUFFERCHECKTIME
   ? parseInt(process.env.MAXSENDBUFFERCHECKTIME, 10)
   : 30 * 1000
 
-module.exports = function (app) {
-  'use strict'
-  const net = require('net')
-  const openSockets = {}
-  const bufferExceededSince = {}
-  let idSequence = 0
-  let server = null
-  const port = Number(process.env.NMEA0183PORT) || 10110
-  const api = {}
+interface SocketWithId extends Socket {
+  id?: number
+  name?: string
+}
 
-  api.start = function () {
+interface NmeaTcpApp extends SignalKServer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  emit(event: string, ...args: any[]): boolean
+  on(event: string, listener: (...args: string[]) => void): this
+}
+
+module.exports = (app: NmeaTcpApp) => {
+  'use strict'
+  const openSockets: Record<number, SocketWithId> = {}
+  const bufferExceededSince: Record<number, number | undefined> = {}
+  let idSequence = 0
+  let server: Server | null = null
+  const port = Number(process.env.NMEA0183PORT) || 10110
+  const api = new Interface()
+
+  api.start = () => {
     debug('Starting tcp interface')
 
-    server = net.createServer(function (socket) {
+    server = createServer((socket: SocketWithId) => {
       socket.id = idSequence++
       socket.name = socket.remoteAddress + ':' + socket.remotePort
       debug('Connected:' + socket.id + ' ' + socket.name)
       openSockets[socket.id] = socket
-      socket.on('data', (data) => {
+      socket.on('data', (data: Buffer) => {
         app.emit('tcpserver0183data', data.toString())
       })
-      socket.on('end', function () {
-        // client disconnects
+      socket.on('end', () => {
         debug('Ended:' + socket.id + ' ' + socket.name)
-        delete openSockets[socket.id]
-        delete bufferExceededSince[socket.id]
+        delete openSockets[socket.id!]
+        delete bufferExceededSince[socket.id!]
       })
-      socket.on('error', function (err) {
+      socket.on('error', (err: Error) => {
         debug('Error:' + err + ' ' + socket.id + ' ' + socket.name)
-        delete openSockets[socket.id]
-        delete bufferExceededSince[socket.id]
+        delete openSockets[socket.id!]
+        delete bufferExceededSince[socket.id!]
       })
     })
-    const send = (data) => {
-      _.values(openSockets).forEach(function (socket) {
+    const send = (data: string) => {
+      Object.values(openSockets).forEach((socket) => {
         try {
           if (socket.writableLength > BUFFER_LIMIT) {
             debug(
@@ -71,27 +81,27 @@ module.exports = function (app) {
               socket.writableLength
             )
             if (MAX_BUFFER > 0 && socket.writableLength > MAX_BUFFER) {
-              if (!bufferExceededSince[socket.id]) {
+              if (!bufferExceededSince[socket.id!]) {
                 console.warn(
                   `NMEA TCP ${socket.name} buffer exceeded max: ${socket.writableLength}`
                 )
-                bufferExceededSince[socket.id] = Date.now()
+                bufferExceededSince[socket.id!] = Date.now()
               }
               if (
-                Date.now() - bufferExceededSince[socket.id] >
+                Date.now() - bufferExceededSince[socket.id!]! >
                 MAX_BUFFER_TIME
               ) {
                 console.error(
                   'NMEA TCP buffer overflow, terminating ' + socket.name
                 )
                 socket.destroy()
-                delete openSockets[socket.id]
-                delete bufferExceededSince[socket.id]
+                delete openSockets[socket.id!]
+                delete bufferExceededSince[socket.id!]
               }
             }
             return
           }
-          delete bufferExceededSince[socket.id]
+          delete bufferExceededSince[socket.id!]
           socket.write(data + '\r\n')
         } catch (e) {
           console.error(e + ' ' + socket)
@@ -101,15 +111,15 @@ module.exports = function (app) {
     app.signalk.on('nmea0183', send)
     app.on('nmea0183out', send)
     server.on('listening', () =>
-      debug('NMEA0138 tcp server listening on ' + port)
+      debug('NMEA0183 tcp server listening on ' + port)
     )
-    server.on('error', (e) => {
-      console.error(`NMEA0138 tcp server error: ${e.message}`)
+    server.on('error', (e: Error) => {
+      console.error(`NMEA0183 tcp server error: ${e.message}`)
     })
     server.listen(port)
   }
 
-  api.stop = function () {
+  api.stop = () => {
     if (server) {
       server.close()
       server = null
@@ -119,7 +129,7 @@ module.exports = function (app) {
   api.mdns = {
     name: '_nmea-0183',
     type: 'tcp',
-    port: port
+    port
   }
 
   return api


### PR DESCRIPTION
## Summary

- Migrate `src/interfaces/nmea-tcp.js` → `nmea-tcp.ts`, matching the existing `tcp.ts` pattern
- Replace `require('lodash')` / `require('net')` with ES imports; drop lodash entirely (`_.values` → `Object.values`)
- Add proper types: `SocketWithId` interface, typed socket map, `Server | null`, numeric port parsing
- Use the `Interface` class from `../types` instead of a plain object literal
- Fix pre-existing `NMEA0138` → `NMEA0183` typo in debug messages

## Motivation

This is the last remaining JS interface file alongside several already-migrated TS siblings (`tcp.ts`, `ws.ts`, `mfd_webapp.ts`). Converting it brings the interfaces directory closer to full TypeScript coverage and makes future changes (e.g. backpressure handling from #2472) land directly in typed code.

## Test plan

- `npm run build` passes
- `npm test` — all 55 tests pass
- `npm run format` — no changes needed
- Runtime: the `index.js` dynamic loader scans compiled `.js` output, so no import-site changes are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **Refactor & TypeScript migration**
  * Migrates the NMEA TCP interface to TypeScript (src/interfaces/nmea-tcp.ts) and uses ES module imports (net) instead of CommonJS require.
  * Replaces lodash usage with Object.values for socket iteration.

* **Type safety & API shape**
  * Introduces SocketWithId and NmeaTcpApp types, types openSockets as Record<number, SocketWithId>, and types server as Server | null.
  * Exposes the interface as an instance of Interface (const api = new Interface()) with typed api.start and api.stop methods.

* **Behavioral / runtime changes**
  * Parses the port numerically via Number(process.env.NMEA0183PORT) || 10110.
  * Emits incoming socket data as 'tcpserver0183data' and broadcasts outgoing NMEA0183 strings to connected sockets, app.signalk, and app events.
  * Cleans up sockets on 'end' and 'error' using non-null assertion for socket.id when deleting from the map.

* **Fixes and consistency**
  * Corrects debug messaging to consistently reference NMEA0183.
  * Keeps runtime compatibility: index.js loader uses compiled .js so import sites require no changes.

* **Tests & build**
  * Build, test, and formatting expectations: npm run build passes, npm test (55 tests) pass, npm run format makes no changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->