### PR TITLE
docs(oidc): fix auto-login bypass parameter

### DIFF
--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -293,7 +293,7 @@ This is useful when:
 - Signal K is behind a reverse proxy that handles authentication
 - You want a seamless SSO experience
 
-**Note**: Local login remains available at `/admin/#/login?local=true`
+**Note**: Local login remains available at `/admin/#/login?noAutoLogin=true`
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary

- Fix documented OIDC auto-login bypass parameter from `?local=true` to `?noAutoLogin=true`

The admin UI's `Login.tsx` component checks for `noAutoLogin=true` in `shouldSkipAutoLogin()`, not `local=true`. The documentation was incorrect.

Fixes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)