### PR TITLE
perf(unitpreferences): cache hot-path lookups in metadata resolver

### DIFF
--- a/src/interfaces/unitpreferences-api.js
+++ b/src/interfaces/unitpreferences-api.js
@@ -134,6 +134,7 @@ const {
   reloadPreset,
   reloadCustomDefinitions,
   reloadCustomCategories,
+  invalidatePresetCache,
   getDefaultCategory,
   getBaseUnitToCategories,
   getCategoryForBaseUnit,
@@ -402,6 +403,7 @@ module.exports = function (app) {
 
       const presetPath = path.join(customDir, `${presetName}.json`)
       atomicWriteFileSync(presetPath, JSON.stringify(req.body, null, 2))
+      invalidatePresetCache(presetName)
       res.json({ success: true })
     } catch (err) {
       debug('Error saving custom preset:', err)
@@ -431,6 +433,7 @@ module.exports = function (app) {
       }
 
       fs.unlinkSync(presetPath)
+      invalidatePresetCache(presetName)
       res.json({ success: true })
     } catch (err) {
       debug('Error deleting preset:', err)
@@ -601,6 +604,7 @@ module.exports = function (app) {
         // Save the preset
         const presetPath = path.join(customDir, `${presetName}.json`)
         atomicWriteFileSync(presetPath, JSON.stringify(preset, null, 2))
+        invalidatePresetCache(presetName)
 
         debug(`Custom preset uploaded: ${presetName}`)
         sendResponse(200, {

--- a/src/unitpreferences/index.ts
+++ b/src/unitpreferences/index.ts
@@ -3,6 +3,7 @@ export {
   reloadPreset,
   reloadCustomDefinitions,
   reloadCustomCategories,
+  invalidatePresetCache,
   getConfig,
   getMergedDefinitions,
   getCategories,

--- a/src/unitpreferences/loader.ts
+++ b/src/unitpreferences/loader.ts
@@ -25,8 +25,12 @@ let customDefinitions: UnitDefinitions
 let activePreset: Preset
 let config: UnitPreferencesConfig
 let defaultCategories: { [path: string]: string } = {}
+let defaultCategoryWildcards: Array<{ regex: RegExp; category: string }> = []
 let baseUnitToCategoriesCache: { [baseUnit: string]: string[] } | null = null
+let mergedDefinitionsCache: UnitDefinitions | null = null
+let categoriesCache: CategoryMap | null = null
 const userPreferencesCache = new Map<string, UserUnitPreferences | null>()
+const presetByNameCache = new Map<string, Preset | null>()
 let applicationDataPath: string = ''
 let configUnitprefsDir: string = ''
 
@@ -169,6 +173,7 @@ export function loadAll(): void {
       }
     }
   }
+  rebuildDefaultCategoryWildcards()
 
   // Load default primary categories (read-only, from package)
   const primaryCatPath = path.join(
@@ -183,10 +188,33 @@ export function loadAll(): void {
 
   // Invalidate caches
   baseUnitToCategoriesCache = null
+  mergedDefinitionsCache = null
+  categoriesCache = null
   userPreferencesCache.clear()
+  presetByNameCache.clear()
 
   // Load active preset
   loadActivePreset()
+}
+
+// Wildcard '*' matches a single signalk path segment (no dots).
+// Example: 'electrical.batteries.*.voltage' matches 'electrical.batteries.house.voltage'
+// but not 'electrical.batteries.house.voltage.value'.
+function rebuildDefaultCategoryWildcards(): void {
+  defaultCategoryWildcards = []
+  for (const [pattern, category] of Object.entries(defaultCategories)) {
+    if (pattern.includes('*')) {
+      const regex = new RegExp(
+        '^' +
+          pattern
+            .replace(/[\\^$+?()[\]{}|]/g, '\\$&')
+            .replace(/\./g, '\\.')
+            .replace(/\*/g, '[^.]+') +
+          '$'
+      )
+      defaultCategoryWildcards.push({ regex, category })
+    }
+  }
 }
 
 function loadActivePreset(): void {
@@ -225,14 +253,19 @@ function loadActivePreset(): void {
   )
 }
 
+// The returned object is shared and must be treated as read-only by callers.
+// Invalidated by loadAll(), reloadCustomCategories().
 export function getCategories(): CategoryMap {
-  // Return merged categories (core + custom)
+  if (categoriesCache) {
+    return categoriesCache
+  }
   const merged = { ...categories }
   merged.categoryToBaseUnit = {
     ...categories.categoryToBaseUnit,
     ...customCategories
   }
-  return merged
+  categoriesCache = merged
+  return categoriesCache
 }
 export function getCustomCategories(): { [category: string]: string } {
   return customCategories
@@ -251,6 +284,7 @@ export function getConfig(): UnitPreferencesConfig {
 }
 
 export function reloadPreset(): void {
+  presetByNameCache.clear()
   // Re-read config from config dir
   const cfgPath = configUnitprefsDir
     ? path.join(configUnitprefsDir, 'config.json')
@@ -261,7 +295,19 @@ export function reloadPreset(): void {
   loadActivePreset()
 }
 
+// Drop a single preset (or all) from the cache. Call after writing or
+// deleting a custom preset file directly so subsequent loads see the new
+// content.
+export function invalidatePresetCache(presetName?: string): void {
+  if (presetName === undefined) {
+    presetByNameCache.clear()
+  } else {
+    presetByNameCache.delete(presetName)
+  }
+}
+
 export function reloadCustomDefinitions(): void {
+  mergedDefinitionsCache = null
   const customPath = configUnitprefsDir
     ? path.join(configUnitprefsDir, 'custom-units-definitions.json')
     : path.join(PACKAGE_UNITPREFS_DIR, 'custom-units-definitions.json')
@@ -274,6 +320,7 @@ export function reloadCustomDefinitions(): void {
 
 export function reloadCustomCategories(): void {
   baseUnitToCategoriesCache = null
+  categoriesCache = null
   const customCatPath = configUnitprefsDir
     ? path.join(configUnitprefsDir, 'custom-categories.json')
     : path.join(PACKAGE_UNITPREFS_DIR, 'custom-categories.json')
@@ -284,7 +331,12 @@ export function reloadCustomCategories(): void {
   }
 }
 
+// The returned object is shared and must be treated as read-only by callers.
+// Invalidated by loadAll(), reloadCustomDefinitions().
 export function getMergedDefinitions(): UnitDefinitions {
+  if (mergedDefinitionsCache) {
+    return mergedDefinitionsCache
+  }
   // Custom definitions override standard
   const merged: UnitDefinitions = structuredClone(standardDefinitions)
   for (const [siUnit, def] of Object.entries(customDefinitions)) {
@@ -297,7 +349,8 @@ export function getMergedDefinitions(): UnitDefinitions {
       }
     }
   }
-  return merged
+  mergedDefinitionsCache = merged
+  return mergedDefinitionsCache
 }
 
 export function getDefaultCategory(
@@ -309,20 +362,9 @@ export function getDefaultCategory(
     return defaultCategories[signalkPath]
   }
 
-  for (const [pattern, category] of Object.entries(defaultCategories)) {
-    if (pattern.includes('*')) {
-      // '*' matches a single path segment, not dots
-      const regex = new RegExp(
-        '^' +
-          pattern
-            .replace(/[\\^$+?()[\]{}|]/g, '\\$&')
-            .replace(/\./g, '\\.')
-            .replace(/\*/g, '[^.]+') +
-          '$'
-      )
-      if (regex.test(signalkPath)) {
-        return category
-      }
+  for (const { regex, category } of defaultCategoryWildcards) {
+    if (regex.test(signalkPath)) {
+      return category
     }
   }
 
@@ -419,11 +461,26 @@ export function saveUserPreferences(
   userPreferencesCache.set(username, structuredClone(prefs))
 }
 
+// Cached results are shared and must be treated as read-only by callers.
+// Invalidated by loadAll(), reloadPreset(), invalidatePresetCache().
 function loadPresetByName(presetName: string): Preset | null {
+  // Reject malformed names before touching the cache so attacker-controlled
+  // values from user prefs cannot grow the Map with junk keys.
   if (!/^[a-zA-Z0-9_-]+$/.test(presetName)) {
     return null
   }
 
+  const cached = presetByNameCache.get(presetName)
+  if (cached !== undefined) {
+    return cached
+  }
+
+  const preset = readPresetFromDisk(presetName)
+  presetByNameCache.set(presetName, preset)
+  return preset
+}
+
+function readPresetFromDisk(presetName: string): Preset | null {
   // Check custom presets in config dir first
   if (configUnitprefsDir) {
     const customPresetPath = path.join(

--- a/test/unitpreferences.ts
+++ b/test/unitpreferences.ts
@@ -7,6 +7,9 @@ import { WsPromiser, serverTestConfigDirectory } from './servertestutilities'
 // Import from dist, not src: the running server loads the dist build and we
 // need the same module instance (and its initialized applicationDataPath).
 import {
+  getActivePresetForUser,
+  getDefaultCategory,
+  invalidatePresetCache,
   loadUserPreferences,
   saveUserPreferences
 } from '../dist/unitpreferences/loader'
@@ -227,6 +230,161 @@ describe('Unit Preferences', function () {
         }
       )
       expect(res.status).to.equal(400)
+    })
+  })
+
+  describe('Cache invalidation', function () {
+    afterEach(async function () {
+      await fetch(`${host}/signalk/v1/unitpreferences/custom-definitions`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      })
+      await fetch(`${host}/signalk/v1/unitpreferences/custom-categories`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      })
+    })
+
+    it('GET /definitions reflects custom definitions after PUT', async function () {
+      // Prime the merged-definitions cache
+      let res = await fetch(`${host}/signalk/v1/unitpreferences/definitions`)
+      const before = await res.json()
+      expect(before['m/s'].conversions).to.not.have.property('cacheTest')
+
+      res = await fetch(
+        `${host}/signalk/v1/unitpreferences/custom-definitions`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            'm/s': {
+              conversions: {
+                cacheTest: {
+                  formula: 'value * 2',
+                  inverseFormula: 'value / 2',
+                  symbol: 'ct'
+                }
+              }
+            }
+          })
+        }
+      )
+      expect(res.status).to.equal(200)
+
+      res = await fetch(`${host}/signalk/v1/unitpreferences/definitions`)
+      const after = await res.json()
+      expect(after['m/s'].conversions).to.have.property('cacheTest')
+      expect(after['m/s'].conversions.cacheTest.symbol).to.equal('ct')
+    })
+
+    it('GET /categories reflects custom categories after PUT', async function () {
+      let res = await fetch(`${host}/signalk/v1/unitpreferences/categories`)
+      const before = await res.json()
+      expect(before.categoryToBaseUnit).to.not.have.property(
+        'cacheTestCategory'
+      )
+
+      res = await fetch(
+        `${host}/signalk/v1/unitpreferences/custom-categories`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cacheTestCategory: 'm/s' })
+        }
+      )
+      expect(res.status).to.equal(200)
+
+      res = await fetch(`${host}/signalk/v1/unitpreferences/categories`)
+      const after = await res.json()
+      expect(after.categoryToBaseUnit).to.have.property(
+        'cacheTestCategory',
+        'm/s'
+      )
+    })
+
+    it('invalidatePresetCache forces re-read of a custom preset on disk', async function () {
+      const TEST_USER = 'cache-test-user'
+      const presetName = 'invalidate-test-preset'
+      const customDir = path.join(
+        serverTestConfigDirectory(),
+        'unitpreferences',
+        'presets',
+        'custom'
+      )
+      const presetPath = path.join(customDir, `${presetName}.json`)
+      const userDir = path.join(
+        serverTestConfigDirectory(),
+        'applicationData',
+        'users',
+        TEST_USER
+      )
+
+      try {
+        fs.mkdirSync(customDir, { recursive: true })
+
+        fs.writeFileSync(
+          presetPath,
+          JSON.stringify({
+            version: '1.0.0',
+            name: 'v1',
+            categories: {
+              speed: { baseUnit: 'm/s', targetUnit: 'kn' }
+            }
+          })
+        )
+        saveUserPreferences(TEST_USER, { activePreset: presetName })
+
+        // Prime the cache.
+        const primed = getActivePresetForUser(TEST_USER)
+        expect(primed.name).to.equal('v1')
+
+        // Overwrite on disk; without invalidation the cache should still win.
+        fs.writeFileSync(
+          presetPath,
+          JSON.stringify({
+            version: '1.0.0',
+            name: 'v2',
+            categories: {
+              speed: { baseUnit: 'm/s', targetUnit: 'mph' }
+            }
+          })
+        )
+        const stillCached = getActivePresetForUser(TEST_USER)
+        expect(stillCached.name).to.equal('v1')
+
+        // Invalidate, then the next read picks up the new file.
+        invalidatePresetCache(presetName)
+        const refreshed = getActivePresetForUser(TEST_USER)
+        expect(refreshed.name).to.equal('v2')
+      } finally {
+        if (fs.existsSync(presetPath)) fs.unlinkSync(presetPath)
+        invalidatePresetCache(presetName)
+        await rimraf(userDir)
+      }
+    })
+  })
+
+  describe('Default category wildcard matching', function () {
+    it('matches single-segment wildcard patterns', function () {
+      expect(getDefaultCategory('propulsion.engine1.temperature')).to.equal(
+        'temperature'
+      )
+      expect(getDefaultCategory('electrical.batteries.house.voltage')).to.equal(
+        'voltage'
+      )
+      expect(getDefaultCategory('propulsion.port.oilPressure')).to.equal(
+        'pressure'
+      )
+    })
+
+    it('does not let wildcard span path segments', function () {
+      // 'propulsion.*.temperature' must not match a deeper path; '*' is one
+      // segment, not greedy across dots.
+      expect(
+        getDefaultCategory('propulsion.engine1.temperature.value')
+      ).to.equal(null)
     })
   })
 


### PR DESCRIPTION
## Motivation

`enhanceTreeMetadata` (rest.js) and the WebSocket meta delivery path call `resolveDisplayUnits` and `getDefaultCategory` for every metadata node in the SignalK tree on every `GET /signalk/v1/api/` and on every new path's first meta delta. With the unitpreferences feature added in 2.23 (#2225), expanded in 2.25 (#2512), and made auto-default in 2.26 (#2580), each per-node call re-cloned the 24 KB standard definitions, re-read preset files from disk, rebuilt a merged categories object, and rebuilt all wildcard regexes from `default-categories.json`.

On boats with 200+ metadata paths (typical with NMEA 2000 + Victron + derived-data) this scaled into seconds of CPU per REST call. Refs #2624.

## Changes

- Cache `getMergedDefinitions()` (24 KB `structuredClone` was running per node). Invalidated on `reloadCustomDefinitions` and `loadAll`.
- Cache `loadPresetByName` results (was reading + parsing the preset JSON per node). Invalidated on `reloadPreset`, `loadAll`, and via a new `invalidatePresetCache` exported for the API to call after direct preset writes/deletes/uploads.
- Pre-compile default-category wildcard regexes once in `loadAll` (was constructing 64 regexes per call to `getDefaultCategory`).
- Memoize `getCategories()` (was rebuilding a merged object per call). Invalidated on `reloadCustomCategories` and `loadAll`.

All cached objects are read-only by convention; existing callers were audited and do not mutate.

## Tests

Existing unit-preferences tests cover the active-preset reload path (`switching preset changes the active preset`, `pushes meta deltas when preset changes`). Added two tests under `Cache invalidation` that PUT to `/custom-definitions` and `/custom-categories` and verify the corresponding GET reflects the change, exercising the new invalidation logic end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces multiple caches and pre-compilations to the metadata resolver to reduce expensive repeated work during metadata resolution. The changes optimize hot-path lookups that execute for every metadata node on `GET /signalk/v1/api/` and on first metadata deltas over WebSocket.

## Changes

### Caching Strategy

The PR adds four main caches:

1. **Merged Definitions Cache**: Caches `getMergedDefinitions()` to avoid repeatedly structured-cloning the 24 KB standard definitions. This cache invalidates on `reloadCustomDefinitions()` and `loadAll()`.

2. **Preset Cache**: Caches `loadPresetByName()` results to avoid re-reading and re-parsing preset JSON files for each metadata node. The cache invalidates on `reloadPreset()`, `loadAll()`, and via a new exported `invalidatePresetCache()` function.

3. **Categories Cache**: Memoizes `getCategories()` to avoid rebuilding merged category objects (core + custom). This cache invalidates on `reloadCustomCategories()` and `loadAll()`.

4. **Default Category Wildcards**: Pre-compiles default-category wildcard regexes once in `loadAll()` instead of rebuilding them per `getDefaultCategory()` call, storing them in a compiled `{regex, category}` list.

### Cache Safety

All cached objects are treated as read-only. The codebase was audited to ensure callers do not mutate cached objects.

### API Integration

Custom preset persistence endpoints now invalidate the preset cache after modifications:
- `PUT /presets/custom/:name` - invalidates preset cache after write
- `DELETE /presets/custom/:name` - invalidates preset cache after deletion  
- `POST /presets/custom/upload` - invalidates preset cache after upload

A new exported `invalidatePresetCache(presetName?)` helper in the unitpreferences loader enables the API layer to trigger cache invalidation after direct preset writes/deletes/uploads.

### Test Coverage

New "Cache invalidation" test suite verifies that server-side cached merged results properly refresh after updates:
- Tests that `GET /definitions` reflects newly added conversions after `PUT` to `/custom-definitions`
- Tests that `GET /categories` reflects newly added category mappings after `PUT` to `/custom-categories`

## Performance Impact

Prior behavior re-cloned definitions, re-read preset files, rebuilt merged categories, and rebuilt wildcard regexes for every metadata node. On installations with 200+ metadata paths, this caused seconds of CPU time per REST call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->