### PR TITLE
fix(oidc): validate config eagerly at startup to prevent auth bypass

### DIFF
--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -366,6 +366,10 @@ export function registerOIDCRoutes(
         }
 
         const oidcConfig = deps.getOIDCConfig()
+        if (!isOIDCEnabled(oidcConfig)) {
+          redirectWithError('OIDC is not configured')
+          return
+        }
         const metadata = await getDiscoveryDocument(oidcConfig.issuer)
 
         // Exchange code for tokens

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -70,7 +70,9 @@ import {
   ExternalUserService,
   ExternalUser,
   ProviderUserLookup,
-  PartialOIDCConfig
+  PartialOIDCConfig,
+  OIDCError,
+  OIDC_DEFAULTS
 } from './oidc'
 import { SERVERROUTESPREFIX } from './constants'
 import { ICallback } from './types'
@@ -414,19 +416,34 @@ function tokenSecurityFactory(
   }
   strategy.getConfiguration = getConfiguration
 
-  // Parse and cache OIDC configuration
+  // Parse and cache OIDC configuration eagerly so that invalid config
+  // is detected at startup rather than on first request (see #2594)
   let cachedOIDCConfig: OIDCConfig | null = null
-  function getOIDCConfig(): OIDCConfig {
-    if (!cachedOIDCConfig) {
+  function parseAndCacheOIDCConfig(): void {
+    try {
       cachedOIDCConfig = parseOIDCConfig(options)
+    } catch (err) {
+      if (err instanceof OIDCError) {
+        console.error(`OIDC configuration error [${err.code}]: ${err.message}`)
+        console.error(
+          'OIDC will be disabled. Fix the configuration and restart.'
+        )
+      } else {
+        console.error('Unexpected error parsing OIDC configuration:', err)
+        console.error('OIDC will be disabled.')
+      }
+      cachedOIDCConfig = { ...OIDC_DEFAULTS, enabled: false } as OIDCConfig
     }
-    return cachedOIDCConfig
+  }
+  parseAndCacheOIDCConfig()
+
+  function getOIDCConfig(): OIDCConfig {
+    return cachedOIDCConfig!
   }
 
-  // Update OIDC configuration in memory and clear cache
   function updateOIDCConfig(newOidcConfig: PartialOIDCConfig): void {
     options.oidc = newOidcConfig as SecurityConfig['oidc']
-    cachedOIDCConfig = null // Clear cache so it gets re-parsed
+    parseAndCacheOIDCConfig()
   }
   strategy.updateOIDCConfig = updateOIDCConfig
 
@@ -965,6 +982,7 @@ function tokenSecurityFactory(
     newConfig.devices = aConfig.devices
     newConfig.secretKey = aConfig.secretKey
     options = newConfig as TokenSecurityOptions
+    parseAndCacheOIDCConfig()
     return newConfig
   }
 


### PR DESCRIPTION
## Summary

- Validate OIDC configuration eagerly during security module initialization instead of lazily on first request
- If validation fails, OIDC is cleanly disabled with a clear error log and local authentication continues working
- Add missing `isOIDCEnabled()` guard in the OIDC callback route

Previously, invalid OIDC config was only detected when the first request triggered `getOIDCConfig()`, which could leave the server in a degraded state. The fallback config now uses `OIDC_DEFAULTS` for proper type shape, and error logging distinguishes between `OIDCError` (config validation) and unexpected errors.

Fixes #2594

## Test plan

- [ ] Configure OIDC with a missing required field (e.g., no `clientSecret`) → server starts, logs `OIDC configuration error [CONFIG_INVALID]: ...`, OIDC disabled, local auth works
- [ ] Configure OIDC correctly → works as before, no behavior change
- [ ] Hit `/signalk/v1/auth/oidc/callback` when OIDC is disabled → redirects to login with error message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR validates OIDC configuration eagerly during security module initialization to prevent authentication bypass when OIDC is misconfigured. Configuration issues are detected at startup, logged clearly, and OIDC is cleanly disabled so the server continues using local authentication.

## Changes

### src/tokensecurity.ts
- Imports OIDCError and OIDC_DEFAULTS to support early validation and a typed fallback.
- Parses and caches OIDC configuration during tokenSecurityFactory initialization (eager validation) instead of parsing lazily on first request.
- Wraps parseOIDCConfig(options) in try/catch:
  - If parse throws an OIDCError, logs `OIDC configuration error [code]: message` and disables OIDC.
  - If parse throws any other error, logs an "Unexpected error parsing OIDC configuration" message and disables OIDC.
- On parse failure, sets cachedOIDCConfig to a fallback shaped from OIDC_DEFAULTS with enabled: false to ensure correct types and prevent cascading failures.
- getOIDCConfig() returns the cached value unconditionally, and updateOIDCConfig(newOidcConfig) updates options.oidc then re-parses/re-caches immediately.

### src/oidc/oidc-auth.ts
- Adds an isOIDCEnabled(oidcConfig) guard in the OIDC callback route (/signalk/v1/auth/oidc/callback).
- If OIDC is disabled, the callback redirects to the login UI with an error message (`'OIDC is not configured'`) and terminates early, preventing discovery/token exchange and avoiding crashes.

## Impact

- Configuration errors (e.g., missing fields or invalid redirect URIs) no longer crash the security module or leave the server unauthenticated.
- Logs clearly distinguish configuration validation errors from unexpected errors, aiding troubleshooting.
- The server gracefully degrades to local authentication when OIDC validation fails.
- The OIDC callback route safely handles cases when OIDC is disabled.

## Fixes
Fixes issue #2594.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->