### PR TITLE
refactor: TypeScript hygiene in BackpressureManager, deltachain, deltaeditor

### DIFF
--- a/src/BackpressureManager.ts
+++ b/src/BackpressureManager.ts
@@ -20,19 +20,15 @@ export interface BackpressureTransport {
   destroy(): void
 }
 
-export interface BackpressureOptions {
-  enterThreshold: number
-  exitThreshold: number
-  maxBufferSize: number
-  maxBufferCheckTime: number
-  beforeWrite?: (delta: Delta) => void
-}
-
 export interface BackpressureThresholds {
   enterThreshold: number
   exitThreshold: number
   maxBufferSize: number
   maxBufferCheckTime: number
+}
+
+export interface BackpressureOptions extends BackpressureThresholds {
+  beforeWrite?: (delta: Delta) => void
 }
 
 export function parseBackpressureThresholds(configFallbacks?: {
@@ -60,13 +56,19 @@ export class BackpressureManager {
   private active = false
   private readonly accumulator: Map<string, AccumulatedItem> = new Map()
   private since: number | null = null
-  private bufferSizeExceeded: number | undefined = undefined
-  private readonly transport: BackpressureTransport
-  private readonly options: BackpressureOptions
+  private bufferSizeExceeded?: number
 
-  constructor(transport: BackpressureTransport, options: BackpressureOptions) {
-    this.transport = transport
-    this.options = options
+  constructor(
+    private readonly transport: BackpressureTransport,
+    private readonly options: BackpressureOptions
+  ) {}
+
+  get isActive(): boolean {
+    return this.active
+  }
+
+  get accumulatorSize(): number {
+    return this.accumulator.size
   }
 
   onDrain(): void {
@@ -103,8 +105,8 @@ export class BackpressureManager {
     const duration = this.since ? Date.now() - this.since : 0
     const deltas = buildFlushDeltas(this.accumulator, duration)
     for (const delta of deltas) {
-      this.options.beforeWrite?.(delta as Delta)
-      this.transport.write(delta as Delta)
+      this.options.beforeWrite?.(delta)
+      this.transport.write(delta)
     }
     this.accumulator.clear()
     this.active = false
@@ -145,13 +147,5 @@ export class BackpressureManager {
     this.active = false
     this.since = null
     this.bufferSizeExceeded = undefined
-  }
-
-  get isActive(): boolean {
-    return this.active
-  }
-
-  get accumulatorSize(): number {
-    return this.accumulator.size
   }
 }

--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -1,20 +1,18 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { Delta, DeltaInputHandler } from '@signalk/server-api'
 
+type Next = (msg: Delta) => void
+
 export default class DeltaChain {
-  chain: any
-  next: any
-  constructor(private dispatchMessage: any) {
-    this.chain = []
-    this.next = []
-  }
+  private chain: DeltaInputHandler[] = []
+  private next: Next[] = []
+
+  constructor(private dispatchMessage: (msg: Delta) => void) {}
 
   process(msg: Delta) {
     return this.doProcess(0, msg)
   }
 
-  doProcess(index: number, msg: any) {
+  doProcess(index: number, msg: Delta) {
     if (index >= this.chain.length) {
       this.dispatchMessage(msg)
       return
@@ -35,10 +33,8 @@ export default class DeltaChain {
   }
 
   updateNexts() {
-    this.next = this.chain.map((chainElement: any, index: number) => {
-      return (msg: any) => {
-        this.doProcess(index + 1, msg)
-      }
+    this.next = this.chain.map((_handler, index) => (msg: Delta) => {
+      this.doProcess(index + 1, msg)
     })
   }
 }

--- a/src/deltaeditor.ts
+++ b/src/deltaeditor.ts
@@ -16,8 +16,12 @@
  */
 
 import fs from 'fs'
-import _ from 'lodash'
 import { atomicWriteFileSync, atomicWriteFile } from './atomicWrite'
+
+function pull<T>(arr: T[], item: T): void {
+  const index = arr.indexOf(item)
+  if (index >= 0) arr.splice(index, 1)
+}
 
 const VALUES = 'values'
 const META = 'meta'
@@ -34,7 +38,7 @@ class DeltaEditor {
     const data = fs.readFileSync(filename, 'utf8')
     const deltas = JSON.parse(data)
 
-    if (!_.isArray(deltas)) {
+    if (!Array.isArray(deltas)) {
       throw new Error(`${filename} should contain an array of deltas`)
     }
     this.deltas = deltas
@@ -50,7 +54,7 @@ class DeltaEditor {
   }
 
   setValue(context: string, path: string, value: any) {
-    if (_.isUndefined(value)) {
+    if (value === undefined) {
       return this.removeValue(context, path)
     }
 
@@ -97,16 +101,16 @@ class DeltaEditor {
       if (deltaInfo && deltaInfo.kp) {
         delete deltaInfo.kp.value[path]
 
-        if (_.keys(deltaInfo.kp.value).length === 0) {
-          _.pull(this.deltas, deltaInfo.delta)
+        if (Object.keys(deltaInfo.kp.value).length === 0) {
+          pull(this.deltas, deltaInfo.delta)
         }
       }
     } else {
       const deltaInfo = getDelta(this.deltas, context, path, VALUES)
       if (deltaInfo && deltaInfo.kp) {
-        _.pull(deltaInfo.delta.updates[0].values, deltaInfo.kp)
+        pull(deltaInfo.delta.updates[0].values, deltaInfo.kp)
         if (deltaInfo.delta.updates[0].values.length === 0) {
-          _.pull(this.deltas, deltaInfo.delta)
+          pull(this.deltas, deltaInfo.delta)
         }
       }
     }
@@ -119,9 +123,9 @@ class DeltaEditor {
   removeMeta(context: string, path: string) {
     const deltaInfo = getDelta(this.deltas, context, path, META)
     if (deltaInfo && deltaInfo.kp) {
-      _.pull(deltaInfo.delta.updates[0].meta, deltaInfo.kp)
+      pull(deltaInfo.delta.updates[0].meta, deltaInfo.kp)
       if (deltaInfo.delta.updates[0].meta.length === 0) {
-        _.pull(this.deltas, deltaInfo.delta)
+        pull(this.deltas, deltaInfo.delta)
       }
     }
   }


### PR DESCRIPTION
## Why

Three small TS cleanups in adjacent files. None changes behavior.

## How

**BackpressureManager**
- `BackpressureOptions extends BackpressureThresholds` (the 4 threshold fields were duplicated between the two interfaces).
- Use TS constructor parameter properties for \`transport\`/\`options\`.
- Drop two redundant \`as Delta\` casts in \`flush()\` (\`BackpressureDelta\` already extends \`Delta\`).

**deltachain**
- Replace \`any\` typing with \`Delta\` / \`DeltaInputHandler\` / a local \`Next\` callback type.
- Drop the file-wide \`@typescript-eslint/no-explicit-any\` directive that's no longer needed.
- Move field initialization to declarations; use constructor parameter property for \`dispatchMessage\`.

**deltaeditor**
- Drop the \`lodash\` import. Replace \`_.isUndefined\` with \`=== undefined\`, \`_.isArray\` with \`Array.isArray\`, \`_.keys\` with \`Object.keys\`, \`_.pull\` with a small typed local helper.

\`BackpressureManager\` unit tests (21 cases) pass.

Refs #2582.

## Notes

- No version bump per \`AGENTS.md\`.