### PR TITLE
feat: Add name to course next/previous point

### DIFF
--- a/packages/server-api/src/coursetypes.ts
+++ b/packages/server-api/src/coursetypes.ts
@@ -36,6 +36,7 @@ export interface NextPreviousPoint {
   href?: string
   type: CoursePointType
   position: Position
+  name?: string
 }
 
 /** @category Course API */

--- a/packages/server-api/src/typebox/course-schemas.ts
+++ b/packages/server-api/src/typebox/course-schemas.ts
@@ -222,7 +222,8 @@ export const NextPreviousPointSchema = Type.Object(
         "Type of point. Known values: VesselPosition (vessel's current location), RoutePoint (a point on the active route), Location (an arbitrary geographic position).",
       examples: ['RoutePoint', 'Location', 'VesselPosition']
     }),
-    position: PositionSchema
+    position: PositionSchema,
+    name: Type.Optional(Type.String({ description: 'Waypoint name.' }))
   },
   { $id: 'NextPreviousPoint' }
 )

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -208,6 +208,11 @@ export class CourseApi {
                       rte,
                       pointIndex,
                       !!this.courseInfo.activeRoute.reverse
+                    ),
+                    name: this.getRoutePointName(
+                      rte,
+                      pointIndex,
+                      !!this.courseInfo.activeRoute.reverse
                     )
                   }
                   if (this.courseInfo.previousPoint?.type === RoutePoint) {
@@ -217,6 +222,11 @@ export class CourseApi {
                       this.courseInfo.previousPoint = {
                         type: RoutePoint,
                         position: this.getRoutePoint(
+                          rte,
+                          prevIndex,
+                          !!this.courseInfo.activeRoute.reverse
+                        ),
+                        name: this.getRoutePointName(
                           rte,
                           prevIndex,
                           !!this.courseInfo.activeRoute.reverse
@@ -236,6 +246,9 @@ export class CourseApi {
                 ;(this.courseInfo.nextPoint as NextPreviousPoint).position = {
                   latitude: r.feature.geometry.coordinates[1],
                   longitude: r.feature.geometry.coordinates[0]
+                }
+                if (this.courseInfo.nextPoint?.href) {
+                  this.courseInfo.nextPoint.name = r.name ?? ''
                 }
                 this.emitCourseInfo()
               }
@@ -791,6 +804,7 @@ export class CourseApi {
           if (idx !== -1) {
             this.courseInfo.activeRoute.pointIndex = idx
           }
+
           this.emitCourseInfo()
           res.status(200).json(Responses.ok)
           return
@@ -803,7 +817,12 @@ export class CourseApi {
             this.courseInfo.activeRoute.pointIndex as number,
             this.courseInfo.activeRoute.reverse
           ),
-          type: RoutePoint
+          type: RoutePoint,
+          name: this.getRoutePointName(
+            rte,
+            this.courseInfo.activeRoute.pointIndex,
+            !!this.courseInfo.activeRoute.reverse
+          )
         }
 
         // set previousPoint
@@ -831,7 +850,12 @@ export class CourseApi {
               (this.courseInfo.activeRoute.pointIndex as number) - 1,
               this.courseInfo.activeRoute.reverse
             ),
-            type: RoutePoint
+            type: RoutePoint,
+            name: this.getRoutePointName(
+              rte,
+              (this.courseInfo.activeRoute.pointIndex as number) - 1,
+              !!this.courseInfo.activeRoute.reverse
+            )
           }
         }
         this.emitCourseInfo()
@@ -881,7 +905,8 @@ export class CourseApi {
     newCourse.activeRoute = activeRoute
     newCourse.nextPoint = {
       type: RoutePoint,
-      position: this.getRoutePoint(rte, pointIndex, !!reverse)
+      position: this.getRoutePoint(rte, pointIndex, !!reverse),
+      name: this.getRoutePointName(rte, pointIndex, !!reverse)
     }
     newCourse.startTime = new Date().toISOString()
 
@@ -911,7 +936,12 @@ export class CourseApi {
           activeRoute.pointIndex - 1,
           activeRoute.reverse
         ),
-        type: RoutePoint
+        type: RoutePoint,
+        name: this.getRoutePointName(
+          rte,
+          activeRoute.pointIndex - 1,
+          activeRoute.reverse
+        )
       }
     }
 
@@ -952,7 +982,8 @@ export class CourseApi {
                 longitude: r.feature.geometry.coordinates[0]
               },
               href: dest.href,
-              type: (r.type as CoursePointType) ?? 'Waypoint'
+              type: (r.type as CoursePointType) ?? 'Waypoint',
+              name: r.name ?? ''
             }
             newCourse.activeRoute = null
           } else {
@@ -1070,6 +1101,19 @@ export class CourseApi {
       result.altitude = pos[2]
     }
     return result
+  }
+
+  private getRoutePointName(rte: any, index: number, reverse: boolean | null) {
+    if (!Array.isArray(rte.feature.properties?.coordinatesMeta)) {
+      return ''
+    }
+    const meta = reverse
+      ? rte.feature.properties.coordinatesMeta[
+          rte.feature.properties.coordinatesMeta.length - (index + 1)
+        ]
+      : rte.feature.properties.coordinatesMeta[index]
+
+    return meta?.name ?? ''
   }
 
   private getRoutePoints(rte: any) {

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1087,7 +1087,7 @@ export class CourseApi {
     }
   }
 
