### PR TITLE
fix(discovery): dedupe discovered providers by id

### DIFF
--- a/src/interfaces/providers.ts
+++ b/src/interfaces/providers.ts
@@ -150,6 +150,11 @@ module.exports = function (app: App) {
     if (p.enabled === undefined) {
       p.enabled = true
     }
+    // mDNS browsers fire 'update' repeatedly for the same service, so
+    // the list would otherwise accumulate dozens of rows per remote.
+    if (app.discoveredProviders.some((existing) => existing.id === p.id)) {
+      return
+    }
     app.discoveredProviders.push(p)
     app.emit('serverevent', {
       type: 'DISCOVERY_CHANGED',


### PR DESCRIPTION
## Summary

mDNS browsers fire `update` events repeatedly for the same service. Without a guard, every one of those updates appends another row to `app.discoveredProviders`, so the *Discovered Connections* table in the admin UI accumulates dozens of identical entries for a single remote Signal K server until the user clicks Apply or restarts the server.

Skip the `push` when a provider with the same `id` is already in the list.

## Tested

- Local build + full server test suite (499 passing).
- Reproduced before the fix: ~20 identical rows for one remote; after the fix: one row.


## Before
<img width="1829" height="717" alt="image" src="https://github.com/user-attachments/assets/88bf2106-9924-445a-ac12-b0384b62e429" />
