### PR TITLE
chore(deps): bump @signalk/course-provider to ^1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "dependencies": {
     "@assemblyscript/loader": "^0.28.9",
-    "@signalk/course-provider": "^1.0.0",
+    "@signalk/course-provider": "^1.2.7",
     "@signalk/n2k-signalk": ">=4.1.0-beta",
     "@signalk/nmea0183-signalk": "^3.0.0",
     "@signalk/resources-provider": "^1.5.1",


### PR DESCRIPTION
Brings the floor of the dependency in line with the current published version. The existing `^1.0.0` range already covers `1.2.7`, but pinning the lower bound documents what the server is actually tested against and prevents older 1.0.x from being installed in fresh environments.

Latest 1.2.7 over 1.0.0 brings cumulative perf work (delta-handler hot path, debug guards, build-delta-msg shape, active-route spread drop) and several bug fixes. No breaking changes — same major.

## Test plan

- [x] No source changes; in-range minor/patch bump within `^1.x`