### PR TITLE
perf: short-circuit eager JSON.stringify in debug calls

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -938,7 +938,7 @@ export class CourseApi {
     if ('href' in dest) {
       const typedHref = this.parseHref(dest.href)
       if (typedHref) {
-        debug(`fetching ${JSON.stringify(typedHref)}`)
+        debug.enabled && debug(`fetching ${JSON.stringify(typedHref)}`)
         // fetch waypoint resource details
         try {
           const r = (await this.resourcesApi.getResource(

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -198,7 +198,7 @@ export class HistoryApiHttpRegistry {
           if (errors.length > 0) {
             throw new Error(`Validation errors: ${errors.join(', ')}`)
           }
-          debug(JSON.stringify(timeRangeParams, null, 2))
+          debug.enabled && debug(JSON.stringify(timeRangeParams, null, 2))
           return provider.getContexts(timeRangeParams)
         },
         res
@@ -213,7 +213,7 @@ export class HistoryApiHttpRegistry {
           if (errors.length > 0) {
             throw new Error(`Validation errors: ${errors.join(', ')}`)
           }
-          debug(JSON.stringify(timeRangeParams, null, 2))
+          debug.enabled && debug(JSON.stringify(timeRangeParams, null, 2))
           return provider.getPaths(timeRangeParams)
         },
         res
@@ -291,7 +291,7 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
     resolution,
     pathSpecs
   }
-  debug(JSON.stringify(parsed, null, 2))
+  debug.enabled && debug(JSON.stringify(parsed, null, 2))
   return parsed
 }
 

--- a/src/api/resources/index.ts
+++ b/src/api/resources/index.ts
@@ -183,7 +183,8 @@ export class ResourcesApi {
     params: { [key: string]: any },
     providerId?: string
   ) {
-    debug(`** listResources(${resType}, ${JSON.stringify(params)})`)
+    debug.enabled &&
+      debug(`** listResources(${resType}, ${JSON.stringify(params)})`)
 
     const provider = this.checkForProvider(resType, providerId)
     debug(`** provider = ${provider}`)
@@ -199,7 +200,8 @@ export class ResourcesApi {
     data: { [key: string]: any },
     providerId?: string
   ) {
-    debug(`** setResource(${resType}, ${resId}, ${JSON.stringify(data)})`)
+    debug.enabled &&
+      debug(`** setResource(${resType}, ${resId}, ${JSON.stringify(data)})`)
 
     if (isSignalKResourceType(resType)) {
       let isValidId: boolean
@@ -360,7 +362,7 @@ export class ResourcesApi {
 
   /** Retrieve matching resources from ALL providers */
   private async listFromAll(resType: string, params: { [key: string]: any }) {
-    debug(`listFromAll(${resType}, ${JSON.stringify(params)})`)
+    debug.enabled && debug(`listFromAll(${resType}, ${JSON.stringify(params)})`)
 
     const result = {}
     if (!this.resProvider[resType]) {

--- a/src/api/resources/validate.ts
+++ b/src/api/resources/validate.ts
@@ -17,7 +17,8 @@ export const validate = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any
   ): void => {
-    debug(`Validating ${type} ${method} ${JSON.stringify(value)}`)
+    debug.enabled &&
+      debug(`Validating ${type} ${method} ${JSON.stringify(value)}`)
     const endpoint =
       API_SCHEMA[`${RESOURCES_API_PATH}/${type as string}${id ? '/:id' : ''}`][
         method.toLowerCase()
@@ -41,9 +42,10 @@ export const validate = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any
   ): void => {
-    debug(
-      `*** Validating query params for ${type} ${method} ${JSON.stringify(value)}`
-    )
+    debug.enabled &&
+      debug(
+        `*** Validating query params for ${type} ${method} ${JSON.stringify(value)}`
+      )
     const endpoint =
       API_SCHEMA[`${RESOURCES_API_PATH}/${type as string}${id ? '/:id' : ''}`][
         method.toLowerCase()

--- a/src/index.ts
+++ b/src/index.ts
@@ -701,7 +701,8 @@ function startMdns(app: ServerApp & WithConfig) {
 async function startInterfaces(
   app: ServerApp & WithConfig & WithWrappedEmitter
 ) {
-  debug('Interfaces config:' + JSON.stringify(app.config.settings.interfaces))
+  debug.enabled &&
+    debug('Interfaces config:' + JSON.stringify(app.config.settings.interfaces))
   const availableInterfaces = require('./interfaces')
   return await Promise.all(
     Object.keys(availableInterfaces).map(async (name) => {

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -563,7 +563,11 @@ function wsInterface(app: WsApp): WsApi {
                 debug('Failed to parse message: ' + (e as Error).message)
                 return
               }
-              debug('<' + JSON.stringify(parsedMsg))
+              // Guard to avoid JSON.stringify on every inbound message
+              // when the debug namespace is disabled — the argument to
+              // debug() would otherwise be eagerly evaluated for each
+              // message. Pattern mirrors tcp.ts:169/181.
+              debug.enabled && debug('<' + JSON.stringify(parsedMsg))
 
               try {
                 if (parsedMsg.token) {

--- a/src/security.ts
+++ b/src/security.ts
@@ -373,7 +373,7 @@ export function getCertificateOptions(app: WithConfig, cb: any) {
     if (existsSync(chainFile)) {
       debug('Found ssl-chain.pem')
       ca = getCAChainArray(chainFile)
-      debug(JSON.stringify(ca, null, 2))
+      debug.enabled && debug(JSON.stringify(ca, null, 2))
     }
     debug(`Using certificate ssl-key.pem and ssl-cert.pem in ${certLocation}`)
     cb(null, {

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -293,7 +293,7 @@ function contextMatcher(
   subscribeCommand: SubscribeMessage,
   errorCallback: any
 ): ContextMatcher {
-  debug('subscribeCommand:' + JSON.stringify(subscribeCommand))
+  debug.enabled && debug('subscribeCommand:' + JSON.stringify(subscribeCommand))
   if (subscribeCommand.context) {
     if (isString(subscribeCommand.context)) {
       const pattern = subscribeCommand.context

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -814,7 +814,8 @@ function tokenSecurityFactory(
             if (!isNever(theExpiration)) {
               jwtOptions.expiresIn = theExpiration as StringValue
             }
-            debug(`jwt expiration:${JSON.stringify(jwtOptions)}`)
+            debug.enabled &&
+              debug(`jwt expiration:${JSON.stringify(jwtOptions)}`)
             try {
               const token = jwt.sign(
                 payload,

--- a/src/wasm/bindings/env-imports.ts
+++ b/src/wasm/bindings/env-imports.ts
@@ -476,9 +476,10 @@ export function createEnvImports(
             value: any,
             cb: (result: any) => void
           ) => {
-            debug(
-              `[${pluginId}] PUT request received: ${cbContext}.${cbPath} = ${JSON.stringify(value)}`
-            )
+            debug.enabled &&
+              debug(
+                `[${pluginId}] PUT request received: ${cbContext}.${cbPath} = ${JSON.stringify(value)}`
+              )
 
             const handlerName = `handle_put_${cbContext.replace(/\./g, '_')}_${cbPath.replace(/\./g, '_')}`
             const exports =
@@ -531,9 +532,10 @@ export function createEnvImports(
                 }
 
                 const response = JSON.parse(responseJson)
-                debug(
-                  `[${pluginId}] PUT handler response: ${JSON.stringify(response)}`
-                )
+                debug.enabled &&
+                  debug(
+                    `[${pluginId}] PUT handler response: ${JSON.stringify(response)}`
+                  )
                 cb(response)
               } catch (error) {
                 debug(`[${pluginId}] PUT handler error: ${error}`)

--- a/src/wasm/loader/plugin-config.ts
+++ b/src/wasm/loader/plugin-config.ts
@@ -28,9 +28,10 @@ export async function updateWasmPluginConfig(
   }
 
   debug(`updateWasmPluginConfig: Starting for ${pluginId}`)
-  debug(
-    `updateWasmPluginConfig: New configuration: ${JSON.stringify(configuration)}`
-  )
+  debug.enabled &&
+    debug(
+      `updateWasmPluginConfig: New configuration: ${JSON.stringify(configuration)}`
+    )
 
   plugin.configuration = configuration
   debug(`updateWasmPluginConfig: Updated in-memory configuration`)
@@ -48,9 +49,10 @@ export async function updateWasmPluginConfig(
     enabled: plugin.enabled,
     enableDebug: plugin.enableDebug
   }
-  debug(
-    `updateWasmPluginConfig: Writing config to disk: ${JSON.stringify(config)}`
-  )
+  debug.enabled &&
+    debug(
+      `updateWasmPluginConfig: Writing config to disk: ${JSON.stringify(config)}`
+    )
   writePluginConfig(storagePaths.configFile, config)
   debug(`updateWasmPluginConfig: Config written to disk`)
 
@@ -109,9 +111,10 @@ export async function setWasmPluginEnabled(
     enabled,
     enableDebug: plugin.enableDebug
   }
-  debug(
-    `setWasmPluginEnabled: Writing config to disk: ${JSON.stringify(config)}`
-  )
+  debug.enabled &&
+    debug(
+      `setWasmPluginEnabled: Writing config to disk: ${JSON.stringify(config)}`
+    )
   writePluginConfig(storagePaths.configFile, config)
   debug(`setWasmPluginEnabled: Config written to disk`)
 

--- a/src/wasm/loader/plugin-routes.ts
+++ b/src/wasm/loader/plugin-routes.ts
@@ -512,13 +512,14 @@ export function setupWasmPluginRoutes(
   router.post('/config', async (req: Request, res: Response) => {
     try {
       debug(`POST /config received for WASM plugin: ${plugin.id}`)
-      debug(`Request body: ${JSON.stringify(req.body)}`)
+      debug.enabled && debug(`Request body: ${JSON.stringify(req.body)}`)
 
       const newConfig = req.body
 
-      debug(
-        `Current plugin state - enabled: ${plugin.enabled}, enableDebug: ${plugin.enableDebug}, configuration: ${JSON.stringify(plugin.configuration)}`
-      )
+      debug.enabled &&
+        debug(
+          `Current plugin state - enabled: ${plugin.enabled}, enableDebug: ${plugin.enableDebug}, configuration: ${JSON.stringify(plugin.configuration)}`
+        )
 
       // Update enableDebug FIRST (before saving config)
       if (typeof newConfig.enableDebug === 'boolean') {
@@ -538,9 +539,10 @@ export function setupWasmPluginRoutes(
       }
 
       // Update plugin configuration and save everything to disk
-      debug(
-        `Calling updateWasmPluginConfig with: ${JSON.stringify(newConfig.configuration)}`
-      )
+      debug.enabled &&
+        debug(
+          `Calling updateWasmPluginConfig with: ${JSON.stringify(newConfig.configuration)}`
+        )
       await updateWasmPluginConfig(
         app,
         plugin.id,

--- a/src/wasm/loaders/standard-loader.ts
+++ b/src/wasm/loaders/standard-loader.ts
@@ -61,9 +61,10 @@ export async function loadStandardPlugin(
   const imports = WebAssembly.Module.imports(module)
   const moduleExports = WebAssembly.Module.exports(module)
   debug(`Module has ${imports.length} imports, ${moduleExports.length} exports`)
-  debug(
-    `Module imports: ${JSON.stringify(imports.map((i) => `${i.module}.${i.name}`).slice(0, 20))}`
-  )
+  debug.enabled &&
+    debug(
+      `Module imports: ${JSON.stringify(imports.map((i) => `${i.module}.${i.name}`).slice(0, 20))}`
+    )
 
   // Detect plugin type
   // Note: plugin_id is optional since ID can be derived from package.json name

--- a/src/zones.ts
+++ b/src/zones.ts
@@ -22,7 +22,7 @@ export class Zones {
     private sendDelta: (delta: Delta) => void
   ) {
     streambundle.getSelfMetaBus().onValue((metaMessage) => {
-      debug(`${JSON.stringify(metaMessage)}`)
+      debug.enabled && debug(`${JSON.stringify(metaMessage)}`)
       const { path, value } = metaMessage
 
       //send normal notification to clear out any previous notification


### PR DESCRIPTION
## Motivation

Signal K Server typically runs on low-power hardware (Raspberry Pi 3–5, battery-backed marine installations). Every wasted CPU cycle is wasted energy.

Several `debug()` call sites passed strings built via `JSON.stringify(...)` as arguments. Because function arguments are evaluated before the function is invoked, the serialization ran on every call even when the `debug` namespace was disabled.

## Change

Guard each site with `debug.enabled &&`, mirroring the pattern already used in `src/interfaces/tcp.ts:169,181`.

The highest-impact site is `src/interfaces/ws.ts:552`, which ran per inbound WebSocket client message. The rest are on per-HTTP-request, per-plugin-config, and startup paths where the fix is cheap and makes behavior consistent across the codebase.

No behavior change when the `debug` namespace is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Performance optimization: guard debug calls with `debug.enabled` checks

This PR optimizes performance by preventing unnecessary JSON serialization and debug call overhead when debug logging is disabled. The change addresses a performance concern where `JSON.stringify()` calls in debug arguments were being evaluated unconditionally on every invocation, consuming CPU and GC resources even when the debug namespace was disabled—particularly problematic for resource-constrained deployments like Raspberry Pi and battery-backed marine installations.

## Changes

The PR implements a consistent pattern across the codebase: guarding debug calls with `debug.enabled &&` to short-circuit argument evaluation. This prevents debug work (JSON serialization, string formatting, etc.) from executing when debug output is disabled.

**High-impact change:** `src/interfaces/ws.ts` - Guards the inbound WebSocket message logging that runs per client message, avoiding JSON serialization for every incoming message when debug is disabled.

**Other guarded locations:**
- HTTP request/response logging (`src/api/course/index.ts`, `src/api/history/index.ts`, `src/api/resources/index.ts`, `src/api/resources/validate.ts`, `src/wasm/bindings/env-imports.ts`, `src/wasm/loader/plugin-routes.ts`)
- Plugin configuration logging (`src/wasm/loader/plugin-config.ts`, `src/wasm/loaders/standard-loader.ts`)
- Startup and initialization paths (`src/index.ts`, `src/zones.ts`)
- Security and authentication flows (`src/security.ts`, `src/tokensecurity.ts`, `src/subscriptionmanager.ts`)

## Behavior

When debug is enabled, behavior is identical to before. When debug is disabled, the guarded debug calls skip execution entirely, avoiding the overhead of JSON serialization and debug function invocation. No functional changes to error handling, validation, or control flow logic in surrounding code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->