### PR TITLE
Feat: Add config & data preservation option to plugin removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "express": "^4.21.2",
     "express-rate-limit": "^8.2.1",
     "file-timestamp-stream": "^2.1.2",
+    "get-folder-size": "^5.0.0",
     "geolib": "^3.3.3",
     "helmet": "^8.1.0",
     "jose": "^6.1.0",

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { formatBytes } from './ActionCellRenderer'
+
+describe('formatBytes', () => {
+  it('formats bytes', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(500)).toBe('500 B')
+    expect(formatBytes(1023)).toBe('1023 B')
+  })
+
+  it('formats kilobytes', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(10240)).toBe('10.0 KB')
+  })
+
+  it('formats megabytes', () => {
+    expect(formatBytes(1048576)).toBe('1.0 MB')
+    expect(formatBytes(2621440)).toBe('2.5 MB')
+    expect(formatBytes(10485760)).toBe('10.0 MB')
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
@@ -19,4 +19,9 @@ describe('formatBytes', () => {
     expect(formatBytes(2621440)).toBe('2.5 MB')
     expect(formatBytes(10485760)).toBe('10.0 MB')
   })
+
+  it('formats gigabytes', () => {
+    expect(formatBytes(1073741824)).toBe('1.0 GB')
+    expect(formatBytes(2684354560)).toBe('2.5 GB')
+  })
 })

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -428,7 +428,8 @@ export default function ActionCellRenderer({
                   className="form-check-label"
                   htmlFor={`deleteDataCheck-${app.name}`}
                 >
-                  Also delete plugin configuration and data ({formatBytes(dataSize.totalBytes)})
+                  Also delete plugin configuration and data (
+                  {formatBytes(dataSize.totalBytes)})
                 </label>
               </div>
               {deleteData && (

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -416,7 +416,7 @@ export default function ActionCellRenderer({
             </div>
           ) : dataSize && dataSize.hasData ? (
             <div className="mt-3">
-              <div className="form-check form-switch">
+              <div className="form-check">
                 <input
                   className="form-check-input"
                   type="checkbox"
@@ -428,7 +428,7 @@ export default function ActionCellRenderer({
                   className="form-check-label"
                   htmlFor={`deleteDataCheck-${app.name}`}
                 >
-                  Also delete plugin data ({formatBytes(dataSize.totalBytes)})
+                  Also delete plugin configuration and data ({formatBytes(dataSize.totalBytes)})
                 </label>
               </div>
               {deleteData && (

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -25,7 +25,9 @@ interface PluginDataSize {
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 interface AppData {

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -65,6 +65,7 @@ export default function ActionCellRenderer({
   const [deleteData, setDeleteData] = useState(false)
   const [dataSize, setDataSize] = useState<PluginDataSize | null>(null)
   const [loadingDataSize, setLoadingDataSize] = useState(false)
+  const [removeError, setRemoveError] = useState<string | null>(null)
 
   const handleInstallClick = () => {
     fetch(
@@ -135,6 +136,7 @@ export default function ActionCellRenderer({
 
   const handleRemoveClick = async () => {
     setDeleteData(false)
+    setRemoveError(null)
     setShowRemoveModal(true)
     setLoadingDataSize(true)
     setDataSize(null)
@@ -154,14 +156,30 @@ export default function ActionCellRenderer({
     }
   }
 
-  const handleConfirmRemove = () => {
-    fetch(`${window.serverRoutesPrefix}/appstore/remove/${app.name}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ deleteData })
-    })
-    setShowRemoveModal(false)
+  const handleConfirmRemove = async () => {
+    setRemoveError(null)
+    try {
+      const response = await fetch(
+        `${window.serverRoutesPrefix}/appstore/remove/${app.name}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ deleteData })
+        }
+      )
+      if (!response.ok) {
+        setRemoveError(
+          `Failed to remove ${app.name}: server returned ${response.status}`
+        )
+        return
+      }
+      setShowRemoveModal(false)
+    } catch (error) {
+      setRemoveError(
+        `Failed to remove ${app.name}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
   }
 
   let content: ReactNode
@@ -451,12 +469,21 @@ export default function ActionCellRenderer({
               <small>No plugin data found on disk.</small>
             </p>
           ) : null}
+          {removeError && (
+            <div className="alert alert-danger mt-3 py-2 mb-0" role="alert">
+              <small>{removeError}</small>
+            </div>
+          )}
         </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={() => setShowRemoveModal(false)}>
             Cancel
           </Button>
-          <Button variant="danger" onClick={handleConfirmRemove}>
+          <Button
+            variant="danger"
+            onClick={handleConfirmRemove}
+            disabled={loadingDataSize}
+          >
             <FontAwesomeIcon className="me-2" icon={faTrashCan} />
             Remove
           </Button>

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -12,8 +12,21 @@ import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons/faCloudArrow
 import { faGear } from '@fortawesome/free-solid-svg-icons/faGear'
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons/faArrowUpRightFromSquare'
 import { faLink } from '@fortawesome/free-solid-svg-icons/faLink'
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation'
 import { urlToWebapp } from '../../../Webapps/Webapp'
 import semver from 'semver'
+
+interface PluginDataSize {
+  totalBytes: number
+  fileCount: number
+  hasData: boolean
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
 
 interface AppData {
   name: string
@@ -46,6 +59,10 @@ export default function ActionCellRenderer({
   const [distTags, setDistTags] = useState<Record<string, string>>({})
   const [loadingVersions, setLoadingVersions] = useState(false)
   const [showAllVersions, setShowAllVersions] = useState(false)
+  const [showRemoveModal, setShowRemoveModal] = useState(false)
+  const [deleteData, setDeleteData] = useState(false)
+  const [dataSize, setDataSize] = useState<PluginDataSize | null>(null)
+  const [loadingDataSize, setLoadingDataSize] = useState(false)
 
   const handleInstallClick = () => {
     fetch(
@@ -114,13 +131,35 @@ export default function ActionCellRenderer({
     }
   }
 
-  const handleRemoveClick = () => {
-    if (confirm(`Are you sure you want to uninstall ${app.name}?`)) {
-      fetch(`${window.serverRoutesPrefix}/appstore/remove/${app.name}`, {
-        method: 'POST',
-        credentials: 'include'
-      })
+  const handleRemoveClick = async () => {
+    setDeleteData(false)
+    setShowRemoveModal(true)
+    setLoadingDataSize(true)
+    setDataSize(null)
+
+    try {
+      const response = await fetch(
+        `${window.serverRoutesPrefix}/appstore/datasize/${app.name}`,
+        { credentials: 'include' }
+      )
+      if (response.ok) {
+        setDataSize(await response.json())
+      }
+    } catch (error) {
+      console.error('Failed to fetch data size:', error)
+    } finally {
+      setLoadingDataSize(false)
     }
+  }
+
+  const handleConfirmRemove = () => {
+    fetch(`${window.serverRoutesPrefix}/appstore/remove/${app.name}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ deleteData })
+    })
+    setShowRemoveModal(false)
   }
 
   let content: ReactNode
@@ -353,6 +392,72 @@ export default function ActionCellRenderer({
             </p>
           )}
         </Modal.Body>
+      </Modal>
+      {/* Remove Confirmation Modal */}
+      <Modal show={showRemoveModal} onHide={() => setShowRemoveModal(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Remove {app.name}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            Are you sure you want to remove <strong>{app.name}</strong>?
+          </p>
+          {loadingDataSize ? (
+            <div className="text-center">
+              <div
+                className="spinner-border spinner-border-sm text-primary"
+                role="status"
+              >
+                <span className="visually-hidden">Loading...</span>
+              </div>
+              <span className="ms-2">Checking plugin data...</span>
+            </div>
+          ) : dataSize && dataSize.hasData ? (
+            <div className="mt-3">
+              <div className="form-check form-switch">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id={`deleteDataCheck-${app.name}`}
+                  checked={deleteData}
+                  onChange={(e) => setDeleteData(e.target.checked)}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor={`deleteDataCheck-${app.name}`}
+                >
+                  Also delete plugin data ({formatBytes(dataSize.totalBytes)})
+                </label>
+              </div>
+              {deleteData && (
+                <div className="alert alert-danger mt-2 py-2" role="alert">
+                  <FontAwesomeIcon
+                    icon={faTriangleExclamation}
+                    className="me-2"
+                  />
+                  <small>
+                    Plugin configuration and data files ({dataSize.fileCount}{' '}
+                    {dataSize.fileCount === 1 ? 'file' : 'files'}) will be
+                    permanently deleted.
+                  </small>
+                </div>
+              )}
+            </div>
+          ) : dataSize && !dataSize.hasData ? (
+            <p className="text-muted mb-0">
+              <small>No plugin data found on disk.</small>
+            </p>
+          ) : null}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowRemoveModal(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleConfirmRemove}>
+            <FontAwesomeIcon className="me-2" icon={faTrashCan} />
+            Remove
+          </Button>
+        </Modal.Footer>
       </Modal>
     </div>
   )

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -413,7 +413,6 @@ export default function ActionCellRenderer({
           )}
         </Modal.Body>
       </Modal>
-      {/* Remove Confirmation Modal */}
       <Modal show={showRemoveModal} onHide={() => setShowRemoveModal(false)}>
         <Modal.Header closeButton>
           <Modal.Title>Remove {app.name}</Modal.Title>

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -19,7 +19,7 @@ const debug = createDebug('signalk-server:interfaces:appstore')
 const _ = require('lodash')
 const semver = require('semver')
 const { gt } = semver
-const { installModule, removeModule } = require('../modules')
+const { installModule, removeModule, getPluginDataSize } = require('../modules')
 const {
   isTheServerModule,
   findModulesWithKeyword,
@@ -109,11 +109,16 @@ module.exports = function (app) {
                 res.status(404)
                 res.json('No such webapp or plugin available:' + name)
               } else {
+                const deleteData = req.body && req.body.deleteData === true
                 if (moduleInstalling) {
-                  moduleInstallQueue.push({ name: name, isRemove: true })
+                  moduleInstallQueue.push({
+                    name: name,
+                    isRemove: true,
+                    deleteData: deleteData
+                  })
                   sendAppStoreChangedEvent()
                 } else {
-                  removeSKModule(name)
+                  removeSKModule(name, deleteData)
                 }
                 res.json(`Removing ${name}...`)
               }
@@ -124,6 +129,32 @@ module.exports = function (app) {
               res.status(500)
               res.json(error.message)
             })
+        }
+      )
+
+      app.get(
+        [
+          `${SERVERROUTESPREFIX}/appstore/datasize/:name`,
+          `${SERVERROUTESPREFIX}/appstore/datasize/:org/:name`
+        ],
+        (req, res) => {
+          let name = req.params.name
+          if (req.params.org) {
+            name = req.params.org + '/' + name
+          }
+          const plugin = getPlugin(name)
+          const pluginId = plugin ? plugin.id : undefined
+          if (!pluginId) {
+            res.json({ totalBytes: 0, fileCount: 0, hasData: false })
+            return
+          }
+          try {
+            const dataSize = getPluginDataSize(app.config.configPath, pluginId)
+            res.json(dataSize)
+          } catch (error) {
+            console.error('Failed to get plugin data size:', error)
+            res.json({ totalBytes: 0, fileCount: 0, hasData: false })
+          }
         }
       )
 
@@ -404,13 +435,13 @@ module.exports = function (app) {
     updateSKModule(module, version, false)
   }
 
-  function removeSKModule(module) {
+  function removeSKModule(module, deleteData) {
     const plugin = getPlugin(module)
     const pluginId = plugin ? plugin.id : undefined
-    updateSKModule(module, null, true, pluginId)
+    updateSKModule(module, null, true, pluginId, deleteData)
   }
 
-  function updateSKModule(module, version, isRemove, pluginId) {
+  function updateSKModule(module, version, isRemove, pluginId, deleteData) {
     moduleInstalling = {
       name: module,
       output: [],
@@ -442,7 +473,7 @@ module.exports = function (app) {
       if (moduleInstallQueue.length) {
         const next = moduleInstallQueue.splice(0, 1)[0]
         if (next.isRemove) {
-          removeSKModule(next.name)
+          removeSKModule(next.name, next.deleteData)
         } else {
           installSKModule(next.name, next.version)
         }
@@ -459,7 +490,8 @@ module.exports = function (app) {
         onData,
         onErr,
         onClose,
-        pluginId
+        pluginId,
+        deleteData
       )
     } else {
       installModule(app.config, module, version, onData, onErr, onClose)

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -137,7 +137,7 @@ module.exports = function (app) {
           `${SERVERROUTESPREFIX}/appstore/datasize/:name`,
           `${SERVERROUTESPREFIX}/appstore/datasize/:org/:name`
         ],
-        (req, res) => {
+        async (req, res) => {
           let name = req.params.name
           if (req.params.org) {
             name = req.params.org + '/' + name
@@ -149,7 +149,10 @@ module.exports = function (app) {
             return
           }
           try {
-            const dataSize = getPluginDataSize(app.config.configPath, pluginId)
+            const dataSize = await getPluginDataSize(
+              app.config.configPath,
+              pluginId
+            )
             res.json(dataSize)
           } catch (error) {
             console.error('Failed to get plugin data size:', error)

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -176,10 +176,11 @@ function removeModule(
   onData: () => any,
   onErr: (err: Error) => any,
   onClose: (code: number) => any,
-  pluginId?: string
+  pluginId?: string,
+  deleteData: boolean = false
 ) {
   runNpm(config, name, null, 'remove', onData, onErr, (code: number) => {
-    cleanupAfterRemove(config.configPath, name, pluginId)
+    cleanupAfterRemove(config.configPath, name, pluginId, deleteData)
     onClose(code)
   })
 }
@@ -187,7 +188,8 @@ function removeModule(
 function cleanupAfterRemove(
   configPath: string,
   packageName: string,
-  pluginId?: string
+  pluginId?: string,
+  deleteData: boolean = false
 ) {
   const moduleDir = path.join(configPath, 'node_modules', packageName)
   if (fs.existsSync(moduleDir)) {
@@ -225,7 +227,7 @@ function cleanupAfterRemove(
     }
   }
 
-  if (pluginId) {
+  if (pluginId && deleteData) {
     const configFile = pluginConfigPath(configPath, pluginId)
     if (fs.existsSync(configFile)) {
       try {
@@ -243,6 +245,63 @@ function cleanupAfterRemove(
       }
     }
   }
+}
+
+function getDirectorySize(dir: string): {
+  totalBytes: number
+  fileCount: number
+} {
+  let totalBytes = 0
+  let fileCount = 0
+
+  function walk(d: string): void {
+    if (!fs.existsSync(d)) return
+    for (const entry of fs.readdirSync(d)) {
+      try {
+        const entryPath = path.join(d, entry)
+        const stats = fs.statSync(entryPath)
+        if (stats.isFile()) {
+          totalBytes += stats.size
+          fileCount++
+        } else if (stats.isDirectory()) {
+          walk(entryPath)
+        }
+      } catch {
+        // entry may have been removed between readdir and stat
+      }
+    }
+  }
+
+  walk(dir)
+  return { totalBytes, fileCount }
+}
+
+function getPluginDataSize(
+  configPath: string,
+  pluginId: string
+): { totalBytes: number; fileCount: number; hasData: boolean } {
+  let totalBytes = 0
+  let fileCount = 0
+
+  const configFile = pluginConfigPath(configPath, pluginId)
+  if (fs.existsSync(configFile)) {
+    try {
+      const stats = fs.statSync(configFile)
+      totalBytes += stats.size
+      fileCount++
+    } catch {
+      // ignore
+    }
+  }
+
+  const dataDir = pluginDataDir(configPath, pluginId)
+  if (fs.existsSync(dataDir)) {
+    const dirSize = getDirectorySize(dataDir)
+    totalBytes += dirSize.totalBytes
+    fileCount += dirSize.fileCount
+  }
+
+  return { totalBytes, fileCount, hasData: totalBytes > 0 }
 }
 
 export function restoreModules(
@@ -538,5 +597,7 @@ module.exports = {
   getKeywords,
   restoreModules,
   importOrRequire,
-  runNpm
+  runNpm,
+  cleanupAfterRemove,
+  getPluginDataSize
 }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -247,58 +247,68 @@ function cleanupAfterRemove(
   }
 }
 
-function getDirectorySize(dir: string): {
+async function getDirectorySize(dir: string): Promise<{
   totalBytes: number
   fileCount: number
-} {
+}> {
   let totalBytes = 0
   let fileCount = 0
 
-  function walk(d: string): void {
-    if (!fs.existsSync(d)) return
-    for (const entry of fs.readdirSync(d)) {
+  async function walk(d: string): Promise<void> {
+    let entries
+    try {
+      entries = await fs.promises.readdir(d)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
       try {
         const entryPath = path.join(d, entry)
-        const stats = fs.statSync(entryPath)
+        const stats = await fs.promises.lstat(entryPath)
         if (stats.isFile()) {
           totalBytes += stats.size
           fileCount++
-        } else if (stats.isDirectory()) {
-          walk(entryPath)
+        } else if (stats.isDirectory() && !stats.isSymbolicLink()) {
+          await walk(entryPath)
         }
       } catch {
-        // entry may have been removed between readdir and stat
+        // entry may have been removed between readdir and lstat
       }
     }
   }
 
-  walk(dir)
+  await walk(dir)
   return { totalBytes, fileCount }
 }
 
-function getPluginDataSize(
+async function getPluginDataSize(
   configPath: string,
   pluginId: string
-): { totalBytes: number; fileCount: number; hasData: boolean } {
+): Promise<{ totalBytes: number; fileCount: number; hasData: boolean }> {
   let totalBytes = 0
   let fileCount = 0
 
   const configFile = pluginConfigPath(configPath, pluginId)
-  if (fs.existsSync(configFile)) {
-    try {
-      const stats = fs.statSync(configFile)
+  try {
+    const stats = await fs.promises.lstat(configFile)
+    if (stats.isFile()) {
       totalBytes += stats.size
       fileCount++
-    } catch {
-      // ignore
     }
+  } catch {
+    // file does not exist or inaccessible
   }
 
   const dataDir = pluginDataDir(configPath, pluginId)
-  if (fs.existsSync(dataDir)) {
-    const dirSize = getDirectorySize(dataDir)
-    totalBytes += dirSize.totalBytes
-    fileCount += dirSize.fileCount
+  try {
+    const dirStats = await fs.promises.lstat(dataDir)
+    if (dirStats.isDirectory() && !dirStats.isSymbolicLink()) {
+      const dirSize = await getDirectorySize(dataDir)
+      totalBytes += dirSize.totalBytes
+      fileCount += dirSize.fileCount
+    }
+  } catch {
+    // directory does not exist or inaccessible
   }
 
   return { totalBytes, fileCount, hasData: totalBytes > 0 }
@@ -598,6 +608,5 @@ module.exports = {
   restoreModules,
   importOrRequire,
   runNpm,
-  cleanupAfterRemove,
   getPluginDataSize
 }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -247,40 +247,6 @@ function cleanupAfterRemove(
   }
 }
 
-async function getDirectorySize(dir: string): Promise<{
-  totalBytes: number
-  fileCount: number
-}> {
-  let totalBytes = 0
-  let fileCount = 0
-
-  async function walk(d: string): Promise<void> {
-    let entries
-    try {
-      entries = await fs.promises.readdir(d)
-    } catch {
-      return
-    }
-    for (const entry of entries) {
-      try {
-        const entryPath = path.join(d, entry)
-        const stats = await fs.promises.lstat(entryPath)
-        if (stats.isFile()) {
-          totalBytes += stats.size
-          fileCount++
-        } else if (stats.isDirectory()) {
-          await walk(entryPath)
-        }
-      } catch {
-        // entry may have been removed between readdir and lstat
-      }
-    }
-  }
-
-  await walk(dir)
-  return { totalBytes, fileCount }
-}
-
 async function getPluginDataSize(
   configPath: string,
   pluginId: string
@@ -303,9 +269,33 @@ async function getPluginDataSize(
   try {
     const dirStats = await fs.promises.lstat(dataDir)
     if (dirStats.isDirectory()) {
-      const dirSize = await getDirectorySize(dataDir)
-      totalBytes += dirSize.totalBytes
-      fileCount += dirSize.fileCount
+      const { default: getFolderSize } = await import('get-folder-size')
+      totalBytes += await getFolderSize.loose(dataDir)
+
+      async function countFiles(d: string): Promise<number> {
+        let entries: string[]
+        try {
+          entries = await fs.promises.readdir(d)
+        } catch {
+          return 0
+        }
+        let count = 0
+        for (const entry of entries) {
+          try {
+            const stats = await fs.promises.lstat(path.join(d, entry))
+            if (stats.isFile()) {
+              count++
+            } else if (stats.isDirectory()) {
+              count += await countFiles(path.join(d, entry))
+            }
+          } catch {
+            // entry removed or inaccessible between readdir and lstat
+          }
+        }
+        return count
+      }
+
+      fileCount += await countFiles(dataDir)
     }
   } catch {
     // directory does not exist or inaccessible

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -268,7 +268,7 @@ async function getDirectorySize(dir: string): Promise<{
         if (stats.isFile()) {
           totalBytes += stats.size
           fileCount++
-        } else if (stats.isDirectory() && !stats.isSymbolicLink()) {
+        } else if (stats.isDirectory()) {
           await walk(entryPath)
         }
       } catch {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -302,7 +302,7 @@ async function getPluginDataSize(
   const dataDir = pluginDataDir(configPath, pluginId)
   try {
     const dirStats = await fs.promises.lstat(dataDir)
-    if (dirStats.isDirectory() && !dirStats.isSymbolicLink()) {
+    if (dirStats.isDirectory()) {
       const dirSize = await getDirectorySize(dataDir)
       totalBytes += dirSize.totalBytes
       fileCount += dirSize.fileCount

--- a/test/modules.js
+++ b/test/modules.js
@@ -8,7 +8,6 @@ const {
   getLatestServerVersion,
   importOrRequire,
   runNpm,
-  cleanupAfterRemove,
   getPluginDataSize
 } = require('../dist/modules')
 
@@ -312,95 +311,6 @@ describe('runNpm version validation', () => {
   })
 })
 
-describe('cleanupAfterRemove', () => {
-  let tempDir
-
-  beforeEach(() => {
-    tempDir = path.join(
-      require('os').tmpdir(),
-      '_skservertest_cleanup' + Date.now()
-    )
-    fs.mkdirSync(tempDir, { recursive: true })
-  })
-
-  afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true })
-  })
-
-  function setupPluginData(pluginId) {
-    const configDataDir = path.join(tempDir, 'plugin-config-data')
-    fs.mkdirSync(configDataDir, { recursive: true })
-
-    const configFile = path.join(configDataDir, pluginId + '.json')
-    fs.writeFileSync(configFile, JSON.stringify({ enabled: true }))
-
-    const dataDir = path.join(configDataDir, pluginId)
-    fs.mkdirSync(dataDir, { recursive: true })
-    fs.writeFileSync(path.join(dataDir, 'data.txt'), 'test data content')
-
-    return { configFile, dataDir }
-  }
-
-  function setupPackageJson(packageName) {
-    const packageJson = {
-      dependencies: { [packageName]: '1.0.0' }
-    }
-    const packageJsonPath = path.join(tempDir, 'package.json')
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
-    return packageJsonPath
-  }
-
-  it('removes plugin config and data when deleteData is true', () => {
-    const { configFile, dataDir } = setupPluginData('test-plugin')
-    setupPackageJson('test-package')
-
-    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', true)
-
-    chai.expect(fs.existsSync(configFile)).to.equal(false)
-    chai.expect(fs.existsSync(dataDir)).to.equal(false)
-  })
-
-  it('preserves plugin config and data when deleteData is false', () => {
-    const { configFile, dataDir } = setupPluginData('test-plugin')
-    setupPackageJson('test-package')
-
-    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', false)
-
-    chai.expect(fs.existsSync(configFile)).to.equal(true)
-    chai.expect(fs.existsSync(dataDir)).to.equal(true)
-  })
-
-  it('preserves plugin config and data when deleteData is not provided', () => {
-    const { configFile, dataDir } = setupPluginData('test-plugin')
-    setupPackageJson('test-package')
-
-    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin')
-
-    chai.expect(fs.existsSync(configFile)).to.equal(true)
-    chai.expect(fs.existsSync(dataDir)).to.equal(true)
-  })
-
-  it('always removes node_modules directory and package.json entry', () => {
-    const { configFile, dataDir } = setupPluginData('test-plugin')
-    const packageJsonPath = setupPackageJson('test-package')
-
-    const nodeModulesDir = path.join(tempDir, 'node_modules', 'test-package')
-    fs.mkdirSync(nodeModulesDir, { recursive: true })
-    fs.writeFileSync(
-      path.join(nodeModulesDir, 'index.js'),
-      'module.exports = {}'
-    )
-
-    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', false)
-
-    chai.expect(fs.existsSync(nodeModulesDir)).to.equal(false)
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-    chai.expect(packageJson.dependencies).to.not.have.property('test-package')
-    chai.expect(fs.existsSync(configFile)).to.equal(true)
-    chai.expect(fs.existsSync(dataDir)).to.equal(true)
-  })
-})
-
 describe('getPluginDataSize', () => {
   let tempDir
 
@@ -416,7 +326,7 @@ describe('getPluginDataSize', () => {
     fs.rmSync(tempDir, { recursive: true, force: true })
   })
 
-  it('returns correct size for plugin with config and data files', () => {
+  it('returns correct size for plugin with config and data files', async () => {
     const configDataDir = path.join(tempDir, 'plugin-config-data')
     fs.mkdirSync(configDataDir, { recursive: true })
 
@@ -431,22 +341,22 @@ describe('getPluginDataSize', () => {
     fs.writeFileSync(path.join(dataDir, 'data1.txt'), 'hello')
     fs.writeFileSync(path.join(dataDir, 'data2.txt'), 'world')
 
-    const result = getPluginDataSize(tempDir, 'test-plugin')
+    const result = await getPluginDataSize(tempDir, 'test-plugin')
 
     chai.expect(result.hasData).to.equal(true)
     chai.expect(result.fileCount).to.equal(3) // config + 2 data files
     chai.expect(result.totalBytes).to.be.greaterThan(0)
   })
 
-  it('returns zero and hasData false for plugin with no data', () => {
-    const result = getPluginDataSize(tempDir, 'nonexistent-plugin')
+  it('returns zero and hasData false for plugin with no data', async () => {
+    const result = await getPluginDataSize(tempDir, 'nonexistent-plugin')
 
     chai.expect(result.hasData).to.equal(false)
     chai.expect(result.fileCount).to.equal(0)
     chai.expect(result.totalBytes).to.equal(0)
   })
 
-  it('handles config file only without data directory', () => {
+  it('handles config file only without data directory', async () => {
     const configDataDir = path.join(tempDir, 'plugin-config-data')
     fs.mkdirSync(configDataDir, { recursive: true })
 
@@ -456,7 +366,7 @@ describe('getPluginDataSize', () => {
       configContent
     )
 
-    const result = getPluginDataSize(tempDir, 'test-plugin')
+    const result = await getPluginDataSize(tempDir, 'test-plugin')
 
     chai.expect(result.hasData).to.equal(true)
     chai.expect(result.fileCount).to.equal(1)

--- a/test/modules.js
+++ b/test/modules.js
@@ -7,7 +7,9 @@ const {
   checkForNewServerVersion,
   getLatestServerVersion,
   importOrRequire,
-  runNpm
+  runNpm,
+  cleanupAfterRemove,
+  getPluginDataSize
 } = require('../dist/modules')
 
 describe('modulesWithKeyword', () => {
@@ -307,5 +309,157 @@ describe('runNpm version validation', () => {
 
   it('should reject plain git URL', () => {
     return testVersion('git+https://attacker.com/malicious-plugin.git', false)
+  })
+})
+
+describe('cleanupAfterRemove', () => {
+  let tempDir
+
+  beforeEach(() => {
+    tempDir = path.join(
+      require('os').tmpdir(),
+      '_skservertest_cleanup' + Date.now()
+    )
+    fs.mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function setupPluginData(pluginId) {
+    const configDataDir = path.join(tempDir, 'plugin-config-data')
+    fs.mkdirSync(configDataDir, { recursive: true })
+
+    const configFile = path.join(configDataDir, pluginId + '.json')
+    fs.writeFileSync(configFile, JSON.stringify({ enabled: true }))
+
+    const dataDir = path.join(configDataDir, pluginId)
+    fs.mkdirSync(dataDir, { recursive: true })
+    fs.writeFileSync(path.join(dataDir, 'data.txt'), 'test data content')
+
+    return { configFile, dataDir }
+  }
+
+  function setupPackageJson(packageName) {
+    const packageJson = {
+      dependencies: { [packageName]: '1.0.0' }
+    }
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+    return packageJsonPath
+  }
+
+  it('removes plugin config and data when deleteData is true', () => {
+    const { configFile, dataDir } = setupPluginData('test-plugin')
+    setupPackageJson('test-package')
+
+    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', true)
+
+    chai.expect(fs.existsSync(configFile)).to.equal(false)
+    chai.expect(fs.existsSync(dataDir)).to.equal(false)
+  })
+
+  it('preserves plugin config and data when deleteData is false', () => {
+    const { configFile, dataDir } = setupPluginData('test-plugin')
+    setupPackageJson('test-package')
+
+    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', false)
+
+    chai.expect(fs.existsSync(configFile)).to.equal(true)
+    chai.expect(fs.existsSync(dataDir)).to.equal(true)
+  })
+
+  it('preserves plugin config and data when deleteData is not provided', () => {
+    const { configFile, dataDir } = setupPluginData('test-plugin')
+    setupPackageJson('test-package')
+
+    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin')
+
+    chai.expect(fs.existsSync(configFile)).to.equal(true)
+    chai.expect(fs.existsSync(dataDir)).to.equal(true)
+  })
+
+  it('always removes node_modules directory and package.json entry', () => {
+    const { configFile, dataDir } = setupPluginData('test-plugin')
+    const packageJsonPath = setupPackageJson('test-package')
+
+    const nodeModulesDir = path.join(tempDir, 'node_modules', 'test-package')
+    fs.mkdirSync(nodeModulesDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(nodeModulesDir, 'index.js'),
+      'module.exports = {}'
+    )
+
+    cleanupAfterRemove(tempDir, 'test-package', 'test-plugin', false)
+
+    chai.expect(fs.existsSync(nodeModulesDir)).to.equal(false)
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    chai.expect(packageJson.dependencies).to.not.have.property('test-package')
+    chai.expect(fs.existsSync(configFile)).to.equal(true)
+    chai.expect(fs.existsSync(dataDir)).to.equal(true)
+  })
+})
+
+describe('getPluginDataSize', () => {
+  let tempDir
+
+  beforeEach(() => {
+    tempDir = path.join(
+      require('os').tmpdir(),
+      '_skservertest_datasize' + Date.now()
+    )
+    fs.mkdirSync(tempDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns correct size for plugin with config and data files', () => {
+    const configDataDir = path.join(tempDir, 'plugin-config-data')
+    fs.mkdirSync(configDataDir, { recursive: true })
+
+    const configContent = JSON.stringify({ enabled: true, configuration: {} })
+    fs.writeFileSync(
+      path.join(configDataDir, 'test-plugin.json'),
+      configContent
+    )
+
+    const dataDir = path.join(configDataDir, 'test-plugin')
+    fs.mkdirSync(dataDir, { recursive: true })
+    fs.writeFileSync(path.join(dataDir, 'data1.txt'), 'hello')
+    fs.writeFileSync(path.join(dataDir, 'data2.txt'), 'world')
+
+    const result = getPluginDataSize(tempDir, 'test-plugin')
+
+    chai.expect(result.hasData).to.equal(true)
+    chai.expect(result.fileCount).to.equal(3) // config + 2 data files
+    chai.expect(result.totalBytes).to.be.greaterThan(0)
+  })
+
+  it('returns zero and hasData false for plugin with no data', () => {
+    const result = getPluginDataSize(tempDir, 'nonexistent-plugin')
+
+    chai.expect(result.hasData).to.equal(false)
+    chai.expect(result.fileCount).to.equal(0)
+    chai.expect(result.totalBytes).to.equal(0)
+  })
+
+  it('handles config file only without data directory', () => {
+    const configDataDir = path.join(tempDir, 'plugin-config-data')
+    fs.mkdirSync(configDataDir, { recursive: true })
+
+    const configContent = JSON.stringify({ enabled: false })
+    fs.writeFileSync(
+      path.join(configDataDir, 'test-plugin.json'),
+      configContent
+    )
+
+    const result = getPluginDataSize(tempDir, 'test-plugin')
+
+    chai.expect(result.hasData).to.equal(true)
+    chai.expect(result.fileCount).to.equal(1)
+    chai.expect(result.totalBytes).to.be.greaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

- Add option to keep or delete plugin's configuration and data when removing it
- Replace browser `confirm()` dialog for plugin removal with a Bootstrap modal
- Add `GET /appstore/datasize/:name` endpoint to calculate plugin data size on disk
- Extend the remove endpoint to accept a `deleteData` parameter; default behavior now preserves plugin data (safe default)

## Motivation

In #2458 plugin removal was changed to remove also the configuration and data. This may not be appropriate, if the user wants to keep whatever data and configuration there is for later reinstall / recovery. Users who wanted to temporarily remove a plugin or reinstall it later would lose their settings. The new modal gives users visibility into what data exists and explicit control over whether to delete it.

## Test plan

- [x] Unit tests for `getPluginDataSize` (config + data files, no data, config only)
- [x] Unit tests for `formatBytes` utility
- [x] `npm test` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR improves the plugin removal workflow by replacing the browser confirm() dialog with a Bootstrap modal that displays plugin data size and lets users choose whether to preserve or delete plugin configuration and data. The default removal preserves plugin data to avoid accidental loss.

## Backend Changes
- Adds GET /appstore/datasize/:name and GET /appstore/datasize/:org/:name endpoints that resolve the plugin and return { totalBytes, fileCount, hasData } by calling getPluginDataSize(); endpoints return zeroed results and log errors if lookup fails.
- Extends POST /appstore/remove/:name (and /appstore/remove/:org/:name) to accept a deleteData boolean in the request body and propagate it into the removal queue and into removeSKModule/removeModule and cleanup logic.
- Updates removeModule(..., pluginId?, deleteData: boolean = false) to forward the deleteData flag to cleanupAfterRemove.
- Implements getPluginDataSize(configPath, pluginId) and uses the get-folder-size package to compute directory sizes (replacing a hand-rolled walker); it counts regular files recursively, handles missing/unreadable paths as zero, and returns { totalBytes, fileCount, hasData }.
- Exports getPluginDataSize from the modules module.
- Adjusts cleanupAfterRemove to remove plugin config/data only when deleteData is true.

## Frontend Changes
- Replaces synchronous confirm-based uninstall with an async modal workflow that fetches plugin data size from /appstore/datasize/:name before confirming removal.
- The remove modal shows a loading state while fetching, displays formatted total size and file count when data exists, or a "no plugin data found" message when none exists.
- The modal includes a checkbox (shown only when hasData is true) to opt into deleting configuration and data; the confirm action POSTs { deleteData } to /appstore/remove/:name with credentials included, surfaces server errors in the modal, and closes only on success.
- Adds and exports formatBytes(bytes) helper used to format byte values into B, KB, MB, and GB strings with one decimal where appropriate.

## Tests
- Adds unit tests for getPluginDataSize covering: plugin with config + data, nonexistent plugin, and config-only plugin.
- Adds unit tests for formatBytes validating formatting for bytes, KB, MB, and GB ranges.
- npm test passes.

## Dependencies
- Adds get-folder-size ^5.0.0 to package.json to compute directory sizes and correctly handle circular symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->