### PR TITLE
perf(streambundle): reduce allocations on per-delta path

### DIFF
--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -1,6 +1,6 @@
 /**
- * LatestValuesAccumulator - Accumulates Signal K delta values during backpressure,
- * keeping only the latest value for each unique context:path:$source combination.
+ * Accumulates Signal K delta values during backpressure, keeping only the
+ * latest value for each unique context:path:$source combination.
  */
 
 import {
@@ -8,9 +8,11 @@ import {
   Delta,
   hasValues,
   Path,
+  PathValue,
   SourceRef,
   Timestamp,
-  Update
+  Update,
+  Value
 } from '@signalk/server-api'
 
 export interface AccumulatedItem {
@@ -28,41 +30,31 @@ export interface BackpressureDelta extends Delta {
   }
 }
 
-/**
- * Accumulate latest value per context:path:$source during backpressure.
- * Only keeps the most recent value for each unique combination, dropping intermediate updates.
- *
- * @param accumulator - Map to store accumulated values, keyed by context:path:$source
- * @param delta - Signal K delta to accumulate
- */
+const UNKNOWN_SOURCE = 'unknown'
+
 export function accumulateLatestValue(
   accumulator: Map<string, AccumulatedItem>,
   delta: Delta
 ): void {
   if (!delta.updates) return
+  const context = delta.context as Context
   for (const update of delta.updates) {
     if (!hasValues(update)) continue
+    const $source = update.$source
+    const sourceKey = $source || UNKNOWN_SOURCE
+    const timestamp = update.timestamp
     for (const pv of update.values) {
-      const key = `${delta.context}:${pv.path}:${update.$source || 'unknown'}`
-      accumulator.set(key, {
-        context: delta.context as Context,
+      accumulator.set(`${context}:${pv.path}:${sourceKey}`, {
+        context,
         path: pv.path,
         value: pv.value,
-        $source: update.$source,
-        timestamp: update.timestamp
+        $source,
+        timestamp
       })
     }
   }
 }
 
-/**
- * Convert accumulated values to spec-compliant deltas.
- * Groups values by context and $source for proper delta structure.
- *
- * @param accumulator - Map of accumulated values
- * @param duration - How long backpressure was active in milliseconds
- * @returns Array of deltas, one per context, with $backpressure indicator
- */
 export function buildFlushDeltas(
   accumulator: Map<string, AccumulatedItem>,
   duration: number
@@ -71,45 +63,44 @@ export function buildFlushDeltas(
 
   const countBefore = accumulator.size
 
-  // Group by context
-  const byContext = new Map<Context, Map<string, Update>>()
-  for (const [, item] of accumulator) {
-    if (!byContext.has(item.context)) {
-      byContext.set(item.context, new Map())
+  const byContext = new Map<
+    Context,
+    Map<string, Update & { values: PathValue[] }>
+  >()
+  for (const item of accumulator.values()) {
+    let bySource = byContext.get(item.context)
+    if (!bySource) {
+      bySource = new Map()
+      byContext.set(item.context, bySource)
     }
-    // Group by $source within context
-    const bySource = byContext.get(item.context)!
-    const sourceKey = item.$source || 'unknown'
-    if (!bySource.has(sourceKey)) {
-      bySource.set(sourceKey, {
-        $source: item.$source as SourceRef,
-        timestamp: item.timestamp as Timestamp,
+    const sourceKey = item.$source || UNKNOWN_SOURCE
+    let update = bySource.get(sourceKey)
+    if (!update) {
+      update = {
+        $source: item.$source,
+        timestamp: item.timestamp,
         values: []
-      })
-    }
-    const update = bySource.get(sourceKey)!
-    if (hasValues(update)) {
-      update.values.push({
-        path: item.path as Path,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: item.value as any
-      })
-      // Use the most recent timestamp for this source
-      if (
-        item.timestamp &&
-        (!update.timestamp || item.timestamp > update.timestamp)
-      ) {
-        update.timestamp = item.timestamp as Timestamp
       }
+      bySource.set(sourceKey, update)
+    }
+    update.values.push({
+      path: item.path,
+      value: item.value as Value
+    })
+    // Keep the newest timestamp seen for this source so the flushed delta reflects the latest update.
+    if (
+      item.timestamp &&
+      (!update.timestamp || item.timestamp > update.timestamp)
+    ) {
+      update.timestamp = item.timestamp
     }
   }
 
-  // Build one delta per context with backpressure indicator
   const deltas: BackpressureDelta[] = []
-  for (const [context, bySourceTime] of byContext) {
+  for (const [context, bySource] of byContext) {
     deltas.push({
       context,
-      updates: Array.from(bySourceTime.values()),
+      updates: Array.from(bySource.values()),
       $backpressure: {
         accumulated: countBefore,
         duration

--- a/src/streambundle.ts
+++ b/src/streambundle.ts
@@ -17,6 +17,8 @@
 import {
   StreamBundle as IStreamBundle,
   Delta,
+  hasMeta,
+  hasValues,
   NormalizedDelta,
   Path,
   Update,
@@ -55,36 +57,41 @@ export class StreamBundle implements IStreamBundle {
   pushDelta(delta: Delta) {
     try {
       if (delta.updates) {
-        delta.updates.forEach((update) => {
-          const base = {
-            context: delta.context!, // TSTODO: make optional/required match
-            source: update.source,
-            $source: update.$source!, // TSTODO: make optional/required match
-            timestamp: update.timestamp! // TSTODO: make optional/required match
-          }
+        // TSTODO: context/$source/timestamp optionality on Delta/Update does not match NormalizedDelta
+        const context = delta.context!
+        for (const update of delta.updates) {
+          const source = update.source
+          const $source = update.$source!
+          const timestamp = update.timestamp!
 
-          if ('meta' in update) {
-            update.meta.forEach((meta) => {
+          if (hasMeta(update)) {
+            for (const meta of update.meta) {
               this.push(meta.path, {
-                ...base,
+                context,
+                source,
+                $source,
+                timestamp,
                 path: meta.path,
                 value: meta.value,
                 isMeta: true
               })
-            })
+            }
           }
 
-          if ('values' in update) {
-            update.values.forEach((pathValue) => {
+          if (hasValues(update)) {
+            for (const pathValue of update.values) {
               this.push(pathValue.path, {
-                ...base,
+                context,
+                source,
+                $source,
+                timestamp,
                 path: pathValue.path,
                 value: pathValue.value,
                 isMeta: false
               })
-            })
+            }
           }
-        })
+        }
       }
     } catch (e) {
       console.error(e)
@@ -100,9 +107,7 @@ export class StreamBundle implements IStreamBundle {
         this.selfMetaBus.push(normalizedDelta)
       }
     }
-    if (!this.availableSelfPaths[path]) {
-      this.availableSelfPaths[path] = true
-    }
+    this.availableSelfPaths[path] = true
     this.getBus().push(normalizedDelta)
     this.getBus(path).push(normalizedDelta)
     if (isSelf) {


### PR DESCRIPTION
## Why

`pushDelta` and `LatestValuesAccumulator` run on the per-delta hot path (100+ deltas/sec). Two allocation patterns to address:

- `pushDelta` builds a `base` object then double-spreads it into each `NormalizedDelta` per inner iteration. That's an allocation per element plus a per-element shape that depends on whether the input is `meta` or `values` (V8 hidden class churn).
- `LatestValuesAccumulator.buildFlushDeltas` uses `Map.has` then `Map.get!` in two nested levels: two lookups per item per level when one would do.

## How

`pushDelta`: hoist `context`/`source`/`$source`/`timestamp` once per update, then build each `NormalizedDelta` as a single literal with consistent key order. Replace `forEach` with `for...of` per `AGENTS.md` performance guidance. Use the existing `hasMeta`/`hasValues` type guards from `@signalk/server-api` instead of `'meta' in update` / `'values' in update`.

`LatestValuesAccumulator`:
- `accumulateLatestValue`: hoist `context`, `$source`, `sourceKey`, `timestamp` out of the inner `values` loop so they're computed once per update instead of once per path-value.
- `buildFlushDeltas`: replace `if (!byContext.has(...)) ...; byContext.get(...)!` (and the same pattern for `bySource`) with single get-or-create lookups. Iterate `accumulator.values()` to skip the discarded key tuple. Tighten the inner Map type to `Update & { values: PathValue[] }` so the dead `if (hasValues(update))` check goes away. Drop residual `as Path` / `as Timestamp` casts now that the inner type is precise.

No behavior change. `LatestValuesAccumulator` unit tests (13 cases) and `BackpressureManager` tests (downstream consumer) pass unchanged.

Refs #2582.

## Notes

- No version bump per `AGENTS.md`.
- `getMetaBus` / `getSelfMetaBus` / similar public methods on `StreamBundle` are kept even where unreferenced internally — they're part of the plugin-facing surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Performance Optimization: Reduce Allocations on Per-Delta Path

This PR reduces memory allocations on the hot path for per-delta updates (100+ deltas/sec) through refactored object construction and iteration patterns, with no behavioral changes.

## Changes in StreamBundle.pushDelta

The method converts from `forEach`/spread-based construction to explicit `for..of` loops. For each update, the code now:
- Hoists `context`, `source`, `$source`, and `timestamp` computation once per update
- Builds each `NormalizedDelta` as a single object literal with consistent key order, rather than spreading a per-update base object
- Leverages existing type guards (`hasMeta`/`hasValues`) from `@signalk/server-api`

Additionally, `StreamBundle.push` now sets `availableSelfPaths[path]` unconditionally rather than only when previously missing.

## Changes in LatestValuesAccumulator

### accumulateLatestValue
Hoists `context`, `$source`, `sourceKey`, and `timestamp` out of the inner values loop for better cache locality and reduced redundant property access.

### buildFlushDeltas
Refactoring improves efficiency and type safety:
- Replaces separate `Map.has` + `Map.get` patterns with single get-or-create lookups
- Iterates over `accumulator.values()` to skip discarded key tuples
- Strengthens TypeScript typing for grouped `update.values` as `PathValue[]`, removing redundant `hasValues` checks and casts
- Updates timestamp handling to track the newest timestamp per `context`/`$source` group
- Shares a `UNKNOWN_SOURCE` constant for consistent source handling

## Test Coverage & Compatibility

All existing tests pass unchanged:
- 13 LatestValuesAccumulator unit test cases
- BackpressureManager tests
- No version bump required per AGENTS.md
- Public StreamBundle methods retained for plugin compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->