### PR TITLE
fix: move anchor unit category to length

### DIFF
--- a/unitpreferences/default-categories.json
+++ b/unitpreferences/default-categories.json
@@ -80,9 +80,7 @@
         "navigation.courseGreatCircle.nextPoint.distance",
         "navigation.racing.distanceStartline",
         "navigation.racing.distanceLayline",
-        "navigation.closestApproach.distance",
-        "navigation.anchor.maxRadius",
-        "navigation.anchor.currentRadius"
+        "navigation.closestApproach.distance"
       ]
     },
     "length": {
@@ -97,7 +95,9 @@
         "design.draft.canoe",
         "design.airHeight",
         "design.rigging.mast.height",
-        "environment.heave"
+        "environment.heave",
+        "navigation.anchor.maxRadius",
+        "navigation.anchor.currentRadius"
       ]
     },
     "angle": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR moves the anchor-related unit category mappings from the `distance` category to the `length` category in `unitpreferences/default-categories.json`. Specifically, `navigation.anchor.maxRadius` and `navigation.anchor.currentRadius` are now categorized under `length` (siUnit: "m") instead of `distance` (siUnit: "m"). This correction aligns anchor measurements with other length-based vessel dimensions and design specifications rather than with point-to-point distance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->