### PR TITLE
Fix ReDoS vulnerability in chart tile route regex

### DIFF
--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -23,6 +23,8 @@ import { writeSettingsFile } from '../../config/config'
 
 export const RESOURCES_API_PATH = `/signalk/v2/api/resources`
 
+export const CHART_TILE_REGEX = /\/charts\/[^?]+\/\d+\/\d+\/\d+$/
+
 export const skUuid = () => `${uuidv4()}`
 
 interface DefaultProviders {
@@ -599,7 +601,7 @@ export class ResourcesApi {
       async (req: Request, res: Response, next: NextFunction) => {
         debug(`** GET ${RESOURCES_API_PATH}/:resourceType/:resourceId/*`)
 
-        if (req.path.match(`/charts/(\\w*\\W*)+/[0-9]*/[0-9]*/[0-9]*`)) {
+        if (req.path.match(CHART_TILE_REGEX)) {
           debug('*** CHART TILE request -> next()')
           next()
           return

--- a/test/chart-tile-regex.ts
+++ b/test/chart-tile-regex.ts
@@ -1,0 +1,43 @@
+import chai from 'chai'
+chai.should()
+
+import { CHART_TILE_REGEX } from '../src/api/resources/index'
+
+const MAX_REGEX_MATCH_MS = 50
+
+describe('Chart tile route regex', () => {
+  const tilePaths = [
+    '/signalk/v2/api/resources/charts/my-chart/14/8192/5461',
+    '/signalk/v2/api/resources/charts/chart-with-dashes/0/0/0',
+    '/signalk/v2/api/resources/charts/Provider/ChartName/7/64/42'
+  ]
+
+  tilePaths.forEach((path) => {
+    it(`should match tile request: ${path}`, () => {
+      CHART_TILE_REGEX.test(path).should.equal(true)
+    })
+  })
+
+  const nonTilePaths = [
+    '/signalk/v2/api/resources/charts/my-chart/name',
+    '/signalk/v2/api/resources/charts/my-chart/tilemapUrl',
+    '/signalk/v2/api/resources/charts/Canary-Cape Verde/Navionics/Z7-18'
+  ]
+
+  nonTilePaths.forEach((path) => {
+    it(`should not match non-tile request: ${path}`, () => {
+      CHART_TILE_REGEX.test(path).should.equal(false)
+    })
+  })
+
+  // Typically completes in ~1ms. If this gets flaky, 100ms still catches the
+  // catastrophic backtracking regression which takes seconds or never finishes.
+  it(`should complete in under ${MAX_REGEX_MATCH_MS}ms on paths with multiple segments`, () => {
+    const path =
+      '/signalk/v2/api/resources/charts/Canary-Cape Verde/Navionics/Z7-18'
+    const start = Date.now()
+    CHART_TILE_REGEX.test(path)
+    const elapsed = Date.now() - start
+    elapsed.should.be.below(MAX_REGEX_MATCH_MS)
+  })
+})


### PR DESCRIPTION
## Summary

- Replace regex pattern with nested quantifiers `(\w*\W*)+` that causes catastrophic backtracking on chart IDs containing path separators
- New pattern `/\/charts\/[^?]+\/\d+\/\d+\/\d+$/` matches tile requests without backtracking risk

Fixes #2572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a ReDoS vulnerability in the chart tile route regex and adds tests that validate correctness and guard against catastrophic backtracking.

## Changes

**src/api/resources/index.ts**
- Adds and exports CHART_TILE_REGEX = /\/charts\/[^?]+\/\d+\/\d+\/\d+$/ and uses it in the resources route to detect chart tile requests. The new anchored pattern matches /charts/<id>/<z>/<x>/<y> without nested quantifiers, preventing exponential backtracking; on match the handler logs and calls next() as before.

**test/chart-tile-regex.ts** (new)
- Adds a Mocha/Chai test suite that:
  - Asserts CHART_TILE_REGEX matches representative tile paths.
  - Asserts it does not match non-tile chart-related paths.
  - Includes a performance guard that asserts a match against a multi-segment path completes under MAX_REGEX_MATCH_MS (50ms) to detect ReDoS regressions.

## Issues addressed

- Fixes issue #2572 by replacing the vulnerable nested-quantifier pattern with a safe, non-backtracking regex for chart tile routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->