### PR TITLE
docs(plugins): recommend GitHub Releases for plugin changelogs

### DIFF
--- a/docs/develop/plugins/README.md
+++ b/docs/develop/plugins/README.md
@@ -13,6 +13,7 @@ children:
   - custom_renderers.md
   - publishing.md
   - ci.md
+  - release.md
 ---
 
 # Server plugins

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -174,3 +174,7 @@ test-cerbo-hardware:
     - run: npm ci
     - run: npm test
 ```
+
+## See also
+
+- [Releases and Changelogs](./release.md) — once CI passes, automate the release cut and publish step.

--- a/docs/develop/plugins/examples/plugin-dependabot-example.yml
+++ b/docs/develop/plugins/examples/plugin-dependabot-example.yml
@@ -1,0 +1,39 @@
+# ─────────────────────────────────────────────────────────────
+# SignalK Plugin Dependabot Config
+#
+# Drop this file into your plugin repo at:
+#   .github/dependabot.yml
+#
+# Dependabot will then keep your npm dependencies and the
+# GitHub Actions used by your workflows (CI, release) up to date
+# by opening PRs on the schedule configured below.
+#
+# Non-breaking updates (minor + patch) are grouped into a single
+# PR per ecosystem to keep noise down. Major version bumps stay
+# as individual PRs because they usually deserve a closer look.
+#
+# Full reference:
+#   https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+# ─────────────────────────────────────────────────────────────
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/docs/develop/plugins/examples/plugin-release-example.yml
+++ b/docs/develop/plugins/examples/plugin-release-example.yml
@@ -69,6 +69,8 @@ jobs:
 
       - run: npm ci
 
+      # Assumes your package.json defines `prepublishOnly` (or `prepare`) if a
+      # build step is needed — see the AppStore publishing guide.
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/develop/plugins/examples/plugin-release-example.yml
+++ b/docs/develop/plugins/examples/plugin-release-example.yml
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────
+# SignalK Plugin Release + Publish
+#
+# Drop this file into your plugin repo at:
+#   .github/workflows/release.yml
+#
+# On every pushed tag (e.g. `1.4.2` or `v1.4.2`) this workflow:
+#   1. Creates a GitHub Release with auto-generated notes built
+#      from merged PRs since the previous tag.
+#   2. Publishes the package to npm with provenance.
+#
+# Tags containing "beta" (e.g. `1.5.0-beta.1`) are published to
+# the `beta` npm dist-tag instead of `latest`.
+#
+# Prerequisites:
+#   - Create an npm access token and add it as repo secret NPM_TOKEN.
+#     (Needed only if your account requires a token; provenance
+#     works without one via OIDC on public npm packages, but most
+#     accounts still need NPM_TOKEN set.)
+#   - Release the package once manually from your machine so npm
+#     knows the package exists under the correct scope.
+#
+# Releasing a new version:
+#   npm version patch     # or minor / major — updates package.json and tags
+#   git push && git push --tags
+# ─────────────────────────────────────────────────────────────
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, 'beta') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          if [[ "$tag" == *beta* ]]; then
+            npm publish --provenance --access public --tag beta
+          else
+            npm publish --provenance --access public
+          fi

--- a/docs/develop/plugins/publishing.md
+++ b/docs/develop/plugins/publishing.md
@@ -79,3 +79,5 @@ To do this, in a terminal session from within the folder containing `package.jso
 ```shell
 npm publish
 ```
+
+For automated releases with GitHub-generated changelogs and npm provenance, see [Releases and Changelogs](./release.md).

--- a/docs/develop/plugins/release.md
+++ b/docs/develop/plugins/release.md
@@ -55,6 +55,8 @@ steps:
 
 The [example workflow](./examples/plugin-release-example.yml) shows the full shape, including a beta-tag branch for `*-beta*` versions.
 
