### PR TITLE
chore: turn on source maps to enable better debugging

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,8 @@
     "resolveJsonModule": true,
     "composite": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "sourceMap": true
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enables source map generation in the TypeScript compiler configuration by adding `"sourceMap": true` to the `compilerOptions` in `tsconfig.base.json`. This allows developers to debug TypeScript code more effectively by mapping compiled JavaScript back to the original TypeScript source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->