### PR TITLE
fix(history): accept integer seconds for duration over HTTP

### DIFF
--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -300,12 +300,6 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
   return parsed
 }
 
-const getMaybeNumber = (value: unknown): number | undefined => {
-  if (typeof value === 'string') return Number(value)
-  if (typeof value === 'number') return value
-  return undefined
-}
-
 // Maps the single-letter unit suffix in a resolution time expression to seconds.
 const RESOLUTION_UNIT_SECONDS: Record<string, number> = {
   s: 1,
@@ -358,7 +352,8 @@ const splitPathExpression = (pathExpression: string): PathSpec => {
   return pathSpec
 }
 
-const parseTimeRangeParams = (query: Record<string, unknown>) => {
+// Exported for unit testing.
+export const parseTimeRangeParams = (query: Record<string, unknown>) => {
   const errors: string[] = []
 
   const fromStr = query.from as string | undefined
@@ -374,18 +369,22 @@ const parseTimeRangeParams = (query: Record<string, unknown>) => {
   }
 
   const durationStr = query.duration as string | undefined
-  const durationNum = getMaybeNumber(query.duration)
   let duration: Temporal.Duration | undefined
   if (durationStr) {
     try {
       duration = Temporal.Duration.from(durationStr)
-    } catch (error) {
-      errors.push(
-        `duration parameter must be a valid ISO 8601 duration string: ${error instanceof Error ? error.message : 'Invalid format'}`
-      )
+    } catch {
+      // Strict non-negative decimal integer only: rule out negatives, hex
+      // (0x10), exponential (9e2), surrounding whitespace, and fractional
+      // forms that Number() would otherwise silently accept.
+      if (/^\d+$/.test(durationStr)) {
+        duration = Temporal.Duration.from({ seconds: Number(durationStr) })
+      } else {
+        errors.push(
+          `duration parameter must be an ISO 8601 duration string (e.g. 'PT15M') or an integer number of seconds`
+        )
+      }
     }
-  } else if (durationNum !== undefined) {
-    duration = Temporal.Duration.from({ milliseconds: durationNum })
   }
 
   if (!from && !duration) {

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -183,5 +183,31 @@ describe('History API v2', () => {
       const body = await res.json()
       body.error.should.contain('resolution')
     })
+
+    it('accepts an ISO 8601 duration string', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&duration=PT15M`
+      )
+      res.status.should.equal(200)
+    })
+
+    it('accepts an integer number of seconds for duration', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&duration=900`
+      )
+      res.status.should.equal(200)
+    })
+
+    it('returns 400 for an unparseable duration', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&duration=not-a-duration`
+      )
+      res.status.should.equal(400)
+      const body = await res.json()
+      // Match against the specific error from the parser, not just any
+      // mention of "duration", to avoid false greens from unrelated
+      // validators that also mention the word.
+      body.error.should.contain('ISO 8601')
+    })
   })
 })

--- a/test/history-duration.ts
+++ b/test/history-duration.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai'
+import { parseTimeRangeParams } from '../dist/api/history/index.js'
+
+const callParse = (query: Record<string, unknown>) => {
+  try {
+    return parseTimeRangeParams(query)
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}
+
+describe('parseTimeRangeParams duration handling', () => {
+  it('parses an ISO 8601 duration string', () => {
+    const result = callParse({ duration: 'PT15M' })
+    expect(result).to.have.property('timeRangeParams')
+    if (result instanceof Error) throw result
+    expect(result.timeRangeParams.duration?.toString()).to.equal('PT15M')
+  })
+
+  it('parses an integer number of seconds passed as a string', () => {
+    const result = callParse({ duration: '900' })
+    if (result instanceof Error) throw result
+    const total = result.timeRangeParams.duration?.total({
+      unit: 'seconds'
+    })
+    expect(total).to.equal(900)
+  })
+
+  it('parses zero seconds as a valid duration', () => {
+    const result = callParse({ duration: '0', from: '2025-01-01T00:00:00Z' })
+    if (result instanceof Error) throw result
+    expect(
+      result.timeRangeParams.duration?.total({ unit: 'seconds' })
+    ).to.equal(0)
+  })
+
+  it('rejects fractional duration strings', () => {
+    // Spec calls for an integer number of seconds; reject 1.5 etc.
+    const result = callParse({ duration: '1.5' })
+    expect(result).to.be.instanceOf(Error)
+    expect((result as Error).message).to.contain('duration')
+  })
+
+  it('rejects non-numeric, non-ISO duration strings', () => {
+    const result = callParse({ duration: 'not-a-duration' })
+    expect(result).to.be.instanceOf(Error)
+    expect((result as Error).message).to.contain('ISO 8601')
+  })
+
+  // The integer-seconds fallback used to lean on Number() + isInteger, which
+  // silently accepted negatives, hex literals, exponential notation, and
+  // surrounding whitespace. The user-facing error documents only ISO 8601 and
+  // an integer number of seconds, so the parser should reject anything else.
+  ;[
+    ['negative', '-900'],
+    ['hex', '0x10'],
+    ['exponential', '9e2'],
+    ['whitespace-padded', '  900  ']
+  ].forEach(([label, value]) => {
+    it(`rejects ${label} duration strings (${value})`, () => {
+      const result = callParse({ duration: value })
+      expect(result).to.be.instanceOf(Error)
+      expect((result as Error).message).to.contain('ISO 8601')
+    })
+  })
+
+  it('treats an empty duration as missing', () => {
+    // No duration AND no from/to is invalid; assert the error mentions the
+    // missing time range, not the duration format.
+    const result = callParse({ duration: '' })
+    expect(result).to.be.instanceOf(Error)
+    expect((result as Error).message).to.contain(
+      'Either from or duration parameter is required'
+    )
+  })
+
+  it('returns equivalent Temporal.Duration values for ISO and integer-seconds forms', () => {
+    const iso = callParse({ duration: 'PT15M' })
+    const seconds = callParse({ duration: '900' })
+    if (iso instanceof Error) throw iso
+    if (seconds instanceof Error) throw seconds
+    const isoSec = iso.timeRangeParams.duration?.total({ unit: 'seconds' })
+    const intSec = seconds.timeRangeParams.duration?.total({ unit: 'seconds' })
+    expect(isoSec).to.equal(intSec)
+  })
+
+  it('parses ISO 8601 from and to', () => {
+    const result = callParse({
+      from: '2025-01-01T00:00:00Z',
+      to: '2025-01-02T00:00:00Z'
+    })
+    if (result instanceof Error) throw result
+    expect(result.timeRangeParams.from?.toString()).to.equal(
+      '2025-01-01T00:00:00Z'
+    )
+    expect(result.timeRangeParams.to?.toString()).to.equal(
+      '2025-01-02T00:00:00Z'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Per the History API spec, `duration` accepts either an ISO 8601 string (e.g. `PT15M`) or an integer number of seconds (SI). Both arrive as strings over HTTP, but the prior code routed every string to `Temporal.Duration.from` and the numeric branch was unreachable, so `?duration=900` returned 400 with `invalid duration: 900`.

This tries the ISO 8601 form first and falls back to integer parsing if it fails. Fractional and non-numeric input is rejected with a single user-facing message that mentions both accepted forms. \`parseTimeRangeParams\` is exported so the parsing contract is covered by direct unit tests.

Removed the explanatory comment per review feedback.

Refs #2640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes the History API to accept both ISO 8601 duration strings and integer seconds for the `duration` parameter over HTTP.

## Problem
The History API specification allows the `duration` parameter to accept either ISO 8601 duration strings (e.g., `PT15M`) or an integer number of seconds. However, all query parameters arrive as strings over HTTP, and the previous implementation forwarded every string directly to `Temporal.Duration.from()`, making the integer-second branch unreachable and causing requests like `?duration=900` to return a 400 error.

## Solution
The duration parsing logic now attempts to parse the parameter as an ISO 8601 duration string first. If that fails, it falls back to parsing the value as an integer. This allows both forms to work correctly:
- ISO 8601 durations: `PT15M`, `PT1H`, etc.
- Integer seconds: `900`, `3600`, etc.

Invalid input (fractional numbers, non-numeric strings) is rejected with a single user-facing error message that documents both accepted forms.

## Changes
- **src/api/history/index.ts**: Updated the `parseTimeRangeParams` function to implement the fallback parsing logic for duration values, attempting ISO 8601 parsing first and falling back to integer-second parsing.
- **test/history-duration.ts**: Added comprehensive test coverage for duration parsing, including ISO 8601 formats, integer seconds, zero durations, rejection of fractional and invalid inputs, and verification that both forms produce equivalent results.
- **test/history-api.ts**: Added HTTP-level tests for duration-based query parameters with both ISO 8601 and integer-second formats.

The `parseTimeRangeParams` function is exported to enable direct unit testing of the parsing contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->