### PR TITLE
chore: bump @signalk/nmea0183-utilities to ^1.0.0

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -69,7 +69,7 @@
     "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^4.1.0",
     "@signalk/nmea0183-signalk": "^3.0.0",
-    "@signalk/nmea0183-utilities": "^0.12.0",
+    "@signalk/nmea0183-utilities": "^1.0.0",
     "@signalk/signalk-schema": "^1.5.0",
     "any-shell-escape": "^0.1.1",
     "file-timestamp-stream": "^2.1.2",

--- a/packages/streams/src/vendor.d.ts
+++ b/packages/streams/src/vendor.d.ts
@@ -45,10 +45,6 @@ declare module '@signalk/nmea0183-signalk' {
   export = Parser
 }
 
-declare module '@signalk/nmea0183-utilities' {
-  export function appendChecksum(sentence: string): string
-}
-
 declare module '@signalk/client' {
   import { EventEmitter } from 'events'
   interface ClientOptions {


### PR DESCRIPTION
Picks up [`@signalk/nmea0183-utilities@1.0.0`](https://github.com/SignalK/nmea0183-utilities/releases/tag/v1.0.0), the TS-strict major release.

## Change

- `packages/streams/package.json`: `@signalk/nmea0183-utilities`: `^0.12.0` → `^1.0.0`
- `packages/streams/src/vendor.d.ts`: drop the `appendChecksum`-only ambient shim (the package now ships its own `.d.ts`)

`@signalk/nmea0183-signalk` pin is intentionally **not** touched. `^3.0.0` already resolves to the just-released 3.19.0, whose own dep is utilities `^1.0.0` — so npm dedupes to a single top-level utilities copy. An older lockfile still pinning 3.18.x would get a nested `utilities@0.12.x` alongside the new top-level 1.x; both coexist fine because streams only uses `appendChecksum`, which is unchanged between 0.12 and 1.0.

The `@signalk/nmea0183-signalk` ambient shim in `vendor.d.ts` stays, again because we're not explicitly upgrading that pin here.

## Breaking-change audit for utilities 1.0.0

Five symbols were removed/tightened. Grep across `packages/streams/src/`:

| Break | Present in streams? |
|---|---|
| `utils.integer` / `utils.double` removed | no |
| `utils.magneticVariaton` removed | no (only in `nmea0183-signalk/hooks/RMC`, fixed in 3.19.0) |
| `utils.zero(...)` with string/non-integer | no |
| `UnitFormat`/`Pole` tightened types at runtime throw | no (no `transform`/`coordinate`/`magneticVariation` calls in streams) |
| 2-digit year `YY ≥ 80 → 19YY` | no (no `utils.timestamp` calls) |

Streams only imports `appendChecksum` (unchanged).

## Verification

- [x] `npm install` from root — clean resolution, single copy of utilities@1.0.0 and nmea0183-signalk@3.19.0
- [x] `npm run build` from root — `tsc --build` clean after the shim removal
- [x] `cd packages/streams && npx mocha src/nmea0183-signalk.test.ts` — **10/10 passing**
- [x] Full `packages/streams` test run — 59 passing; 2 unrelated pre-existing Windows path-separator failures in `logging.test.ts`

## Companion verification (published npm artifact)

Mounted `@signalk/nmea0183-signalk@3.19.0` into both `cr.signalk.io/signalk/signalk-server:latest` and `:v2.20.0` Docker images and ran a multi-sentence parse (RMC / GGA / AIVDM) from inside the signalk-server install tree — server boots clean, `new Parser().parse(...)` produces correct deltas on both versions, no errors in logs.