### PR TITLE
ci(plugin-ci): drop stale 'type:module' warning

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -161,10 +161,10 @@ jobs:
             warnings.push('No "engines.node" field in package.json — plugins should declare their minimum Node.js version');
           }
 
-          // ESM-only plugins can't be loaded by the server's require() call
-          if (pkg.type === 'module') {
-            warnings.push('package.json has "type": "module" — SignalK server loads plugins with require(). ESM-only plugins may fail to load.');
-          }
+          // ESM plugins are loaded via dynamic import() since #1913
+          // (April 2025); on Node 20.19+ / 22 the require() path also
+          // succeeds via native ESM-from-CJS interop (see modules.ts
+          // requireUserPlugin). No warning needed for "type": "module".
 
           // baconjs is provided by the server — plugins must not bundle their own copy
           if (pkg.dependencies && pkg.dependencies.baconjs) {


### PR DESCRIPTION
## Why

The server has supported ESM plugins since [#1913](https://github.com/SignalK/signalk-server/pull/1913) (April 2025). The loader at `src/modules.ts:552-579` tries `require()` first — which works on Node 20.19+ / 22 via native ESM-from-CJS interop — and falls back to dynamic `import()` via `esm-resolve` otherwise.

The plugin-CI scanner has been printing `"package.json has \"type\": \"module\" — SignalK server loads plugins with require(). ESM-only plugins may fail to load."` for every ESM-flavored plugin since the workflow shipped in [#2400](https://github.com/SignalK/signalk-server/pull/2400) (March 2026). This is incorrect — those plugins do load — and it floods CI output across all platforms.

## How

Remove the warning. Replace it with a short comment pointing at the loader and #1913 so future readers don't re-add the rule.

No behaviour change to the server. Workflow-only edit; tests, format, build all unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's changing

This pull request removes a stale warning from the plugin CI workflow that incorrectly flagged ESM-only packages with `"type": "module"` in their `package.json`. The warning has been emitted since March 2026 but is incorrect because the SignalK server has supported ESM plugins since April 2025.

## How it works

The server's plugin loader (in `src/modules.ts:552–579`) attempts to load plugins via `require()` first, which succeeds on Node 20.19+ and 22+ through native ESM-from-CJS interoperability, then falls back to dynamic `import()` via esm-resolve. This dual-path loading means ESM-only plugins do not fail to load.

## Changes made

The pull request updates `.github/workflows/plugin-ci.yml` to remove the warning and replaces it with a clarifying comment that references the actual loader implementation and the original ESM support PR (#1913) for future maintainers.

## Impact

This is a workflow-only change with no modifications to server behavior, tests, formatting, or build logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->