### PR TITLE
fix(oidc): add redirectUri field to admin GUI and fix ENV validation

### DIFF
--- a/packages/server-admin-ui/src/views/security/OIDCSettings.tsx
+++ b/packages/server-admin-ui/src/views/security/OIDCSettings.tsx
@@ -39,6 +39,7 @@ interface OIDCConfig {
   issuer: string
   clientId: string
   clientSecretSet: boolean
+  redirectUri: string
   providerName: string
   defaultPermission: string
   autoCreateUsers: boolean
@@ -65,6 +66,7 @@ const OIDCSettings: React.FC = () => {
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
   const [clientSecretSet, setClientSecretSet] = useState(false)
+  const [redirectUri, setRedirectUri] = useState('')
   const [providerName, setProviderName] = useState('SSO Login')
   const [defaultPermission, setDefaultPermission] = useState('readonly')
   const [autoCreateUsers, setAutoCreateUsers] = useState(true)
@@ -87,6 +89,7 @@ const OIDCSettings: React.FC = () => {
         setClientId(data.clientId || '')
         setClientSecret('')
         setClientSecretSet(data.clientSecretSet || false)
+        setRedirectUri(data.redirectUri || '')
         setProviderName(data.providerName || 'SSO Login')
         setDefaultPermission(data.defaultPermission || 'readonly')
         setAutoCreateUsers(
@@ -127,6 +130,7 @@ const OIDCSettings: React.FC = () => {
       issuer,
       clientId,
       clientSecret,
+      redirectUri,
       providerName,
       defaultPermission,
       autoCreateUsers,
@@ -169,6 +173,7 @@ const OIDCSettings: React.FC = () => {
     issuer,
     clientId,
     clientSecret,
+    redirectUri,
     providerName,
     defaultPermission,
     autoCreateUsers,
@@ -408,6 +413,29 @@ const OIDCSettings: React.FC = () => {
                     <strong>Recommended:</strong> Set via environment variable{' '}
                     <code>SIGNALK_OIDC_CLIENT_SECRET</code> instead of storing
                     in configuration.
+                  </Form.Text>
+                </Col>
+              </Form.Group>
+
+              <Form.Group as={Row}>
+                <Col md="3">
+                  <Form.Label htmlFor="redirectUri">Redirect URI</Form.Label>
+                  {renderEnvBadge('redirectUri')}
+                </Col>
+                <Col xs="12" md="9">
+                  <Form.Control
+                    type="text"
+                    id="redirectUri"
+                    name="redirectUri"
+                    autoComplete="off"
+                    placeholder="https://your-server/signalk/v1/auth/oidc/callback"
+                    onChange={(e) => setRedirectUri(e.target.value)}
+                    value={redirectUri}
+                    disabled={isFieldDisabled('redirectUri')}
+                  />
+                  <Form.Text muted>
+                    The full public URL of the OIDC callback endpoint on this
+                    server. Must use https unless targeting localhost.
                   </Form.Text>
                 </Col>
               </Form.Group>

--- a/src/oidc/oidc-admin.ts
+++ b/src/oidc/oidc-admin.ts
@@ -206,9 +206,16 @@ export function registerOIDCAdminRoutes(
         newOidcConfig.readwriteGroups = readwriteGroups
       }
 
-      // Preserve existing client secret if new one is empty
-      if (!newOidcConfig.clientSecret && config.oidc?.clientSecret) {
-        newOidcConfig.clientSecret = config.oidc.clientSecret
+      // Fill in values from existing config or environment variables
+      // for fields the form left empty (e.g., secrets set via env var)
+      const envConfig = parseEnvConfig()
+      if (!newOidcConfig.clientSecret) {
+        newOidcConfig.clientSecret =
+          config.oidc?.clientSecret || envConfig.clientSecret
+      }
+      if (!newOidcConfig.redirectUri) {
+        newOidcConfig.redirectUri =
+          config.oidc?.redirectUri || envConfig.redirectUri
       }
 
       // Validate the configuration


### PR DESCRIPTION
## Summary

- Add missing Redirect URI form field to the OIDC settings page in the admin GUI
- Fix PUT handler to merge environment variable values before validation, so saving succeeds when `clientSecret` or `redirectUri` are set via env var

### Missing redirectUri field

The server requires `redirectUri` when OIDC is enabled, and the GET endpoint already returns it with env override status, but the GUI had no form field — users had to edit `security.json` directly or use `SIGNALK_OIDC_REDIRECT_URI`.

### ENV validation bypass

When `SIGNALK_OIDC_CLIENT_SECRET` is set via environment variable, the GUI correctly shows an ENV badge and disables the field. But saving with the field empty failed validation because the PUT handler only checked the form data and existing `security.json` value, not the env var. Now the handler falls back to env var values using the existing `parseEnvConfig()`, matching how `parseOIDCConfig()` works at startup.

Fixes #2593

## Test plan

- [ ] Set `SIGNALK_OIDC_CLIENT_SECRET` via env var → GUI shows ENV badge → save with empty field → succeeds
- [ ] Set `SIGNALK_OIDC_REDIRECT_URI` via env var → GUI shows ENV badge on Redirect URI field → save → succeeds
- [ ] Enter redirect URI in GUI form → save → value persisted to `security.json`
- [ ] No env vars set, fill all fields including Redirect URI → save → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for configuring the OIDC `redirectUri` field through the admin GUI and fixes the save handler to properly recognize values provided via environment variables.

## Changes

### Admin UI (OIDCSettings.tsx)
Adds a new "Redirect URI" form field to the OIDC settings page that:
- Is populated from the fetched configuration data
- Displays an ENV badge when the value is set via the `SIGNALK_OIDC_REDIRECT_URI` environment variable
- Is included in the save payload sent to the server
- Respects the disabled state when configured via environment variable

### API Handler (oidc-admin.ts)
Updates the PUT `/skServer/security/oidc` handler to:
- Fill in `clientSecret` from either the stored configuration or environment variables when the form field is left empty
- Fill in `redirectUri` from either the stored configuration or environment variables when the form field is left empty
- This enables successful saves when secrets or URIs are provided via environment variables but omitted from the form submission

## Behavior
The changes ensure that:
- Users can configure `redirectUri` directly in the admin GUI instead of editing `security.json` or relying solely on environment variables
- Environment variable values are properly recognized during save operations, preventing validation failures when the corresponding form field is empty
- The GUI behavior aligns with server startup validation, which already requires `redirectUri` when OIDC is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->