### PR TITLE
perf(self-data): skip update.values rebuild when nothing is filtered

### DIFF
--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -146,32 +146,39 @@ export const getToPreferredDelta = (
       delta.updates &&
         delta.updates.forEach((update: any) => {
           if ('values' in update) {
-            update.values = update.values.reduce(
-              (acc: any, pathValue: PathValue) => {
-                const latest = getLatest(
+            const values = update.values
+            // Avoid rebuilding the array when every value is preferred: only
+            // allocate a kept-values array once we encounter the first drop.
+            let kept: PathValue[] | null = null
+            for (let i = 0; i < values.length; i++) {
+              const pathValue: PathValue = values[i]
+              const latest = getLatest(
+                delta.context as Context,
+                pathValue.path as Path
+              )
+              const isPreferred = isPreferredValue(
+                pathValue.path as Path,
+                latest,
+                update.$source,
+                millis
+              )
+              if (isPreferred) {
+                setLatest(
                   delta.context as Context,
-                  pathValue.path as Path
-                )
-                const isPreferred = isPreferredValue(
                   pathValue.path as Path,
-                  latest,
-                  update.$source,
+                  update.$source as SourceRef,
                   millis
                 )
-                if (isPreferred) {
-                  setLatest(
-                    delta.context as Context,
-                    pathValue.path as Path,
-                    update.$source as SourceRef,
-                    millis
-                  )
-                  acc.push(pathValue)
-                  return acc
+                if (kept !== null) {
+                  kept.push(pathValue)
                 }
-                return acc
-              },
-              []
-            )
+              } else if (kept === null) {
+                kept = values.slice(0, i)
+              }
+            }
+            if (kept !== null) {
+              update.values = kept
+            }
           }
         })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -778,14 +778,27 @@ function filterStaticSelfData(delta: any, selfContext: string) {
     delta.updates &&
       delta.updates.forEach((update: any) => {
         if ('values' in update && update['$source'] !== 'defaults') {
-          update.values = update.values.reduce((acc: any, pathValue: any) => {
-            const nvp = filterSelfDataKP(pathValue)
-            if (nvp) {
-              acc.push(nvp)
+          const values = update.values
+          // Avoid rebuilding the array when nothing is filtered out: only
+          // allocate a kept-values array once we encounter the first drop.
+          let kept: any[] | null = null
+          for (let i = 0; i < values.length; i++) {
+            const nvp = filterSelfDataKP(values[i])
+            if (nvp === null) {
+              if (kept === null) {
+                kept = values.slice(0, i)
+              }
+            } else if (kept !== null) {
+              kept.push(nvp)
             }
-            return acc
-          }, [])
-          if (update.values.length === 0) {
+          }
+          if (kept !== null) {
+            if (kept.length === 0) {
+              delete update.values
+            } else {
+              update.values = kept
+            }
+          } else if (values.length === 0) {
             delete update.values
           }
         }

--- a/test/deltaPriority.ts
+++ b/test/deltaPriority.ts
@@ -114,4 +114,175 @@ describe('toPreferredDelta logic', () => {
       }, totalDelay + 10)
     })
   })
+
+  describe('multi-value updates', () => {
+    // Each scenario below exercises one branch of the lazy-copy filter inside
+    // getToPreferredDelta. Setup paths p1/p2/p3 with `high` as the preferred
+    // source and a long timeout on `low` so deltas from `low` are dropped
+    // unless their path is unknown to the priorities map (then preferred=true).
+
+    function setup() {
+      const sourcePreferences: SourcePrioritiesData = {
+        p1: [
+          { sourceRef: 'high' as SourceRef, timeout: 0 },
+          { sourceRef: 'low' as SourceRef, timeout: 60_000 }
+        ],
+        p2: [
+          { sourceRef: 'high' as SourceRef, timeout: 0 },
+          { sourceRef: 'low' as SourceRef, timeout: 60_000 }
+        ],
+        p3: [
+          { sourceRef: 'high' as SourceRef, timeout: 0 },
+          { sourceRef: 'low' as SourceRef, timeout: 60_000 }
+        ]
+      }
+      const toPreferredDelta = getToPreferredDelta(sourcePreferences, 200)
+      // Establish `high` as latest for all three paths at t=0.
+      toPreferredDelta(
+        {
+          context: 'self',
+          updates: [
+            {
+              $source: 'high',
+              values: [
+                { path: 'p1', value: 1 },
+                { path: 'p2', value: 2 },
+                { path: 'p3', value: 3 }
+              ]
+            }
+          ]
+        },
+        new Date(0),
+        'self'
+      )
+      return toPreferredDelta
+    }
+
+    it('keeps the original values reference when nothing is dropped', () => {
+      const toPreferredDelta = getToPreferredDelta({}, 200)
+      const inputValues = [
+        { path: 'a', value: 1 },
+        { path: 'b', value: 2 },
+        { path: 'c', value: 3 }
+      ]
+      const delta = {
+        context: 'self',
+        updates: [{ $source: 'src', values: inputValues }]
+      }
+      const result = toPreferredDelta(delta, new Date(), 'self')
+      result.updates[0].values.should.eql(inputValues)
+      assert.strictEqual(
+        result.updates[0].values,
+        inputValues,
+        'lazy-copy must not allocate a new array when no value is dropped'
+      )
+    })
+
+    it('tolerates an empty values array', () => {
+      const toPreferredDelta = getToPreferredDelta({}, 200)
+      const delta = {
+        context: 'self',
+        updates: [{ $source: 'src', values: [] }]
+      }
+      const result = toPreferredDelta(delta, new Date(), 'self')
+      result.updates[0].values.should.eql([])
+    })
+
+    it('drops the first value, keeps the rest', () => {
+      const toPreferredDelta = setup()
+      const result = toPreferredDelta(
+        {
+          context: 'self',
+          updates: [
+            {
+              $source: 'low',
+              values: [
+                { path: 'p1', value: 100 },
+                { path: 'unknown1', value: 200 },
+                { path: 'unknown2', value: 300 }
+              ]
+            }
+          ]
+        },
+        new Date(100),
+        'self'
+      )
+      result.updates[0].values.should.eql([
+        { path: 'unknown1', value: 200 },
+        { path: 'unknown2', value: 300 }
+      ])
+    })
+
+    it('drops the last value, keeps the rest', () => {
+      const toPreferredDelta = setup()
+      const result = toPreferredDelta(
+        {
+          context: 'self',
+          updates: [
+            {
+              $source: 'low',
+              values: [
+                { path: 'unknown1', value: 200 },
+                { path: 'unknown2', value: 300 },
+                { path: 'p1', value: 100 }
+              ]
+            }
+          ]
+        },
+        new Date(100),
+        'self'
+      )
+      result.updates[0].values.should.eql([
+        { path: 'unknown1', value: 200 },
+        { path: 'unknown2', value: 300 }
+      ])
+    })
+
+    it('drops the middle value, preserves order of the rest', () => {
+      const toPreferredDelta = setup()
+      const result = toPreferredDelta(
+        {
+          context: 'self',
+          updates: [
+            {
+              $source: 'low',
+              values: [
+                { path: 'unknown1', value: 200 },
+                { path: 'p1', value: 100 },
+                { path: 'unknown2', value: 300 }
+              ]
+            }
+          ]
+        },
+        new Date(100),
+        'self'
+      )
+      result.updates[0].values.should.eql([
+        { path: 'unknown1', value: 200 },
+        { path: 'unknown2', value: 300 }
+      ])
+    })
+
+    it('returns an empty values array when every value is dropped', () => {
+      const toPreferredDelta = setup()
+      const result = toPreferredDelta(
+        {
+          context: 'self',
+          updates: [
+            {
+              $source: 'low',
+              values: [
+                { path: 'p1', value: 100 },
+                { path: 'p2', value: 200 },
+                { path: 'p3', value: 300 }
+              ]
+            }
+          ]
+        },
+        new Date(100),
+        'self'
+      )
+      result.updates[0].values.should.eql([])
+    })
+  })
 })

--- a/test/staticData.js
+++ b/test/staticData.js
@@ -145,4 +145,80 @@ describe('Static Data', () => {
     self.should.have.nested.property('sensors.gps.fromCenter')
     self.should.have.nested.property('communication.callsignVhf')
   })
+
+  it('passes through a self update where no value is filtered', async function () {
+    const delta = {
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'test.no-filter',
+          values: [
+            { path: 'design.airHeight', value: 5 },
+            { path: 'navigation.speedOverGround', value: 7 }
+          ]
+        }
+      ]
+    }
+    await doSendADelta(delta)
+
+    const fullTree = theServer.app.deltaCache.buildFull(null, [])
+    const self = _.get(fullTree, fullTree.self)
+
+    self.should.have.nested.property('design.airHeight.value', 5)
+    self.should.have.nested.property('navigation.speedOverGround.value', 7)
+  })
+
+  it('drops a self update when every value is on a filtered path', async function () {
+    // The previous "defaults" test wrote design.draft=20 / design.beam=10
+    // under vessels.self. Sending an all-filtered delta from a non-defaults
+    // source must leave those values intact: the filter should drop the
+    // entire update before it can overwrite anything.
+    const delta = {
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'test.all-filtered',
+          values: [
+            { path: 'design.draft', value: 999 },
+            { path: 'design.beam', value: 999 }
+          ]
+        }
+      ]
+    }
+    await doSendADelta(delta)
+
+    const fullTree = theServer.app.deltaCache.buildFull(null, [])
+    const self = _.get(fullTree, fullTree.self)
+
+    self.should.have.nested.property('design.draft.value', 20)
+    self.should.have.nested.property('design.beam.value', 10)
+  })
+
+  it('tolerates an empty values array on a self update', async function () {
+    const empty = {
+      context: 'vessels.self',
+      updates: [{ $source: 'test.empty-values', values: [] }]
+    }
+    await doSendADelta(empty)
+
+    // Follow up with a regular delta to confirm the pipeline is still healthy
+    // and that the empty update did not poison the server state.
+    const followUp = {
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'test.empty-values',
+          values: [{ path: 'environment.outside.temperature', value: 273 }]
+        }
+      ]
+    }
+    await doSendADelta(followUp)
+
+    const fullTree = theServer.app.deltaCache.buildFull(null, [])
+    const self = _.get(fullTree, fullTree.self)
+    self.should.have.nested.property(
+      'environment.outside.temperature.value',
+      273
+    )
+  })
 })


### PR DESCRIPTION
## Motivation

`filterStaticSelfData` (`src/index.ts`) and the `toPreferredDelta` filter (`src/deltaPriority.ts`) both run on every self-context delta. Both used `Array.reduce` to build a fresh `update.values` array even when every input value was kept — the typical case on a busy bus.

## Solution

Switch to a lazy-copy pattern: walk the values, and only allocate a new array on the first drop. When no value is dropped the original array is kept, which is the typical path. Allocation cost in the common case drops from `O(n)` to zero.

Behavior is preserved:
- `filterStaticSelfData` still deletes `update.values` when the result is empty.
- `toPreferredDelta` still leaves `update.values` as an empty array when everything is dropped (the existing test in `test/deltaPriority.ts` asserts on `values.length`).

Existing `staticData` and `deltaPriority` tests pass.

Part of #2582.