### PR TITLE
fix(hot-fix): Pin Vite version 8.0.8

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -78,7 +78,7 @@
     "sass": "^1.81.0",
     "simple-line-icons": "^2.5.5",
     "typescript": "^5.7.2",
-    "vite": "^8.0.3",
+    "vite": "8.0.8",
     "vitest": "^4.1.2"
   },
   "scripts": {


### PR DESCRIPTION
Root cause
Vite 8.0.9 bumped rolldown from rc.15 to rc.16. Rolldown rc.16 added PR #9071 "emit REQUIRE_TLA error when require() loads a module with top-level await".

Your build fails because @module-federation/vite@1.14.5 generates virtual __mf__virtual/__mfe_internal__adminUI__loadShare__react(__dom)?__loadShare__.mjs files containing top-level await, and React/React-DOM's CJS production files (react.production.js, react-dom.production.js, react-compiler-runtime.production.js, html-react-parser) require("react") / require("react-dom"). Rolldown rc.16 now rejects that chain. Vite 8.0.8 (rolldown rc.15) didn't enforce it.

No published fix exists in @module-federation/vite yet — 1.14.5 is still latest as of today.