### PR TITLE
fix: when a notification switches from the normal state, clear acknowledged and silenced

### DIFF
--- a/src/api/notifications/alarm.ts
+++ b/src/api/notifications/alarm.ts
@@ -110,7 +110,17 @@ export class Alarm {
     this.external = true
     this.status.canClear = false
 
+    const prevState = this.value?.state
+
     this.parseDelta(update, context)
+
+    if (
+      prevState === ALARM_STATE.normal &&
+      this.value.state !== ALARM_STATE.normal
+    ) {
+      this.status.acknowledged = false
+      this.status.silenced = false
+    }
 
     if (
       !this.status.acknowledged &&


### PR DESCRIPTION

Currently, if an alarm is acknowledged or silenced, it remains that way forever.

This is a when alarm is silenced, then the alarm goes to normal. if a plugin raises the same alarm, it will never sound or looks like it was acknowledged.

This resets the status whenever an alarm changes from the normal state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds state-transition logic to the `syncFromNotificationUpdate` method in the `Alarm` class that clears the `acknowledged` and `silenced` flags when an alarm transitions from the normal state to any non-normal state.

## Changes

**src/api/notifications/alarm.ts**

The `syncFromNotificationUpdate` method now:
1. Captures the previous alarm state before processing the incoming update
2. Checks if the state has transitioned from normal to non-normal
3. Resets both `acknowledged` and `silenced` flags to `false` when this transition occurs

This ensures that when a notification returns to normal and is later raised again, it will not remain silenced or acknowledged from a previous occurrence, allowing users to see and hear the re-raised alarm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->