### PR TITLE
chore(deps): bump @signalk/nmea0183-signalk to ^3.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@assemblyscript/loader": "^0.28.9",
     "@signalk/course-provider": "^1.2.7",
     "@signalk/n2k-signalk": ">=4.1.0-beta",
-    "@signalk/nmea0183-signalk": "^3.0.0",
+    "@signalk/nmea0183-signalk": "^3.19.1",
     "@signalk/resources-provider": "^1.5.1",
     "@signalk/server-admin-ui": "2.26.x",
     "@signalk/server-api": "^2.24.0",

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -68,7 +68,7 @@
     "@canboat/canboatjs": "^3.3.0",
     "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^4.1.0",
-    "@signalk/nmea0183-signalk": "^3.0.0",
+    "@signalk/nmea0183-signalk": "^3.19.1",
     "@signalk/nmea0183-utilities": "^1.1.0",
     "@signalk/signalk-schema": "^1.5.0",
     "any-shell-escape": "^0.1.1",


### PR DESCRIPTION
Brings the floor of the dependency in line with the current published version, in both the root package.json and packages/streams. The existing `^3.0.0` range already covers `3.19.1`, but pinning the lower bound documents what the server is actually tested against and prevents older 3.0.x from being installed in fresh environments.

Cumulative 3.0.0 -> 3.19.1 brings ~20 minor/patch releases worth of sentence-coverage and parser fixes (no breaking changes — same major).

## Test plan

- [x] No source changes; in-range minor/patch bump within `^3.x`