### PR TITLE
feat(plugins): add registerWebSocket for plugin WebSocket endpoints

### DIFF
--- a/docs/develop/plugins/README.md
+++ b/docs/develop/plugins/README.md
@@ -299,6 +299,35 @@ const openapi = require('./openApi.json')
 plugin.getOpenApi = () => openapi
 ```
 
+### Serving WebSockets
+
+Express routers do not see HTTP `upgrade` requests &mdash; those are emitted on the underlying HTTP server &mdash; so WebSocket endpoints cannot be registered with `registerWithRouter`. Instead, call `app.registerWebSocket(path)` in `plugin.start()` to register a WebSocket endpoint at `ws://{skserver}:3000/plugins/{pluginId}{path}`. The path is matched exactly (query string excluded) and the returned object is a subset of [ws](https://www.npmjs.com/package/ws)'s `WebSocketServer`. The endpoint is removed automatically when the plugin stops.
+
+_Example:_
+
+```javascript
+plugin.start = () => {
+  const wss = app.registerWebSocket('/stream')
+  wss.on('connection', (ws, request) => {
+    ws.on('message', (msg) => {
+      ws.send('echo: ' + msg.toString())
+    })
+  })
+  wss.on('error', (err) => app.error(err))
+}
+```
+
+A plugin that needs the raw HTTP `upgrade` &mdash; typically to forward it to another server &mdash; attaches an `upgrade` listener and handles the upgrade entirely itself. The server then does not complete the handshake and `connection` is never emitted:
+
+```javascript
+const wss = app.registerWebSocket('/ws')
+wss.on('upgrade', (request, socket, head) => {
+  proxy.upgrade(request, socket, head)
+})
+```
+
+Authentication is the plugin's responsibility. The upgrade request carries the same cookies and headers as any other request to the server, so a plugin can apply its own checks before accepting a connection.
+
 ---
 
 ## Add an OpenAPI Definition

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -15,6 +15,47 @@ import { CourseApi } from './course'
 import { HistoryProviderRegistry, WithHistoryApi } from './history'
 import { StreamBundle } from './streambundle'
 import { SubscriptionManager } from './subscriptionmanager'
