### PR TITLE
fix: silence missing security.json on startup

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -298,7 +298,12 @@ export function getSecurityConfig(
       const optionsAsString = readFileSync(pathForSecurityConfig(app), 'utf8')
       return JSON.parse(optionsAsString)
     } catch (e: any) {
-      if (e.code !== 'ENOENT' || !app.securityStrategy?.isDummy()) {
+      // Suppress the ENOENT noise when security is off. The strategy may be
+      // undefined here because setupCors() reads the security config before
+      // startSecurity() installs the dummy strategy — treat that as dummy.
+      const hasRealSecurity =
+        app.securityStrategy && !app.securityStrategy.isDummy()
+      if (e.code !== 'ENOENT' || hasRealSecurity) {
         console.error(
           'Could not parse security config at %s: %s',
           pathForSecurityConfig(app),

--- a/test/security-config-missing.ts
+++ b/test/security-config-missing.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { getSecurityConfig } = require('../dist/security.js')
+
+describe('getSecurityConfig', () => {
+  describe('missing security.json', () => {
+    let configPath: string
+    let restoreConsoleError: () => void
+    let loggedErrors: unknown[][]
+
+    beforeEach(() => {
+      configPath = mkdtempSync(join(tmpdir(), 'sk-security-config-'))
+      loggedErrors = []
+      const originalError = console.error
+      console.error = (...args: unknown[]) => loggedErrors.push(args)
+      restoreConsoleError = () => {
+        console.error = originalError
+      }
+    })
+
+    afterEach(() => {
+      restoreConsoleError()
+    })
+
+    it('returns {} and does not log when securityStrategy is not initialized', () => {
+      // Reproduces startup ordering in src/index.ts: setupCors() reads the
+      // security config before startSecurity() installs the dummy strategy.
+      const app = {
+        config: { configPath },
+        securityStrategy: undefined
+      }
+
+      const result = getSecurityConfig(app)
+
+      expect(result).to.deep.equal({})
+      expect(loggedErrors).to.be.empty
+    })
+
+    it('returns {} and does not log when security is disabled (dummy strategy)', () => {
+      const app = {
+        config: { configPath },
+        securityStrategy: { isDummy: () => true }
+      }
+
+      const result = getSecurityConfig(app)
+
+      expect(result).to.deep.equal({})
+      expect(loggedErrors).to.be.empty
+    })
+
+    it('logs an error when security is enabled and the file is missing', () => {
+      const app = {
+        config: { configPath },
+        securityStrategy: { isDummy: () => false }
+      }
+
+      getSecurityConfig(app)
+
+      expect(loggedErrors).to.have.length(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
A server running without security configured prints
`Could not parse security config at .../security.json: ENOENT: no such
file or directory` every startup, even though the file is intentionally
absent.

The cause is call ordering in `src/index.ts`: `setupCors()` reads the
security config before `startSecurity()` installs the dummy strategy.
The existing `app.securityStrategy?.isDummy()` check returns `undefined`
for an uninitialized strategy, so the ENOENT suppression branch was
never taken.

Treat an uninitialized strategy as equivalent to the dummy: only log
the parse error when real security is active or the failure is not
ENOENT.

## Test plan
- [x] Added `test/security-config-missing.ts` covering uninitialized,
      dummy, and active-strategy paths. First case fails on `master`,
      all three pass with the fix.
- [x] `npm run build` and `npm run test-only` pass.