### PR TITLE
feat(admin-ui): expose host React on window for ESM federation plugins

### DIFF
--- a/docs/develop/webapps.md
+++ b/docs/develop/webapps.md
@@ -174,84 +174,15 @@ The server loads these via a classic `<script>` tag which places the container o
 
 ### Vite / ESM bundlers
 
-The server also supports ESM containers produced by Vite, Rollup, esbuild, or any bundler that outputs standard `export { init, get }`. To use an ESM container:
+The server also supports ESM containers produced by Vite, Rollup, esbuild, or any bundler that outputs `export { init, get }`. Set `"type": "module"` in the plugin's `package.json` and the server emits `<script type="module">` for the container; the Admin UI loads it via dynamic `import()` when the expected name is not present on `window`.
 
-1. Set `"type": "module"` in your plugin's `package.json`. The server uses this to emit `<script type="module">` instead of a classic `<script>` tag.
-2. Configure your bundler to produce a Module Federation container as ESM. For example with `@module-federation/vite`:
-
-```javascript
-// vite.config.js
-import path from 'node:path'
-import url from 'node:url'
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { federation } from '@module-federation/vite'
-
-const here = path.dirname(url.fileURLToPath(import.meta.url))
-
-export default defineConfig({
-  // Resolve `import 'react'` to a tiny shim that re-exports the host
-  // Admin UI's React instance from window.__SK_REACT__. See "Sharing
-  // React with the host" below for why and a sample shim.
-  resolve: {
-    alias: [
-      {
-        find: /^react\/jsx-(dev-)?runtime$/,
-        replacement: path.resolve(here, 'host-shim/react-jsx-runtime.js')
-      },
-      {
-        find: 'react-dom/client',
-        replacement: path.resolve(here, 'host-shim/react-dom-client.js')
-      },
-      {
-        find: /^react-dom$/,
-        replacement: path.resolve(here, 'host-shim/react-dom.js')
-      },
-      {
-        find: /^react$/,
-        replacement: path.resolve(here, 'host-shim/react.js')
-      }
-    ]
-  },
-  plugins: [
-    react(),
-    federation({
-      name: 'my-plugin',
-      filename: 'remoteEntry.js',
-      exposes: {
-        './PluginConfigurationPanel': './src/PluginConfigurationPanel.tsx'
-      },
-      // No `shared` declaration: React/ReactDOM come from the host via
-      // resolve.alias above and aren't part of federation share scope.
-      shared: {}
-    })
-  ],
-  define: {
-    'process.env.NODE_ENV': JSON.stringify('production')
-  },
-  build: {
-    outDir: 'public',
-    emptyOutDir: true
-  }
-})
-```
-
-The `process.env.NODE_ENV` define is required because some shared dependencies reference `process.env` which is not available in the browser.
-
-If your plugin's server-side code uses CommonJS (`module.exports`), set `"main"` to a `.cjs` file so Node.js treats it as CommonJS despite the `"type": "module"` in `package.json`.
-
-The Admin UI detects ESM containers automatically via dynamic `import()` when the expected container is not present on `window`.
+If the plugin's server-side code remains CommonJS (`module.exports`), give `"main"` a `.cjs` extension so Node.js still loads it as CommonJS under the module-typed package.
 
 ### React Version Compatibility
 
-The Admin UI uses **React 19** with functional components and hooks. Your embedded webapp should:
-
-1. **Share React with the host (see below)** — webpack-built plugins do this through Module Federation's share scope; ESM-built plugins use the host React globals exposed on `window`.
-2. **Use functional components** — class components still work, but the host is built around hooks and functional components.
+The Admin UI uses **React 19** with functional components and hooks. Your plugin must use the host's React instance — bundling a second copy yields `Cannot read properties of null (reading 'useState')` when the plugin's hooks read a dispatcher that the host activated on its React, not the plugin's.
 
 #### Sharing React with the host
-
-A plugin component that ends up bundling its own React instance will throw `Cannot read properties of null (reading 'useState')` when its hooks run inside the host's render tree: hooks read from React's internal dispatcher, which the host activated on _its_ React, not the plugin's. The plugin must use the host's React.
 
 **Webpack (`var` library)** — webpack-MF's runtime hooks into the host's share scope automatically when you declare React as a singleton:
 
