### PR TITLE
fix(config): emit per-leaf deltas for legacy defaults.communication shape

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -593,6 +593,36 @@ function scanDefaults(deltaEditor: DeltaEditor, vpath: string, item: any) {
   })
 }
 
+// Walks an object emitted under a parent path and recursively sets a
+// leaf delta per terminal value (strings, numbers, booleans, arrays).
+// Used for legacy defaults.json shapes that nest bare values directly
+// (e.g. `communication: { callsignVhf: "OH..." }`) — scanDefaults only
+// reads `{ value: ... }` leaves so it silently drops bare values, and
+// emitting the whole object at the parent path leaks an out-of-date
+// snapshot of every child every time anyone GETs the parent.
+function emitBareLeafDeltas(
+  deltaEditor: DeltaEditor,
+  parentPath: string,
+  item: unknown
+) {
+  if (!_.isPlainObject(item)) return
+  const obj = item as Record<string, unknown>
+  for (const key of Object.keys(obj)) {
+    const value = obj[key]
+    const childPath = parentPath.length > 0 ? `${parentPath}.${key}` : key
+    if (_.isPlainObject(value)) {
+      // Skip {value:..., meta:...} shapes — scanDefaults already handled
+      // those in the main pass. Recurse into anything else to reach the
+      // bare leaves below.
+      const child = value as Record<string, unknown>
+      if ('value' in child || 'meta' in child) continue
+      emitBareLeafDeltas(deltaEditor, childPath, child)
+    } else if (value !== undefined && value !== null) {
+      deltaEditor.setSelfValue(childPath, value)
+    }
+  }
+}
+
 function convertOldDefaultsToDeltas(
   deltaEditor: DeltaEditor,
   defaults: object
@@ -609,7 +639,13 @@ function convertOldDefaultsToDeltas(
       }
     })
     if (self.communication) {
-      deltaEditor.setSelfValue('communication', self.communication)
+      // Legacy shape stores `communication.*` as bare values, not the
+      // `{ value: ... }` shape scanDefaults walks. Emit them as separate
+      // leaf deltas so they don't collide with paths the spec keeps
+      // under `communication` (e.g. communication.crewNames written by
+      // signalk-logbook), which a parent-path snapshot would otherwise
+      // serve as stale, defaults-sourced JSON in the Data Browser.
+      emitBareLeafDeltas(deltaEditor, 'communication', self.communication)
     }
   }
   return deltas

--- a/test/defaults-communication.ts
+++ b/test/defaults-communication.ts
@@ -1,0 +1,98 @@
+import { expect } from 'chai'
+import { freeport } from './ts-servertestutilities'
+import { startServerP } from './servertestutilities'
+
+const defaultsWithBareCommunication = {
+  defaults: {
+    vessels: {
+      self: {
+        communication: {
+          callsignVhf: 'OHTEST',
+          phoneNumber: '+358501234567',
+          vhf: {
+            channel: 16
+          }
+        }
+      }
+    }
+  }
+}
+
+interface StartedServer {
+  stop?: () => Promise<unknown> | void
+}
+
+describe('Defaults: communication subtree', () => {
+  let serverP: Promise<StartedServer>
+  let port: number
+
+  before(async () => {
+    port = await freeport()
+    serverP = startServerP(port, false, defaultsWithBareCommunication)
+  })
+
+  after(async () => {
+    const server = await serverP
+    if (server && typeof server.stop === 'function') {
+      await server.stop()
+    }
+  })
+
+  it('emits per-leaf deltas (not one blob at the parent path)', async () => {
+    await serverP
+    const res = await fetch(
+      `http://localhost:${port}/signalk/v1/api/vessels/self/communication`
+    )
+    const body = await res.json()
+    // Each leaf is its own SK value with $source/timestamp/value, not
+    // a single defaults-sourced blob hung off the bare parent path.
+    expect(body.callsignVhf).to.include({
+      $source: 'defaults',
+      value: 'OHTEST'
+    })
+    expect(body.phoneNumber).to.include({
+      $source: 'defaults',
+      value: '+358501234567'
+    })
+    expect(body.vhf.channel).to.include({
+      $source: 'defaults',
+      value: 16
+    })
+    // The bare parent path itself must not be a leaf — if it were, the
+    // response would have value/$source/timestamp at the top level.
+    expect(body).to.not.have.property('$source')
+    expect(body).to.not.have.property('value')
+  })
+
+  it('individual leaves are addressable as full SK paths', async () => {
+    await serverP
+    const callsign = await fetch(
+      `http://localhost:${port}/signalk/v1/api/vessels/self/communication/callsignVhf`
+    ).then((r) => r.json())
+    expect(callsign).to.include({ $source: 'defaults', value: 'OHTEST' })
+
+    const channel = await fetch(
+      `http://localhost:${port}/signalk/v1/api/vessels/self/communication/vhf/channel`
+    ).then((r) => r.json())
+    expect(channel).to.include({ $source: 'defaults', value: 16 })
+  })
+
+  it('parent path is not itself a defaults-sourced leaf', async () => {
+    await serverP
+    // The original bug surfaced as a stale parent-path snapshot in
+    // sources.defaults.communication: any later plugin-written child
+    // (e.g. communication.crewNames) would appear duplicated in the
+    // Data Browser, once on its own leaf row and once nested inside
+    // the defaults-sourced parent blob.
+    const res = await fetch(
+      `http://localhost:${port}/signalk/v1/api/sources/defaults/communication`
+    )
+    if (res.status === 404) return
+    expect(res.ok, `unexpected status ${res.status}`).to.equal(true)
+    const body = await res.json()
+    // If a `communication` entry exists under defaults, it must be a
+    // container (no leaf-shape keys), not the whole subtree as one value.
+    expect(body).to.not.have.property('value')
+    expect(body).to.not.have.property('$source')
+  })
+})


