### PR TITLE
perf(deltacache): string-compare ISO 8601 timestamps when sorting

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -217,11 +217,16 @@ export default class DeltaCache {
       []
     )
 
-    deltas.sort((left, right) => {
-      return (
-        new Date(left.timestamp).getTime() - new Date(right.timestamp).getTime()
-      )
-    })
+    // ISO 8601 Zulu timestamps (as produced by new Date().toISOString() in
+    // handleMessage) are lexicographically sortable, so we can avoid
+    // allocating two Date objects per comparison.
+    deltas.sort((left, right) =>
+      left.timestamp < right.timestamp
+        ? -1
+        : left.timestamp > right.timestamp
+          ? 1
+          : 0
+    )
 
     return deltas.map(toDelta).filter((delta) => {
       return this.app.securityStrategy.filterReadDelta(user, delta)


### PR DESCRIPTION
## Motivation

`getCachedDeltas` in `src/deltacache.ts` sorts by timestamp every time a client subscribes. The previous comparator allocated two `Date` objects per pair via `new Date(str).getTime()`, so the cost scales with O(N log N × 2 allocations) even though the input strings are already ordered.

## Change

Timestamps come from `handleMessage` in `src/index.ts:326` via `new Date().toISOString()`, so they are always ISO 8601 in Zulu form, which is lexicographically sortable. Comparing the strings directly avoids the allocations entirely.

No behavior change for well-formed timestamps. The existing `deltacache.js` "deltas ordered properly" test still passes.

Refs #2582 (task 10).