### PR TITLE
chore(deps): bump @signalk/signalk-to-nmea0183 to ^1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@signalk/freeboard-sk": "^2.0.0-beta.3",
     "@signalk/instrumentpanel": "0.x",
     "@signalk/set-system-time": "^1.5.0",
-    "@signalk/signalk-to-nmea0183": "^1.0.0",
+    "@signalk/signalk-to-nmea0183": "^1.16.1",
     "@signalk/udp-nmea-plugin": "^2.0.0",
     "serialport": "^11.0.0",
     "signalk-n2kais-to-nmea0183": "^2.0.0",


### PR DESCRIPTION
Brings the floor of the optional dependency in line with the current published version. The existing `^1.0.0` range already covers `1.16.1`, but pinning the lower bound documents what the server is actually tested against and prevents older 1.0.x from being installed in fresh environments.

Cumulative 1.0.0 -> 1.16.1 brings ~16 minor/patch releases worth of sentence emitter additions and parser fixes (no breaking changes — same major).

## Test plan

- [x] No source changes; in-range minor/patch bump within `^1.x`