### PR TITLE
feat(history): parse resolution time expressions per spec

### DIFF
--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -269,7 +269,12 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
   const { timeRangeParams, errors } = parseTimeRangeParams(query)
 
   const context = query.context as Context | undefined
-  const resolution = getMaybeNumber(query.resolution)
+  let resolution: number | undefined
+  try {
+    resolution = parseResolution(query.resolution)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Invalid resolution')
+  }
 
   const paths = query.paths as string
   if (!paths) {
@@ -299,6 +304,39 @@ const getMaybeNumber = (value: unknown): number | undefined => {
   if (typeof value === 'string') return Number(value)
   if (typeof value === 'number') return value
   return undefined
+}
+
+// Maps the single-letter unit suffix in a resolution time expression to seconds.
+const RESOLUTION_UNIT_SECONDS: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 3_600,
+  d: 86_400
+}
+
+// Matches resolution time expressions per the History API spec, e.g.
+// '1s' -> 1, '15m' -> 900, '2h' -> 7200, '1d' -> 86400.
+const RESOLUTION_TIME_EXPRESSION = /^(\d+)([smhd])$/
+
+// Parses the `resolution` query parameter into seconds.
+// Accepts a number (already in seconds), a numeric string, or a time
+// expression of the form `<integer><unit>` where unit is s|m|h|d.
+// Returns undefined when the parameter is absent.
+// Exported for unit testing.
+export const parseResolution = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value === 'number') return value
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  const match = RESOLUTION_TIME_EXPRESSION.exec(trimmed)
+  if (match) {
+    return Number(match[1]) * RESOLUTION_UNIT_SECONDS[match[2]]
+  }
+  const asNumber = Number(trimmed)
+  if (!Number.isNaN(asNumber)) return asNumber
+  throw new Error(
+    `resolution parameter must be a number of seconds or a time expression like '1s', '1m', '1h', '1d'`
+  )
 }
 
 const splitPathExpression = (pathExpression: string): PathSpec => {

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -167,5 +167,21 @@ describe('History API v2', () => {
       body.should.have.property('error')
       body.error.should.contain('paths')
     })
+
+    it('accepts a time expression resolution like 1m', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&from=${FROM}&to=${TO}&resolution=1m`
+      )
+      res.status.should.equal(200)
+    })
+
+    it('returns 400 for unparseable resolution', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&from=${FROM}&to=${TO}&resolution=1y`
+      )
+      res.status.should.equal(400)
+      const body = await res.json()
+      body.error.should.contain('resolution')
+    })
   })
 })

--- a/test/history-resolution.ts
+++ b/test/history-resolution.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai'
+import { parseResolution } from '../dist/api/history/index.js'
+
+describe('parseResolution', () => {
+  it('is exported as a function (sanity check that the build is current)', () => {
+    expect(parseResolution).to.be.a('function')
+  })
+
+  it('returns undefined for missing values', () => {
+    expect(parseResolution(undefined)).to.equal(undefined)
+    expect(parseResolution(null)).to.equal(undefined)
+    expect(parseResolution('')).to.equal(undefined)
+  })
+
+  it('returns undefined for non-string, non-number values', () => {
+    // Express may parse `?resolution[]=1m` as an array; preserve the
+    // existing tolerant behavior rather than throwing.
+    expect(parseResolution(['1m'])).to.equal(undefined)
+    expect(parseResolution({})).to.equal(undefined)
+  })
+
+  it('passes through numbers as seconds', () => {
+    expect(parseResolution(0)).to.equal(0)
+    expect(parseResolution(1)).to.equal(1)
+    expect(parseResolution(60)).to.equal(60)
+  })
+
+  it('parses numeric strings as seconds', () => {
+    expect(parseResolution('60')).to.equal(60)
+    expect(parseResolution('1000')).to.equal(1000)
+  })
+
+  it('parses time expressions to seconds', () => {
+    expect(parseResolution('1s')).to.equal(1)
+    expect(parseResolution('1m')).to.equal(60)
+    expect(parseResolution('1h')).to.equal(3_600)
+    expect(parseResolution('1d')).to.equal(86_400)
+  })
+
+  it('parses time expressions with multi-digit values', () => {
+    expect(parseResolution('15m')).to.equal(900)
+    expect(parseResolution('2h')).to.equal(7_200)
+    expect(parseResolution('30s')).to.equal(30)
+  })
+
+  it('parses zero time expressions', () => {
+    expect(parseResolution('0s')).to.equal(0)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(parseResolution('  1s  ')).to.equal(1)
+    expect(parseResolution(' 60 ')).to.equal(60)
+    // Tabs and newlines are also whitespace per String.prototype.trim.
+    expect(parseResolution('\t1m\n')).to.equal(60)
+  })
+
+  it('throws for unparseable strings', () => {
+    expect(() => parseResolution('abc')).to.throw(/resolution/)
+    expect(() => parseResolution('1y')).to.throw(/resolution/)
+  })
+
+  it('rejects fractional time expressions', () => {
+    // Spec lists only integer time expressions ('1s', '1m', '1h', '1d').
+    expect(() => parseResolution('1.5s')).to.throw(/resolution/)
+    expect(() => parseResolution('0.5h')).to.throw(/resolution/)
+  })
+
+  it('rejects uppercase unit suffixes', () => {
+    // Spec only documents lowercase suffixes; pinning case sensitivity
+    // here so the contract cannot regress silently.
+    expect(() => parseResolution('1S')).to.throw(/resolution/)
+    expect(() => parseResolution('1H')).to.throw(/resolution/)
+  })
+})


### PR DESCRIPTION
## Summary

The History API spec describes the `resolution` query parameter as

> Length of data sample time window in seconds or as a time expression ('1s', '1m', '1h', '1d')

but the implementation only coerced the string with `Number()`, so `?resolution=1s` produced `NaN` and was forwarded to the provider unchanged.

This adds a `parseResolution` helper that accepts a number or numeric string (interpreted as seconds), the documented time expressions `<integer>s|m|h|d`, and returns 400 with a helpful message for unparseable input. The output is in seconds, matching the SI-units convention used elsewhere in Signal K (see #2642 / #2646).

Refs #2640