### PR TITLE
fix: preserve provider status entry when clearing message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,27 +210,48 @@ class Server {
       type: string,
       statusType = 'provider'
     ) {
-      if (!statusMessage) {
-        delete app.providerStatus[providerId]
-        return
-      }
-
       if (_.isUndefined(app.providerStatus[providerId])) {
         app.providerStatus[providerId] = {}
       }
       const status = app.providerStatus[providerId]
+      const now = new Date().toISOString()
+      if (!statusMessage) {
+        if (type === 'error' && status.lastStatus) {
+          status.type = 'status'
+          status.message = status.lastStatus
+          status.timeStamp = status.lastStatusTimeStamp || now
+        } else {
+          status.type = type
+          status.message = ''
+          status.timeStamp = now
+        }
+        status.id = providerId
+        status.statusType = statusType
+      } else {
+        if (status.type === 'error' && status.message !== statusMessage) {
+          status.lastError = status.message
+          status.lastErrorTimeStamp = status.timeStamp
+        }
+        if (
+          type === 'error' &&
+          status.type === 'status' &&
+          status.message
+        ) {
+          status.lastStatus = status.message
+          status.lastStatusTimeStamp = status.timeStamp
+        }
 
-      if (status.type === 'error' && status.message !== statusMessage) {
-        status.lastError = status.message
-        status.lastErrorTimeStamp = status.timeStamp
+        status.type = type
+        status.id = providerId
+        status.statusType = statusType
+        status.timeStamp = now
+        status.message = statusMessage
+
+        if (type === 'status') {
+          status.lastStatus = statusMessage
+          status.lastStatusTimeStamp = status.timeStamp
+        }
       }
-
-      status.type = type
-      status.id = providerId
-      status.statusType = statusType
-      status.timeStamp = new Date().toISOString()
-
-      status.message = statusMessage
 
       app.emit('serverevent', {
         type: 'PROVIDERSTATUS',

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,52 +210,72 @@ class Server {
       type: string,
       statusType = 'provider'
     ) {
-      if (_.isUndefined(app.providerStatus[providerId])) {
-        app.providerStatus[providerId] = {}
-      }
-      const status = app.providerStatus[providerId]
+      const status = (app.providerStatus[providerId] ??= {})
       const now = new Date().toISOString()
-      if (!statusMessage) {
-        if (type === 'error' && status.lastStatus) {
-          status.type = 'status'
-          status.message = status.lastStatus
-          status.timeStamp = status.lastStatusTimeStamp || now
-        } else {
-          status.type = type
-          status.message = ''
-          status.timeStamp = now
-          status.lastStatus = ''
-          status.lastStatusTimeStamp = undefined
-        }
-        status.id = providerId
-        status.statusType = statusType
+
+      if (statusMessage) {
+        applyMessage(status, type, statusMessage, now)
       } else {
-        if (status.type === 'error' && status.message !== statusMessage) {
-          status.lastError = status.message
-          status.lastErrorTimeStamp = status.timeStamp
-        }
-        if (type === 'error' && status.type === 'status' && status.message) {
-          status.lastStatus = status.message
-          status.lastStatusTimeStamp = status.timeStamp
-        }
-
-        status.type = type
-        status.id = providerId
-        status.statusType = statusType
-        status.timeStamp = now
-        status.message = statusMessage
-
-        if (type === 'status') {
-          status.lastStatus = statusMessage
-          status.lastStatusTimeStamp = status.timeStamp
-        }
+        clearMessage(status, type, now)
       }
+
+      status.id = providerId
+      status.statusType = statusType
 
       app.emit('serverevent', {
         type: 'PROVIDERSTATUS',
         from: 'signalk-server',
         data: app.getProviderStatus()
       })
+    }
+
+    function clearMessage(status: any, type: string, now: string) {
+      const canRestore = type === 'error' && status.lastStatus
+      if (canRestore) {
+        status.type = 'status'
+        status.message = status.lastStatus
+        status.timeStamp = status.lastStatusTimeStamp ?? now
+      } else {
+        status.type = type
+        status.message = ''
+        status.timeStamp = now
+        status.lastStatus = ''
+        status.lastStatusTimeStamp = undefined
+      }
+    }
+
+    function applyMessage(
+      status: any,
+      type: string,
+      message: string,
+      now: string
+    ) {
+      rememberPrevious(status, type, message)
+
+      status.type = type
+      status.message = message
+      status.timeStamp = now
+
+      if (type === 'status') {
+        status.lastStatus = message
+        status.lastStatusTimeStamp = now
+      }
+    }
+
+    function rememberPrevious(status: any, type: string, message: string) {
+      const replacingDifferentError =
+        status.type === 'error' && status.message !== message
+      if (replacingDifferentError) {
+        status.lastError = status.message
+        status.lastErrorTimeStamp = status.timeStamp
+      }
+
+      const errorOverridingStatus =
+        type === 'error' && status.type === 'status' && status.message
+      if (errorOverridingStatus) {
+        status.lastStatus = status.message
+        status.lastStatusTimeStamp = status.timeStamp
+      }
     }
 
     app.getProviderStatus = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,11 +232,7 @@ class Server {
           status.lastError = status.message
           status.lastErrorTimeStamp = status.timeStamp
         }
-        if (
-          type === 'error' &&
-          status.type === 'status' &&
-          status.message
-        ) {
+        if (type === 'error' && status.type === 'status' && status.message) {
           status.lastStatus = status.message
           status.lastStatusTimeStamp = status.timeStamp
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,8 @@ class Server {
           status.type = type
           status.message = ''
           status.timeStamp = now
+          status.lastStatus = ''
+          status.lastStatusTimeStamp = undefined
         }
         status.id = providerId
         status.statusType = statusType


### PR DESCRIPTION
## Issue reference
Fixing issue #2677 

## What problem does this solve?

Calling `app.setPluginError("")` to clear a previous error caused the
plugin to disappear from **Plugin Activity** and reappear under
**Connections Activity** on the Dashboard until the next
`setPluginStatus()` call.

Root cause: `doSetProviderStatus` in [src/index.ts](src/index.ts)
treated any empty `statusMessage` as a delete signal and removed the
entire `providerStatus` entry — including the `statusType: 'plugin'`
marker the Dashboard's `getLinkType()` relies on. With no entry,
`getLinkType()` falls back to `'provider'` and the plugin is routed to
the wrong panel.

Clearing an error with `setPluginError("")` after a successful run
cycle is a natural and common pattern in published plugins, so this is
a real footgun.

### Fix

- Stop deleting the entry on empty messages. Entry removal belongs to
  the plugin lifecycle (already handled in
  [src/interfaces/appstore.js](src/interfaces/appstore.js) on
  uninstall), not to a status setter.
- Mirror the existing `lastError` / `lastErrorTimeStamp` tracking with
  `lastStatus` / `lastStatusTimeStamp`. When an error is cleared,
  restore the last known status message instead of leaving the entry
  blank — matching the expected behaviour described in the issue.

## How was this tested?

- Built a local Docker image with the fix and ran a previously
  affected plugin that calls `setPluginError("")` after each successful
  run cycle.
- Verified on the Dashboard:
  - Plugin now stays in **Plugin Activity** across
    `setPluginStatus("running")` → `setPluginError("oops")` →
    `setPluginError("")` transitions.
  - After clearing an error, the previously reported status message is
    shown again (rather than an empty entry).
  - No regression observed for connections (providers) — they continue
    to appear under Connections Activity as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes an issue where calling app.setPluginError("") (or other status setters with an empty message) causes plugins to disappear from Plugin Activity and reappear under Connections Activity on the Dashboard until the next setPluginStatus() call.

## Root cause

doSetProviderStatus in src/index.ts treats any empty statusMessage as a delete signal and removes the entire providerStatus entry. Removing the entry loses the statusType: 'plugin' marker that the Dashboard's getLinkType() relies on, causing the Dashboard to categorize the plugin as a provider.

## Changes

- Preserve providerStatus entries when statusMessage is empty — doSetProviderStatus no longer deletes the entry; removal remains the responsibility of plugin lifecycle code (src/interfaces/appstore.js).
- Add lastStatus and lastStatusTimeStamp tracking — mirrors existing lastError/lastErrorTimeStamp so the prior non-error status is remembered.
- Restore previous status on error-clear — when clearing an error (incoming type === 'error' with an empty message) and lastStatus exists, the code restores type='status', message=lastStatus, and uses lastStatusTimeStamp (or now) for timeStamp.
- Clear remembered status on explicit clears — if a status is explicitly cleared via setPluginStatus(id, ""), lastStatus and lastStatusTimeStamp are wiped so an intentional clear is not later resurrected by a setPluginError(id, "").
- Improve message handling structure — refactors doSetProviderStatus to initialize the provider status object and delegate message handling to helper paths (applyMessage / clearMessage); updates to lastError/lastErrorTimeStamp are preserved and lastStatus is updated appropriately when transitioning into or out of errors.

## Behavior and testing

- Plugins remain in Plugin Activity across setPluginStatus("running") → setPluginError("oops") → setPluginError("") transitions.
- Clearing an error restores the previous status message when available.
- No regressions observed for connections/providers during manual testing with a local Docker image.

Lines changed: +55/-16
Estimated review effort: High

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2678)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->