### PR TITLE
fix(admin-ui): stabilize Data Browser row heights against scrollbar flicker

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/VirtualTable.css
+++ b/packages/server-admin-ui/src/views/DataBrowser/VirtualTable.css
@@ -56,11 +56,15 @@
   border-bottom: 1px solid var(--bs-border-color, #c2cfd6);
   font-size: 0.875rem;
   content-visibility: auto;
-  contain-intrinsic-block-size: 40px;
+  /* `auto <length>` caches each row's last rendered height as the
+     placeholder, so tall rows (sky-plot SVG, expanded <details>, NMEA
+     labels wrapping 1 to 2 lines) stop swinging page height and
+     flickering the scrollbar on viewport entry. */
+  contain-intrinsic-block-size: auto 40px;
 }
 
 .virtual-table-row[data-raw-row='true'] {
-  contain-intrinsic-block-size: 150px;
+  contain-intrinsic-block-size: auto 150px;
 }
 
 .virtual-table-row:hover {
@@ -179,6 +183,10 @@
     display: block;
     padding: 0.5rem;
     border-bottom: 2px solid var(--bs-border-color, #c2cfd6);
+    /* Stacked-cell rows are roughly 3 to 4 times the desktop height
+       (path-cell plus four label-flex cells plus padding), so raise
+       the first-paint placeholder accordingly. */
+    contain-intrinsic-block-size: auto 150px;
   }
 
   .virtual-table-row.striped {
@@ -311,5 +319,5 @@
 
 .virtual-table-meta-row {
   content-visibility: auto;
-  contain-intrinsic-block-size: 200px;
+  contain-intrinsic-block-size: auto 200px;
 }


### PR DESCRIPTION
## What problem does this solve?

In the Data Browser, the scrollbar visibly jumps as rows with rapidly-changing values cycle in and out of view, and swings further when scrolling past `navigation.gnss.satellitesInView`.

The post-#2379 virtualizer relies on CSS `content-visibility: auto` with fixed `contain-intrinsic-block-size` placeholders (40px row, 150px raw row, 200px meta row) for off-screen rows. Several rows are much taller: the 200x200 sky-plot SVG, expanded `<details>` / JSON `<pre>` blocks, and NMEA 0183 source rows whose labels wrap. Each time a tall row crosses the viewport the browser swaps the placeholder for the real height, swinging total page height and flickering the scrollbar.

## How does it fix it?

Switch the three placeholders to `contain-intrinsic-block-size: auto <length>`. The `auto` form makes the browser cache each row's last rendered height and reuse it as the placeholder once the row has been laid out. The literal length stays as the first-paint estimate. (`contain-intrinsic-size: auto <length>` is Baseline since September 2023 per MDN.)

Mobile (`max-width: 768px`) rows switch to `display: block` with stacked label cells and run 3 to 4 times the desktop height, so an additional `auto 150px` placeholder is added inside that media query.

## Testing

`npm run build` for `@signalk/server-admin-ui` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR addresses visible scrollbar jumps in the Data Browser's virtual table by updating CSS `contain-intrinsic-block-size` placeholders.

## Problem

The virtual table uses CSS `content-visibility: auto` with fixed `contain-intrinsic-block-size` placeholders (40px for regular rows, 150px for raw rows, 200px for meta rows) to skip off-screen layout rendering. However, several rows render significantly taller than these placeholders—notably `navigation.gnss.satellitesInView` which displays a 200×200 sky-plot SVG (~240px tall), expanded `<details>` and JSON `<pre>` blocks that grow naturally, and NMEA sources that cycle text between 1 and 2 wrapped lines. Each time a tall row enters or leaves the viewport, the browser swaps the placeholder for the real height, causing total page height to shift and the scrollbar to flicker.

## Solution

The PR switches all three placeholder values to use the CSS `auto <length>` syntax, which instructs the browser to cache each row's last rendered height as the placeholder once the row has been laid out at least once. The literal value remains as the first-paint estimate:

- `.virtual-table-row`: `contain-intrinsic-block-size: auto 40px`
- `.virtual-table-row[data-raw-row='true']`: `contain-intrinsic-block-size: auto 150px`
- `.virtual-table-meta-row`: `contain-intrinsic-block-size: auto 200px`
- Mobile layout (inside `max-width: 768px` media query): adds `.virtual-table-row` with `contain-intrinsic-block-size: auto 150px` to account for stacked-cell rows being 3 to 4 times the desktop height

This ensures that total page height remains stable once rows have been rendered, eliminating scrollbar flicker on viewport scrolling.

## Testing

The PR was tested with `npm run format`, `npm run lint`, and `npm test` in packages/server-admin-ui (102 tests passing), and manually verified with a live Signal K instance supporting multiple GNSS sources to confirm stable scrolling and correct rendering of expanded details and JSON blocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->