+import type { WebSocket } from 'ws'
+import type { IncomingMessage } from 'http'
+import type { Duplex } from 'stream'
+
+/**
+ * A WebSocket endpoint under the plugin's route, returned by
+ * {@link ServerAPI.registerWebSocket}. A subset of
+ * [ws](https://github.com/websockets/ws)'s `WebSocketServer`.
+ *
+ * @category Server API
+ */
+export interface PluginWebSocketServer {
+  /**
+   * Emitted with each WebSocket connection after the server has completed
+   * the handshake. Not emitted when an `upgrade` listener is attached.
+   */
+  on(
+    event: 'connection',
+    listener: (ws: WebSocket, request: IncomingMessage) => void
+  ): this
+  /**
+   * Escape hatch for plugins that need the raw HTTP `upgrade` — typically
+   * to hand it to a reverse proxy. When at least one `upgrade` listener is
+   * attached the plugin handles the upgrade entirely itself: the server
+   * does not complete the handshake and `connection` is never emitted.
+   * The arguments match Node.js's `http.Server` `upgrade` event.
+   */
+  on(
+    event: 'upgrade',
+    listener: (request: IncomingMessage, socket: Duplex, head: Buffer) => void
+  ): this
+  on(event: 'error', listener: (error: Error) => void): this
+  /** Connections completed by the server (empty when using `upgrade`). */
+  readonly clients: ReadonlySet<WebSocket>
+  /**
+   * Stops accepting new connections and removes the endpoint. Called
+   * automatically when the plugin stops, which also terminates any
+   * connected clients.
+   */
+  close(cb?: (err?: Error) => void): void
+}
 
 /**
  * SignalK server provides an interface to allow {@link Plugin | Plugins } to:
@@ -455,6 +496,45 @@ export interface ServerAPI
       onDelta: (delta: object) => void
     ) => void
   }): void
+
+  /**
+   * Registers a WebSocket endpoint at `path` under the plugin's route, i.e.
+   * at `/plugins/<pluginId><path>`. Express routers never see HTTP `upgrade`
+   * requests — those are emitted on the underlying HTTP server — so
+   * WebSocket endpoints are registered with this method instead of
+   * {@link Plugin.registerWithRouter}.
+   *
+   * The path is matched exactly (query string excluded). Call in
+   * `plugin.start()`; the endpoint is removed automatically when the plugin
+   * stops.
+   *
+   * By default the server completes the WebSocket handshake and emits
+   * `connection` with a ready-to-use socket:
+   *
+   * ```typescript
+   * plugin.start = () => {
+   *   const wss = app.registerWebSocket('/stream')
+   *   wss.on('connection', (ws, request) => {
+   *     ws.on('message', (data) => ws.send(`got ${data}`))
+   *   })
+   * }
+   * ```
+   *
+   * A plugin that needs the raw upgrade — e.g. to forward it to another
+   * server — attaches an `upgrade` listener and handles everything itself:
+   *
+   * ```typescript
+   * const wss = app.registerWebSocket('/ws')
+   * wss.on('upgrade', (request, socket, head) =>
+   *   proxy.upgrade(request, socket, head)
+   * )
+   * ```
+   *
+   * Authentication and authorization are the plugin's responsibility.
+   *
+   * @category Server API
+   */
+  registerWebSocket(path: string): PluginWebSocketServer
 
   /**
    * Returns Ports object which contains information about the serial ports available on the machine.

--- a/src/interfaces/index.js
+++ b/src/interfaces/index.js
@@ -1,8 +1,0 @@
-require('fs')
-  .readdirSync(__dirname + '/')
-  .forEach(function (file) {
-    if (file.match(/.+\.js$/g) !== null && file !== 'index.js') {
-      const name = file.replace('.js', '')
-      exports[name] = require('./' + file)
-    }
-  })

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/*
+ * The set of built-in interfaces and the order in which they start.
+ *
+ * Order is significant: 'plugins' must start before 'ws'. The ws interface
+ * creates the Primus instance, which snapshots the HTTP server's existing
+ * 'upgrade' listeners; the plugin WebSocket dispatcher (installed while
+ * plugins start) has to be attached by then.
+ */
+const interfaceNames = [
+  'applicationData',
+  'appstore',
+  'logfiles',
+  'mfd_webapp',
+  'n2k-discovery',
+  'nmea-tcp',
+  'playground',
+  'plugins',
+  'providers',
+  'rest',
+  'tcp',
+  'unitpreferences-api',
+  'wasm',
+  'webapps',
+  'ws'
+]
+
+const availableInterfaces: { [name: string]: unknown } = {}
+for (const name of interfaceNames) {
+  availableInterfaces[name] = require('./' + name)
+}
+
+export = availableInterfaces

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -223,18 +223,18 @@ module.exports = (theApp: any) => {
     )
   }
 
