### PR TITLE
fix: avoid serverlog recursion in wrapped emitter

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -170,8 +170,13 @@ export function wrapEmitter(targetEmitter: EventEmitter): WrappedEmitter {
 
   let emittedCount = 0
 
-  function safeEmit(this: any, eventName: string, ...args: any[]): boolean {
-    if (eventName !== 'serverlog') {
+  function safeEmit(
+    this: any,
+    eventName: string,
+    originalEventName: string,
+    ...args: any[]
+  ): boolean {
+    if (originalEventName !== 'serverlog') {
       let eventDebug = eventDebugs[eventName]
       if (!eventDebug) {
         eventDebugs[eventName] = eventDebug = createDebug(
@@ -245,8 +250,8 @@ export function wrapEmitter(targetEmitter: EventEmitter): WrappedEmitter {
       emittersForEvent[emitterId] = 0
     }
     emittersForEvent[emitterId]++
-    safeEmit(`${emitterId}:${eventName}`, ...args)
-    return safeEmit(eventName, ...args)
+    safeEmit(`${emitterId}:${eventName}`, eventName, ...args)
+    return safeEmit(eventName, eventName, ...args)
   }
 
   const addListenerWithId = function (

--- a/test/wrapped-emitter-serverlog.ts
+++ b/test/wrapped-emitter-serverlog.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const debugCore = require('debug')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { wrapEmitter } = require('../dist/events.js')
+
+describe('wrapEmitter', () => {
+  describe('serverlog recursion', () => {
+    it('does not recurse when stdout.write re-emits serverlog with events debug enabled', () => {
+      // Reproduces the interaction between src/logging.js (which hooks
+      // process.stdout.write to re-emit content as a `serverlog` event)
+      // and the per-event debug instances created by wrapEmitter. With
+      // DEBUG=signalk-server:events:* enabled, the emitter-id-prefixed
+      // `serverlog` emit calls eventDebug, which writes to stdout, which
+      // re-emits, etc. — and the call stack overflows.
+
+      const wrapped = wrapEmitter(new EventEmitter())
+      const originalWrite = process.stdout.write.bind(process.stdout)
+      const originalDebugLog = debugCore.log
+
+      let stdoutWriteCount = 0
+      ;(process.stdout.write as unknown) = (chunk: unknown) => {
+        stdoutWriteCount++
+        wrapped.emit('serverlog', { row: String(chunk) })
+        return true
+      }
+      // Mirror src/logging.js: send debug output to stdout (not stderr).
+      debugCore.log = console.info.bind(console)
+      debugCore.enable('signalk-server:events:*')
+
+      try {
+        wrapped.emit('serverlog', { row: 'hello' })
+        // With the fix the prefixed `<emitterId>:serverlog` event is
+        // suppressed from debug output, so the hooked stdout.write is
+        // never reached.
+        expect(stdoutWriteCount).to.equal(0)
+      } finally {
+        ;(process.stdout.write as unknown) = originalWrite
+        debugCore.disable()
+        debugCore.log = originalDebugLog
+      }
+    })
+  })
+})


### PR DESCRIPTION
The events wrapper splits each emit into a `<emitterId>:eventName` call and a bare `eventName` call. The guard against debug-printing serverlog only matched the bare name, so the prefixed `NO_EMITTER_ID:serverlog` emission still invoked debug. With DEBUG matching
`signalk-server:events:*`, debug writes to stdout, the logging hook re-emits it as a serverlog event, and the call stack overflows.

Fix by always comparing the original event name and not the prefixed one.

## How was this tested?

Includes test by @sentientapp from #2680  and manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a recursion/stack overflow in the event-emitter wrapper caused by debug output re-emitting serverlog. The wrapper emits both a routed/prefixed event name (e.g., <emitterId>:serverlog) and the bare event name; debug suppression now checks the original (bare) event name so the prefixed emission does not trigger debug output that would be written to stdout and re-emitted as serverlog.

Changes

src/events.ts
- Updates safeEmit signature to accept originalEventName and bases the serverlog debug-suppression check on originalEventName instead of the routed/prefixed eventName.
- Updates emitWithEmitterId calls to pass both the routed event name and the original event name so routing and logging behave correctly.

test/wrapped-emitter-serverlog.ts
- Adds a regression test that patches process.stdout.write to re-emit serverlog, enables signalk-server:events:* debug, emits a serverlog through a wrapped EventEmitter, and asserts stdout.write is never called (verifying recursion is prevented). The test restores patched globals in a finally block.

Includes tests (from `@sentientapp` in `#2680`) and manual verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->