### PR TITLE
fix(streams): silence gpiod-seatalk noise via # comment convention

### DIFF
--- a/packages/streams/src/gpiod-seatalk.ts
+++ b/packages/streams/src/gpiod-seatalk.ts
@@ -36,7 +36,7 @@ ST_BAUD = 4800
 # detect version of gpiod,
 gpiod_v = int(gpiod.__version__.split(".")[0])
 if gpiod_v != 1 and gpiod_v !=2:
-    print("Error: gpiod version {} is not supported".format(gpiod.__version__))
+    print("Error: gpiod version {} is not supported".format(gpiod.__version__), file=sys.stderr)
     sys.exit()
 
 # detect gpiochip, based on model of Raspberry Pi
@@ -60,7 +60,7 @@ elif "Pi 5" in model:
                         gpio_chip = info.name
                         break
 else:
-    print("Warning: Use of {} is untested".format(model))
+    print("Warning: Use of {} is untested".format(model), file=sys.stderr)
     gpio_chip = "gpiochip0"
 
 class st1rx:
@@ -92,7 +92,7 @@ class st1rx:
             chip = gpiod.Chip(gpio_chip)
             self.line = chip.get_line(pin)
             if self.line is None:
-                print("Error connecting to pin ", pin)
+                print("Error connecting to pin ", pin, file=sys.stderr)
                 return False
             self.line.request(
                 consumer="ST1RX",
@@ -164,8 +164,8 @@ class st1rx:
                         if level == 0:
                             sb = True
                         else:
-                            # not a start bit, return None
-                            print("not a start bit")
+                            # not a start bit, drop byte (normal on noisy bus)
+                            print("# not a start bit")
                             return
                     elif b < bits:
                         # store data bits
@@ -176,8 +176,8 @@ class st1rx:
                         if level == 1:
                             stop -= 1
                         else:
-                            # invalid stop bit
-                            print("invalid stop bits")
+                            # invalid stop bit, drop byte (normal on noisy bus)
+                            print("# invalid stop bits")
                             return
                     sample_ns += fullbit_ns
                     remaining_ns -= fullbit_ns
@@ -196,8 +196,8 @@ class st1rx:
             else:
                 # timeout is end of frame
                 if level == 0:
-                    # invalid idle state at end of frame
-                    print("invalid idle state")
+                    # invalid idle state at end of frame, drop byte (normal on noisy bus)
+                    print("# invalid idle state")
                     return
                 # add remaining bits to byte
                 while b < bits:
@@ -209,8 +209,8 @@ class st1rx:
         if stop == 0 and b == bits:
             return data
         else:
-            # missing stop or data bits
-            print("missing stop or data bits")
+            # missing stop or data bits, drop byte (normal on noisy bus)
+            print("# missing stop or data bits")
             return
 
     def read_gpiod2(self):
@@ -259,8 +259,8 @@ class st1rx:
                         if level == 0:
                             sb = True
                         else:
-                            # not a start bit, return None
-                            print("not a start bit")
+                            # not a start bit, drop byte (normal on noisy bus)
+                            print("# not a start bit")
                             return
                     elif b < bits:
                         # store data bits
@@ -271,8 +271,8 @@ class st1rx:
                         if level == 1:
                             stop -= 1
                         else:
-                            # invalid stop bit
-                            print("invalid stop bits")
+                            # invalid stop bit, drop byte (normal on noisy bus)
+                            print("# invalid stop bits")
                             return
                     sample_ns += fullbit_ns
                     remaining_ns -= fullbit_ns
@@ -291,8 +291,8 @@ class st1rx:
             else:
                 # timeout is end of frame
                 if level == 0:
-                    # invalid idle state at end of frame
-                    print("invalid idle state")
+                    # invalid idle state at end of frame, drop byte (normal on noisy bus)
+                    print("# invalid idle state")
                     return
                 # add remaining bits to byte
                 while b < bits:
@@ -304,13 +304,13 @@ class st1rx:
         if stop == 0 and b == bits:
             return data
         else:
-            # missing stop or data bits
-            print("missing stop or data bits")
+            # missing stop or data bits, drop byte (normal on noisy bus)
+            print("# missing stop or data bits")
             return
 
     def read(self):
         if self.line is None:
-            print("Error: no pin connected")
+            print("Error: no pin connected", file=sys.stderr)
             return
         if gpiod_v == 1:
             return self.read_gpiod1()
@@ -335,7 +335,7 @@ if __name__ == "__main__":
     try:
         st = st1rx()
         if st.open(pin=gpio, invert=pol) == False:
-            print("Error: Failed to open Seatalk1 pin")
+            print("Error: Failed to open Seatalk1 pin", file=sys.stderr)
             sys.exit()
 
         st_msg = ""
@@ -360,11 +360,10 @@ if __name__ == "__main__":
                 if st_start == True:
                     st_msg += ",{:02X}".format(d & 0xff)
     except Exception as e:
-        print(e)
+        print(e, file=sys.stderr)
     except KeyboardInterrupt:
         pass
     st.close()
-    print("exit")
 `
 
 interface GpiodSeatalkOptions {

--- a/packages/streams/src/nmea0183-signalk.test.ts
+++ b/packages/streams/src/nmea0183-signalk.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { EventEmitter } from 'events'
 import Nmea0183ToSignalK from './nmea0183-signalk'
+import Liner from './liner'
 import { collectStreamOutput } from './test-helpers'
 
 function createNmeaApp() {
@@ -132,5 +133,86 @@ describe('Nmea0183ToSignalK', () => {
 
     const results = await outputPromise
     expect(results).to.have.length(0)
+  })
+
+  it('drops # comment lines without parsing or emitting events', async () => {
+    const app = createNmeaApp()
+    const stream = new Nmea0183ToSignalK({
+      app,
+      providerId: 'test'
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+
+    stream.write('# not a start bit')
+    stream.write('# invalid stop bits')
+    stream.write('# anything else upstream wants to say')
+    stream.end()
+
+    const results = await outputPromise
+    expect(results).to.have.length(0)
+    expect(app.nmea0183Events).to.have.length(0)
+    expect(app.signalkEvents).to.have.length(0)
+  })
+
+  it('passes valid sentences through when interleaved with # comments', async () => {
+    const app = createNmeaApp()
+    const stream = new Nmea0183ToSignalK({
+      app,
+      providerId: 'test'
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+
+    stream.write('# not a start bit')
+    stream.write(RMC_SENTENCE)
+    stream.write('# invalid stop bits')
+    stream.end()
+
+    const results = await outputPromise
+    expect(results).to.have.length(1)
+    expect(app.nmea0183Events).to.deep.equal([RMC_SENTENCE])
+  })
+
+  it('drops empty input lines silently', async () => {
+    const app = createNmeaApp()
+    const stream = new Nmea0183ToSignalK({
+      app,
+      providerId: 'test'
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+
+    stream.write('')
+    stream.write('   ')
+    stream.end()
+
+    const results = await outputPromise
+    expect(results).to.have.length(0)
+    expect(app.nmea0183Events).to.have.length(0)
+    expect(app.signalkEvents).to.have.length(0)
+  })
+
+  it('parses a valid sentence inside a multi-line chunk via Liner', async () => {
+    const app = createNmeaApp()
+    const liner = new Liner({})
+    const stream = new Nmea0183ToSignalK({
+      app,
+      providerId: 'test'
+    })
+
+    liner.pipe(stream)
+    const outputPromise = collectStreamOutput(stream)
+
+    // Simulate the OS pipe coalescing several Python print() calls into a
+    // single read: a framing-error comment, a real sentence, another
+    // comment, all in one chunk. The Liner splits the chunk back into
+    // individual lines so the parser sees each one on its own.
+    liner.write(`# not a start bit\n${RMC_SENTENCE}\n# invalid stop bits\n`)
+    liner.end()
+
+    const results = await outputPromise
+    expect(results).to.have.length(1)
+    expect(app.nmea0183Events).to.deep.equal([RMC_SENTENCE])
   })
 })