+If the publish step fails transiently after the GitHub Release was already created, re-run the failed `publish` job from the Actions UI. If that's not possible, cut a new patch tag (e.g. `v1.4.3`) rather than force-retagging — tags and releases should be immutable so downstream consumers of the GitHub Release can trust them.
+
 ## Dependabot
 
 Dependabot fetches the GitHub Release notes of each updated package and embeds them into its update PRs — so plugins that follow the contract above already benefit their downstream users. Dependabot is also useful _for_ your plugin: it keeps the dependencies of your plugin (and the versions of the GitHub Actions your CI/release workflows use) up to date.

--- a/docs/develop/plugins/release.md
+++ b/docs/develop/plugins/release.md
@@ -1,0 +1,78 @@
+---
+title: Releases and Changelogs
+---
+
+# Releases and Changelogs for Plugins
+
+When a user updates a plugin through the AppStore, they currently see only the new version number — nothing about what changed. This page describes a light-touch convention that makes per-release notes available to tools (a future AppStore, Dependabot, npm's package page) and to humans browsing your repository.
+
+The recommendation is deliberately tool-agnostic. Pick whichever of the established approaches below fits your workflow; what matters is the **output shape**, not how you produce it.
+
+## The contract
+
+For each npm-published version of your plugin, aim to have:
+
+1. A **GitHub Release** with a tag that matches the npm version (e.g. npm `1.4.2` ↔ git tag `v1.4.2` or `1.4.2`).
+2. A human-readable **release body** in Markdown — a few lines is plenty.
+3. _Optional:_ a `CHANGELOG.md` at the repo root following [Keep a Changelog](https://keepachangelog.com/).
+
+Anything that produces that shape is fine. Downstream consumers read GitHub Releases via the public API, which is the same regardless of which tool produced the notes.
+
+## Approach 1 — GitHub's built-in auto-generated notes (zero config)
+
+The simplest path: let GitHub generate the release body from merged PRs. This is the same logic as the **Generate release notes** button in the GitHub web UI, triggered from a workflow on tag push. No third-party changelog action required.
+
+The [example workflow](./examples/plugin-release-example.yml) uses this approach — tag push → create GitHub Release with auto-generated body → `npm publish --provenance`.
+
+If you want to categorize entries by PR label (Features / Fixes / Other), add a [`.github/release.yml`](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) to your repo. GitHub reads it automatically.
+
+## Approach 2 — release-drafter
+
+[release-drafter](https://github.com/release-drafter/release-drafter) accumulates a draft release across PR merges, so you can review and edit notes before tagging. Useful if you want a human pass over the wording.
+
+## Approach 3 — release-please / semantic-release / changesets
+
+[release-please](https://github.com/googleapis/release-please), [semantic-release](https://semantic-release.gitbook.io/), and [changesets](https://github.com/changesets/changesets) go further: they also drive **version bumps** from conventional commits or intent files, and maintain `CHANGELOG.md` automatically. More automation, more opinion — worth it for plugins that release frequently.
+
+## Commit hygiene
+
+Whichever approach you pick, the quality of the generated notes depends on your commit messages and PR titles. The [Signal K server contributing guide](https://github.com/SignalK/signalk-server/blob/master/CONTRIBUTING.md) already covers this — the same conventions apply to plugin repositories.
+
+When using GitHub's built-in generator (Approach 1), **PR titles become the release-note lines**. Write titles that make sense out of context: "fix AIS fallback when GPS source is missing" beats "fix bug".
+
+## npm publish and provenance
+
+Publish from a GitHub Actions job triggered by the same tag push that creates the release. Use [npm provenance](https://docs.npmjs.com/generating-provenance-statements) so consumers can verify the package was built from the linked commit:
+
+```yaml
+permissions:
+  id-token: write # required for provenance
+  contents: read
+
+steps:
+  - run: npm publish --provenance --access public
+```
+
+The [example workflow](./examples/plugin-release-example.yml) shows the full shape, including a beta-tag branch for `*-beta*` versions.
+
+## Dependabot
+
+Dependabot fetches the GitHub Release notes of each updated package and embeds them into its update PRs — so plugins that follow the contract above already benefit their downstream users. Dependabot is also useful _for_ your plugin: it keeps the dependencies of your plugin (and the versions of the GitHub Actions your CI/release workflows use) up to date.
+
+A minimal `.github/dependabot.yml` should cover two ecosystems:
+
+- `npm` — your plugin's runtime dependencies
+- `github-actions` — the versions of the actions your CI and release workflows use
+
+Group non-breaking upgrades (minor + patch) into a single PR per ecosystem to cut down on noise; leave major-version bumps as their own PRs because they usually need a real look.
+
+See [`examples/plugin-dependabot-example.yml`](./examples/plugin-dependabot-example.yml) for a copy-pasteable config with explanatory comments, and the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) for the full set of tunables.
+
+## See also
+
+- [Continuous Integration for Plugins](./ci.md) — validate your plugin before releasing
+- [Publishing to The AppStore](./publishing.md) — npm keywords and `package.json` shape
+- [Keep a Changelog](https://keepachangelog.com/)
+- [Semantic Versioning](https://semver.org/)
+- [GitHub: Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+- [npm: Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements)


### PR DESCRIPTION
## Summary

Adds a plugin-author recommendation for producing per-version release notes on GitHub Releases, so the AppStore (eventually) and Dependabot (today) can surface what changed between plugin versions.

The recommendation is deliberately tool-agnostic. It describes the output contract — tag matches npm version, Release body contains human-readable notes — and sketches three approaches ordered by setup cost: GitHub's built-in auto-generated notes, release-drafter, and the version-driving tools (release-please / semantic-release / changesets). This responds to @tkurki's Discord feedback to piggyback on industry standard mechanisms rather than invent a Signal K-specific convention.

Two copy-pasteable examples ship alongside the doc: a tag-triggered release + `npm publish --provenance` workflow using `softprops/action-gh-release@v2` with `generate_release_notes: true`, and a Dependabot config covering npm and github-actions ecosystems with grouped minor+patch updates.

## Tested

- Smoke-tested the example release workflow end-to-end on `@signalk/app-dock@0.3.2-beta.1`: tag push produced a GitHub Release with auto-generated body, `beta` dist-tag on npm, SLSA provenance attestation present.
- `npm run format`, `npm run build:all` (typedoc with `treatWarningsAsErrors: true`), and `npm test` all pass locally. New page renders at `docs/dist/Developing/Plugins/Releases_and_Changelogs.html`.

## Follow-ups (separate PRs)

- AppStore UI: fetch GitHub Release notes via the GitHub API and display them next to the update prompt in the Admin UI.
- Example starter plugin repo under the SignalK org with CI + release + dependabot wired up out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds comprehensive documentation for plugin releases and changelogs, recommending that plugin authors publish per-version release notes using GitHub Releases. This enables the SignalK AppStore and Dependabot to surface changes between plugin versions.

## Changes

The PR introduces a new documentation page (`docs/develop/plugins/release.md`) that establishes a tool-agnostic release-notes contract:
- Create GitHub Releases with tags matching npm versions
- Include Markdown release bodies with human-readable notes
- Optionally maintain a `CHANGELOG.md` file

The documentation outlines three approaches for generating release notes, ordered by setup cost:
1. GitHub's auto-generated release notes
2. release-drafter
3. Version-driving tools (release-please, semantic-release, changesets)

## Examples and Configuration

Two copy-pasteable examples are included:

**Tag-triggered release workflow** (`plugin-release-example.yml`): A GitHub Actions workflow that automatically creates releases for pushed git tags matching `x.y.z*` or `vx.y.z*` patterns. It generates release notes using `softprops/action-gh-release@v2`, automatically marks tags containing `beta` as pre-releases, and publishes to npm with provenance enabled.

**Dependabot configuration** (`plugin-dependabot-example.yml`): A minimal template that configures automated dependency updates for `npm` and `github-actions` with grouped minor and patch updates to reduce PR noise.

## Documentation Integration

The new release documentation integrates with existing plugin documentation:
- The plugins section navigation is updated to include the new release guide
- The CI documentation includes a "See also" section pointing readers to the release process after CI passes
- The publishing documentation links to the release guide for guidance on automated releases with GitHub-generated changelogs and npm provenance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->