### PR TITLE
chore(server-admin-ui): restore Vite 8 build

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -66,6 +66,7 @@
     "lodash.set": "^4.3.2",
     "lodash.uniq": "^4.5.0",
     "mathjs": "^15.2.0",
+    "path-browserify": "^1.0.1",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",
@@ -78,7 +79,7 @@
     "sass": "^1.81.0",
     "simple-line-icons": "^2.5.5",
     "typescript": "^5.7.2",
-    "vite": "8.0.8",
+    "vite": "^8.0.9",
     "vitest": "^4.1.2"
   },
   "scripts": {

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
-import { federation } from '@module-federation/vite'
 
 import '@signalk/server-admin-ui-dependencies'
 
@@ -71,8 +70,6 @@ function stripSvgFonts() {
   }
 }
 
-const isTest = process.env.VITEST === 'true'
-
 export default defineConfig({
   base: './',
   publicDir: 'public_src',
@@ -82,29 +79,7 @@ export default defineConfig({
     react(),
     babel({
       presets: [reactCompilerPreset()]
-    }),
-    // Module Federation runtime injects http: imports incompatible with
-    // Node.js ESM loader, so skip it during vitest runs.
-    ...(!isTest
-      ? [
-          federation({
-            name: 'adminUI',
-            filename: 'remoteEntry.js',
-            remotes: {},
-            dts: false,
-            shared: {
-              react: {
-                singleton: true,
-                requiredVersion: '^19.0.0'
-              },
-              'react-dom': {
-                singleton: true,
-                requiredVersion: '^19.0.0'
-              }
-            }
-          })
-        ]
-      : [])
+    })
   ],
   css: {
     preprocessorOptions: {
@@ -159,7 +134,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      path: false,
+      path: 'path-browserify',
       events: 'events',
       buffer: 'buffer'
     }


### PR DESCRIPTION
Remove the admin UI's host-side federation plugin wiring so the host build no longer rewrites its own React imports into async share-loader modules that fail under the current Vite/Rolldown production build.

Replace the unsupported path: false alias with path-browserify so the Vite 8 build config remains browser-compatible and valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR restores Vite 8 build compatibility for the server admin UI by addressing two key issues with the current build configuration:

1. **Removes Module Federation Plugin**: Eliminates the admin UI's host-side federation plugin integration from the Vite build config. This prevents the build from rewriting React imports into async share-loader modules that fail during the current Vite/Rollup production build process.

2. **Replaces Invalid Path Alias**: Replaces the unsupported `path: false` alias configuration with `path-browserify`, ensuring the build config remains valid and browser-compatible while maintaining proper path module resolution.

## Changes

**packages/server-admin-ui/package.json**
- Adds `path-browserify` (`^1.0.1`) to `devDependencies`
- Updates `vite` from `8.0.8` to `^8.0.9`

**packages/server-admin-ui/vite.config.ts**
- Removes the Module Federation Vite plugin import and its conditional injection logic
- Eliminates environment-based control flow (`isTest`) that previously controlled federation activation
- Replaces the `path` module resolution alias from `false` to `'path-browserify'`
- Consolidates the Babel/React plugin configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->