### PR TITLE
perf(streambundle): memoize toDelta result on NormalizedDelta

### DIFF
--- a/src/streambundle.ts
+++ b/src/streambundle.ts
@@ -235,9 +235,35 @@ export class StreamBundle implements IStreamBundle {
   }
 }
 
+// The same NormalizedDelta is fanned out to multiple Bacon buses (allPathsBus,
+// the path-specific bus, the self equivalents) and from there to N subscriber
+// chains, each with its own .map(toDelta). Caching the produced Delta on the
+// source object lets all subscribers for one push share one allocation.
+//
+// The cached Delta is shared by reference across every subscriber for the
+// push, including third-party plugin callbacks. We freeze it (and the inner
+// Update / values / meta arrays + their single entry) so any consumer that
+// tries to mutate the structural wrapper throws loudly instead of silently
+// corrupting other subscribers' view. The leaf `value` and `source`
+// references are left thawed: both are owned by the upstream delta, not by
+// toDelta. `source` in particular is shared with every NormalizedDelta built
+// from the same upstream Update (via the `base` object in pushDelta) and
+// freezing it would freeze the upstream layer's own object. The
+// no-mutation contract for the cached Delta extends to these leaves.
+const cachedDeltaSlot = Symbol('toDeltaCache')
+
+interface MemoizedDelta {
+  [cachedDeltaSlot]?: Delta
+}
+
 export function toDelta(normalizedDeltaData: NormalizedDelta): Delta {
+  const cached = (normalizedDeltaData as MemoizedDelta)[cachedDeltaSlot]
+  if (cached !== undefined) {
+    return cached
+  }
+
   const type = normalizedDeltaData.isMeta ? 'meta' : 'values'
-  const pathValue: Pick<PathValue, 'path' | 'value' | 'state'> = {
+  const entry: Pick<PathValue, 'path' | 'value' | 'state'> = {
     path: normalizedDeltaData.path,
     value: normalizedDeltaData.value
   }
@@ -245,17 +271,27 @@ export function toDelta(normalizedDeltaData: NormalizedDelta): Delta {
   // late-arriving WS subscriber receives the same `state.timedOut`
   // signal a long-lived client got at the moment the path went stale.
   if (!normalizedDeltaData.isMeta && normalizedDeltaData.state) {
-    pathValue.state = normalizedDeltaData.state
+    entry.state = normalizedDeltaData.state
   }
-  const update = {
+  const items = Object.freeze([Object.freeze(entry)])
+  const update = Object.freeze({
     source: normalizedDeltaData.source,
     $source: normalizedDeltaData.$source,
     timestamp: normalizedDeltaData.timestamp,
-    [type]: [pathValue]
-  } as Update
+    [type]: items
+  }) as Update
 
-  return {
+  const delta: Delta = Object.freeze({
     context: normalizedDeltaData.context,
-    updates: [update]
-  }
+    updates: Object.freeze([update]) as Update[]
+  })
+  // Non-enumerable so a future `{...nd}` or `Object.assign({}, nd)` on the
+  // NormalizedDelta does not carry the cached Delta into the copy.
+  Object.defineProperty(normalizedDeltaData, cachedDeltaSlot, {
+    value: delta,
+    writable: true,
+    configurable: true,
+    enumerable: false
+  })
+  return delta
 }

--- a/test/streambundle.ts
+++ b/test/streambundle.ts
@@ -1,0 +1,162 @@
+import { expect } from 'chai'
+import type {
+  Context,
+  NormalizedDelta,
+  Path,
+  SourceRef,
+  Timestamp
+} from '@signalk/server-api'
+import { toDelta } from '../dist/streambundle'
+
+function makeValueDelta(): NormalizedDelta {
+  return {
+    context: 'vessels.self' as Context,
+    $source: 'test-source' as SourceRef,
+    source: { label: 'test-source' },
+    path: 'navigation.speedOverGround' as Path,
+    timestamp: '2024-01-15T10:30:00.000Z' as Timestamp,
+    value: 5.5,
+    isMeta: false
+  }
+}
+
+function makeMetaDelta(): NormalizedDelta {
+  return {
+    context: 'vessels.self' as Context,
+    $source: 'test-source' as SourceRef,
+    source: { label: 'test-source' },
+    path: 'navigation.speedOverGround' as Path,
+    timestamp: '2024-01-15T10:30:00.000Z' as Timestamp,
+    value: { units: 'm/s' },
+    isMeta: true
+  }
+}
+
+describe('toDelta', function () {
+  describe('shape', function () {
+    it('produces a values delta from a NormalizedValueDelta', function () {
+      const nd = makeValueDelta()
+      const delta = toDelta(nd)
+
+      expect(delta).to.have.property('context', 'vessels.self')
+      expect(delta.updates).to.have.lengthOf(1)
+      const update = delta.updates[0] as {
+        values: Array<unknown>
+        source: unknown
+      }
+      expect(update).to.have.property('$source', 'test-source')
+      expect(update)
+        .to.have.property('source')
+        .that.deep.equals({ label: 'test-source' })
+      expect(update).to.have.property('timestamp', '2024-01-15T10:30:00.000Z')
+      expect(update.values).to.deep.equal([
+        { path: 'navigation.speedOverGround', value: 5.5 }
+      ])
+    })
+
+    it('produces a meta delta from a NormalizedMetaDelta', function () {
+      const nd = makeMetaDelta()
+      const delta = toDelta(nd)
+
+      expect(delta).to.have.property('context', 'vessels.self')
+      expect(delta.updates).to.have.lengthOf(1)
+      const update = delta.updates[0] as {
+        meta: Array<unknown>
+        source: unknown
+      }
+      expect(update).to.have.property('$source', 'test-source')
+      expect(update)
+        .to.have.property('source')
+        .that.deep.equals({ label: 'test-source' })
+      expect(update).to.have.property('timestamp', '2024-01-15T10:30:00.000Z')
+      expect(update.meta).to.deep.equal([
+        { path: 'navigation.speedOverGround', value: { units: 'm/s' } }
+      ])
+    })
+  })
+
+  describe('memoization', function () {
+    it('returns the same Delta reference on repeated calls for one NormalizedDelta', function () {
+      const nd = makeValueDelta()
+
+      const first = toDelta(nd)
+      const second = toDelta(nd)
+      const third = toDelta(nd)
+
+      expect(second).to.equal(first)
+      expect(third).to.equal(first)
+    })
+
+    it('keeps caches per-NormalizedDelta and never collides on identical content', function () {
+      const a = makeValueDelta()
+      const b = makeValueDelta()
+
+      const aFirst = toDelta(a)
+      const bFirst = toDelta(b)
+
+      expect(aFirst).to.not.equal(bFirst)
+      expect(toDelta(a)).to.equal(aFirst)
+      expect(toDelta(b)).to.equal(bFirst)
+    })
+
+    it('memoizes meta deltas as well as value deltas', function () {
+      const nd = makeMetaDelta()
+
+      expect(toDelta(nd)).to.equal(toDelta(nd))
+    })
+  })
+
+  describe('immutability', function () {
+    // Subscribers downstream of toDelta share the cached Delta by reference.
+    // Freezing converts an attempted mutation into a thrown TypeError instead
+    // of silent cross-subscriber corruption.
+    it('freezes the returned Delta, its updates array, the inner Update, and the values array', function () {
+      const delta = toDelta(makeValueDelta())
+      const update = delta.updates[0] as { values: Array<unknown> }
+
+      expect(Object.isFrozen(delta)).to.equal(true)
+      expect(Object.isFrozen(delta.updates)).to.equal(true)
+      expect(Object.isFrozen(update)).to.equal(true)
+      expect(Object.isFrozen(update.values)).to.equal(true)
+      expect(Object.isFrozen(update.values[0])).to.equal(true)
+    })
+
+    it('freezes the meta variant equivalently', function () {
+      const delta = toDelta(makeMetaDelta())
+      const update = delta.updates[0] as { meta: Array<unknown> }
+
+      expect(Object.isFrozen(delta)).to.equal(true)
+      expect(Object.isFrozen(update)).to.equal(true)
+      expect(Object.isFrozen(update.meta)).to.equal(true)
+      expect(Object.isFrozen(update.meta[0])).to.equal(true)
+    })
+
+    // Leaves owned by the upstream delta — see toDelta comment. Pinned so a
+    // future "freeze everything" change has to consciously revisit this.
+    it('leaves source and value unfrozen as upstream-owned leaves', function () {
+      const nd = makeValueDelta()
+      const delta = toDelta(nd)
+      const update = delta.updates[0] as {
+        source: object
+        values: Array<{ value: unknown }>
+      }
+
+      expect(update.source).to.equal(nd.source)
+      expect(Object.isFrozen(update.source)).to.equal(false)
+      expect(update.values[0].value).to.equal(nd.value)
+    })
+
+    // Defensive: a future spread or Object.assign on the NormalizedDelta
+    // would otherwise carry the cached Delta into the copy and serve stale
+    // memoized state from a different instance.
+    it('stores the memoization slot as a non-enumerable own property', function () {
+      const nd = makeValueDelta()
+      toDelta(nd)
+
+      const enumerableSymbols = Object.getOwnPropertySymbols(nd).filter(
+        (s) => Object.getOwnPropertyDescriptor(nd, s)?.enumerable === true
+      )
+      expect(enumerableSymbols).to.have.lengthOf(0)
+    })
+  })
+})


### PR DESCRIPTION
Refs #2582 (item 7).

## Why

`toDelta` runs once per delta per subscriber. The same `NormalizedDelta` is fanned out to multiple Bacon buses (`allPathsBus`, the path bus, the self equivalents) and from there to N subscriber chains, each with its own `.map(toDelta)`. With ~100 deltas/sec and 20+ WS clients that is ~5 throwaway allocations × N per push (Delta + updates array + Update + values/meta array + PathValue/Meta).

## How

Cache the produced `Delta` on the source `NormalizedDelta` via a symbol-keyed slot. First subscriber allocates and stashes; the rest return the cached object. Symbol-slot is preferred over `WeakMap` because property load is one inline-cacheable step vs `WeakMap.get`'s identity-hash step, and lifetimes are identical (`deltacache` pins the source until the next emission either way).

## Notes for reviewers

The cached `Delta` is now shared by reference across every subscriber for one push, including third-party plugin callbacks. To prevent silent cross-subscriber corruption from a future consumer that mutates the delta, the cached `Delta` plus its `updates` array + inner `Update` + `values`/`meta` array + their single entry are `Object.freeze`d. The inner `value` reference is left thawed (owned by the upstream delta). Any mutation attempt now throws `TypeError` immediately rather than silently leaking.

Plugin authors / future contributors: subscribers must treat the delta object received from `toDelta` (and therefore from the subscription manager) as immutable. The freeze converts violations into a loud error.

## Test plan

- [x] Existing subscription, deltacache, metadata, multiple-values, BackpressureManager suites green
- [x] New `test/streambundle.ts`: shape × 2 (incl. `source` round-trip), memoization × 3 (reference equality, no cross-contamination across instances, meta variant), immutability × 2 (freeze on values + meta variants)
- [x] ESLint + Prettier clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## perf(streambundle): memoize `toDelta` results on `NormalizedDelta`

This PR caches the `Delta` produced by `toDelta()` on each source `NormalizedDelta` instance. This reduces repeated allocations when subscribers share the same `NormalizedDelta`.

### Changes

**`src/streambundle.ts`**
- Adds a symbol-keyed, non-enumerable cache slot to each `NormalizedDelta`.
- Returns the cached `Delta` for repeated calls with the same `NormalizedDelta` instance.
- Freezes the shared `Delta` structure, including its `updates`, `Update`, `values`/`meta` arrays, and entry objects.
- Keeps upstream-owned leaf references, such as `value` and `source`, unfrozen.
- Stores the cache slot with `Object.defineProperty`.

**`test/streambundle.ts`**
- Tests value and meta delta conversion.
- Tests memoization and instance isolation.
- Tests metadata variants and source round-tripping.
- Tests freezing of the shared delta structure.
- Tests that upstream-owned leaves remain unfrozen.
- Tests the non-enumerable cache property.

### Behavior

`toDelta(normalizedDelta)` returns the same structurally frozen `Delta` for each `NormalizedDelta` instance. Subscribers must treat the returned structure as immutable. Mutation attempts on frozen structures throw `TypeError`.

### Impact

This PR reduces repeated `Delta` allocations and prevents cross-subscriber mutation of shared delta structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->