### PR TITLE
Resources Provider: Fix the test for resource being within a specified distance from a position

### DIFF
--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -23,7 +23,7 @@ export const passFilter = (res: any, type: string, params: any) => {
     if(type ==='notes' && res.position) {
       ok = isPointWithinRadius(res.position, params.position, params.distance)
     } else if( res.feature?.geometry?.type === 'Point') {
-      ok = ok && isPointWithinRadius(
+      ok = isPointWithinRadius(
         res.feature.geometry.coordinates, 
         params.position, 
         params.distance

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -29,7 +29,7 @@ export const passFilter = (res: any, type: string, params: any) => {
         params.distance
       );
     } else if( res.feature?.geometry?.type === 'LineString') {
-      ok = ok && isLineStringWithInRadius(
+      ok = isLineStringWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -18,76 +18,75 @@ import ngeohash from 'ngeohash'
  **/
 export const passFilter = (res: any, type: string, params: any) => {
 
+  let ok = true
   if (params.position && params.distance) {
     if(type ==='notes' && res.position) {
-      return isPointWithinRadius(res.position, params.position, params.distance)
+      ok && isPointWithinRadius(res.position, params.position, params.distance)
     } else if( res.feature?.geometry?.type === 'Point') {
-      return isPointWithinRadius(
+      ok && isPointWithinRadius(
         res.feature.geometry.coordinates, 
         params.position, 
         params.distance
       );
     } else if( res.feature?.geometry?.type === 'LineString') {
-      return isLineStringWithInRadius(
+      ok && isLineStringWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
-    } else if( res.feature?.geometry?.type === 'Polygon') {
-      return isPolygonWithInRadius(
+    } else if( ['MultiLineString', 'Polygon'].includes(res.feature?.geometry?.type)) {
+      ok && isPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
     } else if( res.feature?.geometry?.type === 'MultiPolygon') {
-      return isMultiPolygonWithInRadius(
+      ok && isMultiPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
     }
-  } else {
-
-    let ok = true
-    if (params.href) {
-      if (typeof res.href === 'undefined' || !res.href) {
-        ok = false
-      } else {
-        const ha = res.href.split('/')
-        const hType: string =
-          ha.length === 1
-            ? 'regions'
-            : ha.length > 2
-              ? ha[ha.length - 2]
-              : 'regions'
-        const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
-
-        const pa = params.href.split('/')
-        const pType: string =
-          pa.length === 1
-            ? 'regions'
-            : pa.length > 2
-              ? pa[pa.length - 2]
-              : 'regions'
-        const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
-
-        ok = hType === pType && hId === pId
-      }
-    }
-
-    if (params.group) {
-      if (typeof res.group === 'undefined') {
-        ok = ok && false
-      } else {
-        ok = ok && res.group === params.group
-      }
-    }
-
-    if (params.geobounds) {
-      ok = ok && isInBounds(res, type, params.geobounds)
-    }
-    return ok
   }
+  
+  if (params.href) {
+    if (typeof res.href === 'undefined' || !res.href) {
+      ok = false
+    } else {
+      const ha = res.href.split('/')
+      const hType: string =
+        ha.length === 1
+          ? 'regions'
+          : ha.length > 2
+            ? ha[ha.length - 2]
+            : 'regions'
+      const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
+
+      const pa = params.href.split('/')
+      const pType: string =
+        pa.length === 1
+          ? 'regions'
+          : pa.length > 2
+            ? pa[pa.length - 2]
+            : 'regions'
+      const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
+
+      ok = ok && hType === pType && hId === pId
+    }
+  }
+
+  if (params.group) {
+    if (typeof res.group === 'undefined') {
+      ok = ok && false
+    } else {
+      ok = ok && res.group === params.group
+    }
+  }
+
+  if (params.geobounds) {
+    ok = ok && isInBounds(res, type, params.geobounds)
+  }
+  return ok
 }
 
 /**

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -17,7 +17,6 @@ import ngeohash from 'ngeohash'
  * @returns: true if entry should be included in results 
  **/
 export const passFilter = (res: any, type: string, params: any) => {
-  let ok = true
 
   if (params.position && params.distance) {
     if(type ==='notes' && res.position) {
@@ -47,53 +46,48 @@ export const passFilter = (res: any, type: string, params: any) => {
         params.distance
       )
     }
+  } else {
 
-    return false
-  }
+    let ok = true
+    if (params.href) {
+      if (typeof res.href === 'undefined' || !res.href) {
+        ok = false
+      } else {
+        const ha = res.href.split('/')
+        const hType: string =
+          ha.length === 1
+            ? 'regions'
+            : ha.length > 2
+              ? ha[ha.length - 2]
+              : 'regions'
+        const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
 
-  if (params.href) {
-    // check is attached to another resource
-    if (typeof res.href === 'undefined' || !res.href) {
-      ok = false
-    } else {
-      // deconstruct resource href value
-      const ha = res.href.split('/')
-      const hType: string =
-        ha.length === 1
-          ? 'regions'
-          : ha.length > 2
-            ? ha[ha.length - 2]
-            : 'regions'
-      const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
+        const pa = params.href.split('/')
+        const pType: string =
+          pa.length === 1
+            ? 'regions'
+            : pa.length > 2
+              ? pa[pa.length - 2]
+              : 'regions'
+        const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
 
-      // deconstruct param.href value
-      const pa = params.href.split('/')
-      const pType: string =
-        pa.length === 1
-          ? 'regions'
-          : pa.length > 2
-            ? pa[pa.length - 2]
-            : 'regions'
-      const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
-
-      ok = hType === pType && hId === pId
+        ok = hType === pType && hId === pId
+      }
     }
-  }
 
-  if (params.group) {
-    // check is attached to group
-    if (typeof res.group === 'undefined') {
-      ok = ok && false
-    } else {
-      ok = ok && res.group === params.group
+    if (params.group) {
+      if (typeof res.group === 'undefined') {
+        ok = ok && false
+      } else {
+        ok = ok && res.group === params.group
+      }
     }
-  }
 
-  if (params.geobounds) {
-    // check is within bounds
-    ok = ok && isInBounds(res, type, params.geobounds)
+    if (params.geobounds) {
+      ok = ok && isInBounds(res, type, params.geobounds)
+    }
+    return ok
   }
-  return ok
 }
 
 /**
@@ -286,7 +280,7 @@ const isMultiPolygonWithInRadius = (
  * @returns The supplied value if it is numeric.
  */
 const checkForNumber = (value: number): number => {
-  if (!Number.isFinite(value)) {
+  if (!Number.isFinite(Number(value))) {
     throw new Error(`Supplied value is not a number! (${value})`)
   } else {
     return Number(value)
@@ -302,6 +296,7 @@ const checkForNumberArray = (value: number[]): Array<number> => {
   if (!Array.isArray(value)) {
     throw new Error(`Supplied value is not valid! (Array<number>) (${value})`)
   } else {
+    value = value.map( i => Number(i) )
     value.forEach((i: number) => {
       if (!Number.isFinite(i)) {
         throw new Error(

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -41,7 +41,7 @@ export const passFilter = (res: any, type: string, params: any) => {
         params.distance
       )
     } else if( res.feature?.geometry?.type === 'MultiPolygon') {
-      ok = ok && isMultiPolygonWithInRadius(
+      ok = isMultiPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -9,40 +9,33 @@ import {
 import { GeolibInputCoordinates } from 'geolib/es/types'
 import ngeohash from 'ngeohash'
 
-/** 
- * Filter the supplied Resource entry
- * @param res - Resource entry
- * @param type - Resource type
- * @params params - query string parameters
- * @returns: true if entry should be included in results 
- **/
-export const passFilter = (res: any, type: string, params: any) => {
 
+export const passFilter = (resource: any, type: string, params: any) => {
   let ok = true
   if (params.position && typeof params.distance !== 'undefined') {
-    if(type === 'notes' && res.position) {
-      ok = isPointWithinRadius(res.position, params.position, params.distance)
-    } else if( res.feature?.geometry?.type === 'Point') {
+    if(type === 'notes' && resource.position) {
+      ok = isPointWithinRadius(resource.position, params.position, params.distance)
+    } else if( resource.feature?.geometry?.type === 'Point') {
       ok = isPointWithinRadius(
-        res.feature.geometry.coordinates, 
+        resource.feature.geometry.coordinates, 
         params.position, 
         params.distance
       );
-    } else if( res.feature?.geometry?.type === 'LineString') {
+    } else if( resource.feature?.geometry?.type === 'LineString') {
       ok = isLineStringWithInRadius(
-        res.feature.geometry.coordinates,
+        resource.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
-    } else if( ['MultiLineString', 'Polygon'].includes(res.feature?.geometry?.type)) {
+    } else if( ['MultiLineString', 'Polygon'].includes(resource.feature?.geometry?.type)) {
       ok = isPolygonWithInRadius(
-        res.feature.geometry.coordinates,
+        resource.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
-    } else if( res.feature?.geometry?.type === 'MultiPolygon') {
+    } else if( resource.feature?.geometry?.type === 'MultiPolygon') {
       ok = isMultiPolygonWithInRadius(
-        res.feature.geometry.coordinates,
+        resource.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
@@ -50,10 +43,10 @@ export const passFilter = (res: any, type: string, params: any) => {
   }
 
   if (params.href) {
-    if (typeof res.href === 'undefined' || !res.href) {
+    if (typeof resource.href === 'undefined' || !resource.href) {
       ok = false
     } else {
-      const ha = res.href.split('/')
+      const ha = resource.href.split('/')
       const hType: string =
         ha.length === 1
           ? 'regions'
@@ -76,24 +69,19 @@ export const passFilter = (res: any, type: string, params: any) => {
   }
 
   if (params.group) {
-    if (typeof res.group === 'undefined') {
+    if (typeof resource.group === 'undefined') {
       ok = ok && false
     } else {
-      ok = ok && res.group === params.group
+      ok = ok && resource.group === params.group
     }
   }
 
   if (params.geobounds) {
-    ok = ok && isInBounds(res, type, params.geobounds)
+    ok = ok && isInBounds(resource, type, params.geobounds)
   }
   return ok
 }
 
-/**
- * Parse query parameters
- * @param params - object containing query values
- * @returns Transformed params object
- */
 export const processParameters = (params: any) => {
   if (typeof params.limit !== 'undefined') {
     params.limit = checkForNumber(params.limit)
@@ -101,7 +89,6 @@ export const processParameters = (params: any) => {
 
   if (typeof params.bbox !== 'undefined') {
     params.bbox = checkForNumberArray(params.bbox)
-    // generate geobounds polygon from bbox
     params.geobounds = toPolygon(params.bbox)
     if (params.geobounds.length !== 5) {
       params.geobounds = null
@@ -121,75 +108,34 @@ export const processParameters = (params: any) => {
   return params
 }
 
-/**
- * check geometry is in bounds
- * @param val - Resource entry
- * @param type - Resource type
- * @param polygon - Area to test that the resource is within
- * @returns true when resource contains coordinates that are within the polygon.
- */
 const isInBounds = (
-  val: any,
+  resource: any,
   type: string,
-  polygon: GeolibInputCoordinates[]
+  bounds: GeolibInputCoordinates[]
 ): boolean => {
   let ok = false
-  switch (type) {
-    case 'notes':
-    case 'waypoints':
-      if (val?.feature?.geometry?.coordinates) {
-        ok = isPointInPolygon(val?.feature?.geometry?.coordinates, polygon)
-      }
-      if (val.position) {
-        ok = isPointInPolygon(val.position, polygon)
-      }
-      if (val.geohash) {
-        const bar = ngeohash.decode_bbox(val.geohash)
-        const bounds = toPolygon([bar[1], bar[0], bar[3], bar[2]])
-        const center = getCenterOfBounds(bounds)
-        ok = isPointInPolygon(center, polygon)
-      }
-      break
-    case 'routes':
-      if (val.feature.geometry.coordinates) {
-        val.feature.geometry.coordinates.forEach((pt: any) => {
-          ok = ok || isPointInPolygon(pt, polygon)
-        })
-      }
-      break
-    case 'regions':
-      if (
-        val.feature.geometry.coordinates &&
-        val.feature.geometry.coordinates.length > 0
-      ) {
-        if (val.feature.geometry.type === 'Polygon') {
-          val.feature.geometry.coordinates.forEach((ls: any) => {
-            ls.forEach((pt: any) => {
-              ok = ok || isPointInPolygon(pt, polygon)
-            })
-          })
-        } else if (val.feature.geometry.type === 'MultiPolygon') {
-          val.feature.geometry.coordinates.forEach((polygon: any) => {
-            polygon.forEach((ls: any) => {
-              ls.forEach((pt: any) => {
-                ok = ok || isPointInPolygon(pt, polygon)
-              })
-            })
-          })
-        }
-      }
-      break
+  if (type === 'notes') {
+    if(resource.position) {
+      ok = isPointInPolygon(resource.position, bounds)
+    } else if (resource.geohash) {
+      const bar = ngeohash.decode_bbox(resource.geohash)
+      const p = toPolygon([bar[1], bar[0], bar[3], bar[2]])
+      const center = getCenterOfBounds(p)
+      ok = isPointInPolygon(center, bounds)
+    }
+  } else if( resource.feature?.geometry?.type === 'Point') {
+    ok = isPointInPolygon(resource.feature?.geometry?.coordinates, bounds)
+  } else if (resource.feature?.geometry?.type === 'LineString') {
+    ok = isLineStringWithInBounds(resource.feature.geometry.coordinates, bounds)
+  } else if( ['MultiLineString', 'Polygon'].includes(resource.feature?.geometry?.type)) {
+    ok = isPolygonWithInBounds(resource.feature.geometry.coordinates, bounds)
+  } else if( resource.feature?.geometry?.type === 'MultiPolygon') {
+    ok = isMultiPolygonWithInBounds(resource.feature.geometry.coordinates, bounds)
   }
   return ok
 }
 
-/**
- * Test if any LineString coordinates are within the distance from the center point
- * @param coords LineString coordinates
- * @param center 
- * @param distance 
- * @returns true if any coordinate is within the radius
- */
+
 const isLineStringWithInRadius = (
   coords: Array<GeolibInputCoordinates>, 
   center: GeolibInputCoordinates,
@@ -211,13 +157,22 @@ const isLineStringWithInRadius = (
   return res
 }
 
-/**
- * Test if any Polygon coordinates are within the distance from the center point
- * @param coords Polygon coordinates
- * @param center 
- * @param radius 
- * @returns true if any coordinate is within the radius
- */
+const isLineStringWithInBounds = (
+  coords: Array<GeolibInputCoordinates>, 
+  bounds: Array<GeolibInputCoordinates>
+): boolean => {
+  let res = false
+  for(let i = 0; i < coords.length; ++i) {
+    if(
+      isPointInPolygon(coords[i], bounds)
+    ) {
+      res = true
+      break
+    }
+  }
+  return res
+}
+
 const isPolygonWithInRadius = (
   coords: Array<GeolibInputCoordinates[]>, 
   center: GeolibInputCoordinates,
@@ -239,13 +194,25 @@ const isPolygonWithInRadius = (
   return res
 }
 
-/**
- * Test if any MultiPolygon coordinates are within the distance from the center point
- * @param coords MultiPolygon coordinates
- * @param center 
- * @param radius 
- * @returns true if any coordinate is within the radius
- */
+const isPolygonWithInBounds = (
+  coords: Array<GeolibInputCoordinates[]>, 
+  bounds: Array<GeolibInputCoordinates>,
+): boolean => {
+  let res = false
+  for (let lineNo = 0; lineNo < coords.length; ++lineNo) {
+    if(
+      isLineStringWithInBounds(
+        coords[lineNo],
+        bounds
+      )
+    ) {
+      res = true
+      break
+    }
+  }
+  return res
+}
+
 const isMultiPolygonWithInRadius = (
   coords: Array<Array<GeolibInputCoordinates[]>>, 
   center: GeolibInputCoordinates,
@@ -253,31 +220,41 @@ const isMultiPolygonWithInRadius = (
 ): boolean => {
   let res = false
   for (let polygonNo = 0; polygonNo < coords.length; ++polygonNo) {
-    const polygon = coords[polygonNo]
-    for (let lineNo = 0; lineNo < polygon.length; ++lineNo) {
-      if(
-        isLineStringWithInRadius(
-          coords[polygonNo][lineNo],
-          center,
-          distance
-        )
-      ) {
-        res = true
-        break
-      }
-    }
-    if (res) {
+    const polygonCoords = coords[polygonNo]
+    if(
+      isPolygonWithInRadius(
+        polygonCoords,
+        center,
+        distance
+      )
+    ) {
+      res = true
       break
     }
   }
   return res
 }
 
-/**
- * Test for numeric value
- * @param value - Value to test 
- * @returns The supplied value if it is numeric.
- */
+const isMultiPolygonWithInBounds = (
+  coords: Array<Array<GeolibInputCoordinates[]>>, 
+  bounds: Array<GeolibInputCoordinates>
+): boolean => {
+  let res = false
+  for (let polygonNo = 0; polygonNo < coords.length; ++polygonNo) {
+    const polygonCoords = coords[polygonNo]
+    if(
+      isPolygonWithInBounds(
+        polygonCoords,
+        bounds
+      )
+    ) {
+      res = true
+      break
+    }
+  }
+  return res
+}
+
 const checkForNumber = (value: number): number => {
   if (!Number.isFinite(Number(value))) {
     throw new Error(`Supplied value is not a number! (${value})`)
@@ -286,11 +263,6 @@ const checkForNumber = (value: number): number => {
   }
 }
 
-/**
- * Test value for an array of numbers
- * @param value - Value to test 
- * @returns The supplied value if it contains an array of numbers
- */
 const checkForNumberArray = (value: number[]): Array<number> => {
   if (!Array.isArray(value)) {
     throw new Error(`Supplied value is not valid! (Array<number>) (${value})`)
@@ -307,11 +279,6 @@ const checkForNumberArray = (value: number[]): Array<number> => {
   }
 }
 
-/**
- * Convert bbox string to array of points (polygon)
- * @param bbox 
- * @returns 
- */
 const toPolygon = (bbox: number[]): GeolibInputCoordinates[] => {
   const polygon: GeolibInputCoordinates[] = []
   if (bbox.length === 4) {
@@ -320,10 +287,6 @@ const toPolygon = (bbox: number[]): GeolibInputCoordinates[] => {
     polygon.push([bbox[2], bbox[3]])
     polygon.push([bbox[2], bbox[1]])
     polygon.push([bbox[0], bbox[1]])
-  } else {
-    console.error(
-      `*** Error: Bounding box contains invalid coordinate value (${bbox}) ***`
-    )
   }
   return polygon
 }

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -21,7 +21,7 @@ export const passFilter = (res: any, type: string, params: any) => {
   let ok = true
   if (params.position && params.distance) {
     if(type ==='notes' && res.position) {
-      ok = ok && isPointWithinRadius(res.position, params.position, params.distance)
+      ok = isPointWithinRadius(res.position, params.position, params.distance)
     } else if( res.feature?.geometry?.type === 'Point') {
       ok = ok && isPointWithinRadius(
         res.feature.geometry.coordinates, 

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -35,7 +35,7 @@ export const passFilter = (res: any, type: string, params: any) => {
         params.distance
       )
     } else if( ['MultiLineString', 'Polygon'].includes(res.feature?.geometry?.type)) {
-      ok = ok && isPolygonWithInRadius(
+      ok = isPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -19,8 +19,8 @@ import ngeohash from 'ngeohash'
 export const passFilter = (res: any, type: string, params: any) => {
 
   let ok = true
-  if (params.position && params.distance) {
-    if(type ==='notes' && res.position) {
+  if (params.position && typeof params.distance !== 'undefined') {
+    if(type === 'notes' && res.position) {
       ok = isPointWithinRadius(res.position, params.position, params.distance)
     } else if( res.feature?.geometry?.type === 'Point') {
       ok = isPointWithinRadius(

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -54,7 +54,7 @@ export const passFilter = (res: any, type: string, params: any) => {
   if (params.href) {
     // check is attached to another resource
     if (typeof res.href === 'undefined' || !res.href) {
-      ok = ok && false
+      ok = false
     } else {
       // deconstruct resource href value
       const ha = res.href.split('/')
@@ -76,7 +76,7 @@ export const passFilter = (res: any, type: string, params: any) => {
             : 'regions'
       const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
 
-      ok = ok && hType === pType && hId === pId
+      ok = hType === pType && hId === pId
     }
   }
 

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -21,34 +21,34 @@ export const passFilter = (res: any, type: string, params: any) => {
   let ok = true
   if (params.position && params.distance) {
     if(type ==='notes' && res.position) {
-      ok && isPointWithinRadius(res.position, params.position, params.distance)
+      ok = ok && isPointWithinRadius(res.position, params.position, params.distance)
     } else if( res.feature?.geometry?.type === 'Point') {
-      ok && isPointWithinRadius(
+      ok = ok && isPointWithinRadius(
         res.feature.geometry.coordinates, 
         params.position, 
         params.distance
       );
     } else if( res.feature?.geometry?.type === 'LineString') {
-      ok && isLineStringWithInRadius(
+      ok = ok && isLineStringWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
     } else if( ['MultiLineString', 'Polygon'].includes(res.feature?.geometry?.type)) {
-      ok && isPolygonWithInRadius(
+      ok = ok && isPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
     } else if( res.feature?.geometry?.type === 'MultiPolygon') {
-      ok && isMultiPolygonWithInRadius(
+      ok = ok && isMultiPolygonWithInRadius(
         res.feature.geometry.coordinates,
         params.position, 
         params.distance
       )
     }
   }
-  
+
   if (params.href) {
     if (typeof res.href === 'undefined' || !res.href) {
       ok = false

--- a/packages/resources-provider-plugin/src/lib/utils.ts
+++ b/packages/resources-provider-plugin/src/lib/utils.ts
@@ -2,15 +2,140 @@
 // utility library functions
 
 import {
-  computeDestinationPoint,
   getCenterOfBounds,
-  isPointInPolygon
+  isPointInPolygon,
+  isPointWithinRadius
 } from 'geolib'
 import { GeolibInputCoordinates } from 'geolib/es/types'
 import ngeohash from 'ngeohash'
 
-// check geometry is in bounds
-export const inBounds = (
+/** 
+ * Filter the supplied Resource entry
+ * @param res - Resource entry
+ * @param type - Resource type
+ * @params params - query string parameters
+ * @returns: true if entry should be included in results 
+ **/
+export const passFilter = (res: any, type: string, params: any) => {
+  let ok = true
+
+  if (params.position && params.distance) {
+    if(type ==='notes' && res.position) {
+      return isPointWithinRadius(res.position, params.position, params.distance)
+    } else if( res.feature?.geometry?.type === 'Point') {
+      return isPointWithinRadius(
+        res.feature.geometry.coordinates, 
+        params.position, 
+        params.distance
+      );
+    } else if( res.feature?.geometry?.type === 'LineString') {
+      return isLineStringWithInRadius(
+        res.feature.geometry.coordinates,
+        params.position, 
+        params.distance
+      )
+    } else if( res.feature?.geometry?.type === 'Polygon') {
+      return isPolygonWithInRadius(
+        res.feature.geometry.coordinates,
+        params.position, 
+        params.distance
+      )
+    } else if( res.feature?.geometry?.type === 'MultiPolygon') {
+      return isMultiPolygonWithInRadius(
+        res.feature.geometry.coordinates,
+        params.position, 
+        params.distance
+      )
+    }
+
+    return false
+  }
+
+  if (params.href) {
+    // check is attached to another resource
+    if (typeof res.href === 'undefined' || !res.href) {
+      ok = ok && false
+    } else {
+      // deconstruct resource href value
+      const ha = res.href.split('/')
+      const hType: string =
+        ha.length === 1
+          ? 'regions'
+          : ha.length > 2
+            ? ha[ha.length - 2]
+            : 'regions'
+      const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
+
+      // deconstruct param.href value
+      const pa = params.href.split('/')
+      const pType: string =
+        pa.length === 1
+          ? 'regions'
+          : pa.length > 2
+            ? pa[pa.length - 2]
+            : 'regions'
+      const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
+
+      ok = ok && hType === pType && hId === pId
+    }
+  }
+
+  if (params.group) {
+    // check is attached to group
+    if (typeof res.group === 'undefined') {
+      ok = ok && false
+    } else {
+      ok = ok && res.group === params.group
+    }
+  }
+
+  if (params.geobounds) {
+    // check is within bounds
+    ok = ok && isInBounds(res, type, params.geobounds)
+  }
+  return ok
+}
+
+/**
+ * Parse query parameters
+ * @param params - object containing query values
+ * @returns Transformed params object
+ */
+export const processParameters = (params: any) => {
+  if (typeof params.limit !== 'undefined') {
+    params.limit = checkForNumber(params.limit)
+  }
+
+  if (typeof params.bbox !== 'undefined') {
+    params.bbox = checkForNumberArray(params.bbox)
+    // generate geobounds polygon from bbox
+    params.geobounds = toPolygon(params.bbox)
+    if (params.geobounds.length !== 5) {
+      params.geobounds = null
+      throw new Error(
+        `Bounding box contains invalid coordinate value (${params.bbox})`
+      )
+    }
+  } 
+
+  if (typeof params.distance !== 'undefined') {
+    params.distance = checkForNumber(params.distance)
+  }
+
+  if (params.position) {
+    params.position = checkForNumberArray(params.position)
+  }
+  return params
+}
+
+/**
+ * check geometry is in bounds
+ * @param val - Resource entry
+ * @param type - Resource type
+ * @param polygon - Area to test that the resource is within
+ * @returns true when resource contains coordinates that are within the polygon.
+ */
+const isInBounds = (
   val: any,
   type: string,
   polygon: GeolibInputCoordinates[]
@@ -65,109 +190,135 @@ export const inBounds = (
   return ok
 }
 
-/** Apply filters to Resource entry
- * returns: true if entry should be included in results **/
-export const passFilter = (res: any, type: string, params: any) => {
-  let ok = true
-  if (params.href) {
-    // check is attached to another resource
-    if (typeof res.href === 'undefined' || !res.href) {
-      ok = ok && false
-    } else {
-      // deconstruct resource href value
-      const ha = res.href.split('/')
-      const hType: string =
-        ha.length === 1
-          ? 'regions'
-          : ha.length > 2
-            ? ha[ha.length - 2]
-            : 'regions'
-      const hId = ha.length === 1 ? ha[0] : ha[ha.length - 1]
-
-      // deconstruct param.href value
-      const pa = params.href.split('/')
-      const pType: string =
-        pa.length === 1
-          ? 'regions'
-          : pa.length > 2
-            ? pa[pa.length - 2]
-            : 'regions'
-      const pId = pa.length === 1 ? pa[0] : pa[pa.length - 1]
-
-      ok = ok && hType === pType && hId === pId
+/**
+ * Test if any LineString coordinates are within the distance from the center point
+ * @param coords LineString coordinates
+ * @param center 
+ * @param distance 
+ * @returns true if any coordinate is within the radius
+ */
+const isLineStringWithInRadius = (
+  coords: Array<GeolibInputCoordinates>, 
+  center: GeolibInputCoordinates,
+  distance: number
+): boolean => {
+  let res = false
+  for(let i = 0; i < coords.length; ++i) {
+    if( 
+      isPointWithinRadius(
+        coords[i], 
+        center, 
+        distance
+      )
+    ) {
+      res = true
+      break
     }
   }
-  if (params.group) {
-    // check is attached to group
-    if (typeof res.group === 'undefined') {
-      ok = ok && false
-    } else {
-      ok = ok && res.group === params.group
-    }
-  }
-  if (params.geobounds) {
-    // check is within bounds
-    ok = ok && inBounds(res, type, params.geobounds)
-  }
-  return ok
+  return res
 }
 
-const checkForNumberArray = (param: number[]): Array<number> => {
-  if (!Array.isArray(param)) {
-    throw new Error(`Supplied value is not valid! (Array<number>) (${param})`)
+/**
+ * Test if any Polygon coordinates are within the distance from the center point
+ * @param coords Polygon coordinates
+ * @param center 
+ * @param radius 
+ * @returns true if any coordinate is within the radius
+ */
+const isPolygonWithInRadius = (
+  coords: Array<GeolibInputCoordinates[]>, 
+  center: GeolibInputCoordinates,
+  distance: number
+): boolean => {
+  let res = false
+  for (let lineNo = 0; lineNo < coords.length; ++lineNo) {
+    if(
+      isLineStringWithInRadius(
+        coords[lineNo],
+        center, 
+        distance
+      )
+    ) {
+      res = true
+      break
+    }
+  }
+  return res
+}
+
+/**
+ * Test if any MultiPolygon coordinates are within the distance from the center point
+ * @param coords MultiPolygon coordinates
+ * @param center 
+ * @param radius 
+ * @returns true if any coordinate is within the radius
+ */
+const isMultiPolygonWithInRadius = (
+  coords: Array<Array<GeolibInputCoordinates[]>>, 
+  center: GeolibInputCoordinates,
+  distance: number
+): boolean => {
+  let res = false
+  for (let polygonNo = 0; polygonNo < coords.length; ++polygonNo) {
+    const polygon = coords[polygonNo]
+    for (let lineNo = 0; lineNo < polygon.length; ++lineNo) {
+      if(
+        isLineStringWithInRadius(
+          coords[polygonNo][lineNo],
+          center,
+          distance
+        )
+      ) {
+        res = true
+        break
+      }
+    }
+    if (res) {
+      break
+    }
+  }
+  return res
+}
+
+/**
+ * Test for numeric value
+ * @param value - Value to test 
+ * @returns The supplied value if it is numeric.
+ */
+const checkForNumber = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`Supplied value is not a number! (${value})`)
   } else {
-    param.forEach((i: number) => {
-      if (typeof i !== 'number') {
+    return Number(value)
+  }
+}
+
+/**
+ * Test value for an array of numbers
+ * @param value - Value to test 
+ * @returns The supplied value if it contains an array of numbers
+ */
+const checkForNumberArray = (value: number[]): Array<number> => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Supplied value is not valid! (Array<number>) (${value})`)
+  } else {
+    value.forEach((i: number) => {
+      if (!Number.isFinite(i)) {
         throw new Error(
-          `Supplied value is not a number array! (Array<number>) (${param})`
+          `Supplied value is not a number array! (Array<number>) (${value})`
         )
       }
     })
-    return param
+    return value
   }
 }
 
-const checkForNumber = (param: number): number => {
-  if (isNaN(param)) {
-    throw new Error(`Supplied value is not a number! (${param})`)
-  } else {
-    return param
-  }
-}
-
-// process query parameters
-export const processParameters = (params: any) => {
-  if (typeof params.limit !== 'undefined') {
-    params.limit = checkForNumber(params.limit)
-  }
-
-  if (typeof params.bbox !== 'undefined') {
-    params.bbox = checkForNumberArray(params.bbox)
-    // generate geobounds polygon from bbox
-    params.geobounds = toPolygon(params.bbox)
-    if (params.geobounds.length !== 5) {
-      params.geobounds = null
-      throw new Error(
-        `Bounding box contains invalid coordinate value (${params.bbox})`
-      )
-    }
-  } else if (typeof params.distance !== 'undefined' && params.position) {
-    params.distance = checkForNumber(params.distance)
-    params.position = checkForNumberArray(params.position)
-    const sw = computeDestinationPoint(params.position, params.distance, 225)
-    const ne = computeDestinationPoint(params.position, params.distance, 45)
-    params.geobounds = toPolygon([
-      sw.longitude,
-      sw.latitude,
-      ne.longitude,
-      ne.latitude
-    ])
-  }
-  return params
-}
-
-// convert bbox  string to array of points (polygon)
-export const toPolygon = (bbox: number[]): GeolibInputCoordinates[] => {
+/**
+ * Convert bbox string to array of points (polygon)
+ * @param bbox 
+ * @returns 
+ */
+const toPolygon = (bbox: number[]): GeolibInputCoordinates[] => {
   const polygon: GeolibInputCoordinates[] = []
   if (bbox.length === 4) {
     polygon.push([bbox[0], bbox[1]])

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -79,7 +79,7 @@ describe('Resources Api', () => {
         [138.34794155831, -34.8965531416984],
         [138.437388789013, -34.8549193092418],
         [138.266384575389, -34.7607885290325]
-      ].map(async ([latitude, longitude]) => {
+      ].map(async ([longitude, latitude]) => {
         const r = await post(`/resources/waypoints/`, {
           feature: {
             type: 'Feature',

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -99,8 +99,7 @@ describe('Resources Api', () => {
       )
     ).json()) as object
     const returnedIds = Object.keys(r)
-    returnedIds.length.should.equal(2)
-    returnedIds[0].should.equal(resourceIds[1])
+    returnedIds.should.have.members([resourceIds[0], resourceIds[1]])
   })
 
   it('Create route with route point metadata', async function () {

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -71,6 +71,38 @@ describe('Resources Api', () => {
     returnedIds[0].should.equal(resourceIds[1])
   })
 
+  it('distance from position search works for waypoints', async function () {
+    const { get, post } = await startServer()
+
+    const resourceIds = await Promise.all(
+      [
+        [138.34794155831, -34.8965531416984],
+        [138.437388789013, -34.8549193092418],
+        [138.266384575389, -34.7607885290325]
+      ].map(async ([latitude, longitude]) => {
+        const r = await post(`/resources/waypoints/`, {
+          feature: {
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [longitude, latitude]
+            }
+          }
+        })
+        const { id } = (await r.json()) as { id: string }
+        return id
+      })
+    )
+    const r = (await (
+      await get(
+        '/resources/waypoints?position=[138.40299,-34.87222]&distance=6000'
+      )
+    ).json()) as object
+    const returnedIds = Object.keys(r)
+    returnedIds.length.should.equal(2)
+    returnedIds[0].should.equal(resourceIds[1])
+  })
+
   it('Create route with route point metadata', async function () {
     const { post, stop } = await startServer()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes distance-based filtering in the resources-provider plugin so resources are correctly tested for being within a specified distance from a position by using direct radius checks instead of deriving bbox/destination approximations.

### Changes to packages/resources-provider-plugin/src/lib/utils.ts

- Geometry/radius checks:
  - Uses geolib.isPointWithinRadius for radial checks.
  - passFilter applies radius filtering only when both params.position and params.distance are present.
  - Radius checks dispatch by geometry:
    - notes: tests res.position against the radius.
    - Point features: tests feature.geometry.coordinates against the radius.
    - LineString: tests coordinates with isLineStringWithInRadius (checks any vertex against the radius).
    - Polygon and MultiLineString: test coordinate rings via isPolygonWithInRadius.
    - MultiPolygon: tests polygon sets via isMultiPolygonWithInRadius.
  - href and group filters remain applied after the radius test; geobounds still gates results via the in-bounds check.

- processParameters behavior:
  - Generates params.geobounds only from bbox when bbox is provided (no longer synthesizes geobounds from position + distance).
  - Validates that the bbox-derived polygon has length 5 and throws on malformed bbox.
  - Coerces/validates numeric parameters: limit, distance, bbox and position are normalized.

- Validation improvements:
  - checkForNumber and checkForNumberArray coerce inputs with Number(...) and validate using Number.isFinite(...).
  - checkForNumberArray maps values to Number(...) and validates each entry.

- API surface / exports:
  - Keeps exports for passFilter and processParameters.
  - Makes geometry helpers non-exported local constants: inBounds → isInBounds (non-exported) and toPolygon → toPolygon (non-exported).
  - Adds internal helpers isLineStringWithInRadius, isPolygonWithInRadius, isMultiPolygonWithInRadius to perform radius checks over complex geometries.

Overall, the PR replaces bbox/destination-based distance approximations with precise radius-based checks per geometry type, tightens numeric validation/coercion, and reduces the exported helper surface area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->