### PR TITLE
feat: include app-dock by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   },
   "optionalDependencies": {
     "@mxtommy/kip": "^4.0.0",
+    "@signalk/app-dock": "^0.2.0",
     "@signalk/freeboard-sk": "^2.0.0-beta.3",
     "@signalk/instrumentpanel": "0.x",
     "@signalk/set-system-time": "^1.5.0",

--- a/test/modules.js
+++ b/test/modules.js
@@ -14,6 +14,7 @@ const {
 describe('modulesWithKeyword', () => {
   it('returns a list of modules with one "installed" update in config dir', () => {
     const expectedModules = [
+      '@signalk/app-dock',
       '@signalk/instrumentpanel',
       '@signalk/freeboard-sk',
       '@signalk/server-admin-ui',


### PR DESCRIPTION
Add app-dock to the webapps included in the default installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds `@signalk/app-dock` as an optional dependency to the SignalK server, making it included by default in the installation. The change adds `@signalk/app-dock` version `^0.2.0` to the `optionalDependencies` in `package.json`, alongside other included webapps such as `@mxtommy/kip`, `@signalk/freeboard-sk`, and `@signalk/instrumentpanel`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->