### PR TITLE
ci: thank issue reporters on close with sponsor link

### DIFF
--- a/.github/workflows/thank-issue-reporters.yml
+++ b/.github/workflows/thank-issue-reporters.yml
@@ -1,0 +1,29 @@
+name: Thank issue reporters
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  thank:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.issue.state_reason == 'completed' &&
+      github.event.issue.user.type != 'Bot' &&
+      github.event.issue.user.login != 'tkurki'
+    steps:
+      - name: Post thank-you comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          {
+            printf 'Thanks for taking the time to report this, @%s! 🙏\n\n' "$AUTHOR"
+            printf 'SignalK is built and maintained by volunteers in their spare time. If the project has been useful to you, please consider [becoming a sponsor on Open Collective](https://opencollective.com/signalk) — even a small recurring contribution helps keep things healthy and sustainable.\n\n'
+            printf 'Fair winds! ⛵\n'
+          } > /tmp/body.md
+          gh issue comment "$ISSUE_URL" --body-file /tmp/body.md


### PR DESCRIPTION
Adds a workflow that posts a thank-you comment on issues closed as completed, inviting the reporter to sponsor on Open Collective. Volunteers maintain Signal K in their spare time, and a closing-issue prompt is a low-friction moment to surface that.

Skips bot-authored issues and issues opened by @tkurki to avoid noise on internal/maintenance issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a new GitHub Actions workflow that automatically posts thank-you comments on issues closed as completed.

The workflow (`thank-issue-reporters.yml`) triggers whenever an issue is closed and verifies three conditions before posting: the issue must be marked as completed (not dismissed or not planned), the author must not be a bot, and the author must not be `tkurki` (to avoid noise on internal issues).

When these conditions are met, the workflow generates a thank-you comment that includes the issue reporter's username, acknowledges that SignalK is built and maintained by volunteers, and encourages the reporter to consider becoming a sponsor on Open Collective. The comment is posted using the GitHub CLI with the repository token.

This automation surfaces a sponsorship prompt at the low-friction moment when an issue is resolved, helping to raise awareness about project funding needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->