### PR TITLE
refactor(subscriptions): drop named lodash imports and tighten error types

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -29,12 +29,14 @@ import {
 } from '@signalk/server-api'
 import * as Bacon from 'baconjs'
 import { isPointWithinRadius } from 'geolib'
-import _, { forOwn, get, isString } from 'lodash'
+import _ from 'lodash'
 import { createDebug } from './debug'
 import DeltaCache from './deltacache'
 import { StreamBundle, toDelta } from './streambundle'
 import { ContextMatcher } from './types'
 const debug = createDebug('signalk-server:subscriptionmanager')
+
+const VALID_POLICIES: ReadonlySet<string> = new Set(['instant', 'fixed'])
 
 interface BusesMap {
   [path: Path]: Bacon.Bus<NormalizedDelta>
@@ -100,14 +102,12 @@ class SubscriptionManager implements ISubscriptionManager {
     if (command.announceNewPaths) {
       const announcedPaths = new Set<string>()
 
-      // 1. Announce ALL existing paths matching context (send cached deltas once)
       const existingDeltas = this.app.deltaCache.getCachedDeltas(
         contextFilter,
         user
       )
       if (existingDeltas) {
         existingDeltas.forEach((delta: any) => {
-          // Track which paths we've announced
           delta.updates?.forEach((update: any) => {
             update.values?.forEach((vp: any) => {
               if (vp.path) {
@@ -119,27 +119,24 @@ class SubscriptionManager implements ISubscriptionManager {
         })
       }
 
-      // 2. Listen for NEW paths appearing later and announce once
       unsubscribes.push(
         this.streambundle.keys.onValue((path: string) => {
           if (announcedPaths.has(path)) {
-            return // Already announced this path
+            return
           }
           announcedPaths.add(path)
 
-          // Subscribe to the bus to get the first value for this new path
-          // We can't rely on deltaCache here because it might not have
-          // received the value yet (race condition with keys.onValue)
+          // deltaCache may not yet hold the value when keys.onValue fires,
+          // so subscribe to the bus directly for the first value.
           const bus = this.streambundle.getBus(path as Path)
           const unsubscribeBus = bus
             .filter(contextFilter)
-            .take(1) // Only take the first value
+            .take(1)
             .map(toDelta)
             .onValue((delta: any) => {
               callback(delta)
             })
 
-          // Add to unsubscribes so it gets cleaned up
           unsubscribes.push(unsubscribeBus)
         })
       )
@@ -150,13 +147,11 @@ class SubscriptionManager implements ISubscriptionManager {
     if (
       msg.unsubscribe &&
       msg.context === '*' &&
-      msg.unsubscribe &&
       msg.unsubscribe.length === 1 &&
       msg.unsubscribe[0].path === '*'
     ) {
       debug('Unsubscribe all')
       unsubscribes.forEach((unsubscribe) => unsubscribe())
-      // clear unsubscribes
       unsubscribes.length = 0
     } else {
       throw new Error(
@@ -175,10 +170,10 @@ function handleSubscribeRows(
   buses: BusesMap,
   filter: ContextMatcher,
   callback: SubscribeCallback,
-  errorCallback: any,
+  errorCallback: (err: unknown) => void,
   user?: string
 ) {
-  rows.reduce((acc, subscribeRow) => {
+  for (const subscribeRow of rows) {
     if (subscribeRow.path !== undefined) {
       handleSubscribeRow(
         app,
@@ -191,8 +186,7 @@ function handleSubscribeRows(
         user
       )
     }
-    return acc
-  }, unsubscribes)
+  }
 }
 
 interface App {
@@ -206,76 +200,73 @@ function handleSubscribeRow(
   buses: BusesMap,
   filter: ContextMatcher,
   callback: SubscribeCallback,
-  errorCallback: any,
+  errorCallback: (err: unknown) => void,
   user?: string
 ) {
   const matcher = pathMatcher(subscribeRow.path)
-  // iterate over all the buses, checking if we want to subscribe to its values
-  forOwn(buses, (bus, key) => {
-    if (matcher(key)) {
-      debug('Subscribing to key ' + key)
-      let filteredBus: Bacon.EventStream<NormalizedDelta> = bus.filter(filter)
-      if (subscribeRow.minPeriod) {
-        if (subscribeRow.policy && subscribeRow.policy !== 'instant') {
-          errorCallback(
-            `minPeriod assumes policy 'instant', ignoring policy ${subscribeRow.policy}`
-          )
-        }
-        const minPeriodValue = Number(subscribeRow.minPeriod)
-        debug('minPeriod:' + subscribeRow.minPeriod)
-        if (isNaN(minPeriodValue)) {
-          errorCallback(
-            `invalid minPeriod value '${subscribeRow.minPeriod}', ignoring`
-          )
-        } else if (key !== '') {
-          // we can not apply minPeriod for empty path subscriptions
-          debug('debouncing')
-          filteredBus = filteredBus.debounceImmediate(minPeriodValue)
-        }
-      } else if (
-        subscribeRow.period ||
-        (subscribeRow.policy && subscribeRow.policy === 'fixed')
-      ) {
-        if (subscribeRow.policy && subscribeRow.policy !== 'fixed') {
-          errorCallback(
-            `period assumes policy 'fixed', ignoring policy ${subscribeRow.policy}`
-          )
-        } else if (key !== '') {
-          // we can not apply period for empty path subscriptions
-          const interval = Number(subscribeRow.period) || 1000
-          filteredBus = filteredBus
-            .bufferWithTime(interval)
-            .flatMapLatest((bufferedValues: any) => {
-              const uniqueValues = _(bufferedValues)
-                .reverse()
-                .uniqBy(
-                  (value) =>
-                    value.context + ':' + value.$source + ':' + value.path
-                )
-                .value()
-              return Bacon.fromArray(uniqueValues)
-            })
-        }
-      }
-      if (subscribeRow.format && subscribeRow.format !== 'delta') {
-        errorCallback('Only delta format supported, using it')
-      }
-      if (
-        subscribeRow.policy &&
-        !['instant', 'fixed'].some((s) => s === subscribeRow.policy)
-      ) {
+  for (const key in buses) {
+    if (!matcher(key)) {
+      continue
+    }
+    const bus = buses[key as Path]
+    debug.enabled && debug('Subscribing to key ' + key)
+    let filteredBus: Bacon.EventStream<NormalizedDelta> = bus.filter(filter)
+    if (subscribeRow.minPeriod) {
+      if (subscribeRow.policy && subscribeRow.policy !== 'instant') {
         errorCallback(
-          `Only 'instant' and 'fixed' policies supported, ignoring policy ${subscribeRow.policy}`
+          `minPeriod assumes policy 'instant', ignoring policy ${subscribeRow.policy}`
         )
       }
-      unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
-
-      const latest = app.deltaCache.getCachedDeltas(filter, user, key)
-      if (latest) {
-        latest.forEach(callback)
+      const minPeriodValue = Number(subscribeRow.minPeriod)
+      debug.enabled && debug('minPeriod:' + subscribeRow.minPeriod)
+      if (isNaN(minPeriodValue)) {
+        errorCallback(
+          `invalid minPeriod value '${subscribeRow.minPeriod}', ignoring`
+        )
+      } else if (key !== '') {
+        // minPeriod can not apply to empty-path subscriptions
+        debug.enabled && debug('debouncing')
+        filteredBus = filteredBus.debounceImmediate(minPeriodValue)
+      }
+    } else if (
+      subscribeRow.period ||
+      (subscribeRow.policy && subscribeRow.policy === 'fixed')
+    ) {
+      if (subscribeRow.policy && subscribeRow.policy !== 'fixed') {
+        errorCallback(
+          `period assumes policy 'fixed', ignoring policy ${subscribeRow.policy}`
+        )
+      } else if (key !== '') {
+        const interval = Number(subscribeRow.period) || 1000
+        filteredBus = filteredBus
+          .bufferWithTime(interval)
+          .flatMapLatest((bufferedValues: any) => {
+            const uniqueValues = _(bufferedValues)
+              .reverse()
+              .uniqBy(
+                (value) =>
+                  value.context + ':' + value.$source + ':' + value.path
+              )
+              .value()
+            return Bacon.fromArray(uniqueValues)
+          })
       }
     }
-  })
+    if (subscribeRow.format && subscribeRow.format !== 'delta') {
+      errorCallback('Only delta format supported, using it')
+    }
+    if (subscribeRow.policy && !VALID_POLICIES.has(subscribeRow.policy)) {
+      errorCallback(
+        `Only 'instant' and 'fixed' policies supported, ignoring policy ${subscribeRow.policy}`
+      )
+    }
+    unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
+
+    const latest = app.deltaCache.getCachedDeltas(filter, user, key)
+    if (latest) {
+      latest.forEach(callback)
+    }
+  }
 }
 
 function pathMatcher(path: string = '*') {
@@ -291,11 +282,11 @@ function contextMatcher(
   selfContext: string,
   app: any,
   subscribeCommand: SubscribeMessage,
-  errorCallback: any
+  errorCallback: (err: unknown) => void
 ): ContextMatcher {
   debug.enabled && debug('subscribeCommand:' + JSON.stringify(subscribeCommand))
   if (subscribeCommand.context) {
-    if (isString(subscribeCommand.context)) {
+    if (typeof subscribeCommand.context === 'string') {
       const pattern = subscribeCommand.context
         .replace(/[\\^$+?()[\]{}|]/g, '\\$&')
         .replace(/\./g, '\\.')
@@ -307,10 +298,11 @@ function contextMatcher(
           subscribeCommand.context === 'self') &&
           normalizedDeltaData.context === selfContext)
     } else if ('radius' in subscribeCommand.context) {
+      const origin = subscribeCommand.context
       if (
-        !get(subscribeCommand.context, 'radius') ||
-        !get(subscribeCommand.context, 'position.latitude') ||
-        !get(subscribeCommand.context, 'position.longitude')
+        !origin.radius ||
+        !origin.position?.latitude ||
+        !origin.position?.longitude
       ) {
         errorCallback(
           'Please specify a radius and position for relativePosition'
@@ -318,11 +310,7 @@ function contextMatcher(
         return () => false
       }
       return (normalizedDeltaData: WithContext) =>
-        checkPosition(
-          app,
-          subscribeCommand.context as RelativePositionOrigin,
-          normalizedDeltaData
-        )
+        checkPosition(app, origin, normalizedDeltaData)
     }
   }
   return () => true
@@ -333,8 +321,9 @@ function checkPosition(
   origin: RelativePositionOrigin,
   normalizedDelta: WithContext
 ): boolean {
-  const vessel = get(app.signalk.root, normalizedDelta.context)
-  const position = get(vessel, 'navigation.position')
+  // context is a runtime dotted path; optional chaining can't replace this lookup.
+  const vessel = _.get(app.signalk.root, normalizedDelta.context)
+  const position = vessel?.navigation?.position
 
   return (
     position &&

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -600,6 +600,78 @@ describe('Subscriptions', (_) => {
       })
   })
 
+  it('relativePosition subscription without position errors', function () {
+    let wsPromiser
+
+    return serverP
+      .then(() => {
+        wsPromiser = new WsPromiser(
+          'ws://localhost:' + port + '/signalk/v1/stream?subscribe=none'
+        )
+        return wsPromiser.nextMsg()
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          wsPromiser.send({
+            context: {
+              radius: 1
+            },
+            subscribe: [
+              {
+                path: 'navigation.position'
+              }
+            ]
+          })
+        ])
+      })
+      .then(([response]) => {
+        assert.equal(
+          '"Please specify a radius and position for relativePosition"',
+          response
+        )
+      })
+  })
+
+  it('subscription with invalid policy errors', function () {
+    let self, wsPromiser
+
+    return serverP
+      .then(() => {
+        wsPromiser = new WsPromiser(
+          'ws://localhost:' + port + '/signalk/v1/stream?subscribe=none'
+        )
+        return wsPromiser.nextMsg()
+      })
+      .then((wsHello) => {
+        self = JSON.parse(wsHello).self
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getDelta({ context: self }), deltaUrl)
+        ])
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          wsPromiser.send({
+            context: '*',
+            subscribe: [
+              {
+                path: 'navigation.courseOverGroundTrue',
+                policy: 'invalid'
+              }
+            ]
+          })
+        ])
+      })
+      .then(([response]) => {
+        assert.equal(
+          "\"Only 'instant' and 'fixed' policies supported, ignoring policy invalid\"",
+          response
+        )
+      })
+  })
+
   it('JSON subscription with string period works', async function () {
     await serverP
     const wsPromiser = new WsPromiser(


### PR DESCRIPTION
## Why

This is a maintainability cleanup of `subscriptionmanager.ts`. Most of the changes run at subscribe time, not per-delta. The earlier description framed this as a per-delta perf PR and mentioned a `globToRegExp` extraction that isn't actually in the diff (it was in an earlier draft and got dropped for scope); the framing has been corrected.

## What's in the diff

**Subscribe-time cleanup (no measurable perf impact):**
- Drop `forOwn`, `get`, `isString` named imports from lodash. The default `_` is still imported because the `bufferWithTime` chain still uses `_(...).reverse().uniqBy(...)` and `_.get(app.signalk.root, normalizedDelta.context)` is kept in `checkPosition` (runtime dotted path).
- `forOwn(buses, ...)` → `for (const key in buses)` with early `continue`.
- `rows.reduce(side-effect)` → `for...of`.
- Hoist `VALID_POLICIES = new Set(['instant', 'fixed'])` to module scope.
- `isString(...)` → `typeof ... === 'string'`.
- Three `_.get` calls in the radius-validation path (subscribe-time only) → optional chaining.
- Type three `errorCallback: any` → `(err: unknown) => void`.
- Wrap eager-string `debug()` calls with `debug.enabled &&`.

**Small per-delta win (radius-context only, rare):**
- `_.get(vessel, 'navigation.position')` → `vessel?.navigation?.position` in `checkPosition`.

**Small bug fix:**
- Remove the duplicate `msg.unsubscribe &&` check in `unsubscribe()`.

**New tests:**
- Subscribe with radius but no position, asserts the `Please specify a radius and position for relativePosition` error path.
- Subscribe with `policy: 'invalid'` and no `minPeriod`, asserts the `Only 'instant' and 'fixed' policies supported` error. Today's only test in that area uses `policy: 'ideal'` with `minPeriod: 500`, which short-circuits on the earlier `minPeriod assumes policy 'instant'` error and never reaches the `VALID_POLICIES.has` branch.

## Notes

- `_.get(app.signalk.root, normalizedDelta.context)` in `contextMatcher` is intentionally kept: context is a runtime dotted path, so optional chaining doesn't apply. Now annotated with a one-line comment so it doesn't get "fixed" in a future cleanup.
- `_(bufferedValues).reverse().uniqBy(...)` in `subscribeToKeys` is unchanged: it runs once per buffer interval (>=1s), not per-delta, and `lodash.reverse` mutates so swapping requires care. Out of scope.
- A separate behavior bug in `checkPosition` (truthy `position.value.latitude && position.value.longitude` rejects the equator/prime meridian) is pre-existing and not addressed here.
- No version bump per AGENTS.md.

Refs #2582.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors `SubscriptionManager` to improve code maintainability and reduce lodash dependencies. The changes focus on subscription-time operations rather than per-delta performance, with a primary goal of code clarity and type safety.

## Changes

**src/subscriptionmanager.ts:**
- Removes named lodash imports (`forOwn`, `get`, `isString`) while retaining the default `_` import for remaining uses
- Replaces `forOwn(buses, ...)` loops with `for...in` iteration
- Converts `rows.reduce` with side effects to `for...of` loops
- Introduces a module-level `VALID_POLICIES = new Set(['instant', 'fixed'])` constant for policy validation
- Replaces `isString(...)` calls with `typeof` checks
- Converts three `_.get` calls in radius-validation logic to optional chaining syntax
- Tightens `errorCallback` type signatures from `any` to `(err: unknown) => void` (three instances)
- Guards eager `debug()` calls with `debug.enabled &&` checks to avoid unnecessary string operations
- Replaces one per-delta `_.get(vessel, 'navigation.position')` call with optional chaining (`vessel?.navigation?.position`)
- Removes a duplicate `msg.unsubscribe &&` check in the `unsubscribe()` method

**test/subscriptions.js:**
- Adds test for relativePosition subscription without position: verifies error message "Please specify a radius and position for relativePosition"
- Adds test for invalid policy subscription: verifies error message when policy other than 'instant' or 'fixed' is supplied

## Scope

The refactoring applies mostly at subscribe time rather than per-delta, making the maintainability improvements (cleaner code structure, type safety, reduced external dependencies) the primary value. A `_.get(app.signalk.root, normalizedDelta.context)` call is intentionally retained because `context` is a runtime dotted path that requires the lodash deep-access behavior.

## Testing

The full test suite (507 cases) passes locally. TypeScript, Prettier, and ESLint checks are clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->