### PR TITLE
perf(streambundle): build NormalizedDelta in final shape on pushDelta

### DIFF
--- a/src/streambundle.ts
+++ b/src/streambundle.ts
@@ -54,37 +54,46 @@ export class StreamBundle implements IStreamBundle {
 
   pushDelta(delta: Delta) {
     try {
-      if (delta.updates) {
-        delta.updates.forEach((update) => {
-          const base = {
-            context: delta.context!, // TSTODO: make optional/required match
-            source: update.source,
-            $source: update.$source!, // TSTODO: make optional/required match
-            timestamp: update.timestamp! // TSTODO: make optional/required match
-          }
+      if (!delta.updates) {
+        return
+      }
+      // TSTODO: the ! coercions below cover optional fields that are required
+      // here; tighten the Delta types when possible.
+      const context = delta.context!
+      for (const update of delta.updates) {
+        const source = update.source
+        const $source = update.$source!
+        const timestamp = update.timestamp!
 
-          if ('meta' in update) {
-            update.meta.forEach((meta) => {
-              this.push(meta.path, {
-                ...base,
-                path: meta.path,
-                value: meta.value,
-                isMeta: true
-              })
+        if ('meta' in update) {
+          for (const meta of update.meta) {
+            // Build the NormalizedDelta in its final shape with a stable key
+            // order across both branches so V8 can reuse one hidden class.
+            this.push(meta.path, {
+              context,
+              source,
+              $source,
+              timestamp,
+              path: meta.path,
+              value: meta.value,
+              isMeta: true
             })
           }
+        }
 
-          if ('values' in update) {
-            update.values.forEach((pathValue) => {
-              this.push(pathValue.path, {
-                ...base,
-                path: pathValue.path,
-                value: pathValue.value,
-                isMeta: false
-              })
+        if ('values' in update) {
+          for (const pathValue of update.values) {
+            this.push(pathValue.path, {
+              context,
+              source,
+              $source,
+              timestamp,
+              path: pathValue.path,
+              value: pathValue.value,
+              isMeta: false
             })
           }
-        })
+        }
       }
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
## Motivation

`pushDelta` runs once per value of every delta, so on a busy bus it sits squarely on the hot fanout path. The current implementation builds the `NormalizedDelta` in two steps: a `base` object literal followed by a spread plus three extra keys. The spread allocates an intermediate object and forces V8 down a slower transition path before reaching a stable hidden class.

## Solution

- Hoist `context` out of the per-update loop (it does not change per update).
- Drop the intermediate `base` object.
- Write all seven `NormalizedDelta` keys in a single object literal with the same key order across the `meta` and `values` branches so V8 can reuse one hidden class.
- Switch the iteration to `for...of` to drop the per-update arrow-function closure (per `AGENTS.md`).

Pure performance change, no behavior change. Subscription, metadata, staticData, and zones tests pass.

Part of #2582.