### PR TITLE
fix(streams): skip provider error on gpsd initial connect

### DIFF
--- a/packages/streams/src/gpsd.test.ts
+++ b/packages/streams/src/gpsd.test.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai'
+import net from 'net'
+import { Writable } from 'stream'
+import Gpsd from './gpsd'
+import { createMockApp, createDebugStub } from './test-helpers'
+
+describe('Gpsd', () => {
+  let server: net.Server
+  let serverPort: number
+  const activeSockets = new Set<net.Socket>()
+  const pendingStreams = new Set<Gpsd>()
+  const pendingIntervals = new Set<ReturnType<typeof setInterval>>()
+
+  beforeEach((done) => {
+    server = net.createServer((socket) => {
+      activeSockets.add(socket)
+      socket.on('close', () => activeSockets.delete(socket))
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as net.AddressInfo
+      serverPort = addr.port
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    pendingIntervals.forEach((i) => clearInterval(i))
+    pendingIntervals.clear()
+    pendingStreams.forEach((s) => s.end())
+    pendingStreams.clear()
+    activeSockets.forEach((s) => s.destroy())
+    activeSockets.clear()
+    if (server.listening) {
+      server.close(() => done())
+    } else {
+      done()
+    }
+  })
+
+  it('does not report a provider error for the initial connection attempt', function (done) {
+    this.timeout(5000)
+
+    server.on('connection', (socket) => {
+      socket.write('$GPRMC,,V,,,,,,,,,,N*53\r\n')
+    })
+
+    const app = createMockApp()
+    const gpsd = new Gpsd({
+      host: '127.0.0.1',
+      port: serverPort,
+      app,
+      providerId: 'test-gpsd',
+      createDebug: createDebugStub()
+    })
+    pendingStreams.add(gpsd)
+
+    const writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback()
+      }
+    })
+
+    writable.on('pipe', () => {
+      setTimeout(() => {
+        const retryZeroErrors = app.providerErrors.filter((e) =>
+          e.msg.includes('retry 0')
+        )
+        expect(retryZeroErrors).to.have.lengthOf(0)
+        expect(
+          app.providerStatuses.some((s) => s.msg.includes('Connected'))
+        ).to.equal(true)
+        done()
+      }, 200)
+    })
+
+    gpsd.pipe(writable)
+  })
+
+  it('reports a provider error for actual reconnect attempts (retry > 0)', function (done) {
+    this.timeout(5000)
+
+    // Close the listener so connection attempts fail and reconnect-core retries.
+    server.close(() => {
+      const app = createMockApp()
+      const gpsd = new Gpsd({
+        host: '127.0.0.1',
+        port: serverPort,
+        app,
+        providerId: 'test-gpsd',
+        createDebug: createDebugStub()
+      })
+      pendingStreams.add(gpsd)
+
+      const writable = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback()
+        }
+      })
+
+      const check = setInterval(() => {
+        const retryErrors = app.providerErrors.filter((e) =>
+          /retry [1-9]/.test(e.msg)
+        )
+        if (retryErrors.length > 0) {
+          clearInterval(check)
+          pendingIntervals.delete(check)
+          done()
+        }
+      }, 50)
+      pendingIntervals.add(check)
+
+      gpsd.pipe(writable)
+    })
+  })
+})

