### PR TITLE
fix(oidc): persist user identity metadata to security.json

### DIFF
--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -204,7 +204,7 @@ export async function findOrCreateOIDCUser(
       try {
         await deps.userService.updateUser(user.username, {
           type: mappedPermission,
-          providerData: oidcMetadata
+          providerData: { oidc: oidcMetadata }
         })
         // Update local reference for return
         user.type = mappedPermission
@@ -238,7 +238,7 @@ export async function findOrCreateOIDCUser(
   const newUser: ExternalUser = {
     username: finalUsername,
     type: mappedPermission,
-    providerData: oidcMetadata
+    providerData: { oidc: oidcMetadata }
   }
 
   debug(


### PR DESCRIPTION
## Summary

- Wrap `oidcMetadata` under the `oidc` key when passing to `userService.createUser()` and `updateUser()`
- Without this fix, OIDC users lose their identity after server restart, causing duplicate user creation or login failures

The receiving end in `tokensecurity.ts` reads `externalUser.providerData?.oidc`, but `oidc-auth.ts` was passing the metadata directly as `providerData` (without the `.oidc` nesting). This caused `isOIDCUserIdentifier(undefined)` to return false, so the `oidc` field was never written to the persisted user object.

This mismatch was introduced in the type safety refactor (#2283) which added the `ExternalUser`/`providerData` abstraction layer. The original inline code used `user.oidc = oidcMetadata` directly and did not have this bug.

Fixes #2590

## Test plan

- [ ] Configure OIDC with any provider, log in → check `security.json` contains `oidc: { sub, issuer, email, ... }` on the user entry
- [ ] Restart server → log in via OIDC again → same user matched (no duplicate created)
- [ ] With `autoCreateUsers: false` → restart → OIDC login succeeds for previously created user

🤖 Generated with [Claude Code](https://claude.com/claude-code)