### PR TITLE
fix: suppress missing security.json warning on fresh install

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -298,11 +298,13 @@ export function getSecurityConfig(
       const optionsAsString = readFileSync(pathForSecurityConfig(app), 'utf8')
       return JSON.parse(optionsAsString)
     } catch (e: any) {
-      console.error(
-        'Could not parse security config at %s: %s',
-        pathForSecurityConfig(app),
-        e.message
-      )
+      if (e.code !== 'ENOENT' || !app.securityStrategy?.isDummy()) {
+        console.error(
+          'Could not parse security config at %s: %s',
+          pathForSecurityConfig(app),
+          e.message
+        )
+      }
       return {}
     }
   }


### PR DESCRIPTION
On a clean installation with no security.json file, the server logs two 'Could not parse security config' warnings at startup because the dummy security strategy calls getSecurityConfig before the file exists.

Since the dummy strategy implies security is not configured, a missing file is expected and not an error condition. Suppress the warning when the error is ENOENT and the active strategy is dummy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR suppresses spurious "Could not parse security config" warnings that appear on clean installations where no security.json file exists yet.

## Changes
In the `getSecurityConfig` function, the error handling is updated to conditionally suppress the console error message. The warning is now suppressed when both conditions are met:
1. The error code is `ENOENT` (file not found)
2. The active security strategy is dummy

For all other error cases—including `ENOENT` with a non-dummy strategy or any non-`ENOENT` errors—the logging behavior remains unchanged and the empty object fallback is still returned.

## Impact
On fresh installations using the dummy security strategy, the spurious warnings no longer appear during startup, improving the user experience while maintaining proper error logging for actual configuration problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->