### PR DESCRIPTION
## Summary

Legacy `defaults.json` stores `vessels.self.communication` as bare values (e.g. `{ callsignVhf: "OH..." }`) rather than the `{ value: ... }` shape `scanDefaults` walks. The migration in [src/config/config.ts](src/config/config.ts) short-circuited that by writing the entire `communication` object as a single leaf at the parent path — which then appeared in `/signalk/v1/api` as a stale `defaults`-sourced JSON blob shadowing every plugin-written child under `communication.*`.

Most visible symptom: a logbook plugin writing the proper leaf `communication.crewNames` shows twice in the Data Browser — once on its own row, once nested inside the `defaults` parent blob — and the nested copy never updates after the plugin re-emits.

The fix walks the object recursively and emits a `setSelfValue` per terminal value. The legacy bare-value shape still works, but each leaf now lives at its own SK path with its own `$source`/`timestamp`/`meta`, matching the spec and removing the duplicate row.

Pre-existing since #481 (2020). Unrelated to source-priority-ux.

## Tested

- New `test/defaults-communication.ts`: 3 cases covering per-leaf emission, full-path addressability, and absence of a parent-path leaf. Verified the bug pre-fix: with the special-case removed they assert correctly and the old behaviour fails them.
- Full server test suite: 695 passing.
- `ci-lint` clean, `cr review --plain` no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes how legacy defaults for `vessels.self.communication` are migrated from `defaults.json`. Legacy defaults used bare values (e.g., `{ callsignVhf: "..." }`) rather than the `{ value: ... }` shape expected by the Signal K defaults scanning logic. The previous migration strategy emitted the entire communication object as a single leaf at the parent path, which created an out-of-date defaults blob that shadowed individual plugin-written children, resulting in duplicate entries in the Data Browser.

## Changes

**src/config/config.ts**

Adds a new helper function `emitBareLeafDeltas` that recursively walks a legacy defaults object and emits individual leaf deltas by calling `setSelfValue` for each non-null/non-undefined terminal value. The conversion flow is updated to call this helper for the communication subtree instead of emitting the entire communication object as a single delta. This ensures each leaf path is emitted with its own `$source`, timestamp, and metadata, aligning with the Signal K specification and eliminating duplicate Data Browser rows.

**test/defaults-communication.ts**

Adds a comprehensive test suite that verifies:
- Per-leaf delta emission: each leaf includes `$source: 'defaults'` and `value`
- Full-path addressability: individual leaves are retrievable via complete Signal K API paths (e.g., `/communication/callsignVhf`, `/communication/vhf/channel`)
- Absence of parent-path leaf: the parent `sources/defaults/communication` endpoint does not expose a leaf-shaped defaults value, preventing stale snapshots from duplicating data

## Testing

- New tests in `test/defaults-communication.ts` with 3 test cases demonstrating the fix
- Full server test suite: 695 passing
- ci-lint and code review checks: clean

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->