### PR TITLE
perf(backpressure): cache getBufferLength across send and assertBufferSize

### DIFF
--- a/src/BackpressureManager.ts
+++ b/src/BackpressureManager.ts
@@ -94,7 +94,7 @@ export class BackpressureManager {
       this.options.beforeWrite?.(delta)
       this.transport.write(delta)
     }
-    this.assertBufferSize()
+    this.assertBufferSize(bufferLength)
   }
 
   flush(): void {
@@ -116,9 +116,9 @@ export class BackpressureManager {
     )
   }
 
-  assertBufferSize(): void {
+  assertBufferSize(knownBufferLength?: number): void {
     if (this.options.maxBufferSize === 0) return
-    const bufferLength = this.transport.getBufferLength()
+    const bufferLength = knownBufferLength ?? this.transport.getBufferLength()
     if (bufferLength > this.options.maxBufferSize) {
       if (!this.bufferSizeExceeded) {
         console.warn(

--- a/test/BackpressureManager.ts
+++ b/test/BackpressureManager.ts
@@ -11,6 +11,7 @@ interface MockTransport extends BackpressureTransport {
   _bufferLength: number
   _writes: Delta[]
   _destroyed: boolean
+  _bufferLengthCalls: number
 }
 
 function createMockTransport(bufferLength = 0): MockTransport {
@@ -19,7 +20,9 @@ function createMockTransport(bufferLength = 0): MockTransport {
     _bufferLength: bufferLength,
     _writes: [],
     _destroyed: false,
+    _bufferLengthCalls: 0,
     getBufferLength() {
+      this._bufferLengthCalls++
       return this._bufferLength
     },
     write(delta: Delta) {
@@ -110,6 +113,15 @@ describe('BackpressureManager', function () {
       manager.send(createDelta('navigation.speedOverGround', 6.0))
 
       expect(manager.accumulatorSize).to.equal(1)
+    })
+
+    it('should read transport buffer length only once per send', function () {
+      const transport = createMockTransport(0)
+      const manager = new BackpressureManager(transport, defaultOptions)
+
+      manager.send(createDelta('navigation.speedOverGround', 5.0))
+
+      expect(transport._bufferLengthCalls).to.equal(1)
     })
 
     it('should work without beforeWrite hook', function () {


### PR DESCRIPTION
## Why

`BackpressureManager.send()` reads `transport.getBufferLength()` to decide whether to accumulate or write, then calls `assertBufferSize()`, which reads it again. Two kernel/socket lookups per delta for no reason.

## How

Pass the already-read buffer length into `assertBufferSize()` via an optional parameter. `send()` now issues exactly one `getBufferLength()` call. External callers (`onDrain`) are unaffected.

A new test pins the call count to 1 per `send()` via a counter on the mock transport.

Refs #2582 (item 8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Performance optimization for BackpressureManager buffer length caching

This PR reduces redundant buffer length lookups in `BackpressureManager.send()` by caching the result of `transport.getBufferLength()` and reusing it across internal method calls.

### Changes

**BackpressureManager.ts:**
- Updates `assertBufferSize()` signature to accept an optional `knownBufferLength?: number` parameter
- `send()` now computes the transport buffer length once and passes it to `assertBufferSize(knownBufferLength)`, eliminating the duplicate kernel/socket lookup
- When `knownBufferLength` is provided, `assertBufferSize()` uses that value; otherwise, it falls back to calling `this.transport.getBufferLength()`
- External callers of `assertBufferSize()` (e.g., `onDrain`) remain unaffected and continue to work without arguments
- Buffer overflow detection, warning/error emission, and destruction behavior are unchanged

**test/BackpressureManager.ts:**
- Extends `MockTransport` with a `_bufferLengthCalls` counter to track invocations of `getBufferLength()`
- Adds a test case verifying that `manager.send()` performs exactly one buffer length lookup per send call

### Impact

This optimization eliminates one kernel/socket lookup per delta message sent, improving performance in high-throughput scenarios while maintaining backward compatibility with existing callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->