### PR TITLE
fix(admin-ui): priority-group trash works under auth and for vanished sources

### DIFF
--- a/packages/server-admin-ui/src/store/slices/prioritiesSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/prioritiesSlice.test.ts
@@ -457,6 +457,23 @@ describe('priorityGroups slice', () => {
     ])
   })
 
+  it('unsuppressNewcomerInGroup removes a single ref and prunes empty groups', () => {
+    useStore.getState().suppressNewcomerInGroup('g1', 'u0183.II')
+    useStore.getState().suppressNewcomerInGroup('g1', 'u0183.GP')
+    useStore.getState().unsuppressNewcomerInGroup('g1', 'u0183.II')
+    expect(useStore.getState().suppressedNewcomersByGroup.g1).toEqual([
+      'u0183.GP'
+    ])
+    useStore.getState().unsuppressNewcomerInGroup('g1', 'u0183.GP')
+    expect(useStore.getState().suppressedNewcomersByGroup).toEqual({})
+  })
+
+  it('unsuppressNewcomerInGroup is a no-op for unknown refs', () => {
+    const before = useStore.getState().suppressedNewcomersByGroup
+    useStore.getState().unsuppressNewcomerInGroup('g1', 'missing')
+    expect(useStore.getState().suppressedNewcomersByGroup).toBe(before)
+  })
+
   it('setPriorityGroupsFromServer keeps suppression but marks it retiring', () => {
     useStore.getState().suppressNewcomerInGroup('g1', 'u0183.II')
     useStore

--- a/packages/server-admin-ui/src/store/slices/prioritiesSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/prioritiesSlice.ts
@@ -75,6 +75,7 @@ export interface PrioritiesSliceActions {
   setGroupSources: (groupId: string, sources: string[]) => void
   setGroupInactive: (groupId: string, inactive: boolean) => void
   suppressNewcomerInGroup: (groupId: string, sourceRef: string) => void
+  unsuppressNewcomerInGroup: (groupId: string, sourceRef: string) => void
   clearRetiredSuppressions: (
     newcomerSourcesByGroup: Record<string, string[]>
   ) => void
@@ -493,6 +494,21 @@ export const createPrioritiesSlice: StateCreator<
           [groupId]: [...existing, sourceRef]
         }
       }
+    })
+  },
+
+  unsuppressNewcomerInGroup: (groupId, sourceRef) => {
+    set((state) => {
+      const existing = state.suppressedNewcomersByGroup[groupId] ?? []
+      if (!existing.includes(sourceRef)) return state
+      const filtered = existing.filter((ref) => ref !== sourceRef)
+      const next = { ...state.suppressedNewcomersByGroup }
+      if (filtered.length > 0) {
+        next[groupId] = filtered
+      } else {
+        delete next[groupId]
+      }
+      return { suppressedNewcomersByGroup: next }
     })
   },
 

--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -773,38 +773,35 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                               : undefined
                             const deviceLabel =
                               identity?.modelId ?? identity?.manufacturerCode
-                            // Offline either means the server explicitly
-                            // reports the source down, or — once the
-                            // status snapshot has loaded — that the
-                            // source has been silent since boot. The
-                            // slice merges incoming snapshots, so an
-                            // entry that was once present can never
-                            // disappear due to transient upstream
-                            // reconnect drift; missing-after-loaded
-                            // therefore means "never seen this session".
+                            // Badge only when the server positively reports
+                            // the source offline. The slice replaces (not
+                            // merges) on each SOURCESTATUS snapshot, so a
+                            // missing entry is "unknown" — it could mean
+                            // the server intentionally removed the ref
+                            // (n2kRemoveSource, device reset) or that the
+                            // ref never landed in sourceMeta this session
+                            // — but it is not evidence of an offline
+                            // device. Showing Offline for absence brings
+                            // back the stale-badge problem 48c133d2 fixed.
                             const statusEntry = sourceStatus[src]
-                            const isOffline = !sourceStatusLoaded
-                              ? false
-                              : statusEntry
+                            const isOffline =
+                              sourceStatusLoaded && statusEntry
                                 ? !statusEntry.online
-                                : true
+                                : false
                             const isPlugin = isPluginSource(src)
                             const isNewcomer = newcomerSet.has(src)
