### PR TITLE
feat(admin-ui): expose Act as N2K device toggle for canbus connections

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1198,10 +1198,12 @@ function CreateDeviceInput({
         </Form.Label>
       </Col>
       <Col xs="7" md="6" className="form-text text-muted small">
-        Claim an N2K address and participate actively on the bus. Recommended
-        for Yacht Devices gateways — when off, the gateway may drop ISO Requests
-        for PGN 60928 / 126996 / 126998 and device identity (model, software
-        version, serial) stays incomplete.
+        Claim an N2K address and participate actively on the bus. When off, the
+        server stays receive-only on this connection: it can read frames but
+        cannot send ISO Requests, so Device Discovery and PGN 126208 instance
+        edits are unavailable, and identity fields (model, software version,
+        serial) stay incomplete. Recommended on unless another node on the same
+        bus is already claiming addresses on your behalf.
       </Col>
     </Form.Group>
   )
@@ -1398,7 +1400,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           <CamelCaseCompatInput value={value.options} onChange={onChange} />
         )}
       {value.options.type !== undefined &&
-        /^ydwg02/.test(value.options.type) && (
+        (/^ydwg02/.test(value.options.type) ||
+          value.options.type === 'canbus-canboatjs') && (
           <CreateDeviceInput value={value.options} onChange={onChange} />
         )}
     </div>


### PR DESCRIPTION
## Summary

The "Act as N2K device (createDevice)" toggle in the connection editor was only rendered for YDGW gateways. Surface it for `canbus-canboatjs` connections too, so users can opt-out of having the server claim a CAN address — useful when another node on the same bus is already claiming addresses on the user's behalf, or for purely passive audit / recording setups.

Also reworks the toggle's help text to be transport-agnostic: explains the receive-only consequence (no Discover Devices, no PGN 126208 instance edits, identity fields stay incomplete) instead of the previous YDGW-specific phrasing.

## Soft dependency

Effective for canbus connections only with [canboat/canboatjs#427](https://github.com/canboat/canboatjs/pull/427), which teaches `CanbusStream` to honour `options.createDevice` (default `true` for back-compat).

Without that change, the toggle is harmless for canbus (canbus always created a `CanDevice` regardless). For YDGW the toggle keeps working exactly as before — canboatjs already respects it there.

## Tested

- Build clean, full test suite passes (545 tests on this branch).
- Format / lint clean.
- Locally `npm link`-ed against the patched canboatjs branch and exercised the new toggle in the admin UI against a live canbus connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR exposes the "Act as N2K device (createDevice)" toggle in the admin UI connection editor for `canbus-canboatjs` connections, in addition to the existing YDGW gateway support. Users can now opt out of the server claiming a CAN address on canbus connections, which enables passive audit/recording setups or scenarios where another node on the bus already claims addresses.

## Changes

Updates `packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx`:

- Modifies the `NMEA2000` component's conditional rendering to display `CreateDeviceInput` when the connection type matches either YDGW devices (via regex `/^ydwg02/`) or `canbus-canboatjs` (previously YDGW-only)
- Revises the toggle's help text to be transport-agnostic, explaining the receive-only mode consequences: Discover Devices becomes unavailable, PGN 126208 instance edits cannot be performed, and identity fields (model, software version, serial) remain incomplete

## Notes

- The feature is effective for canbus connections only when `@canboat/canboatjs` implements honoring the `options.createDevice` flag (see canboat/canboatjs#427). That change defaults `options.createDevice` to true for backward compatibility.
- Without the canboatjs update, toggling this option on canbus connections has no effect (canbus continues to always create a CanDevice). For YDGW gateways, the toggle behavior remains unchanged as canboatjs already respects it there.
- Testing confirms all 545 tests pass and format/lint checks are clean.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->