--- a/packages/streams/src/nmea0183-signalk.ts
+++ b/packages/streams/src/nmea0183-signalk.ts
@@ -103,6 +103,22 @@ export default class Nmea0183ToSignalK extends Transform {
       sentence = chunk.trim()
     }
 
+    if (sentence === '') {
+      // Empty input (e.g. trailing newline from upstream source). Drop
+      // silently without emitting events or invoking the parser.
+      done()
+      return
+    }
+
+    if (sentence !== undefined && sentence.startsWith('#')) {
+      // Comment line from upstream source (e.g. gpiod-seatalk framing
+      // diagnostics). Log at debug level and drop without parsing or
+      // emitting nmea0183 events.
+      this.debug(sentence)
+      done()
+      return
+    }
+
     try {
       if (sentence !== undefined) {
         if (this.appendChecksumFlag) {

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -427,6 +427,10 @@ function seatalkInput(subOptions: SubOptions): PipeElement[] {
   } else {
     pipePart.push(new PigpioSeatalk(subOptions))
   }
+  // Split the child process stdout on newlines so each $STALK frame and
+  // each '# ...' comment from the bit-bang reader becomes its own line,
+  // even when multiple writes get coalesced into one read by the OS pipe.
+  pipePart.push(new Liner(subOptions))
   pipePart.push(...seatalk1inputFilter(subOptions.ignoredSentences ?? []))
   return pipePart
 }


### PR DESCRIPTION
## Summary

The embedded Python SeaTalk1 reader in `gpiod-seatalk` emits framing errors (`not a start bit`, `invalid stop bits`, `invalid idle state`, `missing stop or data bits`) on every garbage byte from the optoelectric SeaTalk bus. They were going to stdout, were piped into `Nmea0183ToSignalK`, and surfaced as continuous stack traces in the log:

```
signalk:streams:nmea0183-signalk Error: Sentence "invalid stop bits $STALK,60,0C,01,00,00,..." is invalid
signalk:streams:nmea0183-signalk Error: Sentence "invalid idle state $STALK,10,01,02,83" is invalid
signalk:streams:nmea0183-signalk Error: Sentence "not a start bit" is invalid
signalk:streams:nmea0183-signalk Error: Sentence "" is invalid
```

These framing events are normal operation on a noisy bus, not errors. But routing them to stderr would have been worse: `Execute.startProcess` (`packages/streams/src/execute.ts:98-102`) forwards every stderr byte to `app.setProviderError`, which would have produced a continuous flood of red provider errors in the admin UI. Stderr is unusable as a debug channel here without changing `Execute`.

## The fix: a `#` comment convention on stdout

`Nmea0183ToSignalK._transform` now recognises lines that start with `#` as upstream debug comments, logs them via the existing `signalk:streams:nmea0183-signalk` debug namespace, and drops them without parsing or emitting `nmea0183` events. NMEA0183 sentences always start with `$` or `!`, so `#` is unambiguous as a comment marker.

This gives any subprocess-based stream a clean, opt-in way to surface diagnostic chatter alongside its data without flooding the parser or the provider-error UI.

In `gpiod-seatalk`:
- **Framing errors** are prefixed with `# ` and stay on stdout. Visible with `DEBUG=signalk:streams:nmea0183-signalk`, silent otherwise.
- **Setup/fatal errors** (`gpiod version not supported`, `Error connecting to pin`, `Failed to open Seatalk1 pin`, generic exception handler) go to `sys.stderr`, surfacing as provider errors.
- The unused `print("exit")` shutdown trace is dropped — `Execute` already logs the close event with `|cmd| exited with $code`.

## Two related issues fixed in the same PR

While tracing the pipeline I found two more bugs that were either causing the symptom or would expose new failures after the comment-convention fix:

**1. Empty input lines.** They hit `Nmea0183ToSignalK`, were emitted on the `nmea0183` event, then threw inside the parser (the `Sentence "" is invalid` case from the original report). Skip them silently in `_transform` alongside the `#` check.

**2. The seatalk pipeline had no `Liner`.** Every other `Execute`-based source (`tcp`, `udp`, `gpsd`, `file`) inserts `new Liner(subOptions)` after the source. Seatalk did not. Without it, when the OS pipe coalesces several Python `print()` calls into one read, the parser sees the whole multi-line chunk as a single sentence and either throws (old behaviour) or drops the entire chunk including any embedded `$STALK` frame (new behaviour with the `#` skip, since the chunk would start with `#`). This is a pre-existing data-loss bug masked by the framing-error noise — and exactly the cause of the original concatenated `"invalid stop bits $STALK,60,0C,..."` error in the issue. Insert `new Liner(subOptions)` in `seatalkInput()` so each line reaches the parser independently. The same fix applies to both `gpiod` and `pigpio` sources because they share the helper.

## Changes

- `packages/streams/src/nmea0183-signalk.ts` — In `_transform`, skip empty input silently and route `#`-prefixed lines through `this.debug` then drop. No behaviour change for any other input.
- `packages/streams/src/gpiod-seatalk.ts` — Prefix the four framing-error `print()` calls with `# `, route setup/fatal `print()` calls to `sys.stderr`, drop the `print("exit")` shutdown trace. Bit-bang reader logic untouched.
- `packages/streams/src/simple.ts` — Insert `new Liner(subOptions)` in `seatalkInput()` between the source and the input filter, matching every other `Execute`-based pipeline.
- `packages/streams/src/nmea0183-signalk.test.ts` — Four new behavioural tests:
  1. `# ` comment lines produce no delta and emit no `nmea0183` events on either `app` or `app.signalk`.
  2. Valid sentences interleaved with `# ` comments still parse and emit normally.
  3. Empty input is dropped silently with no event emission.
  4. A multi-line chunk piped through `Liner` yields exactly the embedded valid sentence and drops the surrounding `# ` comments.

## Test plan

- [x] `npx mocha src/nmea0183-signalk.test.ts` in `packages/streams` — 10 passing, including 4 new tests
- [x] Verified each new test fails when its corresponding fix is reverted (catches the regression directly)
- [x] Full `packages/streams` mocha suite: 59 passing (the 2 failing tests in `logging.test.ts` are pre-existing Windows path-separator issues unrelated to this change)
- [x] `prettier --check` clean on all touched files
- [ ] Manual smoke test on a Raspberry Pi with real SeaTalk1 wiring -> Can do that in a Signalk prerelease.

## Fixes
- Resolves SignalK/nmea0183-signalk#259.
- Improves performance (not call parser)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes diagnostic noise from the embedded Python SeaTalk1 reader in gpiod-seatalk by treating framing-error output as non-parsable debug comments, preventing them from flooding NMEA0183 parser logs and the admin UI.

## Changes

**gpiod-seatalk.ts** (embedded Python script):
- Routes setup/fatal errors and unsupported-version warnings to stderr
- Prefixes malformed-frame diagnostics (not a start bit, invalid stop bits, invalid idle state, missing stop/data bits) with `#` to mark them as debug comments rather than warnings
- Removes unused script-end `print("exit")` statement

**nmea0183-signalk.ts**:
- Adds early filtering in `_transform` to drop empty sentences without parsing or event emission
- Treats lines starting with `#` as upstream debug comments: logs them via the debug namespace and skips parsing and event emission

**simple.ts**:
- Inserts a `Liner` transform in `seatalkInput()` to split multi-line stdout chunks into individual lines before parsing, preventing data loss when the OS coalesces output from the subprocess

**nmea0183-signalk.test.ts**:
- Adds four new test cases validating comment-line handling, empty line behavior, interleaved valid sentences with comments, and multi-line chunk splitting with the Liner transform

## Results

The changes prevent framing diagnostics from being parsed as invalid NMEA sentences, eliminating parser error floods while preserving genuine setup/fatal errors for provider error reporting. Multi-line subprocess output handling is corrected to ensure $STALK frames are not lost or concatenated with diagnostic noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->