### PR TITLE
chore(deps): bump mathjs to ^15.2.0 (GHSA-jvff-x2qm-6286) (#71)

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "marked": "^17.0.5",
-    "mathjs": "^12.4.0",
+    "mathjs": "^15.2.0",
     "mdns-js": "^1.0.3",
     "minimist": "^1.2.8",
     "moment": "^2.10.6",

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -65,7 +65,7 @@
     "lodash.remove": "^4.7.0",
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
-    "mathjs": "^12.4.0",
+    "mathjs": "^15.2.0",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
Resolves HIGH severity prototype-pollution advisory in mathjs <15.2.0. Usage is limited to compile()/evaluate({ value }) on arithmetic formulas, which is unaffected by v13-v15 breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR updates the `mathjs` dependency from `^12.4.0` to `^15.2.0` to resolve a HIGH-severity prototype-pollution vulnerability (GHSA-jvff-x2qm-6286) affecting mathjs versions earlier than 15.2.0.

## Changes

The PR updates the `mathjs` version constraint in two `package.json` files:
- Root `package.json`
- `packages/server-admin-ui/package.json`

Both files have the same dependency version bumped to `^15.2.0`.

## Impact

The codebase's usage of mathjs is limited to `compile()` and `evaluate()` on arithmetic formulas, which remain unaffected by breaking changes introduced between versions 13 and 15. The version upgrade addresses the security vulnerability without causing functional issues in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->