### PR TITLE
chore(test): remove unused eslint-disable in discovery.ts

### DIFF
--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -130,7 +130,6 @@ describe('runDiscovery', () => {
 
     delete require.cache[discoveryModulePath]
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { runDiscovery } = require('../dist/discovery.js') as DiscoveryModule
 
     const app: App = {


### PR DESCRIPTION
## Summary

`test/discovery.ts` carries an `// eslint-disable-next-line @typescript-eslint/no-require-imports` directive on the `require('../dist/discovery.js')` call that doesn't suppress any actual lint message. ESLint reports it as an "Unused eslint-disable directive" warning.

The asymmetry between the lint scripts means everyone running the project's own `npm run format` ends up with a spurious one-line diff:

- `npm run format` runs `eslint --fix` which auto-removes the unused directive.
- CI runs `ci-lint` which uses plain `eslint` (no `--fix`) — emits the warning but leaves the file alone.

So whichever side you're on, the file disagrees with the other. Removing the comment eliminates the warning and the diff drift.

## Tested

- `npx eslint test/discovery.ts` is silent after the change
- `npm run format` and `npm run ci-lint` both leave `test/discovery.ts` alone
- Full chain (`npm run format`, `npm run build`, `npm test`) passes; 545+16+69 tests green
- CodeRabbit local review: no findings