### PR TITLE
perf: use structuredClone for metadata deep clones

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -211,7 +211,7 @@ module.exports = function (app) {
 
           if (meta) {
             // Deep clone to avoid mutating the cached metadata object
-            const metaCopy = JSON.parse(JSON.stringify(meta))
+            const metaCopy = structuredClone(meta)
             // Extract signalk path (remove vessels.self prefix)
             const signalkPath = metaPath.replace(/^vessels\.[^.]+\./, '')
             const username = req.skPrincipal?.identifier

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1016,9 +1016,7 @@ function handleValuesMeta(
         > | null
         if (meta) {
           // Clone and enhance metadata with displayUnits formulas
-          const metaClone: Record<string, unknown> = JSON.parse(
-            JSON.stringify(meta)
-          )
+          const metaClone = structuredClone(meta) as Record<string, unknown>
           let storedDisplayUnits = metaClone.displayUnits as
             | Record<string, unknown>
             | undefined


### PR DESCRIPTION
## Motivation

`JSON.parse(JSON.stringify(x))` is the slowest builtin way to deep-clone a JSON-shaped object. Node 17+ ships `structuredClone` as a builtin that is noticeably faster and has the same semantics for JSON-safe data.

## Change

Apply `structuredClone` to the two metadata clone sites:
- `src/interfaces/ws.ts` — per-path metadata send to WebSocket subscribers.
- `src/interfaces/rest.js` — REST single-path `/meta` handler.

No behavior change. Node 24 is the target runtime, so the builtin is guaranteed.

Refs #2582 (task 4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR replaces JSON-based deep cloning with the faster `structuredClone` built-in function for metadata objects across two critical paths in the Signal K server.

## Overview
The PR addresses a performance optimization identified in task #2582 by replacing `JSON.parse(JSON.stringify(meta))` calls with the Node.js built-in `structuredClone()` function. This provides faster deep cloning for JSON-shaped objects while maintaining semantic equivalence for the metadata use cases. The change targets Node 24 where `structuredClone` has been stable since Node 17.

## Changes
- **src/interfaces/rest.js (line 214):** Replaces the JSON-based deep clone in the metadata GET handler with `structuredClone(meta)`. The cloned metadata is then enhanced via `enhanceMetadataResponse()` before being sent to clients.

- **src/interfaces/ws.ts (line 1019):** Replaces the JSON-based deep clone in the `handleValuesMeta` WebSocket handler with `structuredClone(meta)`. The cloned metadata is subsequently enhanced with `displayUnits` formulas and written to the WebSocket connection.

## Impact
Both changes preserve existing control flow and behavior while improving cloning performance. The use of `structuredClone` provides better support for native data types compared to JSON serialization, though for metadata objects the practical difference is minimal since they contain JSON-safe values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->