### PR TITLE
ci(plugin-ci): gate ES2023 check by engines.node

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1068,6 +1068,26 @@ jobs:
           # Cerbo GX (Venus OS) runs Node 20 which supports ES2023 syntax.
           # Plugins using ES2024+ syntax (RegExp v flag, import attributes)
           # will crash with SyntaxError on Node 20.
+          #
+          # Skip the check when the plugin's package.json has explicitly
+          # opted out of Node 20 via engines.node >= 22.  Mirrors how the
+          # node:sqlite check above gates on engines.node — if a plugin
+          # has declared "I require Node 22+", warning about Cerbo GX
+          # (Node 20) compatibility is noise.
+          OPTED_OUT=$(node -e "
+            const pkg = require('./package.json');
+            const range = pkg.engines && pkg.engines.node;
+            if (!range) { console.log('no'); process.exit(0); }
+            const m = range.match(/(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+            if (!m) { console.log('no'); process.exit(0); }
+            const major = parseInt(m[1], 10);
+            console.log(major >= 22 ? 'yes' : 'no');
+          " 2>/dev/null)
+          if [ "$OPTED_OUT" = "yes" ]; then
+            echo "Skipping ES2023 check: package.json engines.node opts out of Node 20 (Cerbo GX)."
+            exit 0
+          fi
+
           # Only check server-side JS (dist/, lib/, main entry) — skip public/
           # which is frontend code running in browsers.
           FILES=""


### PR DESCRIPTION
## Why

The 'Check ES2023 compatibility (Cerbo GX / Node 20)' step warns plugins about ES2024+ syntax that would crash Node 20. Plugins that have explicitly declared `engines.node >= 22` in their `package.json` have already opted out of Node 20 / Cerbo GX support — warning them about Cerbo compatibility is noise that floods CI output.

## How

Skip the check entirely when `engines.node` parses to a minimum major `>= 22`. Mirrors how the `node:sqlite` check at lines 900-935 already gates on `engines.node`: if the plugin has declared its minimum, respect it.

The check still runs unchanged for plugins that:
- have no `engines.node` field (warning is appropriate — they may be installed on Cerbo)
- declare `engines.node` allowing Node 20 (e.g. `>=18`, `>=20`, `^20`)

No behaviour change to the server. Workflow-only edit.