### PR TITLE
docs(agents): add performance guidance for the hot path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,30 @@ Do not add error handling, fallbacks, or validation for scenarios that cannot ha
 - Unit tests for business logic; integration tests for boundaries
 - Aim for meaningful coverage, not arbitrary percentages
 
+## Performance
+
+Signal K Server runs on Raspberry Pi 3-5 hardware, often on battery power. CPU cycles cost watts. Treat the delta ingestion and fanout path as allocation-sensitive.
+
+### Hot paths
+
+Assume 100+ deltas/sec, 20+ WebSocket clients:
+
+- `src/streambundle.ts` `pushDelta` / `push` — per value
+- `src/subscriptionmanager.ts` subscriber callbacks — per delta per client
+- `src/interfaces/ws.ts` `onChange`, `data` handler — per client, per message
+- `src/BackpressureManager.ts` `send` — per delta per client
+- `src/deltacache.ts` `onValue` — per delta
+- `src/interfaces/rest.js` tree traversal — per HTTP request
+
+### Rules
+
+- **Guard `debug()` arguments.** `debug('x=' + JSON.stringify(obj))` evaluates eagerly even when disabled. Wrap with `debug.enabled &&` (see `src/interfaces/tcp.ts`).
+- **Build objects in their final shape.** On hot paths, write all properties in a single object literal with consistent key order (V8 hidden class / shape optimization). Do not build up objects incrementally via spread or `Object.assign`.
+- **Minimize allocations on the per-delta path.** Hoist constants, `Set`s, and closures to module scope. Do not `reduce` into a new array when nothing was removed. Prefer `for...of` over `.forEach`.
+- **Use `structuredClone`**, not `JSON.parse(JSON.stringify(...))`, for deep cloning.
+- **Prefer `Set` over `Array.includes`** for repeated membership checks.
+- **Avoid lodash on hot paths.** `_.get`/`_.set` re-parse path strings; use `obj?.a?.b`. `_.isUndefined(x)` is just `x === undefined`.
+
 ## Git Commit Conventions
 
 Use conventional format: `<type>(<scope>): <subject>` where type = feat|fix|docs|style|refactor|test|chore|perf. Subject: 50 chars max, imperative mood ("add" not "added"), no period. For small changes: one-line commit only. For complex changes: add body explaining what/why (72-char lines) and reference issues.


### PR DESCRIPTION
## Motivation

Signal K Server runs on low-power hardware (Raspberry Pi 3-5) and often on battery power. The delta ingestion and fanout path is allocation- and latency-sensitive, but nothing in AGENTS.md today tells a contributor (human or AI) which files count as "hot path" or which patterns to avoid. This leads to small regressions slipping in per PR.

## Change

Add a **Performance** section to AGENTS.md with:

- The target hardware and why it matters.
- A concrete list of the hot-path files so contributors know where to be careful.
- Five short rules covering the patterns that actually bite in this codebase: guarded `debug()` calls, no per-call allocations, `structuredClone` over `JSON.parse(JSON.stringify(...))`, `Set` over `Array.includes`, and caution with lodash path accessors.

Docs-only change. No behavior impact.

Refs #2582 (task 11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds performance guidance to the project documentation by introducing a new Performance section in AGENTS.md. The section explains the deployment constraints (Raspberry Pi 3–5, often battery-backed) and emphasizes that the delta ingestion and WebSocket fanout paths are allocation- and latency-sensitive.

The documentation provides:

- Hardware context explaining why low-power deployment targets affect optimization priorities
- A list of hot-path modules/functions involved in delta ingestion and per-client fanout (e.g., streambundle.pushDelta/push, subscription manager callbacks, WebSocket onChange/data handlers, BackpressureManager.send, deltacache.onValue, REST tree traversal)
- Concrete coding rules for hot paths:
  1. Guard expensive debug() argument evaluation (use debug.enabled && ...)
  2. Build objects in their final single-literal shape to preserve V8 hidden-class stability
  3. Minimize per-delta allocations by hoisting constants/Sets/closures and avoiding unnecessary array creation
  4. Prefer structuredClone over JSON.parse(JSON.stringify(...)) for deep clones
  5. Prefer Set for repeated membership checks over Array.includes
  6. Avoid lodash path accessors (use optional chaining and direct undefined checks)

This is a documentation-only change (AGENTS.md), adding 24 lines with no effect on runtime behavior or public API declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->