### PR TITLE
ci(plugin-ci): remove the v1 history-provider informational notice

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -729,15 +729,6 @@ jobs:
             },
           ];
 
-          // ── Informational notices ────────────────────────────────
-          // Not errors or warnings — just pointers to newer alternatives
-          const informational = [
-            {
-              pattern: /\bregisterHistoryProvider\s*\(/g,
-              message: 'registerHistoryProvider() is the v1 history API (playback/snapshots). For time-series history, see registerHistoryApiProvider() (v2 History API)',
-            },
-          ];
-
           // ── API misuse (errors) ─────────────────────────────────
           // These access internal server properties not exposed to plugins
           const misuse = [
@@ -826,7 +817,6 @@ jobs:
           }
           collectFiles('.');
 
-          const notices = [];
           const warnings = [];
           const errors = [];
 
@@ -877,7 +867,6 @@ jobs:
               }
             }
 
-            scanPatterns(informational, notices);
             scanPatterns(deprecated, warnings);
             scanPatterns(misuse, errors);
             scanPatterns(routeAntiPatterns, warnings);
@@ -950,10 +939,9 @@ jobs:
             }
           }
 
-          if (notices.length === 0 && warnings.length === 0 && errors.length === 0) {
+          if (warnings.length === 0 && errors.length === 0) {
             console.log('No deprecated or misused API patterns found');
           }
-          notices.forEach(n => console.log('::notice::' + n));
           warnings.forEach(w => console.log('::warning::' + w));
           errors.forEach(e => console.log('::error::' + e));
 


### PR DESCRIPTION
## Summary

Per @tkurki's feedback in the original review thread: the notice is ill-advised — v1 (playback/snapshots) and v2 (REST aggregates) are two different APIs for different purposes, and using both is perfectly fine. CI is not the place to educate plugin authors on which API matches their use case; that becomes obvious during development.

This PR drops the notice entirely instead of trying to make it smarter via heuristics.

## What changed

- Removed the `informational` pattern array
- Removed the `notices` collector, its `scanPatterns` call, and its printer
- Removed the early-out condition's `notices.length === 0` check

The `deprecated` (warnings) and `misuse` (errors) checks are unaffected.

## Tested

Ran the inline JS locally against a `signalk-questdb` checkout (which previously emitted this notice) — output is now clean: *"No deprecated or misused API patterns found"*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the plugin CI linter to suppress the informational notice that points authors from registerHistoryProvider() (v1) to registerHistoryApiProvider() (v2) when the scanned plugin codebase also registers v2 anywhere.

## Changes

- Add a v2-detection regex (registerHistoryApiProvider\s*\() that is checked once per file against the linter’s comment-stripped codeLines so commented-out occurrences do not match.
- Convert v1 notices into identifiable objects and perform cross-file suppression: after scanning all files, filter out v1 informational notices if any v2 registration is detected across the scanned files.
- Require the v2 identifier to be immediately followed by '(' so type declarations (e.g., registerHistoryApiProvider: (...) => void) and commented examples do not match.
- Update final log emission paths to use the notice object's text field and adjust the empty-result check to consider the filtered notices.

## Rationale

This reduces noise for plugins that intentionally implement both v1 and v2 (for example, legacy WebSocket playback plus v2 REST aggregates) while preserving guidance for v1-only plugins.

## Testing

Verifies:
- v1-only plugin → notice fires
- v1 + v2 in same file → notice suppressed
- v1 + v2 in different files → notice suppressed
- v1 + commented-out v2 → notice still fires
- End-to-end verification on signalk-questdb confirms suppression where appropriate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->