### PR TITLE
chore(deps): bump @signalk/app-dock to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "optionalDependencies": {
     "@mxtommy/kip": "^4.0.0",
-    "@signalk/app-dock": "^0.2.0",
+    "@signalk/app-dock": "^1.0.0",
     "@signalk/freeboard-sk": "^2.0.0-beta.3",
     "@signalk/instrumentpanel": "0.x",
     "@signalk/set-system-time": "^1.5.0",


### PR DESCRIPTION
Bumps bundled `@signalk/app-dock` from `^0.2.0` to `^1.0.0` to pull in the 1.0.0 release.

## Tested
- npm test (full suite passes)