--- a/packages/streams/src/gpsd.ts
+++ b/packages/streams/src/gpsd.ts
@@ -77,7 +77,9 @@ export default class Gpsd extends Transform {
       })
       .on('reconnect', (n: number, delay: number) => {
         const msg = `Reconnect ${label} retry ${n} delay ${delay}`
-        this.options.app.setProviderError(this.options.providerId, msg)
+        if (n > 0) {
+          this.options.app.setProviderError(this.options.providerId, msg)
+        }
         this.debug(msg)
       })
       .on('disconnect', () => {


### PR DESCRIPTION
## Summary

The `Gpsd` stream in `@signalk/streams` currently logs a provider error on every SK server startup for healthy gpsd connections:

```
Reconnect localhost:2947 retry 0 delay 0
```

This happens even when gpsd is running, reachable, and the connection succeeds immediately. It's noise in the provider error log, and it surfaces as a red "error" banner in the admin UI for any gpsd-backed NMEA0183 provider.

## Root cause

`reconnect-core` emits its `reconnect(n, delay)` event **before every connection attempt, including the initial one** (`n === 0`, `delay === 0`). `packages/streams/src/gpsd.ts` wires that event unconditionally to `app.setProviderError(...)`, so the first attempt of every connection lifecycle gets flagged as a failure — even when the very next `connect` event fires a few milliseconds later and reports "Connected to host:port".

Relevant code before the fix:

```ts
.on('reconnect', (n: number, delay: number) => {
  const msg = `Reconnect ${label} retry ${n} delay ${delay}`
  this.options.app.setProviderError(this.options.providerId, msg)
  this.debug(msg)
})
```

## Fix

Only treat `reconnect` events as provider errors when there was actually a prior failure (`n > 0`). The initial attempt is still logged via `debug()` for troubleshooting, and successful connects continue to be reported through the existing `connect` handler's `setProviderStatus("Connected to ...")` call.

```ts
.on('reconnect', (n: number, delay: number) => {
  const msg = `Reconnect ${label} retry ${n} delay ${delay}`
  if (n > 0) {
    this.options.app.setProviderError(this.options.providerId, msg)
  }
  this.debug(msg)
})
```

## Behavior change

| Scenario | Before | After |
| --- | --- | --- |
| SK server starts, gpsd reachable, first connect succeeds | `setProviderError("Reconnect ... retry 0 delay 0")` then `setProviderStatus("Connected to ...")` | `setProviderStatus("Connecting to ...")` then `setProviderStatus("Connected to ...")` |
| gpsd unreachable, reconnect-core backs off and retries | `setProviderError` on every attempt including retry 0 | `setProviderError` on retry 1+ only |
| Connection drops mid-session and reconnect attempts begin | Unchanged — still reported as provider errors | Unchanged — still reported as provider errors |

Only the retry-0 "false positive" is suppressed. Real reconnect activity and disconnect events are still reported exactly as before.

## Tests

Adds `packages/streams/src/gpsd.test.ts` with two cases using the same mock-TCP-server pattern as `tcp.test.ts`:

1. **Initial connection is not an error** — starts a local listener, connects a `Gpsd` stream, waits, and asserts that no provider error containing `retry 0` was recorded and that a `Connected ...` status was recorded.
2. **Real retries are still errors** — closes the listener first so connect fails, then asserts that a provider error with `retry 1+` is eventually recorded.

All existing streams tests continue to pass (`npm run test:streams`).

## Notes

- No version bump, per `AGENTS.md` PR guidelines.
- No behavior change for any consumer that was checking for `retry 0` entries — those were always followed immediately by a `Connected ...` status, so they carried no actionable information.
- `console.error` output from genuine connection errors (e.g. `ECONNREFUSED`) in the `error` handler is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes noisy provider-error logging from the Gpsd stream that incorrectly reports "Reconnect host:port retry 0 delay 0" on Signal K server startup when gpsd is reachable and the connection succeeds immediately.

## Problem
reconnect-core emits a reconnect(n, delay) event before every connection attempt, including the initial attempt where n === 0. The Gpsd stream previously calls app.setProviderError(...) on every reconnect event, causing false-positive provider errors on initial successful connections.

## Solution
The reconnect event handler in the Gpsd stream now only calls setProviderError when the retry count n is greater than 0. The initial reconnect event (n === 0) is still logged via debug(), and successful connects continue to set provider status via the existing connect handler. Real retries (n ≥ 1) and mid-session disconnects continue to report provider errors as before.

## Changes

packages/streams/src/gpsd.ts
- Adds a conditional check (n > 0) before calling this.options.app.setProviderError(...) in the reconnect event handler.
- Keeps debug logging and existing reconnect/connect control flow unchanged.

packages/streams/src/gpsd.test.ts (new)
- Adds a test suite that:
  - Verifies an initial successful connection does not produce a retry-0 provider error and that provider status updates to "Connected".
  - Verifies actual reconnect attempts (retry > 0) produce provider error messages containing retry counts ≥ 1.

## Behavior Changes
- Suppresses the false-positive retry-0 provider error on initial successful connects (connecting → connected now appears correctly).
- Maintains reporting for real retries (n ≥ 1) and mid-session disconnects.
- Leaves debug logging for reconnect events and console.error output for genuine connection failures unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->