### PR TITLE
feat(admin-ui): createDevice checkbox for Yacht Devices gateways

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -23,6 +23,7 @@ interface ProviderOptions {
   mfgCode?: string
   useCanName?: boolean
   useCamelCompat?: boolean
+  createDevice?: boolean
   sendNetworkStats?: boolean
   noDataReceivedTimeout?: string
   remoteSelf?: string
@@ -1151,6 +1152,44 @@ function UseCanNameInput({
   )
 }
 
+function CreateDeviceInput({
+  value,
+  onChange
+}: {
+  value: ProviderOptions
+  onChange: OnChangeHandler
+}) {
+  return (
+    <Form.Group as={Row} className="mb-3">
+      <Col xs="3" md="3">
+        <Form.Label htmlFor="provider-createDevice">
+          Act as N2K device (createDevice)
+        </Form.Label>
+      </Col>
+      <Col xs="2" md="3">
+        <Form.Label className="switch switch-text switch-primary">
+          <input
+            type="checkbox"
+            id="provider-createDevice"
+            name="options.createDevice"
+            className="switch-input"
+            onChange={(event) => onChange(event)}
+            checked={value.createDevice === true}
+          />
+          <span className="switch-label" data-on="Yes" data-off="No" />
+          <span className="switch-handle" />
+        </Form.Label>
+      </Col>
+      <Col xs="7" md="6" className="form-text text-muted small">
+        Claim an N2K address and participate actively on the bus. Recommended
+        for Yacht Devices gateways — when off, the gateway may drop ISO Requests
+        for PGN 60928 / 126996 / 126998 and device identity (model, software
+        version, serial) stays incomplete.
+      </Col>
+    </Form.Group>
+  )
+}
+
 function CamelCaseCompatInput({
   value,
   onChange
@@ -1340,6 +1379,10 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
       {value.options.type !== undefined &&
         value.options.type.indexOf('canboatjs') !== -1 && (
           <CamelCaseCompatInput value={value.options} onChange={onChange} />
+        )}
+      {value.options.type !== undefined &&
+        /^ydwg02/.test(value.options.type) && (
+          <CreateDeviceInput value={value.options} onChange={onChange} />
         )}
     </div>
   )

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -112,6 +112,22 @@ const ProvidersConfiguration: React.FC = () => {
 
       const updatedProvider = { ...selectedProvider }
       set(updatedProvider, event.target.name, value)
+      // On a brand-new connection, default createDevice to on when the
+      // user picks a YDWG gateway type — without it the gateway silently
+      // drops ISO Requests for PGN 60928 / 126996 / 126998, leaving
+      // device identity incomplete. Existing connections are left alone:
+      // an MFD on the bus may already be locked onto current $source
+      // refs, and flipping createDevice on retroactively makes the
+      // server claim a new address and disrupts that binding.
+      if (
+        updatedProvider.isNew &&
+        event.target.name === 'options.type' &&
+        typeof value === 'string' &&
+        /^ydwg02/.test(value) &&
+        updatedProvider.options?.createDevice === undefined
+      ) {
+        set(updatedProvider, 'options.createDevice', true)
+      }
       setSelectedProvider(updatedProvider)
     },
     [selectedProvider]

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -112,21 +112,27 @@ const ProvidersConfiguration: React.FC = () => {
 
       const updatedProvider = { ...selectedProvider }
       set(updatedProvider, event.target.name, value)
-      // On a brand-new connection, default createDevice to on when the
-      // user picks a YDWG gateway type — without it the gateway silently
-      // drops ISO Requests for PGN 60928 / 126996 / 126998, leaving
-      // device identity incomplete. Existing connections are left alone:
+      // createDevice only applies to YDWG source types. Drop a stale
+      // value when the user picks a non-YDWG type so we don't submit a
+      // hidden option that no longer has a UI control. On a brand-new
+      // connection picking a YDWG type, default createDevice to on —
+      // without it the gateway silently drops ISO Requests for PGN
+      // 60928 / 126996 / 126998, leaving device identity incomplete.
+      // Existing connections that already store a value are left alone:
       // an MFD on the bus may already be locked onto current $source
       // refs, and flipping createDevice on retroactively makes the
       // server claim a new address and disrupts that binding.
-      if (
-        updatedProvider.isNew &&
-        event.target.name === 'options.type' &&
-        typeof value === 'string' &&
-        /^ydwg02/.test(value) &&
-        updatedProvider.options?.createDevice === undefined
-      ) {
-        set(updatedProvider, 'options.createDevice', true)
+      if (event.target.name === 'options.type' && typeof value === 'string') {
+        const isYdwg = /^ydwg02/.test(value)
+        if (!isYdwg && updatedProvider.options?.createDevice !== undefined) {
+          delete updatedProvider.options.createDevice
+        } else if (
+          isYdwg &&
+          updatedProvider.isNew &&
+          updatedProvider.options?.createDevice === undefined
+        ) {
+          set(updatedProvider, 'options.createDevice', true)
+        }
       }
       setSelectedProvider(updatedProvider)
     },


### PR DESCRIPTION
## Summary

Add a `createDevice` toggle to the connection editor for Yacht Devices YDEN / YDWG gateways. When on, the server claims its own N2K address on the bus so devices recognise it as a legitimate participant and answer ISO Requests for PGN 60928 / 126996 / 126998.

## Why

Without `createDevice` the gateway silently drops many discovery requests, and device identity (modelId, softwareVersionCode, modelSerialCode, installationDescription) stays empty for a large fraction of the bus. In a real-world 36-device install, flipping it on took identity-field coverage from 33% (12/36) to 63% (24/38) immediately after restart.

## Behaviour

- New YDWG connection → `createDevice` defaults to on.
- Existing connection → untouched. Per @sbender9's review on the earlier iteration of this PR: an MFD on the bus may already be paired with current `$source` refs, and flipping `createDevice` on retroactively makes the server claim a new N2K address and breaks those bindings.
- User can still toggle manually in either direction.

## Tested

- Local build + admin-ui test suite (91 passing).
- Live YDEN02 UDP bus, before/after restart: identity coverage 12/36 → 24/38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a createDevice toggle to the admin UI for Yacht Devices YDEN/YDWG gateways (source types matching /^ydwg02/). The toggle lets the server claim an N2K address so Yacht Devices gateways respond to ISO Requests (PGNs 60928, 126996, 126998), enabling devices on the bus to populate identity fields (modelId, softwareVersionCode, modelSerialCode, installationDescription).

## Changes

**packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx**
- Adds `createDevice?: boolean` to `ProviderOptions`.
- Introduces a checkbox input ("Act as N2K device (createDevice)") that is rendered only for NMEA2000 source types whose `options.type` begins with `ydwg02`.
- Checkbox state binds to `options.createDevice` and includes help text describing that the server will claim an N2K address to respond to ISO Requests.

**packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx**
- Enhances `handleProviderChange` to normalize `options.createDevice` on type changes:
  - If the user switches to a non-YDWG type and `options.createDevice` is present, the code deletes `options.createDevice` from the updated provider so hidden/stale options are not submitted.
  - If the user creates a brand-new provider, selects a YDWG type, and `options.createDevice` is undefined, the code defaults `options.createDevice` to `true`.
  - Existing YDWG connections retain any stored `createDevice` value (no retroactive defaulting).

## Tests & Verification

- Local build and admin-ui test suite run (91 passing).
- Live YDEN02 UDP bus verification shows identity-field coverage improving when createDevice is enabled (example: 12/36 → 24/38).
- Code includes an explicit guard to avoid altering existing connections to prevent disrupting MFD $source bindings.

## Design note

The implementation preserves backward compatibility by defaulting createDevice only for newly created YDWG connections and removing the option when selecting non-YDWG types, preventing hidden/stale options from being POSTed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->