### PR TITLE
fix(security): reject unauthenticated WebSocket connections

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -19,11 +19,7 @@ import { Socket } from 'net'
 import Primus from 'primus'
 import WebSocket from 'ws'
 import { getSourceId, getMetadata } from '@signalk/signalk-schema'
-import {
-  requestAccess,
-  InvalidTokenError,
-  WithSecurityStrategy
-} from '../security'
+import { requestAccess, WithSecurityStrategy } from '../security'
 import { WithConfig } from '../app'
 import {
   findRequest,
@@ -33,7 +29,6 @@ import {
 } from '../requestResponse'
 import { putPath, deletePath } from '../put'
 import { createDebug } from '../debug'
-import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { startEvents, startServerEvents } from '../events'
 import {
   AccumulatedItem,
@@ -796,15 +791,7 @@ function createPrimusAuthorize(
         req.source = 'ws.' + identifier.replace(/\./g, '_')
       }
     } catch (error) {
-      if (
-        error instanceof InvalidTokenError ||
-        error instanceof JsonWebTokenError ||
-        error instanceof TokenExpiredError
-      ) {
-        authorized(error as Error)
-      } else {
-        authorized()
-      }
+      authorized(error as Error)
     }
   }
 }

--- a/test/security.js
+++ b/test/security.js
@@ -318,44 +318,20 @@ describe('Security', () => {
     result.status.should.equal(401)
   })
 
-  it('websocket with no token returns only hello', async function () {
-    //send some data semisynchronously, so that there is data in the cache that
-    //should not appear
-    const writePromiser = new WsPromiser(
-      `ws://0.0.0.0:${port}/signalk/v1/stream?subsribe=none&metaDeltas=none&token=${writeToken}`
-    )
-    const msg = await writePromiser.nextMsg()
-    JSON.parse(msg)
-    await writePromiser.send(openNavigationDelta)
-
-    const result = new Promise((resolve, reject) => {
+  it('websocket with no token is rejected', async function () {
+    const statusCode = await new Promise((resolve, reject) => {
       const ws = new WebSocket(`ws://0.0.0.0:${port}/signalk/v1/stream`)
-      let msgCount = 0
-      ws.on('message', (msg) => {
-        const msgStr = msg.toString()
-        msgCount++
-        const parsed = JSON.parse(msgStr)
-        if (!parsed.self) {
-          reject(
-            `ws returned non-hello data:${msgStr} with allow_readonly set to false`
-          )
-        }
+      ws.once('unexpected-response', (_req, res) => {
+        resolve(res.statusCode)
+        ws.terminate()
       })
-      ws.on('connect', () => {
-        // send some data now that non-authenticated client is connected
-        writePromiser.send(openNavigationDelta)
+      ws.once('open', () => {
+        ws.terminate()
+        reject(new Error('unauthenticated websocket unexpectedly opened'))
       })
-      setTimeout(() => {
-        if (msgCount > 1) {
-          reject(
-            `ws returned ${msgCount} messages, expected only hello with allow_readonly set to false`
-          )
-        } else {
-          resolve()
-        }
-      }, 100)
+      ws.once('error', reject)
     })
-    return result
+    statusCode.should.equal(401)
   })
 
   it('websocket with mangled token returns 401', async () => {
@@ -887,7 +863,8 @@ describe('WS Access Request IP reporting', () => {
 
   it('without trustProxy setting the ip address reported is not from x-forwarded-for', async function () {
     const securityConfig = {
-      allowDeviceAccessRequests: true
+      allowDeviceAccessRequests: true,
+      allow_readonly: true
     }
     server = await startServerP(port, true, {}, securityConfig)
 
@@ -923,7 +900,8 @@ describe('WS Access Request IP reporting', () => {
 
   it('with trustProxy: true the ip address reported is from x-forwarded-for', async function () {
     const securityConfig = {
-      allowDeviceAccessRequests: true
+      allowDeviceAccessRequests: true,
+      allow_readonly: true
     }
     server = await startServerP(
       port,


### PR DESCRIPTION
### Problem

When security is enabled and `allow_readonly` is false, unauthenticated WebSocket connections to `/signalk/v1/stream` are accepted and receive the hello message, leaking server name, version, and vessel UUID. If `allow_readonly` is later enabled, these connections will receive all delta updates without any authentication.

### Root cause

The Primus authorize handler in `createPrimusAuthorize()` only passed specific JWT error types (`InvalidTokenError`, `JsonWebTokenError`, `TokenExpiredError`) to reject the connection. When `authorizeWS()` throws a generic `Error("Missing access token")` for unauthenticated requests, the catch block silently called `authorized()` without an error, allowing the connection through.

### Fix

Pass all authorization errors to Primus so every failed authorization rejects the connection with 401. This reduces the catch block from 8 lines to 1 and removes now-unused imports.

### Manual testing

- **Before fix:** unauthenticated WebSocket connection succeeded, received hello message with server identity (name, version, vessel UUID)
- **Before fix:** forged JWT tokens (alg:none, invalid signature) were correctly rejected with 401
- **After fix:** unauthenticated WebSocket connection is rejected with 401
- **After fix:** authenticated WebSocket connections continue to work
- **After fix:** `allow_readonly=true` still permits unauthenticated readonly connections as intended



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authorization error handling so all authentication failures follow a single, consistent response path.
  * Ensured unauthenticated WebSocket/stream connection attempts produce proper HTTP 401 responses.

* **Tests**
  * Updated websocket tests to assert unauthenticated connections are rejected via the unexpected-response flow.
  * Test coverage expanded to include readonly access request scenarios in security configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->