### PR TITLE
fix(admin-ui): restore logo loading broken by Vite 8 upgrade

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -232,7 +232,10 @@ module.exports = function (
   app.use(
     '/admin/assets/public_src/img',
     express.static(
-      path.join(__dirname, '/../node_modules/@signalk/server-admin-ui/public/img')
+      path.join(
+        __dirname,
+        '/../node_modules/@signalk/server-admin-ui/public/img'
+      )
     )
   )
 

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -189,13 +189,17 @@ module.exports = function (
   const logopath = path.resolve(app.config.configPath, 'logo.svg')
   if (fs.existsSync(logopath)) {
     debug(`Found custom logo at ${logopath}, adding route for it`)
-    // Intercept both Webpack (fonts/) and Vite (assets/) paths for the main logo
+    // Intercept Webpack (fonts/), Vite 6 (assets/ hashed), and Vite 8 (assets/public_src/img/) paths
     app.use(
       '/admin/fonts/signal-k-logo-image-text.*',
       (req: Request, res: Response) => res.sendFile(logopath)
     )
     app.use(
       '/admin/assets/signal-k-logo-image-text*.svg',
+      (req: Request, res: Response) => res.sendFile(logopath)
+    )
+    app.use(
+      '/admin/assets/public_src/img/signal-k-logo-image-text.svg',
       (req: Request, res: Response) => res.sendFile(logopath)
     )
 
@@ -207,7 +211,7 @@ module.exports = function (
     const minimizedLogo = fs.existsSync(minimizedLogoPath)
       ? minimizedLogoPath
       : logopath
-    // Intercept both Webpack (fonts/) and Vite (assets/) paths for the minimized logo
+    // Intercept Webpack (fonts/), Vite 6 (assets/ hashed), and Vite 8 (assets/public_src/img/) paths
     app.use(
       '/admin/fonts/signal-k-logo-image.*',
       (req: Request, res: Response) => res.sendFile(minimizedLogo)
@@ -216,7 +220,21 @@ module.exports = function (
       '/admin/assets/signal-k-logo-image*.svg',
       (req: Request, res: Response) => res.sendFile(minimizedLogo)
     )
+    app.use(
+      '/admin/assets/public_src/img/signal-k-logo-image.svg',
+      (req: Request, res: Response) => res.sendFile(minimizedLogo)
+    )
   }
+
+  // Vite 8 (Rolldown) changed CSS url() rewriting for publicDir assets: the built CSS
+  // references logos as url(public_src/img/...) which resolves to assets/public_src/img/
+  // relative to the CSS file, not the actual img/ location. Serve default logos from there.
+  app.use(
+    '/admin/assets/public_src/img',
+    express.static(
+      path.join(__dirname, '/../node_modules/@signalk/server-admin-ui/public/img')
+    )
+  )
 
   // mount before the main /admin
   mountSwaggerUi(app, '/doc/openapi')


### PR DESCRIPTION
Vite 8 (Rolldown) changed how CSS url() references to publicDir assets are rewritten. Previously (Vite 6) the SVG logos were moved to assets/ with content hashes. Now the built CSS retains a relative path (public_src/img/...) that resolves to assets/public_src/img/ when loaded from the assets/ directory, but the actual files live at img/.

Add server routes for the new Vite 8 URL pattern so custom logo overrides are intercepted correctly, and add a static route at /admin/assets/public_src/img so the default logos are served for all users regardless of custom logo configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix logo loading broken by Vite 8 upgrade

This PR restores logo loading that was broken by the Vite 8 (Rollup/Rolldown) upgrade. Vite 8 changed how CSS `url()` references to publicDir assets are rewritten—while Vite 6 moved SVG logos to `assets/` with content hashes, Vite 8 retains relative paths (`public_src/img/...`) in the built CSS that resolve to `assets/public_src/img/` when loaded from the assets directory, but the actual files remain at `img/`.

The PR adds Express middleware routes to intercept custom logo requests under the new Vite 8 URL pattern and serve the user-configured logos. For the main logo text variant, it registers routes for both the legacy Webpack path pattern (`/admin/fonts/signal-k-logo-image-text.*`) and the Vite hashed path pattern (`/admin/assets/signal-k-logo-image-text*.svg`) to serve a custom `logo.svg` when present. Similarly, for the minimized sidebar logo, it adds routes for both path patterns to serve either a custom `logo-minimized.svg` (if present) or falls back to the main `logo.svg`.

Additionally, the PR registers a static file middleware at `/admin/assets/public_src/img` that serves default logos directly from the admin-ui package public directory, ensuring all users receive the default logos regardless of custom logo configuration.

Changes are limited to registering Express middleware routes in `src/serverroutes.ts` (+20/-2 lines).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->