### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 # Template - PLEASE READ
+
 <!--
 Before opening this PR, please consider:
 
@@ -11,11 +12,11 @@ Before opening this PR, please consider:
   (include before/after numbers).
 - Refactors, style changes, and "improvements" without a concrete
   problem being solved are likely to be closed.
-- Js conversion to ts are in general welcome, but if the queue is long 
+- JS-to-TS conversions are generally welcome, but if the queue is long,
   they will often go stale before getting attention.
 
 If you cannot articulate what real problem this solves for users,
-it probably should not be a PR at this time. 
+it probably should not be a PR at this time.
 -->
 
 ## What problem does this solve?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# Template - PLEASE READ
+<!--
+Before opening this PR, please consider:
+
+- AI has made contributing much, much easier, creating quite a lot of work
+  for project maintainers.
+- Every PR requires maintainer time to review. Look at the number of
+  open PRs and ask yourself: is this change worth adding to the queue?
+- Bug fixes that affect real-world end users are always welcome.
+- Performance improvements must demonstrate nontrivial, measurable gains
+  (include before/after numbers).
+- Refactors, style changes, and "improvements" without a concrete
+  problem being solved are likely to be closed.
+- Js conversion to ts are in general welcome, but if the queue is long 
+  they will often go stale before getting attention.
+
+If you cannot articulate what real problem this solves for users,
+it probably should not be a PR at this time. 
+-->
+
+## What problem does this solve?
+
+<!-- Describe the bug, limitation, feature or user-facing issue this addresses. -->
+
+## How was this tested?
+
+<!-- Describe how you verified the fix/change works. For performance
+     changes, include before/after measurements. -->


### PR DESCRIPTION
Add PR template that will hopefully make PR
authors think a little harder before adding
low value PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a pull request template at .github/pull_request_template.md to encourage more thoughtful contributions. The template includes guidance that prompts authors to consider maintainer review load and whether the change is worth adding to the queue, outlines expectations for bug fixes and measurable performance improvements (requiring before/after numbers), discourages refactors/style-only changes without a concrete problem statement, and notes that JS-to-TS conversions may become stale if the review queue is long. The template provides sections for authors to describe the user-facing problem being solved and how the change is tested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->