### PR TITLE
chore(logging): log full error objects to capture stack traces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ class Server {
           app.config.settings.sourcePriorities
         )
       } catch (e) {
-        console.error(`getToPreferredDelta failed: ${(e as any).message}`)
+        console.error('getToPreferredDelta failed:', e)
       }
     }
     app.activateSourcePriorities()

--- a/src/interfaces/tcp.ts
+++ b/src/interfaces/tcp.ts
@@ -95,7 +95,7 @@ module.exports = (app: SignalKServer) => {
               try {
                 return JSON.parse(s)
               } catch (e: any) {
-                console.log(e.message)
+                console.log(e)
               }
             }
           })
@@ -182,7 +182,7 @@ function socketMessageHandler(
       try {
         app.subscriptionmanager.unsubscribe(msg, unsubscribes)
       } catch (e: any) {
-        console.error(e.message)
+        console.error(e)
         socket.write(JSON.stringify(e.message))
         socket.end(() => {
           console.error(`Closed ${socket.name}`)
@@ -191,3 +191,5 @@ function socketMessageHandler(
     }
   }
 }
+
+module.exports.socketMessageHandler = socketMessageHandler

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1100,7 +1100,7 @@ function processUnsubscribe(
       spark.sentMetaData = {}
     }
   } catch (e) {
-    console.log((e as Error).message)
+    console.log(e)
     spark.write((e as Error).message)
     spark.end()
   }

--- a/test/error-logging.ts
+++ b/test/error-logging.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tcpInterface = require('../dist/interfaces/tcp.js')
+
+describe('Error logging', () => {
+  describe('tcp socketMessageHandler', () => {
+    it('logs the full error (including stack) when subscriptionmanager.unsubscribe throws', () => {
+      const originalError = console.error
+      const logged: unknown[] = []
+      console.error = (...args: unknown[]) => {
+        logged.push(args[0])
+      }
+
+      try {
+        const thrown = new Error('boom')
+        const app = {
+          securityStrategy: { isDummy: () => true },
+          subscriptionmanager: {
+            unsubscribe: () => {
+              throw thrown
+            }
+          }
+        }
+        const socket = {
+          name: 'testsocket',
+          write: () => undefined,
+          end: () => undefined
+        }
+
+        const handler = tcpInterface.socketMessageHandler(app, socket, [])
+        handler({ unsubscribe: [{ path: 'foo' }] })
+
+        // First logged argument must be the Error itself, not a string,
+        // so the stack trace is preserved in the output.
+        expect(logged.length).to.be.greaterThan(0)
+        expect(logged[0]).to.be.instanceOf(Error)
+        expect((logged[0] as Error).stack).to.be.a('string')
+        expect((logged[0] as Error).stack).to.contain('Error: boom')
+      } finally {
+        console.error = originalError
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

I'm seeing errors in the server log like (sometimes also other errors) `Cannot read properties of null (reading 'position')` while users report strange behaviour that eventually can only be resolved by restarting signalk. I want to:

1. Get the log error-free.
2. Check if there is a relation between the logged errors and the reported behaviour.

Today I can't do (2) because several `catch` blocks only log `err.message`, which discards the stack trace — so the errors are untraceable back to where they're thrown (plugin, subscription handler, delta callback, etc.).

## Change

Log the full `Error` object (so the stack is printed) in four catch sites:

- `src/interfaces/ws.ts` — WebSocket unsubscribe handler
- `src/interfaces/tcp.ts` — TCP JSON parse + unsubscribe handlers
- `src/index.ts` — `activateSourcePriorities`

Log level (`console.log` vs `console.error`) is unchanged at each site.

A unit test exercises the TCP unsubscribe catch block and asserts the first argument passed to `console.error` is an `Error` with a populated `stack`, guarding against a regression back to `.message`-only logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates error logging across the Signal K server to capture full error objects instead of only error messages, enabling stack traces and better error tracing.

## Changes

**src/index.ts**
- The `activateSourcePriorities` catch block now logs the full error object alongside a message (`console.error('getToPreferredDelta failed:', e)`) instead of interpolating only the message into a template string.

**src/interfaces/tcp.ts**
- The JSON parse error handler now logs the full error object (`console.log(e)`) instead of only `e.message`.
- The `socketMessageHandler` unsubscribe catch block now logs the full error object (`console.error(e)`) instead of only `e.message`, while still writing the message to the socket and closing the connection.
- `socketMessageHandler` is newly exported via `module.exports.socketMessageHandler`.

**src/interfaces/ws.ts**
- The `processUnsubscribe` catch block now logs the full caught exception (`console.log(e)`) instead of only `(e as Error).message`. The function still writes the message to the response and ends the connection as before.

**test/error-logging.ts**
- A new test validates that `tcpInterface.socketMessageHandler` properly logs error objects with stack traces. The test stubs `console.error`, triggers an error in the unsubscribe handler, and asserts that the logged argument is an Error instance with a populated stack property.

Log levels remain unchanged, and all changes maintain backward compatibility with existing socket behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->