### PR TITLE
feat(admin-ui): remember last sidebar page and keep dropdowns independent

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,13 @@
-import React, { useMemo, useCallback, MouseEvent, ReactNode } from 'react'
-import { NavLink, Location } from 'react-router-dom'
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  MouseEvent,
+  ReactNode
+} from 'react'
+import { NavLink, Location, useNavigate } from 'react-router-dom'
 import Badge from 'react-bootstrap/Badge'
 import Nav from 'react-bootstrap/Nav'
 import {
@@ -41,11 +49,16 @@ interface NavItemData {
   props?: Record<string, unknown>
 }
 
+function pathMatchesChild(pathname: string, childUrl: string): boolean {
+  return pathname === childUrl || pathname.startsWith(childUrl + '/')
+}
+
 interface SidebarProps {
   location: Location
 }
 
 export default function Sidebar({ location }: SidebarProps) {
+  const navigate = useNavigate()
   const appStore = useAppStore()
   const accessRequests = useAccessRequests()
   const devices = useDevices()
@@ -275,21 +288,100 @@ export default function Sidebar({ location }: SidebarProps) {
     return result
   }, [appStore, accessRequests, expiredDeviceCount, loginStatus, plugins])
 
-  const handleClick = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    ;(e.target as HTMLElement).parentElement?.classList.toggle('open')
-  }, [])
+  const [openDropdowns, setOpenDropdowns] = useState<Set<string>>(
+    () => new Set<string>()
+  )
+
+  const lastPathnameRef = useRef<string | null>(null)
+
+  // Auto-open dropdown matching the current path (only on pathname changes)
+  useEffect(() => {
+    if (lastPathnameRef.current === location.pathname) return
+
+    const toOpen: string[] = []
+    for (const item of items) {
+      if (item.children?.length && item.url) {
+        const hasActiveChild = item.children.some(
+          (child) => child.url && pathMatchesChild(location.pathname, child.url)
+        )
+        if (hasActiveChild) {
+          toOpen.push(item.url)
+        }
+      }
+    }
+    if (toOpen.length > 0) {
+      setOpenDropdowns((prev) => {
+        if (toOpen.every((url) => prev.has(url))) return prev
+        const next = new Set(prev)
+        for (const url of toOpen) {
+          next.add(url)
+        }
+        return next
+      })
+    }
+    lastPathnameRef.current = location.pathname
+  }, [location.pathname, items])
+
+  const handleClick = useCallback(
+    (item: NavItemData) => (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault()
+      const itemUrl = item.url || ''
+      const wasOpen = openDropdowns.has(itemUrl)
+      setOpenDropdowns((prev) => {
+        const next = new Set(prev)
+        if (wasOpen) {
+          next.delete(itemUrl)
+        } else {
+          next.add(itemUrl)
+        }
+        return next
+      })
+      if (!wasOpen && item.children?.length && item.url) {
+        const storageKey = `admin.v1.sidebar.lastPage.${item.url}`
+        let lastPage: string | null = null
+        try {
+          lastPage = localStorage.getItem(storageKey)
+        } catch (e) {
+          console.warn('localStorage.getItem failed:', e)
+        }
+        const target =
+          lastPage && item.children.some((c) => c.url === lastPage)
+            ? lastPage
+            : item.children[0].url
+        if (target) {
+          navigate(target)
+        }
+      }
+    },
+    [navigate, openDropdowns]
+  )
+
+  useEffect(() => {
+    for (const item of items) {
+      if (item.children?.length && item.url) {
+        const matchedChild = item.children.find(
+          (child) => child.url && pathMatchesChild(location.pathname, child.url)
+        )
+        if (matchedChild?.url) {
+          try {
+            localStorage.setItem(
+              `admin.v1.sidebar.lastPage.${item.url}`,
+              matchedChild.url
+            )
+          } catch (e) {
+            console.warn('localStorage.setItem failed:', e)
+          }
+        }
+      }
+    }
+  }, [location.pathname, items])
 
   const activeRoute = useCallback(
-    (routeName: string, children?: NavItemData[]) => {
-      const isActive = children?.length
-        ? children.some(
-            (child) => child.url && location.pathname.indexOf(child.url) > -1
-          )
-        : location.pathname.indexOf(routeName) > -1
-      return isActive ? 'nav-item nav-dropdown open' : 'nav-item nav-dropdown'
+    (routeName: string) => {
+      const isOpen = openDropdowns.has(routeName)
+      return isOpen ? 'nav-item nav-dropdown open' : 'nav-item nav-dropdown'
     },
-    [location.pathname]
+    [openDropdowns]
   )
 
   const renderBadge = (badgeData?: BadgeData | null): ReactNode => {
@@ -400,11 +492,11 @@ export default function Sidebar({ location }: SidebarProps) {
 
   const navDropdown = (item: NavItemData, key: number): ReactNode => {
     return (
-      <li key={key} className={activeRoute(item.url || '', item.children)}>
+      <li key={key} className={activeRoute(item.url || '')}>
         <a
           className="nav-link nav-dropdown-toggle"
           href="#"
-          onClick={handleClick}
+          onClick={handleClick(item)}
         >
           {renderIcon(item.icon)}
           {item.name}


### PR DESCRIPTION
When clicking a top-level dropdown item to open it, automatically navigate to the last child page visited under that section. The last visited child page per section is stored in localStorage (admin.v1.sidebar.lastPage.*). If no previous page is stored, navigate to the first child item.

An effect auto-opens the dropdown matching the current URL path on initial load and subsequent navigations, ensuring the active section is always visible.

Replace DOM classList-based dropdown toggle with React state (useState<Set>) so that opening one sidebar dropdown no longer collapses previously opened ones. Each dropdown's open/close state is tracked independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This PR modifies the Sidebar component to improve dropdown management and navigation behavior:

### State-based dropdown management
- Replaces DOM class manipulation with React state (`openDropdowns: Set<string>`) to independently track which dropdowns are open. Multiple dropdowns can remain open simultaneously.

### Remember last child per section
- Clicking a top-level dropdown navigates automatically to the last child page visited within that section. The per-section last visited child pathname is persisted to localStorage under keys prefixed with `admin.v1.sidebar.lastPage.*`. If no stored child exists or is invalid, the first child item is used.

### Automatic dropdown opening
- Adds an effect that auto-opens the dropdown parent matching the current URL path on initial load and on subsequent navigations so the active section is visible.

### Persisting matched child route
- Adds an effect that saves the matched child route for each dropdown parent into localStorage when the pathname changes to a child of that parent.

### Implementation details
- `handleClick(item)` prevents default navigation, toggles the parent key in `openDropdowns`, and—when opening a dropdown with children—navigates (via `useNavigate`) to the remembered child route or the first child.
- `activeRoute` determines dropdown styling from membership in `openDropdowns` rather than direct DOM classList manipulation or inspecting children against `location.pathname`.
- Dropdown open/closed states are managed independently via a single `Set` in React state; opening one dropdown no longer collapses others.

No exported component signature changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->