-                            // Offer removal when the source is plainly
-                            // not contributing right now (Offline badge
-                            // fired) — drag-rank is the right tool for
-                            // online sources we actually want to keep.
-                            // Also offer it for newcomers: by
-                            // definition the user has not added the
-                            // source to the saved ranking. If they
-                            // already trashed it once and the
-                            // reconciler re-promoted it (because the
-                            // source is still publishing into the
-                            // cache), they need a second click to make
-                            // the deletion stick across the next
-                            // reconcile, or to drop it again after
-                            // saving.
-                            const canRemove = isOffline || isNewcomer
+                            // Deletion is broader than the badge: offer
+                            // the trash for any source that is plainly
+                            // not contributing right now. That's the
+                            // Offline case, the newcomer case (user
+                            // never added it to the saved ranking), and
+                            // the missing-after-loaded case (saved ref
+                            // the server no longer tracks — the only
+                            // way to clean it out of the group).
+                            const isMissingFromStatus =
+                              sourceStatusLoaded && !statusEntry
+                            const canRemove =
+                              isOffline || isNewcomer || isMissingFromStatus
                             const displayLabel = getDisplayName(
                               src,
                               sourcesData

--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -30,7 +30,8 @@ import {
   useStore,
   useSourceStatus,
   useSourceStatusLoaded,
-  useLivePreferredSources
+  useLivePreferredSources,
+  useLoginStatus
 } from '../../store'
 import { getWebSocketService } from '../../hooks/useWebSocket'
 import type { ReconciledGroup } from '../../utils/sourceGroups'
@@ -323,9 +324,18 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
   const removePriorityOverride = useStore((s) => s.removePriorityOverride)
   const deletePath = useStore((s) => s.deletePath)
   const suppressNewcomerInGroup = useStore((s) => s.suppressNewcomerInGroup)
+  const unsuppressNewcomerInGroup = useStore((s) => s.unsuppressNewcomerInGroup)
   const sourceStatus = useSourceStatus()
   const livePreferredSourcesRaw = useLivePreferredSources()
   const sourceStatusLoaded = useSourceStatusLoaded()
+  const loginStatus = useLoginStatus()
+  // Both removeSource and n2kRemoveSource sit behind addAdminMiddleware.
+  // A non-admin click silently 401s — the trash icon would appear, the
+  // confirm dialog would fire, the local store would optimistically
+  // drop the row, the server would reject the DELETE, and on the next
+  // reconcile the source would reappear with no visible explanation.
+  const isAdmin =
+    !loginStatus.authenticationRequired || loginStatus.userLevel === 'admin'
   const { getDisplayName, getDisplayParts } = useSourceAliases()
 
   const [expanded, setExpanded] = useState(false)
@@ -498,16 +508,6 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
     // its bus-address state cleared. Also suppress the entry in the
     // local store so the row disappears instantly — without this the
     // dnd list briefly bounces while the eviction round-trips.
-    suppressNewcomerInGroup(group.id, sourceRef)
-    const endpoint = isN2kSource(sourceRef, sourcesData)
-      ? 'n2kRemoveSource'
-      : 'removeSource'
-    void fetch(
-      `${window.serverRoutesPrefix}/${endpoint}?sourceRef=${encodeURIComponent(sourceRef)}`,
-      { method: 'DELETE', credentials: 'include' }
-    ).catch((err) => {
-      console.warn(`Failed to evict source ${sourceRef}:`, err)
-    })
     // Read sources from the LIVE store, not the render-time `group.sources`
     // prop. Two trash clicks in quick succession would otherwise resolve
     // the second one against a snapshot that still contains the source
@@ -522,10 +522,47 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
     const liveSources =
       liveGroups.find((g) => g.id === group.id)?.sources ??
       group.sources.filter((src) => !newcomerLookup.has(src))
+    // Apply the optimistic local edits so the row disappears instantly
+    // — without this the dnd list briefly bounces while the eviction
+    // round-trips. Captured liveSources lets us revert if the server
+    // rejects the DELETE (most commonly 401 on a non-admin session).
+    suppressNewcomerInGroup(group.id, sourceRef)
     setGroupSources(
       group.id,
       liveSources.filter((src) => src !== sourceRef)
     )
+    const endpoint = isN2kSource(sourceRef, sourcesData)
+      ? 'n2kRemoveSource'
+      : 'removeSource'
+    const revertOptimistic = () => {
+      setGroupSources(group.id, liveSources)
+      unsuppressNewcomerInGroup(group.id, sourceRef)
+    }
+    void fetch(
+      `${window.serverRoutesPrefix}/${endpoint}?sourceRef=${encodeURIComponent(sourceRef)}`,
+      { method: 'DELETE', credentials: 'include' }
+    )
+      .then((res) => {
+        // 401/403/404/5xx don't throw — without an explicit check the
+        // user sees the row briefly disappear (optimistic local edit)
+        // and then reappear on the next reconcile with no clue why.
+        // Most common cause is a non-admin session: addAdminMiddleware
+        // rejects the DELETE with 401.
+        if (res.ok) return
+        const detail =
+          res.status === 401 || res.status === 403
+            ? 'admin permission required'
+            : `server returned ${res.status}`
+        revertOptimistic()
+        window.alert(`Could not remove ${label}: ${detail}.`)
+      })
+      .catch((err) => {
+        console.warn(`Failed to evict source ${sourceRef}:`, err)
+        revertOptimistic()
+        window.alert(
+          `Could not remove ${label}: network error. See console for details.`
+        )
+      })
     // Plan the per-path mutations first against the render-time
     // snapshot, then apply them by resolving each path's current index
     // from the live store right before the call. Walking the snapshot
@@ -797,11 +834,14 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                             // never added it to the saved ranking), and
                             // the missing-after-loaded case (saved ref
                             // the server no longer tracks — the only
-                            // way to clean it out of the group).
+                            // way to clean it out of the group). Gated
+                            // on isAdmin since both removeSource and
+                            // n2kRemoveSource sit behind admin auth.
                             const isMissingFromStatus =
                               sourceStatusLoaded && !statusEntry
                             const canRemove =
-                              isOffline || isNewcomer || isMissingFromStatus
+                              isAdmin &&
+                              (isOffline || isNewcomer || isMissingFromStatus)
                             const displayLabel = getDisplayName(
                               src,
                               sourcesData


### PR DESCRIPTION
## Summary

The priority-group trash button silently failed under several common conditions. This PR addresses three issues that compound the symptom "click does nothing":

**1. Stale-Offline / can't trash vanished sources**

The source-priority-ux rebase silently reverted [48c133d2](https://github.com/SignalK/signalk-server/commit/48c133d2) and reintroduced the wide rule that badges any missing-from-snapshot source as Offline. `setSourceStatus` replaces (not merges) the slice on every SOURCESTATUS event, so a missing entry is genuinely *unknown* — it could be a server-side eviction (n2kRemoveSource, device reset) or a ref that never landed in sourceMeta this session, neither of which is evidence the device is offline.

PriorityGroupCard now matches the rule already used by PrefsEditor and SourceDiscovery: only badge Offline when the server positively reports `online: false`. Trash visibility is decoupled from the badge so users can still evict a saved priority-group member the server no longer tracks — `canRemove` also fires on `isMissingFromStatus`.

**2. Silent 401 on non-admin sessions**

Both `/skServer/removeSource` and `/skServer/n2kRemoveSource` sit behind `addAdminMiddleware`. A non-admin click would 401 silently — the row briefly disappeared (optimistic local edit) and reappeared on the next reconcile with no on-screen explanation. With auth enabled this looked identical to "the trash button does nothing".

- Read `loginStatus` and gate `canRemove` on `isAdmin` so non-admins don't see a trash icon they cannot use.
- Check `res.ok` in the eviction fetch and `window.alert` on failure, with a specific message for 401/403 vs other status codes.

**3. Optimistic local state not reverted on failure**

When the DELETE fails (any non-2xx), the local optimistic edits (`setGroupSources` minus the ref, plus `suppressNewcomerInGroup`) used to stay in place. The source would reappear on the next reconcile but with the suppression flag still set, hiding any "New" badge it would otherwise receive.

- Capture `liveSources` before the optimistic mutation and revert it from both the non-ok response and the network-error catch.
- Add an `unsuppressNewcomerInGroup` action to `prioritiesSlice` and call it from the revert path so the suppression flag matches the restored state.

## Tested

- 172 admin-UI vitest tests pass (added 2 new tests covering `unsuppressNewcomerInGroup`)
- 685 server tests + 34 path-metadata + 86 server-api + 8 plugin-sdk pass
- `cr review --plain` clean
- Verified on a live server: a `derived-data` source from a previously-installed plugin (no longer running) now shows the trash icon and can be evicted from a priority group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR fixes a regression in how the Offline badge and source removal behavior are handled in the admin UI for priority groups.

### Offline badge narrowing
The PR reverts a wide rule that marked any source missing from the snapshot as Offline. Instead, the Offline badge now only displays when the server explicitly reports `online: false`. This better reflects the actual device state, since sources missing from `setSourceStatus` events can be due to server-side eviction, device reset, or absent refs rather than the device being offline.

### Trash visibility and eviction
The PR decouples trash visibility from the Offline badge to enable users to evict saved priority-group members that the server no longer tracks. The `canRemove` logic is broadened to trigger for offline sources, newcomers, or sources missing from the loaded status (isMissingFromStatus).

### Admin gating for eviction
The `PriorityGroupCard` now reads login status to gate the trash icon visibility and eviction functionality to admin users only. Non-admins cannot remove sources from priority groups.

### Optimistic updates with rollback
Source removal now uses optimistic local updates that immediately filter the source from the group while suppressing its newcomer state. If the DELETE request fails (non-200 response or network error), the changes are reverted and users receive appropriate error alerts that distinguish between authorization failures (401/403) and other errors.

### Store changes
A new Zustand action `unsuppressNewcomerInGroup(groupId, sourceRef)` is added to the `PrioritiesSlice` to support rollback of newcomer suppression when eviction fails. The action removes a suppressed source ref from a group's suppression list and deletes the group entry when no suppressed refs remain.

## Verification
- 170 admin-UI vitest tests pass
- 685 server tests, 34 path-metadata tests, 86 server-api tests, and 8 plugin-sdk tests pass
- Live verification confirms sources from stopped plugins display the trash icon and can be evicted from priority groups

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->