### PR TITLE
chore(deps): bump @signalk/nmea0183-utilities to ^0.12.0 in streams

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -69,7 +69,7 @@
     "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^4.1.0",
     "@signalk/nmea0183-signalk": "^3.0.0",
-    "@signalk/nmea0183-utilities": "^0.8.0",
+    "@signalk/nmea0183-utilities": "^0.12.0",
     "@signalk/signalk-schema": "^1.5.0",
     "any-shell-escape": "^0.1.1",
     "file-timestamp-stream": "^2.1.2",


### PR DESCRIPTION
## Summary

Bumps `packages/streams` dependency `@signalk/nmea0183-utilities` from `^0.8.0` → `^0.12.0`.

## Why

`packages/streams/src/nmea0183-signalk.ts` imports only `appendChecksum`, which is unchanged across 0.8.x → 0.12.x — so this is a no-op at runtime. The bump:

- Brings the declared range forward so `npm install` resolves the current latest (v0.12.0) instead of whatever satisfies `^0.8.0`.
- Aligns with [SignalK/nmea0183-signalk#298](https://github.com/SignalK/nmea0183-signalk/pull/298), which bumps the same dep to `^0.12.0` and drops an inline ms workaround now that `utils.timestamp` preserves fractional seconds ([SignalK/nmea0183-utilities#51](https://github.com/SignalK/nmea0183-utilities/pull/51), released as v0.12.0 today).

## Lockfile

Deliberately not included. Master's `package-lock.json` is already stale relative to the declared ranges in the workspace — regenerating it with `npm install --package-lock-only` produces a ~10k-line diff with ~940 unrelated version changes driven by semver drift across the whole tree, not by this bump. CI uses `npm install` (not `npm ci`), so the new range resolves correctly on every run. A lockfile regeneration is worth a separate cleanup PR that can be reviewed on its own merits.

## Test plan

- [x] `npm install` in the worktree — `@signalk/streams` now resolves nmea0183-utilities to 0.12.0 (nested under `packages/streams/node_modules/@signalk/nmea0183-utilities`). Root hoisted 0.8.1 stays because `@signalk/nmea0183-signalk@3.15.3` (the version pinned transitively in streams) still declares `^0.8.0`. That gets cleaned up automatically once [SignalK/nmea0183-signalk#298](https://github.com/SignalK/nmea0183-signalk/pull/298) ships a new release.
- [x] `tsc -b` on packages/streams — clean, no type errors.
- [x] Streams mocha — `Nmea0183ToSignalK` test suite (6 tests) passes; overall streams suite 55 passing / 2 failing, both failures pre-existing Windows-path issues in `src/logging.test.ts` unrelated to this bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the `@signalk/nmea0183-utilities` dependency in `packages/streams` from `^0.8.0` to `^0.12.0`. The package uses only the `appendChecksum` function, which remains unchanged between these versions, so the update introduces no runtime changes to the codebase. This bump aligns the version range with related updates in the nmea0183-signalk repository.

## Testing

The Nmea0183ToSignalK test suite passes (6 tests), and TypeScript compilation completes cleanly. The broader streams test suite shows 55 passing tests with 2 pre-existing Windows-path failures unrelated to this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->