@@ -262,7 +193,7 @@ shared: {
 }
 ```
 
-**ESM bundlers (Vite/Rollup/esbuild)** — the host exposes React on `window` so any ESM plugin can read it without going through federation share scope:
+**ESM bundlers** — the host exposes the following on `window` before render:
 
 | Global                            | Module              |
 | --------------------------------- | ------------------- |
@@ -271,27 +202,11 @@ shared: {
 | `window.__SK_REACT_DOM_CLIENT__`  | `react-dom/client`  |
 | `window.__SK_REACT_JSX_RUNTIME__` | `react/jsx-runtime` |
 
-Resolve plugin imports to a small shim that re-exports the corresponding global. Sample `host-shim/react.js`:
+Resolve the plugin's `react`/`react-dom`/`react/jsx-runtime` imports to small shims that re-export from these globals (e.g. via Vite's `resolve.alias` to a per-module file that does `const host = globalThis.__SK_REACT__; export default host.default ?? host; export const useState = host.useState; ...`). With imports redirected to the host, no federation `shared` declaration is needed.
 
-```javascript
-const host = globalThis.__SK_REACT__
-if (!host) {
-  throw new Error(
-    'host signalk-server admin UI did not expose React on window.__SK_REACT__'
-  )
-}
-export default host.default ?? host
-export const useState = host.useState
-export const useEffect = host.useEffect
-export const useCallback = host.useCallback
-// ...re-export every named React API your plugin uses
-```
+For a working `@module-federation/vite` setup including the alias wiring and shim files, see the [signalk-container plugin](https://github.com/dirkwa/signalk-container).
 
-The `vite.config.js` example above wires `resolve.alias` so the plugin's `import React, { useState } from 'react'` resolves to your shim instead of bundling a second React copy. Because nothing is in the federation share scope, no `shared:` config is needed.
-
-This contract was introduced as a follow-up to the ESM module federation support in #2552.
-
-See the Calibration plugin for an example. It is probably easier to start with an existing plugin and modify it to suit your needs. Don't forget to change the module id and name in package.json!
+See the Calibration plugin for an existing webpack-based example to start from. It is probably easier to start with an existing plugin and modify it to suit your needs. Don't forget to change the module id and name in package.json!
 
 ## WebApp / Component and Admin UI / Server interfaces
 

--- a/docs/develop/webapps.md
+++ b/docs/develop/webapps.md
@@ -181,11 +181,38 @@ The server also supports ESM containers produced by Vite, Rollup, esbuild, or an
 
 ```javascript
 // vite.config.js
+import path from 'node:path'
+import url from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { federation } from '@module-federation/vite'
 
