### PR TITLE
fix(security): remove per-message token override in WebSocket handler

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -109,7 +109,6 @@ interface Spark {
 }
 
 interface WsMessage {
-  token?: string
   updates?: Delta['updates']
   subscribe?: Array<{ path: string }> | string
   unsubscribe?: Array<{ path: string }>
@@ -510,10 +509,6 @@ function wsInterface(app: WsApp): WsApi {
               debug('<' + JSON.stringify(parsedMsg))
 
               try {
-                if (parsedMsg.token) {
-                  spark.request.token = parsedMsg.token
-                }
-
                 if (parsedMsg.updates) {
                   processUpdates(app, pathSources, spark, parsedMsg)
                 }


### PR DESCRIPTION
Clients could inject a token in any WebSocket message body to override the connection's authentication identity. Remove this non-standard pattern and rely solely on connection-level authentication, matching the approach used by Socket.IO, GraphQL-WS, Phoenix Channels, and recommended by OWASP. The login-over-WS flow is unaffected as it manages its own token via processLoginRequest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR removes a security vulnerability that allows clients to inject tokens in WebSocket message bodies to override the connection's authentication identity. The change enforces connection-level authentication exclusively and aligns the server's behavior with Socket.IO, GraphQL-WS, Phoenix Channels, and OWASP recommendations.

## Changes
**src/interfaces/ws.ts**
- The `WsMessage` interface removes the optional `token` field, eliminating support for per-message token override in upstream WebSocket messages
- The real-time connection message handler no longer checks for `parsedMsg.token` or mutates `spark.request.token` based on incoming message content
- Message type processing continues for `updates`, `subscribe`, `unsubscribe`, `accessRequest`, `login`, `put`, `delete`, and request queries

## Impact
- Clients must rely on connection-level authentication rather than per-message token injection
- The login-over-WS flow remains unaffected and continues to manage authentication tokens via the `processLoginRequest` mechanism
- No changes to public API signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->