### PR TITLE
feat(server): add --no-plugins and --no-webapps CLI flags

### DIFF
--- a/docs/installation/command_line.md
+++ b/docs/installation/command_line.md
@@ -8,14 +8,16 @@ Signal K Server provides the following command line options and environment vari
 
 ## Command line options
 
-| Option                   | Description                                                                                                                                                                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-s`                     | Override path to the settings file. _(same as `SIGNALK_NODE_SETTINGS` environment variable)_                                                                                                                                 |
-| `-c`                     | Override the path to find server configuration. _(same as `SIGNALK_NODE_CONFIG_DIR` environment variable)_                                                                                                                   |
-| `--sample-nmea0183-data` | Starts signalk-server with sample NMEA0183 data.                                                                                                                                                                             |
-| `--sample-n2k-data`      | Starts signalk-server with sample NMEA2000 data.                                                                                                                                                                             |
-| `--override-timestamps`  | Override timestamps in the sample NMEA2000 data with current date and time. Doesn't apply nor makes a difference to NMEA0183 sample data.                                                                                    |
-| `--securityenabled`      | Enable security. For a fresh install this makes the Admin UI force the user to create an admin account before he/she can continue further into the UI. See [Security](../security.md#enabling-security) for further details. |
+| Option                   | Description                                                                                                                                                                                                                        |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-s`                     | Override path to the settings file. _(same as `SIGNALK_NODE_SETTINGS` environment variable)_                                                                                                                                       |
+| `-c`                     | Override the path to find server configuration. _(same as `SIGNALK_NODE_CONFIG_DIR` environment variable)_                                                                                                                         |
+| `--sample-nmea0183-data` | Starts signalk-server with sample NMEA0183 data.                                                                                                                                                                                   |
+| `--sample-n2k-data`      | Starts signalk-server with sample NMEA2000 data.                                                                                                                                                                                   |
+| `--override-timestamps`  | Override timestamps in the sample NMEA2000 data with current date and time. Doesn't apply nor makes a difference to NMEA0183 sample data.                                                                                          |
+| `--securityenabled`      | Enable security. For a fresh install this makes the Admin UI force the user to create an admin account before he/she can continue further into the UI. See [Security](../security.md#enabling-security) for further details.       |
+| `--no-plugins`           | Start the server without loading any plugins (Node.js or WASM). Useful for debugging, recovering from a misbehaving plugin, or running a stripped-down server. The Admin UI will not show a plugin list while this flag is active. |
+| `--no-webapps`           | Start the server without serving any webapps (regular, embeddable, or MFD). The core Admin UI is still served. Useful when running the server purely as a data backend or for diagnosing webapp issues.                            |
 
 ## Environment variables
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -740,7 +740,10 @@ async function startInterfaces(
   return await Promise.all(
     Object.keys(availableInterfaces).map(async (name) => {
       if (skippedInterfaces.has(name)) {
-        debug(`Not loading interface '${name}' (disabled by command line flag)`)
+        debug.enabled &&
+          debug(
+            `Not loading interface '${name}' (disabled by command line flag)`
+          )
         return
       }
       const theInterface = availableInterfaces[name]

--- a/src/index.ts
+++ b/src/index.ts
@@ -703,9 +703,46 @@ async function startInterfaces(
 ) {
   debug.enabled &&
     debug('Interfaces config:' + JSON.stringify(app.config.settings.interfaces))
+  const argv = (app as unknown as ConfigApp).argv
+  const noPlugins = argv?.plugins === false
+  const noWebapps = argv?.webapps === false
+  type StartupCollections = {
+    plugins: unknown[]
+    pluginsMap: Record<string, unknown>
+    getPluginsList: (enabled?: boolean) => Promise<unknown[]>
+    webapps: unknown[]
+    addons: unknown[]
+    embeddablewebapps: unknown[]
+    pluginconfigurators: unknown[]
+  }
+  const startupApp = app as unknown as StartupCollections
+  if (noPlugins) {
+    console.log('Plugins disabled by --no-plugins; skipping plugin loading')
+    startupApp.plugins = []
+    startupApp.pluginsMap = {}
+    startupApp.getPluginsList = async () => []
+  }
+  if (noWebapps) {
+    console.log('Webapps disabled by --no-webapps; skipping webapp loading')
+    startupApp.webapps = []
+    startupApp.addons = []
+    startupApp.embeddablewebapps = []
+    startupApp.pluginconfigurators = []
+  }
+  const skippedInterfaces = new Set<string>()
+  if (noPlugins) {
+    skippedInterfaces.add('plugins').add('wasm')
+  }
+  if (noWebapps) {
+    skippedInterfaces.add('webapps').add('mfd_webapp')
+  }
   const availableInterfaces = require('./interfaces')
   return await Promise.all(
     Object.keys(availableInterfaces).map(async (name) => {
+      if (skippedInterfaces.has(name)) {
+        debug(`Not loading interface '${name}' (disabled by command line flag)`)
+        return
+      }
       const theInterface = availableInterfaces[name]
       if (
         _.isUndefined(app.config.settings.interfaces) ||


### PR DESCRIPTION
## Summary

Adds two new command-line flags to start a stripped-down server:

- `--no-plugins` skips loading the `plugins` and `wasm` interfaces, so neither Node.js nor WASM plugins run.
- `--no-webapps` skips the `webapps` and `mfd_webapp` interfaces, so no webapps (regular, embeddable, MFD) are served. The Admin UI itself is still served.

The flags are independent and can be combined.

## Motivation

Useful for:
- recovering a server when a plugin crashes on startup,
- diagnosing whether an issue is plugin- or webapp-related,
- running the server purely as a data backend.

## Implementation notes

- Both flags are read from `app.argv` in `startInterfaces`. Minimist parses `--no-plugins` as `{ plugins: false }`, so the check is `argv?.plugins === false` (and likewise for webapps).
- Disabled interfaces are filtered out before their loaders run.
- App-level collections that are normally populated by these interfaces (`plugins`, `pluginsMap`, `webapps`, `addons`, `embeddablewebapps`, `pluginconfigurators`) are pre-initialised to empty values so consumers (admin UI index renderer, appstore listing, plugin error handler in `index.ts`) keep working.
- `app.getPluginsList` is given an empty-array fallback under `--no-plugins`, because `app.getFeatures()` calls it unconditionally and the discovery API endpoint reaches that path without guards.
- Conditional initialisations use a typed `StartupCollections` shape rather than `as any` casts.

## Tested

- `npm start -- --no-plugins`: `Plugins disabled by --no-plugins` log line, `/skServer/plugins` returns 404, no plugin activity (verified against a system with `signalk-to-influxdb` etc. installed).
- `npm start -- --no-plugins --no-webapps`: both log lines, `/skServer/webapps` returns empty, admin UI still loads, `/signalk` discovery endpoint works.
- `npm run format`, `npm run build:all`, `npm test` (592 tests passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds two independent command-line flags to start the server with reduced functionality:

### New Flags
- --no-plugins: skips loading the plugins and wasm interfaces, preventing Node.js and WASM plugins from running and hiding the plugin list in the Admin UI while the flag is active.
- --no-webapps: skips loading the webapps and mfd_webapp interfaces, preventing regular, embeddable, and MFD webapps from being served while continuing to serve the core Admin UI.

### Implementation
- startInterfaces reads flags from app.argv; minimist parses --no-plugins as { plugins: false } and --no-webapps as { webapps: false }, so checks use argv?.plugins === false and argv?.webapps === false.
- Disabled interfaces are recorded in a skippedInterfaces set and filtered out before their loaders run, preventing those interface modules from loading or executing.
- App-level collections normally populated by these interfaces (plugins, pluginsMap, webapps, addons, embeddablewebapps, pluginconfigurators) are pre-initialized to empty values so existing consumers (Admin UI index renderer, appstore listing, plugin error handler) continue to operate.
- app.getPluginsList is given an empty-array fallback when plugins are disabled because app.getFeatures() may call it unconditionally.
- Conditional initializations use a typed StartupCollections shape instead of as any casts.

### Documentation
- docs/installation/command_line.md updates the command-line options table to document --no-plugins and --no-webapps; existing options remain documented.

### Verification
- npm start -- --no-plugins logs "Plugins disabled by --no-plugins"; /skServer/plugins returns 404; no plugin activity is observed on a system with installed plugins.
- npm start -- --no-plugins --no-webapps shows both disabled logs; /skServer/webapps returns empty; Admin UI still loads; /signalk discovery endpoint continues to work.
- Repository formatting, build, and tests are run (npm run format, npm run build:all, npm test) with the test suite passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->