### PR TITLE
feature: retain remote sourceRef

### DIFF
--- a/packages/streams/src/mdns-ws.ts
+++ b/packages/streams/src/mdns-ws.ts
@@ -255,7 +255,7 @@ export default class MdnsWs extends Transform {
         }
         data.updates.forEach((update) => {
           update['$source'] =
-            `${this.options.providerId}.${client.options.hostname}:${client.options.port}`
+            `${this.options.providerId}.${client.options.hostname}:${client.options.port}.${update['$source'] ?? '-'}`
         })
       }
 


### PR DESCRIPTION
Previously data in Signal K format from remote ws
connections had just host:port as sourceRef. This
changes this to just prefix the  value from
the source with `host:port.`` so that the original information is not lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies how the `$source` field is constructed for delta messages received from remote WebSocket connections. Instead of replacing the original source information with just the host:port identifier, the code now preserves the original source value by appending it to a composite source reference.

## Changes

**packages/streams/src/mdns-ws.ts**

The `$source` field injected into each `delta.updates` item is changed from containing only the provider ID, hostname, and port to a composite value that additionally includes the pre-existing `update['$source']` value. The format becomes `providerId.hostname:port.originalSource`, with a hyphen used when no original source exists.

This change occurs in the delta event handler (lines 256-259) where incoming data from remote Signal K servers is processed before being pushed downstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->