### PR TITLE
chore(deps): bump @signalk/nmea0183-utilities to ^1.1.0 in streams

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -69,7 +69,7 @@
     "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^4.1.0",
     "@signalk/nmea0183-signalk": "^3.0.0",
-    "@signalk/nmea0183-utilities": "^1.0.0",
+    "@signalk/nmea0183-utilities": "^1.1.0",
     "@signalk/signalk-schema": "^1.5.0",
     "any-shell-escape": "^0.1.1",
     "file-timestamp-stream": "^2.1.2",


### PR DESCRIPTION
Brings the floor of the dependency in line with the current published version. The existing `^1.0.0` range already covers `1.1.0`, but pinning the lower bound documents what streams is actually tested against and prevents older 1.0.x from being installed in fresh environments.

`packages/streams` is the only place in the server tree that depends on this package. `packages/streams/src/nmea0183-signalk.ts` only imports `appendChecksum`, which has been stable across the 1.x line, so the bump is a no-op at runtime. Same major — no breaking changes.

## Test plan

- [x] No source changes; in-range minor bump within `^1.x`