### PR TITLE
fix: parse websocket PUT responses before matching requestId

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -360,7 +360,10 @@ function wsInterface(app: WsApp): WsApi {
               }
             }
 
-            if (isWsRequestReply(parsedMsg) && parsedMsg.requestId === requestId) {
+            if (
+              isWsRequestReply(parsedMsg) &&
+              parsedMsg.requestId === requestId
+            ) {
               const updateOptions: UpdateOptions = {
                 statusCode: normalizeStatusCode(parsedMsg.statusCode),
                 data: parsedMsg.data ?? null,

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -310,12 +310,21 @@ function wsInterface(app: WsApp): WsApi {
             return
           }
 
-          const listener = (msg: WsMessage) => {
-            if (msg.requestId === requestId) {
+          const listener = (msg: unknown) => {
+            let parsedMsg = msg
+            if (typeof parsedMsg === 'string' || Buffer.isBuffer(parsedMsg)) {
+              try {
+                parsedMsg = JSON.parse(String(parsedMsg))
+              } catch (_err) {
+                return
+              }
+            }
+
+            if ((parsedMsg as WsMessage).requestId === requestId) {
               updateRequest(
                 requestId,
-                msg.state as 'PENDING' | 'COMPLETED' | null,
-                msg
+                (parsedMsg as WsMessage).state as 'PENDING' | 'COMPLETED' | null,
+                parsedMsg as WsMessage
               )
                 .then((reply) => {
                   if (reply.state !== 'PENDING') {

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -142,6 +142,25 @@ function isWsRequestReply(msg: unknown): msg is WsRequestReply {
   )
 }
 
+function normalizeStatusCode(statusCode: unknown): number | null {
+  return typeof statusCode === 'number' && Number.isFinite(statusCode)
+    ? statusCode
+    : null
+}
+
+function normalizeMessage(message: unknown): string | null {
+  return typeof message === 'string' ? message : null
+}
+
+function normalizePercentComplete(percentComplete: unknown): number | null {
+  return typeof percentComplete === 'number' &&
+    Number.isFinite(percentComplete) &&
+    percentComplete >= 0 &&
+    percentComplete <= 100
+    ? percentComplete
+    : null
+}
+
 interface PathSources {
   [path: string]: {
     [source: string]: Spark
@@ -343,10 +362,12 @@ function wsInterface(app: WsApp): WsApi {
 
             if (isWsRequestReply(parsedMsg) && parsedMsg.requestId === requestId) {
               const updateOptions: UpdateOptions = {
-                statusCode: parsedMsg.statusCode ?? null,
+                statusCode: normalizeStatusCode(parsedMsg.statusCode),
                 data: parsedMsg.data ?? null,
-                message: parsedMsg.message ?? null,
-                percentComplete: parsedMsg.percentComplete ?? null
+                message: normalizeMessage(parsedMsg.message),
+                percentComplete: normalizePercentComplete(
+                  parsedMsg.percentComplete
+                )
               }
 
               updateRequest(requestId, parsedMsg.state, updateOptions)

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -29,7 +29,9 @@ import {
   findRequest,
   updateRequest,
   queryRequest,
-  Reply
+  Reply,
+  RequestState,
+  UpdateOptions
 } from '../requestResponse'
 import { putPath, deletePath } from '../put'
 import { createDebug } from '../debug'
@@ -119,6 +121,25 @@ interface WsMessage {
   state?: string
   statusCode?: number
   message?: string
+}
+
+interface WsRequestReply extends UpdateOptions {
+  requestId: string
+  state: RequestState | null
+}
+
+function isWsRequestReply(msg: unknown): msg is WsRequestReply {
+  if (!msg || typeof msg !== 'object') {
+    return false
+  }
+
+  const candidate = msg as Record<string, unknown>
+  const state = candidate.state
+
+  return (
+    typeof candidate.requestId === 'string' &&
+    (state === 'PENDING' || state === 'COMPLETED' || state === null)
+  )
 }
 
 interface PathSources {
@@ -320,12 +341,15 @@ function wsInterface(app: WsApp): WsApi {
               }
             }
 
-            if ((parsedMsg as WsMessage).requestId === requestId) {
-              updateRequest(
-                requestId,
-                (parsedMsg as WsMessage).state as 'PENDING' | 'COMPLETED' | null,
-                parsedMsg as WsMessage
-              )
+            if (isWsRequestReply(parsedMsg) && parsedMsg.requestId === requestId) {
+              const updateOptions: UpdateOptions = {
+                statusCode: parsedMsg.statusCode ?? null,
+                data: parsedMsg.data ?? null,
+                message: parsedMsg.message ?? null,
+                percentComplete: parsedMsg.percentComplete ?? null
+              }
+
+              updateRequest(requestId, parsedMsg.state, updateOptions)
                 .then((reply) => {
                   if (reply.state !== 'PENDING') {
                     spark!.removeListener(


### PR DESCRIPTION
## Summary
Parse raw websocket data before matching pending PUT responses by requestId.

## Problem
When a websocket client responds to a PUT request, the temporary listener in  receives raw  frames from Primus. The code was treating that raw payload as an already-parsed object and checking  directly.

For clients like SensESP that reply with JSON text such as:

 ```json
  {"requestId":"...","state":"COMPLETED","statusCode":200}
  ```

that meant the completion response was ignored, the request stayed PENDING, and Signal K timed it out after 60 seconds with a 504.

## Fix
  - accept unknown in the temporary websocket PUT listener
  - if the incoming payload is a string or buffer, JSON.parse(String(msg))
  - only then match requestId and call updateRequest()

## Verification

  Confirmed locally on a live v2.24.0 system with a SensESP device acting as a PUT target:

  - before the patch, every switch PUT timed out exactly 60 seconds later
  - after the patch, the server matched the completion payload and no 504 occurred

The device payload was:
```json
  {"requestId":"...","state":"COMPLETED","statusCode":200}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket message handling to accept varied payload formats and silently ignore malformed messages.
  * Request status, progress, and related details are now validated and normalized before applying, reducing incorrect updates.
  * Listeners are reliably removed once a request is no longer pending, preventing stray or duplicated processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->