### PR TITLE
fix(admin-ui): restore N2K provider filter editing

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/N2KFilters.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/N2KFilters.tsx
@@ -60,8 +60,7 @@ export default function N2KFilters({ value, onChange }: N2KFiltersProps) {
     onChange({
       target: {
         name: 'options.filtersEnabled',
-        value: event.target.checked,
-        type: 'checkbox'
+        value: event.target.checked
       }
     })
   }
@@ -85,7 +84,7 @@ export default function N2KFilters({ value, onChange }: N2KFiltersProps) {
               type="checkbox"
               name="filtersEnabled"
               className="switch-input"
-              checked={value.options.filtersEnabled}
+              checked={!!value.options.filtersEnabled}
               onChange={handleEnabledChange}
             />
             <span className="switch-label" data-on="Yes" data-off="No" />
@@ -112,10 +111,8 @@ export default function N2KFilters({ value, onChange }: N2KFiltersProps) {
               </thead>
               <tbody>
                 {filters.map((filter, index) => {
-                  // Use composite key - filters don't have stable unique IDs
-                  const filterKey = `${index}-${filter.source}-${filter.pgn}`
                   return (
-                    <tr key={filterKey}>
+                    <tr key={index}>
                       <td>
                         <Form.Control
                           type="text"

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -117,10 +117,6 @@ const ProvidersConfiguration: React.FC = () => {
     [selectedProvider]
   )
 
-  const handleProviderPropChange = useCallback(() => {
-    setSelectedProvider((prev) => (prev ? { ...prev } : null))
-  }, [])
-
   const handleAddProvider = useCallback(() => {
     const newProvider: Provider = {
       type: 'NMEA2000',
@@ -339,7 +335,7 @@ const ProvidersConfiguration: React.FC = () => {
                 <BasicProvider
                   value={selectedProvider}
                   onChange={handleProviderChange}
-                  onPropChange={handleProviderPropChange}
+                  onPropChange={handleProviderChange}
                 />
               ) : (
                 <Form.Control


### PR DESCRIPTION
## Summary

Adding or editing an NMEA 2000 provider filter silently did nothing — the row never appeared, and the Enabled toggle didn't stick. Regression from the React 19 admin-ui port.

Root cause: `ProvidersConfiguration` wired `onPropChange` to a handler that spread the previous state and discarded the incoming event, so filter mutations from `N2KFilters` never reached `selectedProvider`. Wiring it to the existing `handleProviderChange` (which uses `lodash.set` on `options.filters`) fixes it.

Also fixes two related issues surfaced once filters can actually be edited:
- Row key was `${index}-${source}-${pgn}`, so every keystroke changed the key, remounting the input and losing focus.
- `checked={value.options.filtersEnabled}` was uncontrolled when the option was undefined; coerced with `!!`.

## Test plan

- [x] Add provider → select NMEA 2000 → click Add filter → row appears
- [x] Type in Source/PGN fields → focus stays, value persists
- [x] Toggle Enabled → state persists on save
- [x] `npm test` in `packages/server-admin-ui` (91/91 pass)
- [x] `npm run build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix NMEA 2000 provider filter editing in admin-ui

This PR restores functionality for adding and editing NMEA 2000 (N2K) provider filters in the admin UI, which regressed during the React 19 port.

### Problem
Adding or editing N2K provider filters silently failed—new filter rows did not appear and the Enabled toggle did not persist changes.

### Root Cause
The `ProvidersConfiguration` component wired the `onPropChange` handler to `handleProviderPropChange`, which spread the previous provider state while ignoring incoming events. This prevented filter mutations from the `N2KFilters` component from reaching the selected provider.

### Solution
The fix involves two component changes:

**ProvidersConfiguration.tsx**
- Removes the `handleProviderPropChange` callback that only shallow-copied provider state
- Updates the `BasicProvider` component's `onPropChange` prop to use the existing `handleProviderChange` handler, which properly applies field updates to selected provider using `lodash.set` for nested filter updates

**N2KFilters.tsx**
- Updates the Enabled switch control to use only `value: event.target.checked` in the onChange payload
- Coerces the switch's `checked` prop with `!!value.options.filtersEnabled` to handle cases where `filtersEnabled` is undefined
- Simplifies the rendered filter table row React key from a composite string (`${index}-${filter.source}-${filter.pgn}`) to the array index, preventing component remounts on keystroke and preserving focus

### Testing
All 91 unit tests pass in `packages/server-admin-ui` and the build succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->