### PR TITLE
refactor(backpressure): reduce accumulator allocations

### DIFF
--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -1,6 +1,6 @@
 /**
- * LatestValuesAccumulator - Accumulates Signal K delta values during backpressure,
- * keeping only the latest value for each unique context:path:$source combination.
+ * Accumulates Signal K delta values during backpressure, keeping only the
+ * latest value for each unique context:path:$source combination.
  */
 
 import {
@@ -8,9 +8,11 @@ import {
   Delta,
   hasValues,
   Path,
+  PathValue,
   SourceRef,
   Timestamp,
-  Update
+  Update,
+  Value
 } from '@signalk/server-api'
 
 export interface AccumulatedItem {
@@ -28,6 +30,8 @@ export interface BackpressureDelta extends Delta {
   }
 }
 
+const UNKNOWN_SOURCE = 'unknown'
+
 /**
  * Accumulate latest value per context:path:$source during backpressure.
  * Only keeps the most recent value for each unique combination, dropping intermediate updates.
@@ -40,17 +44,28 @@ export function accumulateLatestValue(
   delta: Delta
 ): void {
   if (!delta.updates) return
+  const context = delta.context as Context
   for (const update of delta.updates) {
     if (!hasValues(update)) continue
+    const $source = update.$source
+    const sourceKey = $source || UNKNOWN_SOURCE
+    const timestamp = update.timestamp
     for (const pv of update.values) {
-      const key = `${delta.context}:${pv.path}:${update.$source || 'unknown'}`
-      accumulator.set(key, {
-        context: delta.context as Context,
-        path: pv.path,
-        value: pv.value,
-        $source: update.$source,
-        timestamp: update.timestamp
-      })
+      const key = `${context}:${pv.path}:${sourceKey}`
+      const existing = accumulator.get(key)
+      if (existing) {
+        existing.value = pv.value
+        existing.$source = $source
+        existing.timestamp = timestamp
+      } else {
+        accumulator.set(key, {
+          context,
+          path: pv.path,
+          value: pv.value,
+          $source,
+          timestamp
+        })
+      }
     }
   }
 }
@@ -71,45 +86,44 @@ export function buildFlushDeltas(
 
   const countBefore = accumulator.size
 
-  // Group by context
-  const byContext = new Map<Context, Map<string, Update>>()
-  for (const [, item] of accumulator) {
-    if (!byContext.has(item.context)) {
-      byContext.set(item.context, new Map())
+  const byContext = new Map<
+    Context,
+    Map<string, Update & { values: PathValue[] }>
+  >()
+  for (const item of accumulator.values()) {
+    let bySource = byContext.get(item.context)
+    if (!bySource) {
+      bySource = new Map()
+      byContext.set(item.context, bySource)
     }
-    // Group by $source within context
-    const bySource = byContext.get(item.context)!
-    const sourceKey = item.$source || 'unknown'
-    if (!bySource.has(sourceKey)) {
-      bySource.set(sourceKey, {
-        $source: item.$source as SourceRef,
-        timestamp: item.timestamp as Timestamp,
+    const sourceKey = item.$source || UNKNOWN_SOURCE
+    let update = bySource.get(sourceKey)
+    if (!update) {
+      update = {
+        $source: item.$source,
+        timestamp: item.timestamp,
         values: []
-      })
-    }
-    const update = bySource.get(sourceKey)!
-    if (hasValues(update)) {
-      update.values.push({
-        path: item.path as Path,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: item.value as any
-      })
-      // Use the most recent timestamp for this source
-      if (
-        item.timestamp &&
-        (!update.timestamp || item.timestamp > update.timestamp)
-      ) {
-        update.timestamp = item.timestamp as Timestamp
       }
+      bySource.set(sourceKey, update)
+    }
+    update.values.push({
+      path: item.path,
+      value: item.value as Value
+    })
+    // Keep the newest timestamp seen for this source so the flushed delta reflects the latest update.
+    if (
+      item.timestamp &&
+      (!update.timestamp || item.timestamp > update.timestamp)
+    ) {
+      update.timestamp = item.timestamp
     }
   }
 
-  // Build one delta per context with backpressure indicator
   const deltas: BackpressureDelta[] = []
-  for (const [context, bySourceTime] of byContext) {
+  for (const [context, bySource] of byContext) {
     deltas.push({
       context,
-      updates: Array.from(bySourceTime.values()),
+      updates: Array.from(bySource.values()),
       $backpressure: {
         accumulated: countBefore,
         duration

--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -1,6 +1,6 @@
 /**
- * LatestValuesAccumulator - Accumulates Signal K delta values during backpressure,
- * keeping only the latest value for each unique context:path:$source combination.
+ * Accumulates Signal K delta values during backpressure, keeping only the
+ * latest value for each unique context:path:$source combination.
  */
 
 import {
@@ -8,15 +8,17 @@ import {
   Delta,
   hasValues,
   Path,
+  PathValue,
   SourceRef,
   Timestamp,
-  Update
+  Update,
+  Value
 } from '@signalk/server-api'
 
 export interface AccumulatedItem {
   context: Context
   path: Path
-  value: unknown
+  value: Value
   $source: SourceRef | undefined
   timestamp: Timestamp | undefined
 }
@@ -26,6 +28,15 @@ export interface BackpressureDelta extends Delta {
     accumulated: number
     duration: number
   }
+}
+
+function accumulationKey(
+  context: Context,
+  path: Path,
+  $source: SourceRef | undefined
+): string {
+  const sourceKey = $source === undefined ? '0' : `1${$source}`
+  return `${context}:${path}:${sourceKey}`
 }
 
 /**
@@ -40,17 +51,27 @@ export function accumulateLatestValue(
   delta: Delta
 ): void {
   if (!delta.updates) return
+  const context = delta.context as Context
   for (const update of delta.updates) {
     if (!hasValues(update)) continue
+    const $source = update.$source
+    const timestamp = update.timestamp
     for (const pv of update.values) {
-      const key = `${delta.context}:${pv.path}:${update.$source || 'unknown'}`
-      accumulator.set(key, {
-        context: delta.context as Context,
-        path: pv.path,
-        value: pv.value,
-        $source: update.$source,
-        timestamp: update.timestamp
-      })
+      const key = accumulationKey(context, pv.path, $source)
+      const existing = accumulator.get(key)
+      if (existing) {
+        existing.value = pv.value
+        existing.$source = $source
+        existing.timestamp = timestamp
+      } else {
+        accumulator.set(key, {
+          context,
+          path: pv.path,
+          value: pv.value,
+          $source,
+          timestamp
+        })
+      }
     }
   }
 }
@@ -71,45 +92,42 @@ export function buildFlushDeltas(
 
   const countBefore = accumulator.size
 
-  // Group by context
-  const byContext = new Map<Context, Map<string, Update>>()
-  for (const [, item] of accumulator) {
-    if (!byContext.has(item.context)) {
-      byContext.set(item.context, new Map())
+  const byContext = new Map<
+    Context,
+    Map<SourceRef | undefined, Update & { values: PathValue[] }>
+  >()
+  for (const item of accumulator.values()) {
+    let bySource = byContext.get(item.context)
+    if (!bySource) {
+      bySource = new Map()
+      byContext.set(item.context, bySource)
     }
-    // Group by $source within context
-    const bySource = byContext.get(item.context)!
-    const sourceKey = item.$source || 'unknown'
-    if (!bySource.has(sourceKey)) {
-      bySource.set(sourceKey, {
-        $source: item.$source as SourceRef,
-        timestamp: item.timestamp as Timestamp,
+    let update = bySource.get(item.$source)
+    if (!update) {
+      update = {
+        $source: item.$source,
+        timestamp: item.timestamp,
         values: []
-      })
-    }
-    const update = bySource.get(sourceKey)!
-    if (hasValues(update)) {
-      update.values.push({
-        path: item.path as Path,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: item.value as any
-      })
-      // Use the most recent timestamp for this source
-      if (
-        item.timestamp &&
-        (!update.timestamp || item.timestamp > update.timestamp)
-      ) {
-        update.timestamp = item.timestamp as Timestamp
       }
+      bySource.set(item.$source, update)
+    }
+    update.values.push({
+      path: item.path,
+      value: item.value
+    })
+    if (
+      item.timestamp &&
+      (!update.timestamp || item.timestamp > update.timestamp)
+    ) {
+      update.timestamp = item.timestamp
     }
   }
 
-  // Build one delta per context with backpressure indicator
   const deltas: BackpressureDelta[] = []
-  for (const [context, bySourceTime] of byContext) {
+  for (const [context, bySource] of byContext) {
     deltas.push({
       context,
-      updates: Array.from(bySourceTime.values()),
+      updates: Array.from(bySource.values()),
       $backpressure: {
         accumulated: countBefore,
         duration

--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -30,12 +30,18 @@ export interface BackpressureDelta extends Delta {
   }
 }
 
+const UNDEFINED_SOURCE_KEY = '0'
+const DEFINED_SOURCE_KEY_PREFIX = '1'
+
 function accumulationKey(
   context: Context,
   path: Path,
   $source: SourceRef | undefined
 ): string {
-  const sourceKey = $source === undefined ? '0' : `1${$source}`
+  const sourceKey =
+    $source === undefined
+      ? UNDEFINED_SOURCE_KEY
+      : `${DEFINED_SOURCE_KEY_PREFIX}${$source}`
   return `${context}:${path}:${sourceKey}`
 }
 

--- a/test/LatestValuesAccumulator.js
+++ b/test/LatestValuesAccumulator.js
@@ -326,5 +326,22 @@ describe('LatestValuesAccumulator', function () {
       expect(deltas[0].$backpressure.accumulated).to.equal(10)
       expect(deltas[0].$backpressure.duration).to.equal(2000)
     })
+
+    it('should propagate undefined timestamp when items have no timestamp', function () {
+      const accumulator = new Map()
+      accumulator.set('vessels.self:navigation.speedOverGround:gps', {
+        context: 'vessels.self',
+        path: 'navigation.speedOverGround',
+        value: 5.0,
+        $source: 'gps',
+        timestamp: undefined
+      })
+
+      const deltas = buildFlushDeltas(accumulator, 1000)
+
+      expect(deltas.length).to.equal(1)
+      expect(deltas[0].updates.length).to.equal(1)
+      expect(deltas[0].updates[0].timestamp).to.equal(undefined)
+    })
   })
 })

--- a/test/LatestValuesAccumulator.js
+++ b/test/LatestValuesAccumulator.js
@@ -6,6 +6,13 @@ const {
   buildFlushDeltas
 } = require('../dist/LatestValuesAccumulator')
 
+function findAccumulatedItem(accumulator, context, path, source) {
+  return Array.from(accumulator.values()).find(
+    (item) =>
+      item.context === context && item.path === path && item.$source === source
+  )
+}
+
 describe('LatestValuesAccumulator', function () {
   describe('accumulateLatestValue', function () {
     it('should accumulate a single value', function () {
@@ -29,10 +36,13 @@ describe('LatestValuesAccumulator', function () {
       accumulateLatestValue(accumulator, delta)
 
       expect(accumulator.size).to.equal(1)
-      const key =
-        'vessels.urn:mrn:imo:mmsi:123456789:navigation.position:n2k.115'
-      expect(accumulator.has(key)).to.be.true
-      const item = accumulator.get(key)
+      const item = findAccumulatedItem(
+        accumulator,
+        'vessels.urn:mrn:imo:mmsi:123456789',
+        'navigation.position',
+        'n2k.115'
+      )
+      expect(item).to.exist
       expect(item.context).to.equal('vessels.urn:mrn:imo:mmsi:123456789')
       expect(item.path).to.equal('navigation.position')
       expect(item.value).to.deep.equal({ latitude: 60.0, longitude: 25.0 })
@@ -66,8 +76,11 @@ describe('LatestValuesAccumulator', function () {
       accumulateLatestValue(accumulator, delta2)
 
       expect(accumulator.size).to.equal(1)
-      const item = accumulator.get(
-        'vessels.self:navigation.speedOverGround:gps'
+      const item = findAccumulatedItem(
+        accumulator,
+        'vessels.self',
+        'navigation.speedOverGround',
+        'gps'
       )
       expect(item.value).to.equal(5.5)
       expect(item.timestamp).to.equal('2024-01-15T10:30:01.000Z')
@@ -101,10 +114,20 @@ describe('LatestValuesAccumulator', function () {
 
       expect(accumulator.size).to.equal(2)
       expect(
-        accumulator.get('vessels.self:navigation.speedOverGround:gps1').value
+        findAccumulatedItem(
+          accumulator,
+          'vessels.self',
+          'navigation.speedOverGround',
+          'gps1'
+        ).value
       ).to.equal(5.0)
       expect(
-        accumulator.get('vessels.self:navigation.speedOverGround:gps2').value
+        findAccumulatedItem(
+          accumulator,
+          'vessels.self',
+          'navigation.speedOverGround',
+          'gps2'
+        ).value
       ).to.equal(5.2)
     })
 
@@ -128,11 +151,20 @@ describe('LatestValuesAccumulator', function () {
 
       expect(accumulator.size).to.equal(2)
       expect(
-        accumulator.get('vessels.self:navigation.speedOverGround:gps').value
+        findAccumulatedItem(
+          accumulator,
+          'vessels.self',
+          'navigation.speedOverGround',
+          'gps'
+        ).value
       ).to.equal(5.0)
       expect(
-        accumulator.get('vessels.self:navigation.courseOverGroundTrue:gps')
-          .value
+        findAccumulatedItem(
+          accumulator,
+          'vessels.self',
+          'navigation.courseOverGroundTrue',
+          'gps'
+        ).value
       ).to.equal(1.57)
     })
 
@@ -190,8 +222,14 @@ describe('LatestValuesAccumulator', function () {
       accumulateLatestValue(accumulator, delta)
 
       expect(accumulator.size).to.equal(1)
-      expect(accumulator.has('vessels.self:navigation.speedOverGround:unknown'))
-        .to.be.true
+      expect(
+        findAccumulatedItem(
+          accumulator,
+          'vessels.self',
+          'navigation.speedOverGround',
+          undefined
+        )
+      ).to.exist
     })
 
     it('should handle delta without updates', function () {

--- a/test/LatestValuesAccumulator.ts
+++ b/test/LatestValuesAccumulator.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai'
+import { hasValues, type Delta, type Update } from '@signalk/server-api'
+import type { AccumulatedItem } from '../dist/LatestValuesAccumulator'
+import {
+  accumulateLatestValue,
+  buildFlushDeltas
+} from '../dist/LatestValuesAccumulator'
+
+function delta(source: string | undefined, value: number): Delta {
+  return {
+    context: 'vessels.self',
+    updates: [
+      {
+        $source: source,
+        values: [{ path: 'navigation.speedOverGround', value }]
+      }
+    ]
+  } as Delta
+}
+
+function firstValue(update: Update | undefined) {
+  return update && hasValues(update) ? update.values[0]?.value : undefined
+}
+
+describe('LatestValuesAccumulator TypeScript cases', function () {
+  it('keeps a missing source separate from a real unknown source', function () {
+    const accumulator = new Map<string, AccumulatedItem>()
+
+    accumulateLatestValue(accumulator, delta(undefined, 5))
+    accumulateLatestValue(accumulator, delta('unknown', 6))
+
+    expect(accumulator.size).to.equal(2)
+    const items = Array.from(accumulator.values())
+    expect(items.find((item) => item.$source === undefined)?.value).to.equal(5)
+    expect(items.find((item) => item.$source === 'unknown')?.value).to.equal(6)
+
+    const [flushed] = buildFlushDeltas(accumulator, 1000)
+    expect(flushed.updates).to.have.length(2)
+    expect(
+      firstValue(flushed.updates.find((update) => update.$source === undefined))
+    ).to.equal(5)
+    expect(
+      firstValue(flushed.updates.find((update) => update.$source === 'unknown'))
+    ).to.equal(6)
+  })
+
+  it('propagates an undefined timestamp', function () {
+    const accumulator = new Map<string, AccumulatedItem>()
+    accumulateLatestValue(accumulator, delta('gps', 5))
+
+    const [flushed] = buildFlushDeltas(accumulator, 1000)
+
+    expect(flushed.updates).to.have.length(1)
+    expect(flushed.updates[0].timestamp).to.equal(undefined)
+  })
+})

--- a/test/LatestValuesAccumulator.ts
+++ b/test/LatestValuesAccumulator.ts
@@ -1,21 +1,38 @@
 import { expect } from 'chai'
-import { hasValues, type Delta, type Update } from '@signalk/server-api'
+import {
+  hasValues,
+  type Context,
+  type Delta,
+  type Path,
+  type PathValue,
+  type SourceRef,
+  type Update
+} from '@signalk/server-api'
 import type { AccumulatedItem } from '../dist/LatestValuesAccumulator'
 import {
   accumulateLatestValue,
   buildFlushDeltas
 } from '../dist/LatestValuesAccumulator'
 
-function delta(source: string | undefined, value: number): Delta {
+const SELF_CONTEXT = 'vessels.self' as Context
+const SPEED_OVER_GROUND_PATH = 'navigation.speedOverGround' as Path
+const UNKNOWN_SOURCE = 'unknown' as SourceRef
+const GPS_SOURCE = 'gps' as SourceRef
+const FLUSH_DURATION_MS = 1000
+
+function delta(
+  source: SourceRef | undefined,
+  value: PathValue['value']
+): Delta {
   return {
-    context: 'vessels.self',
+    context: SELF_CONTEXT,
     updates: [
       {
         $source: source,
-        values: [{ path: 'navigation.speedOverGround', value }]
+        values: [{ path: SPEED_OVER_GROUND_PATH, value }]
       }
     ]
-  } as Delta
+  }
 }
 
 function firstValue(update: Update | undefined) {
@@ -27,28 +44,32 @@ describe('LatestValuesAccumulator TypeScript cases', function () {
     const accumulator = new Map<string, AccumulatedItem>()
 
     accumulateLatestValue(accumulator, delta(undefined, 5))
-    accumulateLatestValue(accumulator, delta('unknown', 6))
+    accumulateLatestValue(accumulator, delta(UNKNOWN_SOURCE, 6))
 
     expect(accumulator.size).to.equal(2)
     const items = Array.from(accumulator.values())
     expect(items.find((item) => item.$source === undefined)?.value).to.equal(5)
-    expect(items.find((item) => item.$source === 'unknown')?.value).to.equal(6)
+    expect(
+      items.find((item) => item.$source === UNKNOWN_SOURCE)?.value
+    ).to.equal(6)
 
-    const [flushed] = buildFlushDeltas(accumulator, 1000)
+    const [flushed] = buildFlushDeltas(accumulator, FLUSH_DURATION_MS)
     expect(flushed.updates).to.have.length(2)
     expect(
       firstValue(flushed.updates.find((update) => update.$source === undefined))
     ).to.equal(5)
     expect(
-      firstValue(flushed.updates.find((update) => update.$source === 'unknown'))
+      firstValue(
+        flushed.updates.find((update) => update.$source === UNKNOWN_SOURCE)
+      )
     ).to.equal(6)
   })
 
   it('propagates an undefined timestamp', function () {
     const accumulator = new Map<string, AccumulatedItem>()
-    accumulateLatestValue(accumulator, delta('gps', 5))
+    accumulateLatestValue(accumulator, delta(GPS_SOURCE, 5))
 
-    const [flushed] = buildFlushDeltas(accumulator, 1000)
+    const [flushed] = buildFlushDeltas(accumulator, FLUSH_DURATION_MS)
 
     expect(flushed.updates).to.have.length(1)
     expect(flushed.updates[0].timestamp).to.equal(undefined)


### PR DESCRIPTION
## Why

`LatestValuesAccumulator` runs on the per-delta path while a client is in backpressure mode. Its accumulation and flush loops performed redundant lookups and allocated a replacement object for every overwritten path value.

This is the focused `LatestValuesAccumulator.ts` portion of #2648. The `streambundle.ts` portion was superseded by #2622.

## Approach

- Reuse accumulated entries when a path value is overwritten.
- Use single get-or-create lookups while grouping flush updates.
- Keep missing sources distinct from a real `unknown` source.
- Use the declared Signal K value types without unchecked assertions.

## Verification

- `npm run format`
- `npm run build`
- `npx mocha test/LatestValuesAccumulator.js test/LatestValuesAccumulator.ts`: 15 passing
- `npm run ci-lint`

Refs #2582.