+  // Install the plugin upgrade dispatcher here, in the interface factory,
+  // rather than in start(). Factories run synchronously as the interface
+  // list is built, before any interface's start() is awaited — so the
+  // dispatcher is attached before the ws interface's start() creates Primus,
+  // which snapshots the server's existing 'upgrade' listeners. Doing this in
+  // start() would make correctness depend on start() completion order, which
+  // Promise.all does not guarantee.
+  installUpgradeListenerOnce()
+
   return {
     async start() {
       ensureExists(path.join(theApp.config.configPath, PLUGIN_CONFIG_DATA_DIR))
-
-      // Install the plugin upgrade dispatcher early — before the WS
-      // interface (Primus) attaches. Primus's transformer snapshots any
-      // pre-existing 'upgrade' listeners as previous::upgrade and forwards
-      // non-matching upgrades back to them; a listener installed after
-      // Primus never sees Primus's miss path. The interface loader runs
-      // 'plugins' (alphabetical) before 'ws', and theApp.server is already
-      // assigned by then.
-      installUpgradeListenerOnce()
 
       theApp.getPluginsList = async (enabled?: boolean) => {
         return await getPluginsList(enabled)

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -45,11 +45,15 @@ import {
   AccessScopedRouter,
   PluginRouter,
   RouteAccessLevel,
-  RoutePermission
+  RoutePermission,
+  PluginWebSocketServer
 } from '@signalk/server-api'
 import { getLogger } from '@signalk/streams/logging'
 import express, { IRouter, Request, RequestHandler, Response } from 'express'
 import fs from 'fs'
+import { IncomingMessage } from 'http'
+import { Duplex } from 'stream'
+import { WebSocketServer } from 'ws'
 import { deprecate } from 'util'
 import _ from 'lodash'
 import path from 'path'
@@ -143,9 +147,94 @@ function mergeExcludeSelf(
 module.exports = (theApp: any) => {
   const onStopHandlers: any = {}
   const appNodeModules = path.join(theApp.config.appPath, 'node_modules/')
+
+  // Outer key is the plugin id, inner key the normalized path.
+  const pluginWebSocketServers: Map<
+    string,
+    Map<string, WebSocketServer>
+  > = new Map()
+  let upgradeListenerInstalled = false
+
+  function normalizeWebSocketPath(wsPath: string): string {
+    const withLeadingSlash = wsPath.startsWith('/') ? wsPath : '/' + wsPath
+    return withLeadingSlash.length > 1 && withLeadingSlash.endsWith('/')
+      ? withLeadingSlash.slice(0, -1)
+      : withLeadingSlash
+  }
+
+  function installUpgradeListenerOnce() {
+    if (upgradeListenerInstalled || !theApp.server) {
+      return
+    }
+    upgradeListenerInstalled = true
+    debug('plugin WebSocket upgrade dispatcher installed on app.server')
+    theApp.server.on(
+      'upgrade',
+      (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+        const match = (request.url ?? '').match(/^\/plugins\/([^/?#]+)([^?#]*)/)
+        if (!match) {
+          return
+        }
+        const [, pluginId, rest] = match
+        const forPlugin = pluginWebSocketServers.get(pluginId)
+        if (!forPlugin) {
+          // The plugin does not use registerWebSocket — leave the event
+          // for other upgrade listeners.
+          return
+        }
+        // Log the plugin id + normalized path, not request.url — the query
+        // string may carry credentials (?token=...).
+        const wssPath = normalizeWebSocketPath(rest || '/')
+        const wss = forPlugin.get(wssPath)
+        if (!wss) {
+          debug(
+            'no WebSocket endpoint matches /plugins/%s%s',
+            pluginId,
+            wssPath
+          )
+          try {
+            // end() flushes the 404 before closing; destroy() could drop it.
+            socket.end('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n')
+          } catch {
+            // socket already gone
+          }
+          return
+        }
+        try {
+          if (wss.listenerCount('upgrade') > 0) {
+            // The plugin handles the upgrade entirely itself.
+            wss.emit('upgrade', request, socket, head)
+          } else {
+            wss.handleUpgrade(request, socket, head, (ws) =>
+              wss.emit('connection', ws, request)
+            )
+          }
+        } catch (err) {
+          console.error(
+            `Error handling WebSocket upgrade for /plugins/${pluginId}${wssPath}: ${err}`
+          )
+          try {
+            socket.destroy()
+          } catch {
+            // socket already gone
+          }
+        }
+      }
+    )
+  }
+
   return {
     async start() {
       ensureExists(path.join(theApp.config.configPath, PLUGIN_CONFIG_DATA_DIR))
+
+      // Install the plugin upgrade dispatcher early — before the WS
+      // interface (Primus) attaches. Primus's transformer snapshots any
+      // pre-existing 'upgrade' listeners as previous::upgrade and forwards
+      // non-matching upgrades back to them; a listener installed after
+      // Primus never sees Primus's miss path. The interface loader runs
+      // 'plugins' (alphabetical) before 'ws', and theApp.server is already
+      // assigned by then.
+      installUpgradeListenerOnce()
 
       theApp.getPluginsList = async (enabled?: boolean) => {
         return await getPluginsList(enabled)
@@ -607,7 +696,23 @@ module.exports = (theApp: any) => {
         app.autopilotApi.unRegister(plugin.id)
         app.weatherApi.unRegister(plugin.id)
       })
-      plugin.start(safeConfiguration, restart)
+      const handlersBeforeStart = onStopHandlers[plugin.id].length
+      try {
+        plugin.start(safeConfiguration, restart)
+      } catch (e) {
+        // Roll back anything the failed start() registered (e.g. a
+        // WebSocket endpoint left in the dispatch registry), otherwise a
+        // later restart re-registers it and throws on the duplicate.
+        const added = onStopHandlers[plugin.id].splice(handlersBeforeStart)
+        for (const f of added.reverse()) {
+          try {
+            f()
+          } catch (cleanupErr) {
+            console.error(cleanupErr)
+          }
+        }
+        throw e
+      }
       debug('Started plugin ' + plugin.name)
       setPluginStartedMessage(plugin)
     } catch (e: any) {
@@ -978,6 +1083,75 @@ module.exports = (theApp: any) => {
       onStopHandlers[plugin.id].push(() => {
         app.unregisterHistoryProvider(provider)
       })
+    }
+
+    appCopy.registerWebSocket = (wsPath: string): PluginWebSocketServer => {
+      installUpgradeListenerOnce()
+      if (typeof wsPath !== 'string') {
+        // JavaScript plugins are untyped, so guard this public boundary.
+        throw new TypeError(`${plugin.id}: WebSocket path must be a string`)
+      }
+      if (wsPath.includes('?') || wsPath.includes('#')) {
+        // The dispatcher matches on the path only (query/fragment stripped),
+        // so a registered path carrying either could never be reached.
+        throw new Error(
+          `${plugin.id}: WebSocket path ${wsPath} must not contain '?' or '#'`
+        )
+      }
+      const normalized = normalizeWebSocketPath(wsPath)
+      let forPlugin = pluginWebSocketServers.get(plugin.id)
+      if (!forPlugin) {
+        forPlugin = new Map()
+        pluginWebSocketServers.set(plugin.id, forPlugin)
+      }
+      if (forPlugin.has(normalized)) {
+        throw new Error(
+          `${plugin.id}: WebSocket path ${normalized} is already registered`
+        )
+      }
+      const wss = new WebSocketServer({ noServer: true })
+      // Baseline 'error' handler so an error from a plugin that forgot to
+      // attach its own listener is logged rather than crashing the process
+      // (unhandled 'error' events on an EventEmitter throw).
+      wss.on('error', (err) => {
+        console.error(
+          `${plugin.id}: WebSocket endpoint ${normalized} error: ${err}`
+        )
+      })
+      // Each accepted client socket is its own EventEmitter. A baseline
+      // 'error' listener keeps a mid-connection failure (e.g. a client
+      // dropping the TCP connection, ECONNRESET) from crashing the process
+      // when the plugin has not attached its own handler.
+      wss.on('connection', (ws) => {
+        ws.on('error', (err) => {
+          debug(
+            '%s: WebSocket client error on %s: %s',
+            plugin.id,
+            normalized,
+            err
+          )
+        })
+      })
+      forPlugin.set(normalized, wss)
+      debug('%s: registered WebSocket endpoint %s', plugin.id, normalized)
+      const removeEndpoint = () => {
+        if (forPlugin.get(normalized) === wss) {
+          forPlugin.delete(normalized)
+        }
+      }
+      wss.on('close', removeEndpoint)
+      onStopHandlers[plugin.id].push(() => {
+        removeEndpoint()
+        for (const client of wss.clients) {
+          client.terminate()
+        }
+        try {
+          wss.close()
+        } catch {
+          // already closed by the plugin
+        }
+      })
+      return wss
     }
 
     const startupOptions = getPluginOptions(plugin.id)

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -148,7 +148,9 @@ module.exports = (theApp: any) => {
   const onStopHandlers: any = {}
   const appNodeModules = path.join(theApp.config.appPath, 'node_modules/')
 
-  // Outer key is the plugin id, inner key the normalized path.
+  // Partitioned by plugin id so the dispatcher can tell a plugin that does
+  // not use registerWebSocket at all (leave the upgrade event to other
+  // listeners) apart from a registered plugin with an unknown path (404).
   const pluginWebSocketServers: Map<
     string,
     Map<string, WebSocketServer>

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -691,12 +691,12 @@ module.exports = (theApp: any) => {
         console.error(`${plugin.id}:no configuration data`)
         safeConfiguration = {}
       }
+      const handlersBeforeStart = onStopHandlers[plugin.id].length
       onStopHandlers[plugin.id].push(() => {
         app.resourcesApi.unRegister(plugin.id)
         app.autopilotApi.unRegister(plugin.id)
         app.weatherApi.unRegister(plugin.id)
       })
-      const handlersBeforeStart = onStopHandlers[plugin.id].length
       try {
         plugin.start(safeConfiguration, restart)
       } catch (e) {

--- a/test/plugin-test-config/node_modules/upgradetestplugin/index.js
+++ b/test/plugin-test-config/node_modules/upgradetestplugin/index.js
@@ -1,0 +1,35 @@
+module.exports = function (app) {
+  return {
+    id: 'upgradetestplugin',
+    name: 'Upgrade Test Plugin',
+    schema: { type: 'object', properties: {} },
+    start: function (options) {
+      const echo = app.registerWebSocket('/echo')
+      echo.on('connection', (ws) => {
+        ws.on('message', (msg) => {
+          ws.send('echo:' + msg.toString())
+        })
+      })
+
+      // The test flips this to prove a start() that registers an endpoint
+      // and then throws leaves nothing behind in the dispatch registry.
+      if (options && options.failAfterRegister) {
+        throw new Error('deliberate start failure after registerWebSocket')
+      }
+
+      // Reverse-proxy style: the plugin takes the raw upgrade itself. The
+      // 418 response proves the listener ran and that the server did not
+      // complete the handshake.
+      const raw = app.registerWebSocket('/raw')
+      raw.on('upgrade', (request, socket) => {
+        socket.write(
+          'HTTP/1.1 418 Raw Upgrade Received\r\nConnection: close\r\n\r\n'
+        )
+        socket.destroy()
+      })
+    },
+    stop: function () {
+      // endpoints registered with registerWebSocket are closed by the server
+    }
+  }
+}

--- a/test/plugin-test-config/node_modules/upgradetestplugin/package.json
+++ b/test/plugin-test-config/node_modules/upgradetestplugin/package.json
@@ -1,0 +1,8 @@
+{
+  "id": "upgradetestplugin",
+  "name": "upgradetestplugin",
+  "keywords": [
+    "signalk-node-server-plugin"
+  ],
+  "entrypoint": "index.js"
+}

--- a/test/plugin-websocket-upgrade.ts
+++ b/test/plugin-websocket-upgrade.ts
@@ -1,0 +1,205 @@
+import { strict as assert } from 'assert'
+import fs from 'fs'
+import path from 'path'
+import WebSocket from 'ws'
+
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Server = require('../dist/')
+
+const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
+const PLUGIN_CONFIG_FILE = path.join(
+  CONFIG_DIR,
+  'plugin-config-data',
+  'upgradetestplugin.json'
+)
+const OPEN_TIMEOUT_MS = 5000
+const SETTLE_TIMEOUT_MS = 5000
+const POLL_INTERVAL_MS = 50
+
+function writeUpgradePluginConfig(enabled: boolean) {
+  fs.writeFileSync(
+    PLUGIN_CONFIG_FILE,
+    JSON.stringify({ enabled, configuration: {} }, null, 2)
+  )
+}
+
+async function setPluginConfig(
+  port: number,
+  enabled: boolean,
+  configuration: Record<string, unknown> = {}
+) {
+  const res = await fetch(
+    `http://localhost:${port}/skServer/plugins/upgradetestplugin/config`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled, configuration })
+    }
+  )
+  assert.equal(res.status, 200)
+}
+
+// The config POST returns before the async stop/restart cycle finishes, so
+// poll the /echo endpoint until it reaches the expected state rather than
+// sleeping a fixed interval that can be too short on slow CI.
+async function waitForEcho(
+  open: (pathname: string) => Promise<string>,
+  present: boolean
+) {
+  const deadline = Date.now() + SETTLE_TIMEOUT_MS
+  for (;;) {
+    let reached: boolean
+    try {
+      reached = (await open('/plugins/upgradetestplugin/echo')) === 'echo:hello'
+    } catch (err) {
+      // The endpoint 404s (or otherwise fails) while the plugin is stopped.
+      reached = !present && /404/.test(String(err))
+    }
+    if (reached) {
+      return
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `/echo did not become ${present ? 'available' : 'unavailable'} in time`
+      )
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+  }
+}
+
+interface ServerHandle {
+  start(): Promise<unknown>
+  stop(): Promise<unknown>
+}
+
+describe('plugin WebSocket endpoints', () => {
+  let server: ServerHandle
+  let port: number
+  let previousConfigDir: string | undefined
+
+  before(async () => {
+    previousConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
+    process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
+    writeUpgradePluginConfig(true)
+    port = await freeport()
+    server = new Server({ config: { settings: { port } } }) as ServerHandle
+    await server.start()
+  })
+
+  after(async () => {
+    writeUpgradePluginConfig(false)
+    try {
+      if (server) {
+        await server.stop()
+      }
+    } finally {
+      // Always restore the env var, even if stop() rejects, so the change
+      // does not leak into other test files.
+      if (previousConfigDir === undefined) {
+        delete process.env.SIGNALK_NODE_CONFIG_DIR
+      } else {
+        process.env.SIGNALK_NODE_CONFIG_DIR = previousConfigDir
+      }
+    }
+  })
+
+  function open(pathname: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${port}${pathname}`)
+      const timer = setTimeout(() => {
+        ws.close()
+        reject(new Error(`WebSocket open() timeout for ${pathname}`))
+      }, OPEN_TIMEOUT_MS)
+      ws.on('open', () => ws.send('hello'))
+      ws.on('message', (data) => {
+        clearTimeout(timer)
+        ws.close()
+        resolve(data.toString())
+      })
+      ws.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+  }
+
+  it('completes the handshake and emits connection on a registered path', async () => {
+    const reply = await open('/plugins/upgradetestplugin/echo')
+    assert.equal(reply, 'echo:hello')
+  })
+
+  it('matches paths exactly — sub-paths are not dispatched', async () => {
+    await assert.rejects(open('/plugins/upgradetestplugin/echo/sub'), /404/)
+  })
+
+  it('rejects paths the plugin has not registered', async () => {
+    await assert.rejects(open('/plugins/upgradetestplugin/nope'), /404/)
+  })
+
+  it("hands the raw upgrade to an 'upgrade' listener instead of completing the handshake", async () => {
+    await assert.rejects(open('/plugins/upgradetestplugin/raw'), /418/)
+  })
+
+  it('does not break the primary Signal K WebSocket', (done) => {
+    const ws = new WebSocket(`ws://localhost:${port}/signalk/v1/stream`)
+    ws.on('open', () => {
+      ws.close()
+      done()
+    })
+    ws.on('error', done)
+  })
+
+  it('re-registers endpoints across a config-change restart', async () => {
+    await setPluginConfig(port, true)
+    await waitForEcho(open, true)
+    const reply = await open('/plugins/upgradetestplugin/echo')
+    assert.equal(reply, 'echo:hello')
+  })
+
+  it('rolls back a registered endpoint when start() throws', async () => {
+    // A start() that registers an endpoint and then throws must leave
+    // nothing behind, so the endpoint 404s and a later clean start still
+    // succeeds (rather than throwing on a duplicate registration).
+    await setPluginConfig(port, true, { failAfterRegister: true })
+    await waitForEcho(open, false)
+    await assert.rejects(open('/plugins/upgradetestplugin/echo'), /404/)
+
+    await setPluginConfig(port, true, {})
+    await waitForEcho(open, true)
+    const reply = await open('/plugins/upgradetestplugin/echo')
+    assert.equal(reply, 'echo:hello')
+  })
+
+  it('removes endpoints when the plugin stops', async () => {
+    // A live connection must be terminated when the plugin stops, and new
+    // upgrades must then be rejected.
+    await setPluginConfig(port, true, {})
+    await waitForEcho(open, true)
+
+    const live = new WebSocket(
+      `ws://localhost:${port}/plugins/upgradetestplugin/echo`
+    )
+    await new Promise<void>((resolve, reject) => {
+      live.on('open', () => resolve())
+      live.on('error', reject)
+    })
+    const closed = new Promise<void>((resolve, reject) => {
+      live.on('close', () => resolve())
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error('live connection was not closed when plugin stopped')
+          ),
+        SETTLE_TIMEOUT_MS
+      )
+      live.on('close', () => clearTimeout(timer))
+    })
+
+    await setPluginConfig(port, false)
+    await closed
+    await waitForEcho(open, false)
+    await assert.rejects(open('/plugins/upgradetestplugin/echo'), /404/)
+  })
+})

--- a/test/plugin-websocket-upgrade.ts
+++ b/test/plugin-websocket-upgrade.ts
@@ -142,13 +142,27 @@ describe('plugin WebSocket endpoints', () => {
     await assert.rejects(open('/plugins/upgradetestplugin/raw'), /418/)
   })
 
-  it('does not break the primary Signal K WebSocket', (done) => {
-    const ws = new WebSocket(`ws://localhost:${port}/signalk/v1/stream`)
-    ws.on('open', () => {
-      ws.close()
-      done()
+  function connect(pathname: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${port}${pathname}`)
+      const timer = setTimeout(() => {
+        ws.close()
+        reject(new Error(`WebSocket connect timeout for ${pathname}`))
+      }, OPEN_TIMEOUT_MS)
+      ws.on('open', () => {
+        clearTimeout(timer)
+        resolve(ws)
+      })
+      ws.on('error', (err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
     })
-    ws.on('error', done)
+  }
+
+  it('does not break the primary Signal K WebSocket', async () => {
+    const ws = await connect('/signalk/v1/stream')
+    ws.close()
   })
 
   it('re-registers endpoints across a config-change restart', async () => {
@@ -173,18 +187,10 @@ describe('plugin WebSocket endpoints', () => {
   })
 
   it('removes endpoints when the plugin stops', async () => {
-    // A live connection must be terminated when the plugin stops, and new
-    // upgrades must then be rejected.
     await setPluginConfig(port, true, {})
     await waitForEcho(open, true)
 
-    const live = new WebSocket(
-      `ws://localhost:${port}/plugins/upgradetestplugin/echo`
-    )
-    await new Promise<void>((resolve, reject) => {
-      live.on('open', () => resolve())
-      live.on('error', reject)
-    })
+    const live = await connect('/plugins/upgradetestplugin/echo')
     const closed = new Promise<void>((resolve, reject) => {
       live.on('close', () => resolve())
       const timer = setTimeout(


### PR DESCRIPTION
## Summary

Express routers cannot handle HTTP `upgrade` events — those are emitted on the underlying HTTP server. Without an explicit hook, plugins cannot serve WebSockets, including the increasingly common case of reverse-proxying a WebSocket-using third-party service through Signal K.

Following the API discussion below, plugins call `app.registerWebSocket(path)` in `start()` to register a WebSocket endpoint at `/plugins/<pluginId><path>`. The returned object is a subset of [ws](https://github.com/websockets/ws)'s `WebSocketServer`:

- By default the server completes the handshake and emits `connection` with a ready-to-use socket — plugins don't bring their own `ws`.
- A plugin that attaches an `upgrade` listener handles the upgrade entirely itself and receives the raw `(request, socket, head)` — the reverse-proxy case.
- Paths are matched exactly (query string excluded). Endpoints are removed automatically when the plugin stops; registering in `start()` makes them survive config-change restarts naturally.

The server installs a single `upgrade` listener on `app.server` — before Primus's WS interface, so Primus's `previous::upgrade` chain correctly forwards non-matching events to it. Plugins that do not use the API are not affected: their upgrade events are left untouched.

Authentication is the plugin's responsibility — `app.securityStrategy.authorizeWS(request)` is available if needed.

## Motivation

Originally surfaced by SignalK/app-dock#12 — embedding the Victron Cerbo Remote Console in App Dock. Resolving that ask cleanly requires a reverse-proxy bridge plugin, which in turn requires this hook for the noVNC WebSocket. The same hook benefits any plugin that proxies or serves WebSockets — Grafana panels, MQTT-over-WS, custom IoT integrations, Socket.IO-based plugins, etc.

## Tested

Unit tests in `test/plugin-websocket-upgrade.ts` (7 cases): connection dispatch on a registered path, exact-path matching (sub-paths and unregistered paths rejected with 404), raw `upgrade` handover suppressing `connection`, non-interference with `/signalk/v1/stream`, re-registration across a config-change restart, and endpoint removal on plugin stop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds plugin-scoped WebSocket endpoint support through `app.registerWebSocket(path)`.

- `ServerAPI` exposes `registerWebSocket(path: string): PluginWebSocketServer`. The interface supports `connection`, `upgrade`, and `error` events, a readonly `clients` set, and `close(cb?)`.
- Plugins register endpoints under `/plugins/<pluginId><path>`. The server uses exact path matching, excludes query strings, rejects duplicates, and removes endpoints when plugins stop. Connected clients are terminated during cleanup.
- The server routes HTTP upgrade requests to registered plugin endpoints. When a plugin listens for `upgrade`, it handles the raw request and the server suppresses the default handshake and `connection` event. Otherwise, the server completes the handshake and emits `connection`. Unmatched paths return `404`.
- Plugin start rollback removes newly registered stop handlers when `plugin.start()` throws.
- Documentation describes endpoint registration, exact path matching, raw upgrade handling, cleanup, and plugin-owned authentication.
- End-to-end tests cover handshakes, path matching, upgrade handling, existing stream behavior, restarts, failed starts, endpoint removal, and connected-client cleanup.
- Interface initialization uses an explicit ordered entry module instead of directory auto-discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->