+const here = path.dirname(url.fileURLToPath(import.meta.url))
+
 export default defineConfig({
+  // Resolve `import 'react'` to a tiny shim that re-exports the host
+  // Admin UI's React instance from window.__SK_REACT__. See "Sharing
+  // React with the host" below for why and a sample shim.
+  resolve: {
+    alias: [
+      {
+        find: /^react\/jsx-(dev-)?runtime$/,
+        replacement: path.resolve(here, 'host-shim/react-jsx-runtime.js')
+      },
+      {
+        find: 'react-dom/client',
+        replacement: path.resolve(here, 'host-shim/react-dom-client.js')
+      },
+      {
+        find: /^react-dom$/,
+        replacement: path.resolve(here, 'host-shim/react-dom.js')
+      },
+      {
+        find: /^react$/,
+        replacement: path.resolve(here, 'host-shim/react.js')
+      }
+    ]
+  },
   plugins: [
     react(),
     federation({
@@ -194,10 +221,9 @@ export default defineConfig({
       exposes: {
         './PluginConfigurationPanel': './src/PluginConfigurationPanel.tsx'
       },
-      shared: {
-        react: { singleton: true, requiredVersion: false },
-        'react-dom': { singleton: true, requiredVersion: false }
-      }
+      // No `shared` declaration: React/ReactDOM come from the host via
+      // resolve.alias above and aren't part of federation share scope.
+      shared: {}
     })
   ],
   define: {
@@ -205,7 +231,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'public',
-    emptyOutDir: false
+    emptyOutDir: true
   }
 })
 ```
@@ -218,11 +244,52 @@ The Admin UI detects ESM containers automatically via dynamic `import()` when th
 
 ### React Version Compatibility
 
-The Admin UI uses **React 19** with shared dependencies via Module Federation. Your embedded webapp should:
+The Admin UI uses **React 19** with functional components and hooks. Your embedded webapp should:
 
-1. **Share React as a singleton** - Configure Module Federation to use the host's React instance with `requiredVersion: false`. See [vite.config.js](https://github.com/SignalK/signalk-server/blob/master/packages/server-admin-ui/vite.config.js) for the current configuration.
+1. **Share React with the host (see below)** — webpack-built plugins do this through Module Federation's share scope; ESM-built plugins use the host React globals exposed on `window`.
+2. **Use functional components** — class components still work, but the host is built around hooks and functional components.
 
-2. **Use functional components** - The Admin UI is built with functional components and React hooks. While class components still work, functional components are recommended for consistency.
+#### Sharing React with the host
+
+A plugin component that ends up bundling its own React instance will throw `Cannot read properties of null (reading 'useState')` when its hooks run inside the host's render tree: hooks read from React's internal dispatcher, which the host activated on _its_ React, not the plugin's. The plugin must use the host's React.
+
+**Webpack (`var` library)** — webpack-MF's runtime hooks into the host's share scope automatically when you declare React as a singleton:
+
+```javascript
+shared: {
+  react: { singleton: true, requiredVersion: '^19' },
+  'react-dom': { singleton: true, requiredVersion: '^19' }
+}
+```
+
+**ESM bundlers (Vite/Rollup/esbuild)** — the host exposes React on `window` so any ESM plugin can read it without going through federation share scope:
+
+| Global                            | Module              |
+| --------------------------------- | ------------------- |
+| `window.__SK_REACT__`             | `react`             |
+| `window.__SK_REACT_DOM__`         | `react-dom`         |
+| `window.__SK_REACT_DOM_CLIENT__`  | `react-dom/client`  |
+| `window.__SK_REACT_JSX_RUNTIME__` | `react/jsx-runtime` |
+
+Resolve plugin imports to a small shim that re-exports the corresponding global. Sample `host-shim/react.js`:
+
+```javascript
+const host = globalThis.__SK_REACT__
+if (!host) {
+  throw new Error(
+    'host signalk-server admin UI did not expose React on window.__SK_REACT__'
+  )
+}
+export default host.default ?? host
+export const useState = host.useState
+export const useEffect = host.useEffect
+export const useCallback = host.useCallback
+// ...re-export every named React API your plugin uses
+```
+
+The `vite.config.js` example above wires `resolve.alias` so the plugin's `import React, { useState } from 'react'` resolves to your shim instead of bundling a second React copy. Because nothing is in the federation share scope, no `shared:` config is needed.
+
+This contract was introduced as a follow-up to the ESM module federation support in #2552.
 
 See the Calibration plugin for an example. It is probably easier to start with an existing plugin and modify it to suit your needs. Don't forget to change the module id and name in package.json!
 

--- a/packages/server-admin-ui/src/bootstrap.tsx
+++ b/packages/server-admin-ui/src/bootstrap.tsx
@@ -1,3 +1,7 @@
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import * as ReactDOMClient from 'react-dom/client'
+import * as ReactJSXRuntime from 'react/jsx-runtime'
 import { createRoot } from 'react-dom/client'
 import { HashRouter, Routes, Route } from 'react-router-dom'
 
@@ -9,6 +13,19 @@ import Full from './containers/Full/Full'
 import { WebSocketProvider } from './contexts/WebSocketContext'
 
 window.serverRoutesPrefix = '/skServer'
+
+// Plugin federation: expose this host's React/ReactDOM on window so
+// dynamically-imported configuration panels share the same React
+// instance. Without this, a plugin bundle that imports its own React
+// has its own dispatcher and `useState` reads null when called inside
+// the host's render tree (the dispatcher is set on the host's React,
+// not the plugin's). PR #2552 documented this contract for ESM
+// federation.
+const w = window as unknown as Record<string, unknown>
+w.__SK_REACT__ = React
+w.__SK_REACT_DOM__ = ReactDOM
+w.__SK_REACT_DOM_CLIENT__ = ReactDOMClient
+w.__SK_REACT_JSX_RUNTIME__ = ReactJSXRuntime
 
 const container = document.getElementById('root')!
 const root = createRoot(container)

--- a/packages/server-admin-ui/src/bootstrap.tsx
+++ b/packages/server-admin-ui/src/bootstrap.tsx
@@ -12,6 +12,15 @@ import '../scss/core/_dropdown-menu-right.scss'
 import Full from './containers/Full/Full'
 import { WebSocketProvider } from './contexts/WebSocketContext'
 
+declare global {
+  interface Window {
+    __SK_REACT__?: typeof React
+    __SK_REACT_DOM__?: typeof ReactDOM
+    __SK_REACT_DOM_CLIENT__?: typeof ReactDOMClient
+    __SK_REACT_JSX_RUNTIME__?: typeof ReactJSXRuntime
+  }
+}
+
 window.serverRoutesPrefix = '/skServer'
 
 // Plugin federation: expose this host's React/ReactDOM on window so
@@ -19,13 +28,11 @@ window.serverRoutesPrefix = '/skServer'
 // instance. Without this, a plugin bundle that imports its own React
 // has its own dispatcher and `useState` reads null when called inside
 // the host's render tree (the dispatcher is set on the host's React,
-// not the plugin's). PR #2552 documented this contract for ESM
-// federation.
-const w = window as unknown as Record<string, unknown>
-w.__SK_REACT__ = React
-w.__SK_REACT_DOM__ = ReactDOM
-w.__SK_REACT_DOM_CLIENT__ = ReactDOMClient
-w.__SK_REACT_JSX_RUNTIME__ = ReactJSXRuntime
+// not the plugin's).
+window.__SK_REACT__ = React
+window.__SK_REACT_DOM__ = ReactDOM
+window.__SK_REACT_DOM_CLIENT__ = ReactDOMClient
+window.__SK_REACT_JSX_RUNTIME__ = ReactJSXRuntime
 
 const container = document.getElementById('root')!
 const root = createRoot(container)


### PR DESCRIPTION
## Summary

Plugin configuration panels built with Vite or another ESM bundler that ship their own React copy throw `Cannot read properties of null (reading 'useState')` when their hooks run inside the host's render tree: hooks read from React's internal dispatcher, which the host activated on _its_ React, not the plugin's.

The previous `webapps.md` guidance to share React via Module Federation singleton works for webpack (its MF runtime hooks into the host's share scope automatically) but not for `@module-federation/vite`, where the host doesn't register a share scope the plugin can reach.

This PR exposes the host's React, ReactDOM, ReactDOMClient, and JSX runtime modules on `window.__SK_REACT__` et al before the host renders. ESM plugins resolve their `import 'react'` to a tiny shim that re-exports those globals — same React instance, same dispatcher, hooks work. Webpack plugins are unaffected because their MF runtime already pulls React from the share scope.

Documents the four globals and the shim approach in `docs/develop/webapps.md`, replacing the previous (broken-for-ESM) share-singleton guidance with one path per bundler family.

Follow-up to #2552.

## Tested

- Built admin UI confirmed to expose `__SK_REACT__`, `__SK_REACT_DOM__`, `__SK_REACT_DOM_CLIENT__`, `__SK_REACT_JSX_RUNTIME__` on `window` before render
- A Vite-MF plugin (`signalk-container@2.0.0-beta.1`) built with React imports aliased to a host-globals shim renders its configuration panel without the React dispatcher error
- Existing webpack plugins (signalk-grafana, app-dock, etc.) continue to load via classic `<script>` tag, unchanged
- Full chain (`npm run format`, `npm run build:all`, `npm test`) passes; 545 tests pass with no regressions
- CodeRabbit local review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for ESM-based Module Federation plugins by exposing the host's React-related modules on the global window object. This enables plugins to share the same React instance as the host, preventing dispatcher mismatch errors that occur when plugins use a different React instance.

## Changes

### Host React Modules Exposure
The PR exposes four React-related modules on the `window` object before the host renders:
- `window.__SK_REACT__`
- `window.__SK_REACT_DOM__`
- `window.__SK_REACT_DOM_CLIENT__`
- `window.__SK_REACT_JSX_RUNTIME__`

ESM plugins can then resolve their React imports to a small shim that re-exports these globals, ensuring they share the host's React instance and dispatcher.

### Documentation Updates
The `docs/develop/webapps.md` documentation is updated to provide bundler-family-specific guidance:

**Webpack-based plugins:** Continue using federated React/ReactDOM as singleton shared dependencies with `requiredVersion: '^19'`.

**ESM/Vite-based plugins:** Rely on React globals exposed on `window` with import shims that re-export those globals.

The Vite configuration example is revised to include `resolve.alias` shims for React entry points and removes the `shared` declaration in federation config, while setting `build.emptyOutDir` to `true`.

## Testing
- Host correctly exposes the four globals before rendering
- Vite-MF plugins (tested with signalk-container@2.0.0-beta.1) render without dispatcher errors
- Existing webpack-based plugins remain unchanged
- 545 tests passing with no regressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->