-  private getRoutePoint(rte: any, index: number, reverse: boolean | null) {
+  private getRoutePoint(rte: Route, index: number, reverse: boolean | null) {
     const pos = reverse
       ? rte.feature.geometry.coordinates[
           rte.feature.geometry.coordinates.length - (index + 1)
@@ -1103,15 +1103,16 @@ export class CourseApi {
     return result
   }
 
-  private getRoutePointName(rte: any, index: number, reverse: boolean | null) {
-    if (!Array.isArray(rte.feature.properties?.coordinatesMeta)) {
+  private getRoutePointName(rte: Route, index: number, reverse: boolean | null) {
+    const {coordinatesMeta} = rte.feature.properties as Record<string, {name: string}>
+    if (!Array.isArray(coordinatesMeta)) {
       return ''
     }
     const meta = reverse
-      ? rte.feature.properties.coordinatesMeta[
-          rte.feature.properties.coordinatesMeta.length - (index + 1)
+      ? coordinatesMeta[
+          coordinatesMeta.length - (index + 1)
         ]
-      : rte.feature.properties.coordinatesMeta[index]
+      : coordinatesMeta[index]
 
     return meta?.name ?? ''
   }

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1103,15 +1103,20 @@ export class CourseApi {
     return result
   }
 
-  private getRoutePointName(rte: Route, index: number, reverse: boolean | null) {
-    const {coordinatesMeta} = rte.feature.properties as Record<string, {name: string}>
+  private getRoutePointName(
+    rte: Route,
+    index: number,
+    reverse: boolean | null
+  ) {
+    const { coordinatesMeta } = rte.feature.properties as Record<
+      string,
+      { name: string }
+    >
     if (!Array.isArray(coordinatesMeta)) {
       return ''
     }
     const meta = reverse
-      ? coordinatesMeta[
-          coordinatesMeta.length - (index + 1)
-        ]
+      ? coordinatesMeta[coordinatesMeta.length - (index + 1)]
       : coordinatesMeta[index]
 
     return meta?.name ?? ''

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1111,7 +1111,7 @@ export class CourseApi {
     index: number,
     reverse: boolean | null
   ) {
-    const { coordinatesMeta } = rte.feature.properties as Record<
+    const { coordinatesMeta } = (rte.feature.properties ?? {}) as Record<
       string,
       { name: string }
     >

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -248,7 +248,7 @@ export class CourseApi {
                   longitude: r.feature.geometry.coordinates[0]
                 }
                 if (this.courseInfo.nextPoint?.href) {
-                  this.courseInfo.nextPoint.name = r.name ?? ''
+                  this.courseInfo.nextPoint.name = r.name ?? 'WP1'
                 }
                 this.emitCourseInfo()
               }
@@ -921,7 +921,8 @@ export class CourseApi {
         if (position && position.value) {
           newCourse.previousPoint = {
             position: position.value,
-            type: VesselPosition
+            type: VesselPosition,
+            name: `VP`
           }
         } else {
           throw new Error(`Error: Unable to retrieve vessel position!`)
@@ -983,7 +984,7 @@ export class CourseApi {
               },
               href: dest.href,
               type: (r.type as CoursePointType) ?? 'Waypoint',
-              name: r.name ?? ''
+              name: r.name ?? 'WP1'
             }
             newCourse.activeRoute = null
           } else {
@@ -999,7 +1000,8 @@ export class CourseApi {
       if (this.isValidPosition(dest.position)) {
         newCourse.nextPoint = {
           position: dest.position,
-          type: Location
+          type: Location,
+          name: 'DP'
         }
       } else {
         throw new Error(`Error: position is not valid`)
@@ -1017,7 +1019,8 @@ export class CourseApi {
       if (position && position.value) {
         newCourse.previousPoint = {
           position: position.value,
-          type: VesselPosition
+          type: VesselPosition,
+          name: 'VP'
         }
       } else {
         throw new Error(
@@ -1119,7 +1122,7 @@ export class CourseApi {
       ? coordinatesMeta[coordinatesMeta.length - (index + 1)]
       : coordinatesMeta[index]
 
-    return meta?.name ?? ''
+    return meta?.name ?? `WP${index + 1}`
   }
 
   private getRoutePoints(rte: any) {

--- a/test/course.ts
+++ b/test/course.ts
@@ -304,7 +304,7 @@ describe('Course Api', () => {
             longitude: 3.3452
           },
           type: 'RoutePoint',
-          name: 'WP1'
+          name: ''
         }
       },
       {
@@ -351,7 +351,7 @@ describe('Course Api', () => {
           latitude: points.feature.geometry.coordinates[0][1]
         },
         type: 'RoutePoint',
-        name: 'WP1'
+        name: ''
       },
       previousPoint: {
         type: 'VesselPosition',

--- a/test/course.ts
+++ b/test/course.ts
@@ -37,7 +37,8 @@ describe('Course Api', () => {
             latitude: -35.5,
             longitude: 138.7
           },
-          type: 'Location'
+          type: 'Location',
+          name: 'DP'
         }
       },
       {
@@ -47,7 +48,8 @@ describe('Course Api', () => {
             latitude: -35.45,
             longitude: 138
           },
-          type: 'VesselPosition'
+          type: 'VesselPosition',
+          name: 'VP'
         }
       }
     ]
@@ -64,11 +66,13 @@ describe('Course Api', () => {
       activeRoute: null,
       nextPoint: {
         type: 'Location',
-        position: { latitude: -35.5, longitude: 138.7 }
+        position: { latitude: -35.5, longitude: 138.7 },
+        name: 'DP'
       },
       previousPoint: {
         type: 'VesselPosition',
-        position: { latitude: -35.45, longitude: 138 }
+        position: { latitude: -35.45, longitude: 138 },
+        name: 'VP'
       }
     })
 
@@ -93,7 +97,8 @@ describe('Course Api', () => {
     const v2courseDelta = JSON.parse(await wsPromiser.nthMessage(4))
     deltaHasPathValue(v2courseDelta, 'navigation.course.nextPoint', {
       position: validDestinationPosition,
-      type: 'Location'
+      type: 'Location',
+      name: 'DP'
     })
 
     await selfPut('navigation/course/destination', {
@@ -160,14 +165,16 @@ describe('Course Api', () => {
         value: {
           href: `/resources/waypoints/${id}`,
           position: { latitude: 60.1699, longitude: 24.9384 },
-          type: 'Waypoint'
+          type: 'Waypoint',
+          name: 'WP1'
         }
       },
       {
         path: 'navigation.course.previousPoint',
         value: {
           position: { latitude: -35.45, longitude: 138 },
-          type: 'VesselPosition'
+          type: 'VesselPosition',
+          name: 'VP'
         }
       }
     ]
@@ -194,11 +201,13 @@ describe('Course Api', () => {
         position: {
           longitude: destination.feature.geometry.coordinates[0],
           latitude: destination.feature.geometry.coordinates[1]
-        }
+        },
+        name: 'WP1'
       },
       previousPoint: {
         type: 'VesselPosition',
-        position: vesselPosition
+        position: vesselPosition,
+        name: 'VP'
       }
     })
 
@@ -294,7 +303,8 @@ describe('Course Api', () => {
             latitude: 65.4567,
             longitude: 3.3452
           },
-          type: 'RoutePoint'
+          type: 'RoutePoint',
+          name: 'WP1'
         }
       },
       {
@@ -308,7 +318,8 @@ describe('Course Api', () => {
             latitude: -35.45,
             longitude: 138
           },
-          type: 'VesselPosition'
+          type: 'VesselPosition',
+          name: 'VP'
         }
       }
     ]
@@ -339,11 +350,13 @@ describe('Course Api', () => {
           longitude: points.feature.geometry.coordinates[0][0],
           latitude: points.feature.geometry.coordinates[0][1]
         },
-        type: 'RoutePoint'
+        type: 'RoutePoint',
+        name: 'WP1'
       },
       previousPoint: {
         type: 'VesselPosition',
-        position: vesselPosition
+        position: vesselPosition,
+        name: 'VP'
       }
     })
 


### PR DESCRIPTION
(#2595)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an optional name property to the course next/previous point API and populates it where route, waypoint, or position metadata is available.

## Changes

- Type definitions: Updates the NextPreviousPoint interface in packages/server-api/src/coursetypes.ts to include an optional name?: string property.

- Schema: Extends NextPreviousPointSchema in packages/server-api/src/typebox/course-schemas.ts to define the new optional name string property (description: "Waypoint name.").

- API implementation: Populates nextPoint.name and previousPoint.name throughout course logic:
  - Adds a private getRoutePointName(rte, index, reverse) helper that reads waypoint names from rte.feature.properties.coordinatesMeta and returns meta?.name ?? `WP${index + 1}` (falls back to an auto-generated "WPn" id when coordinatesMeta entry lacks a name).
  - Uses getRoutePointName when constructing route-derived next/previous points (processResourceDeltas, active-route flows including refresh/activate/set-active-route).
  - When the destination is a waypoint resource, nextPoint.name is set from the waypoint resource (r.name ?? 'WP1').
  - When the destination is a position, nextPoint is set with type: Location and name: 'DP'.
  - When previousPoint is set to vessel position in relevant flows, previousPoint.name is set to 'VP'.
  - Tightens the getRoutePoint helper parameter type from any to Route.

Behavioral note: next/previous point objects always include the optional name field when available; the implementation supplies sensible defaults (WPn, WP1, DP, VP) rather than leaving name empty in those cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->