### PR TITLE
fix: avoid serverlog recursion in wrapped emitter

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -171,7 +171,11 @@ export function wrapEmitter(targetEmitter: EventEmitter): WrappedEmitter {
   let emittedCount = 0
 
   function safeEmit(this: any, eventName: string, ...args: any[]): boolean {
-    if (eventName !== 'serverlog') {
+    // Skip debug output for serverlog (and its `<emitterId>:serverlog` form).
+    // The logging layer hooks stdout.write to re-emit it as a serverlog event,
+    // so emitting debug here would write to stdout and recurse until the
+    // call stack overflows whenever DEBUG matches signalk-server:events:*.
+    if (eventName !== 'serverlog' && !eventName.endsWith(':serverlog')) {
       let eventDebug = eventDebugs[eventName]
       if (!eventDebug) {
         eventDebugs[eventName] = eventDebug = createDebug(

--- a/test/wrapped-emitter-serverlog.ts
+++ b/test/wrapped-emitter-serverlog.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const debugCore = require('debug')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { wrapEmitter } = require('../dist/events.js')
+
+describe('wrapEmitter', () => {
+  describe('serverlog recursion', () => {
+    it('does not recurse when stdout.write re-emits serverlog with events debug enabled', () => {
+      // Reproduces the interaction between src/logging.js (which hooks
+      // process.stdout.write to re-emit content as a `serverlog` event)
+      // and the per-event debug instances created by wrapEmitter. With
+      // DEBUG=signalk-server:events:* enabled, the emitter-id-prefixed
+      // `serverlog` emit calls eventDebug, which writes to stdout, which
+      // re-emits, etc. — and the call stack overflows.
+
+      const wrapped = wrapEmitter(new EventEmitter())
+      const originalWrite = process.stdout.write.bind(process.stdout)
+      const originalDebugLog = debugCore.log
+
+      let stdoutWriteCount = 0
+      ;(process.stdout.write as unknown) = (chunk: unknown) => {
+        stdoutWriteCount++
+        wrapped.emit('serverlog', { row: String(chunk) })
+        return true
+      }
+      // Mirror src/logging.js: send debug output to stdout (not stderr).
+      debugCore.log = console.info.bind(console)
+      debugCore.enable('signalk-server:events:*')
+
+      try {
+        wrapped.emit('serverlog', { row: 'hello' })
+        // With the fix the prefixed `<emitterId>:serverlog` event is
+        // suppressed from debug output, so the hooked stdout.write is
+        // never reached.
+        expect(stdoutWriteCount).to.equal(0)
+      } finally {
+        ;(process.stdout.write as unknown) = originalWrite
+        debugCore.disable()
+        debugCore.log = originalDebugLog
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
With `DEBUG=signalk-server:events:*` (or any wildcard matching that prefix),
the server stack-overflows shortly after startup.

The wrapped emitter splits each emit into `<emitterId>:eventName` and bare
`eventName` calls. The existing serverlog suppression only matched the bare
name, so the prefixed `NO_EMITTER_ID:serverlog` form still invoked the
per-event debug instance. That write hits stdout, `src/logging.js`'s
stdout hook re-emits it as a `serverlog` event, and the cycle repeats
until the stack overflows.

Extending the guard to also skip event names ending in `:serverlog`
breaks the cycle and leaves all other event routing unchanged.

## Test plan
- [x] Added `test/wrapped-emitter-serverlog.ts` — fails on `master`
      (stack overflow), passes with the fix.
- [x] `npm run build` and `npm run test-only` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a stack overflow issue in the wrapped emitter that occurs when DEBUG matching patterns like `signalk-server:events:*` are enabled. The fix extends the guard condition in `wrapEmitter`'s debug output to prevent recursive re-emission of `serverlog` events.

## Problem

When DEBUG is configured to match `signalk-server:events:*` (or similar wildcards), the server stack-overflows shortly after startup. The wrapped emitter emits event names in two forms: both the bare event name (e.g., `eventName`) and the prefixed form (e.g., `<emitterId>:eventName`). The existing guard only matched the bare `serverlog` event name, allowing prefixed forms like `NO_EMITTER_ID:serverlog` to pass through and trigger debug logging. This debug output writes to stdout, which has a hook that re-emits a `serverlog` event, creating a recursive loop that leads to stack overflow.

## Solution

The guard in `src/events.ts` now skips debug output for any event name that ends with `:serverlog`, not just the bare `serverlog` event. This prevents the recursive re-emission while preserving all other event routing behavior.

## Changes

**src/events.ts** (+5/-1)
- Extends the condition in `wrapEmitter`'s `safeEmit` function to filter out event names ending with `:serverlog`, in addition to the exact `serverlog` match

**test/wrapped-emitter-serverlog.ts** (+46)
- Adds a Mocha/Chai test that verifies the fix by wrapping an `EventEmitter`, hooking `process.stdout.write` to re-emit `serverlog` events, enabling DEBUG for `signalk-server:events:*`, and confirming that recursion is suppressed (no stdout writes occur)
- Test passes with the fix and fails on master (stack overflow)

## Validation

- `npm run build` passes
- `npm run test-only` passes
- New test prevents regression of this recursion issue

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2680)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->