### PR TITLE
refactor(deltacache): drop lodash and tighten types

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -18,7 +18,6 @@
 import { createDebug } from './debug'
 const debug = createDebug('signalk-server:deltacache')
 import { FullSignalK, getSourceId } from '@signalk/signalk-schema'
-import _, { isUndefined } from 'lodash'
 import { toDelta, StreamBundle } from './streambundle'
 import { ContextMatcher, SignalKServer } from './types'
 import { Context, NormalizedDelta, SourceRef } from '@signalk/server-api'
@@ -80,10 +79,8 @@ export default class DeltaCache {
   }
 
   onValue(msg: NormalizedDelta) {
-    // debug(`onValue ${JSON.stringify(msg)}`)
-
+    // meta is managed by FullSignalK
     if (msg.isMeta) {
-      // ignore meta data since it's getting managed by FullSignalK
       return
     }
 
@@ -97,12 +94,12 @@ export default class DeltaCache {
     if (msg.path.length !== 0) {
       leaf[sourceRef] = msg
     } else if (msg.value) {
-      _.keys(msg.value).forEach((key) => {
+      for (const key of Object.keys(msg.value)) {
         if (!leaf[key]) {
           leaf[key] = {}
         }
         leaf[key][sourceRef] = msg
-      })
+      }
     }
     this.lastModifieds[msg.context] = Date.now()
   }
@@ -155,7 +152,7 @@ export default class DeltaCache {
     const signalk = new FullSignalK(this.app.selfId, this.app.selfType)
 
     const addDelta = signalk.addDelta.bind(signalk)
-    _.values(this.sourceDeltas).forEach(addDelta)
+    Object.values(this.sourceDeltas).forEach(addDelta)
 
     return signalk.retrieve().sources
   }
@@ -170,7 +167,7 @@ export default class DeltaCache {
     const addDelta = signalk.addDelta.bind(signalk)
 
     if (includeSources) {
-      _.values(this.sourceDeltas).forEach(addDelta)
+      Object.values(this.sourceDeltas).forEach(addDelta)
     }
 
     if (deltas && deltas.length) {
@@ -184,38 +181,31 @@ export default class DeltaCache {
   }
 
   getCachedDeltas(contextFilter: ContextMatcher, user?: string, key?: string) {
-    const contexts: Context[] = []
-    _.keys(this.cache).forEach((type) => {
-      _.keys(this.cache[type]).forEach((id) => {
+    const keyParts = key ? key.split('.') : undefined
+    const deltas: NormalizedDelta[] = []
+    for (const type of Object.keys(this.cache)) {
+      const typeBranch = this.cache[type]
+      for (const id of Object.keys(typeBranch)) {
         const context = `${type}.${id}` as Context
-        if (contextFilter({ context })) {
-          contexts.push(this.cache[type][id])
+        if (!contextFilter({ context })) {
+          continue
         }
-      })
-    })
-
-    const deltas = contexts.reduce(
-      (acc: NormalizedDelta[], context: Context) => {
-        let deltasToProcess
-
-        if (key) {
-          deltasToProcess = _.get(context, key)
+        const contextBranch = typeBranch[id]
+        if (keyParts) {
+          const leaf = getLeafObject(contextBranch, keyParts, false)
+          if (!leaf) continue
+          for (const akey of Object.keys(leaf)) {
+            if (akey !== 'meta') {
+              deltas.push(leaf[akey])
+            }
+          }
         } else {
-          deltasToProcess = findDeltas(context)
+          for (const delta of findDeltas(contextBranch)) {
+            deltas.push(delta)
+          }
         }
-        if (deltasToProcess) {
-          acc = acc.concat(
-            _.values(
-              _.pickBy(deltasToProcess, (val, akey) => {
-                return akey !== 'meta'
-              })
-            )
-          )
-        }
-        return acc
-      },
-      []
-    )
+      }
+    }
 
     // ISO 8601 Zulu timestamps (as produced by new Date().toISOString() in
     // handleMessage) are lexicographically sortable, so we can avoid
@@ -234,7 +224,7 @@ export default class DeltaCache {
   }
 }
 
-function pathToProcessForFull(pathArray: any[]) {
+function pathToProcessForFull(pathArray: string[]) {
   if (pathArray.length > 0 && pathArray[0] === 'sources') {
     return []
   }
@@ -243,9 +233,9 @@ function pathToProcessForFull(pathArray: any[]) {
 
 function pickDeltasFromBranch(acc: any[], obj: any) {
   if (typeof obj === 'object') {
-    if (isUndefined(obj.path) || isUndefined(obj.value)) {
+    if (obj.path === undefined || obj.value === undefined) {
       // not a delta, so process possible children
-      _.values(obj).reduce(pickDeltasFromBranch, acc)
+      Object.values(obj).reduce(pickDeltasFromBranch, acc)
     } else {
       acc.push(obj)
     }
@@ -254,7 +244,7 @@ function pickDeltasFromBranch(acc: any[], obj: any) {
 }
 
 function findDeltas(branchOrLeaf: any) {
-  return _.values(branchOrLeaf).reduce(pickDeltasFromBranch, [])
+  return Object.values(branchOrLeaf).reduce(pickDeltasFromBranch, [])
 }
 
 function ensureHasDollarSource(normalizedDelta: NormalizedDelta): SourceRef {
@@ -276,7 +266,7 @@ function getLeafObject(
 
   for (let i = 0; i < contextAndPathParts.length; i++) {
     const p = contextAndPathParts[i]
-    if (isUndefined(current[p])) {
+    if (current[p] === undefined) {
       if (createIfMissing) {
         current[p] = {}
       } else {

--- a/src/deltastats.ts
+++ b/src/deltastats.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
 */
 
-import { isUndefined, values } from 'lodash'
 import { EventEmitter } from 'node:events'
 
 const STATS_UPDATE_INTERVAL_SECONDS = 5
@@ -92,7 +91,7 @@ export function startDeltaStatistics(
 
 export function incDeltaStatistics(
   app: WithProviderStatistics,
-  providerId: any
+  providerId: string
 ) {
   app.deltaCount++
 
@@ -104,12 +103,12 @@ export function incDeltaStatistics(
 
 function updateProviderPeriodStats(app: any) {
   app.providers.forEach((provider: any) => {
-    if (isUndefined(app.providerStatistics[provider.id])) {
+    if (app.providerStatistics[provider.id] === undefined) {
       app.providerStatistics[provider.id] = new ProviderStats()
     }
   })
 
-  values(app.providerStatistics).forEach((stats: ProviderStats) => {
+  for (const stats of Object.values<ProviderStats>(app.providerStatistics)) {
     stats.deltaRate =
       (stats.deltaCount - stats.lastIntervalDeltaCount) /
       STATS_UPDATE_INTERVAL_SECONDS
@@ -118,5 +117,5 @@ function updateProviderPeriodStats(app: any) {
       (stats.writeCount - stats.lastIntervalWriteCount) /
       STATS_UPDATE_INTERVAL_SECONDS
     stats.lastIntervalWriteCount = stats.writeCount
-  })
+  }
 }

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -4,6 +4,7 @@ chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
 const _ = require('lodash')
 import { startServer } from './ts-servertestutilities'
+import DeltaCache from '../src/deltacache'
 
 const testDelta = {
   context: 'vessels.self',
@@ -221,5 +222,83 @@ describe('Deltacache', () => {
       defaults: {},
       deltaFromHttp: {}
     })
+  })
+
+  it('getCachedDeltas with key returns only matching path', function () {
+    const deltas = theServer.app.deltaCache.getCachedDeltas(
+      () => true,
+      null,
+      'navigation.trip.log'
+    )
+    deltas.length.should.equal(1)
+    deltas[0].updates[0].values[0].path.should.equal('navigation.trip.log')
+    deltas[0].updates[0].values[0].value.should.equal(43374)
+  })
+
+  it('getCachedDeltas with non-existent key returns empty array', function () {
+    const deltas = theServer.app.deltaCache.getCachedDeltas(
+      () => true,
+      null,
+      'navigation.does.not.exist'
+    )
+    deltas.length.should.equal(0)
+  })
+})
+
+describe('DeltaCache unit', () => {
+  let cache
+
+  beforeEach(() => {
+    const fakeStreambundle = {
+      keys: { onValue: () => {} },
+      getBus: () => ({ onValue: () => {} })
+    }
+    const fakeApp = {
+      securityStrategy: {
+        filterReadDelta: (_user, delta) => delta,
+        shouldFilterDeltas: () => false
+      }
+    }
+    cache = new DeltaCache(fakeApp, fakeStreambundle)
+  })
+
+  it('getCachedDeltas with key returns deltas under that path after direct populate', () => {
+    cache.onValue({
+      context: 'vessels.urn:test',
+      path: 'navigation.position',
+      $source: 'unit-test',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      value: { latitude: 60.1, longitude: 24.9 }
+    })
+
+    const deltas = cache.getCachedDeltas(
+      () => true,
+      null,
+      'navigation.position'
+    )
+    deltas.length.should.equal(1)
+    deltas[0].context.should.equal('vessels.urn:test')
+    deltas[0].updates[0].values[0].path.should.equal('navigation.position')
+    deltas[0].updates[0].values[0].value.should.deep.equal({
+      latitude: 60.1,
+      longitude: 24.9
+    })
+  })
+
+  it('getCachedDeltas with non-existent key returns empty array', () => {
+    cache.onValue({
+      context: 'vessels.urn:test',
+      path: 'navigation.position',
+      $source: 'unit-test',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      value: { latitude: 60.1, longitude: 24.9 }
+    })
+
+    const deltas = cache.getCachedDeltas(
+      () => true,
+      null,
+      'navigation.speedOverGround'
+    )
+    deltas.length.should.equal(0)
   })
 })


### PR DESCRIPTION
## Why

Maintainability cleanup of `deltacache.ts` and `deltastats.ts`. The per-delta win here is small: a single `isUndefined` → `=== undefined` swap in `getLeafObject` (nanoseconds per path segment, called once per `onValue`). The rest of the diff runs at subscribe time or on the 5-second stats timer, so the framing is mostly type hygiene and getting another file off lodash.

## What's in the diff

**Subscribe-time / timer cleanup:**
- Drop lodash imports from `src/deltacache.ts` and `src/deltastats.ts`. `_.keys` / `_.values` → `Object.keys` / `Object.values`; `isUndefined(x)` → `x === undefined`.
- Rewrite `getCachedDeltas` to walk the cache directly via `getLeafObject` (keyed branch) and `findDeltas` (unkeyed branch), dropping the intermediate context-collection step and a `_.pickBy` + `_.values` chain.
- `pickDeltasFromBranch`, `findDeltas` switched from `_.values` to `Object.values`.

**Per-delta micro-win:**
- `isUndefined(current[p])` → `current[p] === undefined` in `getLeafObject` (called per path segment in `onValue`).

**Type tightening:**
- `pathToProcessForFull(pathArray: any[])` → `string[]`.
- `incDeltaStatistics(providerId: any)` → `string`.

**New tests:**
- `getCachedDeltas(filter, user, 'navigation.trip.log')` returns only the matching path.
- `getCachedDeltas(filter, user, 'navigation.does.not.exist')` returns an empty array.

These exercise the keyed branch of `getCachedDeltas`, which is only called from `subscriptionmanager.ts:273` and was not exercised by any existing test before this PR. They lock in the lodash → native equivalence for that branch.

Refs #2582.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Refactor(deltacache): Drop lodash and tighten types

This PR removes lodash dependencies from `src/deltacache.ts` and `src/deltastats.ts` while tightening type signatures throughout.

## Changes

**src/deltacache.ts:**
- Replaces lodash utilities (`_.keys`, `_.values`, `isUndefined`) with native alternatives (`Object.keys`, `Object.values`, `=== undefined`)
- Rewrites `getCachedDeltas` to directly traverse the internal cache tree via nested object iteration, using `getLeafObject` for keyed lookups and `findDeltas` for full-tree extraction, eliminating an intermediate context-collection step and `_.pickBy + _.values` chain
- Converts `pickDeltasFromBranch` and `findDeltas` to use `Object.values` instead of lodash
- Micro-optimizes the hot-path in `getLeafObject` by replacing `isUndefined` checks with `=== undefined`
- Tightens type signature: `pathToProcessForFull(pathArray: any[])` becomes `pathToProcessForFull(pathArray: string[])`

**src/deltastats.ts:**
- Removes lodash usage in `updateProviderPeriodStats` by replacing `_.values` with `Object.values` and undefined checks with direct comparison
- Tightens type signature: `incDeltaStatistics(providerId: any)` becomes `incDeltaStatistics(providerId: string)`

**test/deltacache.js:**
- Adds unit tests for the keyed branch of `getCachedDeltas` that was previously untested
- Tests verify that `getCachedDeltas` with a specific key path returns only matching deltas and returns an empty array for non-existent paths
- New `DeltaCache unit` test suite constructs a `DeltaCache` instance directly to validate both keyed-branch outcomes

## Impact

Most changes occur at subscribe-time or during the 5-second timer cycle. The per-delta runtime improvement is limited to the micro-optimization in `getLeafObject`. Primary benefits focus on maintainability: eliminating lodash imports, improving type safety, and simplifying the `getCachedDeltas` implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->