### PR TITLE
feat(subscribe): add excludeSources/excludeSelf to SubscribeMessage

### DIFF
--- a/docs/develop/plugins/deltas.md
+++ b/docs/develop/plugins/deltas.md
@@ -183,6 +183,44 @@ ws://localhost:3000/signalk/v1/stream?subscribe=self&sourcePolicy=all
 
 The query-string default applies to the bootstrap cache replay and to per-message subscriptions that don't carry their own `sourcePolicy`. A subscribe message can still override it on a per-call basis by including `sourcePolicy` in the message body.
 
+#### Excluding Sources: `excludeSources` / `excludeSelf`
+
+A derived-data plugin often consumes one or more upstream sources for a path and publishes an improved value on the same path under its own label. With the user's [source priority](../../setup/source-priority.md) ranking the plugin's output above the upstream sources, downstream consumers get the improved value. But the plugin itself cannot just subscribe with `sourcePolicy: 'preferred'` — that returns the priority winner, which is the plugin's own output, creating a feedback loop. Subscribing with `sourcePolicy: 'all'` avoids the loop but loses the priority cascade across the upstream sources.
+
+`excludeSources` removes the listed source refs from the priority cascade's candidate set. The subscription still receives a single priority-resolved value per path; the cascade just runs without the excluded sources, with the same fallback semantics the user configured.
+
+```javascript
+let localSubscription = {
+  context: 'vessels.self',
+  excludeSelf: true,
+  subscribe: [
+    {
+      path: 'environment.wind.speedTrue'
+    }
+  ]
+}
+```
+
+With user ranking `myPlugin > sourceB > sourceA`:
+
+| Bus state                                  | Delivered to plugin |
+| ------------------------------------------ | ------------------- |
+| `sourceB` publishing                       | `sourceB`           |
+| `sourceB` silent past its fallback timeout | `sourceA`           |
+| `sourceB` resumes                          | `sourceB`           |
+| `myPlugin` (own output)                    | _(never delivered)_ |
+
+| Field                      | Behaviour                                                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `excludeSources: string[]` | Drop these `$source` refs from the cascade. Explicit form; works in both plugin and WebSocket subscriptions.               |
+| `excludeSelf: true`        | Plugin-only shorthand. The server resolves it to `[plugin.id]`. Combine with `excludeSources` to add explicit refs on top. |
+
+Both fields take effect only when `sourcePolicy` is `'preferred'` (the default). Under `sourcePolicy: 'all'` they are ignored — `'all'` already bypasses the priority cascade and partial filtering would be surprising.
+
+`excludeSelf` resolves to the plugin's id only — a single ref, not a prefix match. A plugin that publishes under additional labels (e.g. `myPlugin.windFromPolars`) should use the explicit `excludeSources` form to list every ref it produces.
+
+WebSocket subscriptions can use `excludeSources` directly. `excludeSelf` is meaningless for them (there is no plugin identity to resolve against) and is silently ignored — WebSocket clients should always use the explicit form.
+
 ## Sending Deltas
 
 A SignalK plugin can not only read deltas, but can also send them. This is done using the `handleMessage()` API method and supplying:

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -44,6 +44,8 @@ In the past, plugins processing NMEA data streams have directly populated the ma
 
 ### Stream updates
 
+`SubscribeMessage` now accepts `excludeSources` and `excludeSelf`, letting a subscription apply the user's source-priority cascade across the upstream sources while filtering out the subscriber's own (or other named) output. See [Excluding Sources](./develop/plugins/deltas.md#excluding-sources-) for the canonical derived-data-plugin use case.
+
 The new REST APIs emit `v2` deltas with values that are objects.
 
 For example, when a course is activated, deltas will be emitted for `navigation.course.previousPoint`, `navigation.course.nextPoint` and `navigation.course.activeRoute` where the value is an object.

--- a/packages/server-api/src/subscriptionmanager.ts
+++ b/packages/server-api/src/subscriptionmanager.ts
@@ -1,5 +1,5 @@
 import { RelativePositionOrigin } from '.'
-import { Context, Delta, Path } from './deltas'
+import { Context, Delta, Path, SourceRef } from './deltas'
 
 /** @category Server API  */
 export interface SubscriptionManager {
@@ -51,6 +51,40 @@ export interface SubscribeMessage {
    * - `all`: all sources for every path, useful for source comparison and diagnostics
    */
   sourcePolicy?: 'preferred' | 'all'
+
+  /**
+   * Drop the listed source refs from the candidate set used by the
+   * priority cascade. The subscription still receives the
+   * priority-resolved single winner per path, just computed over the
+   * remaining sources. Use this to let a derived-data plugin subscribe
+   * to upstream sources with the user's priority ranking applied,
+   * without seeing its own output in the cascade.
+   *
+   * Effective only when `sourcePolicy` is `'preferred'` (the default).
+   * Ignored under `sourcePolicy: 'all'`, which already bypasses
+   * priority resolution.
+   *
+   * When combined with `excludeSelf`, the union of both sets is
+   * excluded.
+   */
+  excludeSources?: SourceRef[]
+
+  /**
+   * Plugin-API shorthand for `excludeSources: [<this plugin's id>]`.
+   * Resolved on the server side, so plugins don't need to know their
+   * own id. Useful for plugins that publish on the same path they
+   * consume — without the exclude their own output would dominate the
+   * priority cascade and they'd never see any other source.
+   *
+   * Only meaningful for subscriptions made through
+   * `app.subscriptionmanager.subscribe()` from inside a plugin. On
+   * WebSocket subscriptions there is no plugin identity to resolve
+   * against, and `excludeSelf` is ignored — WebSocket clients should
+   * use the explicit `excludeSources` form.
+   *
+   * Effective only when `sourcePolicy` is `'preferred'` (the default).
+   */
+  excludeSelf?: boolean
 }
 
 /** @inline

--- a/src/deltaPriority.ts
+++ b/src/deltaPriority.ts
@@ -37,6 +37,19 @@ export interface PriorityResolutionConfig {
    * does not re-canonicalise the seed.
    */
   seenPublishersByPath?: Record<string, string[]>
+  /**
+   * Source identities to drop from the candidate set entirely.
+   * Keys are sourceRefIdentity() outputs (the CAN Name when present,
+   * otherwise the raw sourceRef) — the caller pre-canonicalises so the
+   * per-delta path doesn't pay for the lookup. A delta whose source
+   * matches an excluded identity is filtered out before any precedence
+   * check runs and leaves no trace in pathSeenPublishers /
+   * pathToGroupId; the engine behaves as if the source never emitted.
+   * Used by per-subscription engines to let a derived-data plugin
+   * apply the user's source ranking to upstream sources without seeing
+   * its own output in the cascade.
+   */
+  excludeIdentities?: Set<string>
 }
 
 // An NMEA 2000 CAN Name is a 64-bit identifier rendered as 16 hex
@@ -250,10 +263,12 @@ export const getToPreferredDelta = (
   const fallbackMs = config.fallbackMs ?? DEFAULT_FALLBACK_MS
   const unknownSourceTimeout = config.unknownSourceTimeout ?? 10000
   const canonicalise = config.canonicalise ?? identityCanonicaliser
+  const excludeIdentities = config.excludeIdentities
+  const hasExcludes = !!excludeIdentities && excludeIdentities.size > 0
 
   const hasOverrides = Object.keys(overrides).length > 0
   const hasActiveGroups = groups.some((g) => !g.inactive)
-  if (!hasOverrides && !hasActiveGroups) {
+  if (!hasOverrides && !hasActiveGroups && !hasExcludes) {
     debug('No priorities data')
     const passthrough = ((delta: any, _now: Date, _selfContext: string) =>
       delta) as ToPreferredDelta
@@ -528,6 +543,20 @@ export const getToPreferredDelta = (
   }
 
   const fn = ((delta: any, now: Date, selfContext: string) => {
+    // Excludes act on every context (a plugin subscribed with
+    // context:'*' still doesn't want its own output back), so run the
+    // identity check before the self-context guard that gates the
+    // priority cascade.
+    if (hasExcludes && delta.updates) {
+      for (const update of delta.updates) {
+        if ('values' in update && update.values && update.values.length > 0) {
+          const canonicalSource = canonicalise(update.$source) as SourceRef
+          if (excludeIdentities!.has(sourceRefIdentity(canonicalSource))) {
+            update.values = []
+          }
+        }
+      }
+    }
     if (delta.context === selfContext) {
       const millis = now.getTime()
       delta.updates &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,11 @@ import { ConfigApp, load, sendBaseDeltas } from './config/config'
 import { createDebug } from './debug'
 import DeltaCache, { buildSrcToCanonicalMap } from './deltacache'
 import DeltaChain from './deltachain'
-import { getToPreferredDelta, ToPreferredDelta } from './deltaPriority'
+import {
+  getToPreferredDelta,
+  sourceRefIdentity,
+  ToPreferredDelta
+} from './deltaPriority'
 import { filterStaticSelfData } from './staticDataFilter'
 import { incDeltaStatistics, startDeltaStatistics } from './deltastats'
 import { checkForNewServerVersion } from './modules'
@@ -387,6 +391,39 @@ class Server {
       }
     }
     app.activateSourcePriorities()
+
+    // Build a per-subscription priority engine that runs the user's
+    // ranking with a sourceRef exclusion mask. Used by
+    // SubscribeMessage.excludeSources / excludeSelf: a derived-data
+    // plugin that publishes on the same path it consumes can still
+    // receive the priority cascade across the upstream sources
+    // without seeing its own output in the candidate set.
+    //
+    // Reads groups / overrides / fallbackMs from the live settings
+    // each time so a per-subscription engine reflects whatever the
+    // user has currently saved, and shares the canonicaliseSourceRef
+    // closure so canName matching behaves the same as the global
+    // engine. Seeding seenPublishersByPath is not needed — the
+    // resulting engine is consumed by a single subscriber callback
+    // and never feeds routesPath consumers.
+    app.buildSubscriptionEngine = (
+      excludeSourceRefs: string[]
+    ): ToPreferredDelta => {
+      const excludeIdentities = new Set<string>()
+      for (const ref of excludeSourceRefs) {
+        if (typeof ref === 'string' && ref.length > 0) {
+          excludeIdentities.add(sourceRefIdentity(canonicaliseSourceRef(ref)))
+        }
+      }
+      const s = app.config.settings
+      return getToPreferredDelta({
+        groups: s.priorityGroups ?? [],
+        overrides: s.priorityOverrides ?? {},
+        fallbackMs: s.priorityDefaults?.fallbackMs,
+        canonicalise: canonicaliseSourceRef,
+        excludeIdentities
+      })
+    }
 
     // Defer migration so that the moved device's own re-arbitration
     // address claim has time to land in app.signalk.sources first.

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -107,6 +107,27 @@ function backwardsCompat(url: string) {
   return [`${SERVERROUTESPREFIX}${url}`, url]
 }
 
+// Resolve excludeSelf:true to the plugin's id and union it with any
+// explicit excludeSources. Returns undefined when neither field is
+// set so the existing "no excludes" fast path in subscriptionmanager
+// is preserved.
+function mergeExcludeSelf(
+  excludeSources: SourceRef[] | undefined,
+  excludeSelf: boolean | undefined,
+  pluginId: string
+): SourceRef[] | undefined {
+  const hasList = Array.isArray(excludeSources) && excludeSources.length > 0
+  if (!hasList && !excludeSelf) return undefined
+  const merged = new Set<string>()
+  if (hasList) {
+    for (const ref of excludeSources!) {
+      if (typeof ref === 'string' && ref.length > 0) merged.add(ref)
+    }
+  }
+  if (excludeSelf) merged.add(pluginId)
+  return merged.size > 0 ? (Array.from(merged) as SourceRef[]) : undefined
+}
+
 module.exports = (theApp: any) => {
   const onStopHandlers: any = {}
   const appNodeModules = path.join(theApp.config.appPath, 'node_modules/')
@@ -671,13 +692,25 @@ module.exports = (theApp: any) => {
         // a specific device — silently never see non-preferred deltas
         // because plugin subscriptions read streambundle.buses (the
         // post-toPreferredDelta bus). Same plumbing the WS interface uses.
+        //
+        // Resolve excludeSelf: true to [plugin.id] here so the engine
+        // downstream only ever sees excludeSources. Plugins emitting
+        // multiple labels (e.g. "myplugin.windFromPolars") should set
+        // excludeSources explicitly; excludeSelf is the simple case
+        // where the plugin's $source is plugin.id verbatim.
+        const excludeSources = mergeExcludeSelf(
+          command.excludeSources,
+          command.excludeSelf,
+          plugin.id
+        )
         app.subscriptionmanager.subscribe(
           command,
           unsubscribes,
           errorCallback,
           safeCallback,
           user,
-          command.sourcePolicy
+          command.sourcePolicy,
+          excludeSources
         )
       },
       unsubscribe: (msg: UnsubscribeMessage, unsubscribes: Unsubscribes) => {

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -121,6 +121,8 @@ interface WsMessage {
   statusCode?: number
   message?: string
   sourcePolicy?: SourcePolicy
+  excludeSources?: string[]
+  excludeSelf?: boolean
 }
 
 interface WsRequestReply extends UpdateOptions {
@@ -196,7 +198,8 @@ interface SubscriptionManager {
     write: (data: unknown) => void,
     onChange: (delta: Delta) => void,
     principal?: SkPrincipal,
-    sourcePolicy?: string
+    sourcePolicy?: string,
+    excludeSources?: string[]
   ) => void
   unsubscribe: (msg: WsMessage, unsubscribes: Array<() => void>) => void
 }
@@ -1123,6 +1126,16 @@ function processSubscribe(
     // listener attached in handleRealtimeConnection. Falling back to the
     // spark-level policy keeps the URL-query default working for clients
     // that never send a per-message override.
+    //
+    // excludeSelf is only meaningful for plugin subscriptions (where
+    // the server can resolve it to the plugin's id); WebSocket clients
+    // have no identity to resolve against, so it's logged and ignored.
+    // Explicit excludeSources is forwarded as-is.
+    if (msg.excludeSelf) {
+      debug(
+        'WebSocket subscribe ignores excludeSelf: there is no plugin identity to resolve; use excludeSources instead'
+      )
+    }
     app.subscriptionmanager.subscribe(
       msg,
       unsubscribes,
@@ -1136,7 +1149,10 @@ function processSubscribe(
         spark.backpressureManager!.send(filtered)
       },
       spark.request.skPrincipal,
-      msg.sourcePolicy ?? spark.sourcePolicy
+      msg.sourcePolicy ?? spark.sourcePolicy,
+      Array.isArray(msg.excludeSources) && msg.excludeSources.length > 0
+        ? msg.excludeSources
+        : undefined
     )
   }
 }

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -25,19 +25,55 @@ import {
   SubscriptionOptions,
   UnsubscribeMessage,
   SubscribeCallback,
-  RelativePositionOrigin
+  RelativePositionOrigin,
+  Delta,
+  SourceRef
 } from '@signalk/server-api'
 import * as Bacon from 'baconjs'
 import { isPointWithinRadius } from 'geolib'
 import _, { forOwn, get, isString } from 'lodash'
 import { createDebug } from './debug'
 import DeltaCache from './deltacache'
+import { ToPreferredDelta } from './deltaPriority'
 import { StreamBundle, toDelta } from './streambundle'
 import { ContextMatcher } from './types'
 const debug = createDebug('signalk-server:subscriptionmanager')
 
 interface BusesMap {
   [path: Path]: Bacon.Bus<NormalizedDelta>
+}
+
+// Run a delta through a per-subscription priority engine and return
+// the filtered delta, or null if every update was emptied. The
+// engine mutates update.values in place (a clone is made first so
+// other subscribers/bridges sharing the source delta keep their copy
+// intact), then anything with no surviving values is dropped.
+function runPerSubEngine(
+  engine: ToPreferredDelta,
+  delta: Delta,
+  now: Date,
+  selfContext: string
+): Delta | null {
+  const cloned: Delta = {
+    context: delta.context,
+    updates: delta.updates.map((u: any) => {
+      if ('values' in u && Array.isArray(u.values)) {
+        return { ...u, values: u.values.slice() }
+      }
+      return { ...u }
+    })
+  }
+  const result = engine(cloned, now, selfContext)
+  if (!result || !result.updates) return null
+  const surviving = result.updates.filter((u: any) => {
+    if ('values' in u) {
+      return Array.isArray(u.values) && u.values.length > 0
+    }
+    // meta-updates and other shapes pass through unchanged
+    return true
+  })
+  if (surviving.length === 0) return null
+  return { ...result, updates: surviving }
 }
 
 class SubscriptionManager implements ISubscriptionManager {
@@ -56,7 +92,8 @@ class SubscriptionManager implements ISubscriptionManager {
     errorCallback: (err: unknown) => void,
     callback: SubscribeCallback,
     user?: string,
-    sourcePolicy?: 'preferred' | 'all'
+    sourcePolicy?: 'preferred' | 'all',
+    excludeSources?: SourceRef[]
   ) {
     const contextFilter = contextMatcher(
       this.selfContext,
@@ -64,7 +101,37 @@ class SubscriptionManager implements ISubscriptionManager {
       command,
       errorCallback
     )
-    const useUnfiltered = sourcePolicy === 'all'
+    // Exclude semantics only make sense under the priority cascade.
+    // Under sourcePolicy='all' the caller has opted into raw fan-out
+    // and partial filtering would be surprising — log and ignore.
+    // Sanitize at the boundary: a WebSocket message or plugin command
+    // can carry empty strings or non-string entries, and an array
+    // length > 0 of garbage shouldn't flip the subscription into
+    // per-engine mode.
+    const sanitizedExcludes = Array.isArray(excludeSources)
+      ? excludeSources.filter(
+          (ref): ref is SourceRef => typeof ref === 'string' && ref.length > 0
+        )
+      : []
+    const effectiveExcludes =
+      sourcePolicy === 'all' || sanitizedExcludes.length === 0
+        ? undefined
+        : sanitizedExcludes
+    if (sourcePolicy === 'all' && sanitizedExcludes.length > 0) {
+      debug(
+        "ignoring excludeSources under sourcePolicy:'all' — excludes only apply to 'preferred'"
+      )
+    }
+    // When the caller asks for exclude semantics, route through a
+    // per-subscription priority engine fed from the unfiltered bus
+    // (every source). Without excludes, keep the existing fast paths:
+    // 'preferred' reads from the pre-filtered global bus, 'all' from
+    // the unfiltered bus, neither needs a per-subscription engine.
+    const perSubEngine: ToPreferredDelta | null =
+      effectiveExcludes && this.app.buildSubscriptionEngine
+        ? this.app.buildSubscriptionEngine(effectiveExcludes)
+        : null
+    const useUnfiltered = sourcePolicy === 'all' || perSubEngine !== null
     const buses = useUnfiltered
       ? this.streambundle.unfilteredBuses
       : this.streambundle.buses
@@ -78,7 +145,9 @@ class SubscriptionManager implements ISubscriptionManager {
         callback,
         errorCallback,
         user,
-        sourcePolicy
+        sourcePolicy,
+        perSubEngine,
+        this.selfContext
       )
       // listen to new keys and then use the same logic to check if we
       // want to subscribe, passing in a map with just that single bus
@@ -97,7 +166,9 @@ class SubscriptionManager implements ISubscriptionManager {
             callback,
             errorCallback,
             user,
-            sourcePolicy
+            sourcePolicy,
+            perSubEngine,
+            this.selfContext
           )
         })
       )
@@ -110,23 +181,33 @@ class SubscriptionManager implements ISubscriptionManager {
       const announcedPaths = new Set<string>()
 
       // 1. Announce ALL existing paths matching context (send cached deltas once)
+      // With a per-subscription engine in play, fetch every cached
+      // source (sourcePolicy='all') and re-run the engine so the
+      // bootstrap snapshot honours the exclude mask the same way live
+      // deltas do. Without this, the announce-path replay would leak
+      // the excluded source on its very first emission.
       const existingDeltas = this.app.deltaCache.getCachedDeltas(
         contextFilter,
         user,
         undefined,
-        sourcePolicy
+        perSubEngine ? 'all' : sourcePolicy
       )
       if (existingDeltas) {
+        const now = new Date()
         existingDeltas.forEach((delta: any) => {
+          const filtered = perSubEngine
+            ? runPerSubEngine(perSubEngine, delta, now, this.selfContext)
+            : delta
+          if (!filtered) return
           // Track which paths we've announced
-          delta.updates?.forEach((update: any) => {
+          filtered.updates?.forEach((update: any) => {
             update.values?.forEach((vp: any) => {
               if (vp.path) {
                 announcedPaths.add(vp.path)
               }
             })
           })
-          callback(delta)
+          callback(filtered)
         })
       }
 
@@ -149,7 +230,17 @@ class SubscriptionManager implements ISubscriptionManager {
             .take(1) // Only take the first value
             .map(toDelta)
             .onValue((delta: any) => {
-              callback(delta)
+              if (perSubEngine) {
+                const filtered = runPerSubEngine(
+                  perSubEngine,
+                  delta,
+                  new Date(),
+                  this.selfContext
+                )
+                if (filtered) callback(filtered)
+              } else {
+                callback(delta)
+              }
             })
 
           // Add to unsubscribes so it gets cleaned up
@@ -190,7 +281,9 @@ function handleSubscribeRows(
   callback: SubscribeCallback,
   errorCallback: any,
   user?: string,
-  sourcePolicy?: 'preferred' | 'all'
+  sourcePolicy?: 'preferred' | 'all',
+  perSubEngine?: ToPreferredDelta | null,
+  selfContext?: string
 ) {
   rows.reduce((acc, subscribeRow) => {
     if (subscribeRow.path !== undefined) {
@@ -203,7 +296,9 @@ function handleSubscribeRows(
         callback,
         errorCallback,
         user,
-        sourcePolicy
+        sourcePolicy,
+        perSubEngine,
+        selfContext
       )
     }
     return acc
@@ -223,7 +318,9 @@ function handleSubscribeRow(
   callback: SubscribeCallback,
   errorCallback: any,
   user?: string,
-  sourcePolicy?: 'preferred' | 'all'
+  sourcePolicy?: 'preferred' | 'all',
+  perSubEngine?: ToPreferredDelta | null,
+  selfContext?: string
 ) {
   const matcher = pathMatcher(subscribeRow.path)
   // iterate over all the buses, checking if we want to subscribe to its values
@@ -284,16 +381,59 @@ function handleSubscribeRow(
           `Only 'instant' and 'fixed' policies supported, ignoring policy ${subscribeRow.policy}`
         )
       }
-      unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
+      // With a per-subscription priority engine in play, run each
+      // delta through the engine before delivering. The engine carries
+      // the user's saved priority groups/overrides minus the excluded
+      // sources, so the subscriber sees a single priority-resolved
+      // value per path with the cascade respected — the same shape
+      // the global preferred-only bus would deliver, but with the
+      // plugin's own (or otherwise excluded) sources removed from the
+      // candidate set.
+      if (perSubEngine) {
+        const engineStream = filteredBus
+          .map(toDelta)
+          .flatMap((delta: Delta) => {
+            const filtered = runPerSubEngine(
+              perSubEngine,
+              delta,
+              new Date(),
+              selfContext ?? ''
+            )
+            return filtered ? Bacon.once(filtered) : Bacon.never()
+          }) as Bacon.EventStream<Delta>
+        unsubscribes.push(engineStream.onValue(callback))
+      } else {
+        unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
+      }
 
+      // Bootstrap snapshot: fetch every source's last cached value
+      // (sourcePolicy='all') when a per-subscription engine owns this
+      // subscription, then replay through the engine so the snapshot
+      // honours the exclude mask. Without the override the snapshot
+      // would carry the global preferred winner — which may BE the
+      // excluded source — and the subscriber would see it once on
+      // startup.
       const latest = app.deltaCache.getCachedDeltas(
         filter,
         user,
         key,
-        sourcePolicy
+        perSubEngine ? 'all' : sourcePolicy
       )
       if (latest) {
-        latest.forEach(callback)
+        if (perSubEngine) {
+          const now = new Date()
+          for (const delta of latest) {
+            const filtered = runPerSubEngine(
+              perSubEngine,
+              delta,
+              now,
+              selfContext ?? ''
+            )
+            if (filtered) callback(filtered)
+          }
+        } else {
+          latest.forEach(callback)
+        }
       }
     }
   })

--- a/test/deltaPriority.ts
+++ b/test/deltaPriority.ts
@@ -1102,3 +1102,117 @@ describe('toPreferredDelta.routesPath', () => {
     fn.routesPath('environment.outside.temperature', 'bar.B').should.equal(true)
   })
 })
+
+describe('excludeIdentities', () => {
+  const PATH = 'environment.wind.speedApparent'
+
+  function emit(
+    engine: ReturnType<typeof getToPreferredDelta>,
+    sourceRef: string,
+    value: number,
+    at: number
+  ) {
+    return engine(makeDelta(sourceRef, PATH, value), new Date(at), 'self')
+  }
+
+  it('drops deltas from an excluded source', () => {
+    const fn = getToPreferredDelta({
+      excludeIdentities: new Set(['c'])
+    })
+    accepted(emit(fn, 'c', 1, 0)).should.equal(false)
+    accepted(emit(fn, 'a', 2, 1)).should.equal(true)
+  })
+
+  it('runs the priority cascade across the remaining sources', () => {
+    // User ranking: c > b > a. Plugin owns c and excludes it, so the
+    // engine should hand it b while b publishes and fall back to a
+    // after b's fallback timeout.
+    const overrides: SourcePrioritiesData = {
+      [PATH]: [
+        { sourceRef: 'c' as SourceRef, timeout: 0 },
+        { sourceRef: 'b' as SourceRef, timeout: 100 },
+        { sourceRef: 'a' as SourceRef, timeout: 200 }
+      ]
+    }
+    const fn = getToPreferredDelta({
+      overrides,
+      excludeIdentities: new Set(['c'])
+    })
+    // a emits first and is the only candidate; accepted.
+    accepted(emit(fn, 'a', 1, 0)).should.equal(true)
+    // b emits — outranks a and is accepted immediately.
+    accepted(emit(fn, 'b', 2, 1)).should.equal(true)
+    // While b keeps winning, a is suppressed (lower rank, within a's
+    // own takeover window — a's timeout=200 governs the gap a must
+    // wait before it can displace the higher-ranked winner).
+    accepted(emit(fn, 'a', 3, 50)).should.equal(false)
+    // b goes silent past a's timeout (200ms). a finally takes over.
+    accepted(emit(fn, 'a', 4, 250)).should.equal(true)
+    // b returns — outranks a and is accepted immediately (timeout
+    // governs the lower-ranked source's takeover wait, not the
+    // higher-ranked source's re-entry).
+    accepted(emit(fn, 'b', 5, 260)).should.equal(true)
+  })
+
+  it('an excluded source never wins even when ranked highest', () => {
+    const overrides: SourcePrioritiesData = {
+      [PATH]: [
+        { sourceRef: 'c' as SourceRef, timeout: 0 },
+        { sourceRef: 'b' as SourceRef, timeout: 100 }
+      ]
+    }
+    const fn = getToPreferredDelta({
+      overrides,
+      excludeIdentities: new Set(['c'])
+    })
+    // c is rank 1 but excluded: every emission from c is dropped.
+    accepted(emit(fn, 'c', 1, 0)).should.equal(false)
+    accepted(emit(fn, 'c', 2, 50)).should.equal(false)
+    // b emits — accepted because c is invisible to the engine.
+    accepted(emit(fn, 'b', 3, 100)).should.equal(true)
+    // c keeps publishing but stays excluded.
+    accepted(emit(fn, 'c', 4, 150)).should.equal(false)
+    accepted(emit(fn, 'b', 5, 200)).should.equal(true)
+  })
+
+  it('excluded source emissions do not pollute pathSeenPublishers', () => {
+    // A path with only one real publisher should report routesPath=false
+    // (single-publisher paths never get a Preferred badge). An excluded
+    // source's emissions should not count toward the publisher gate.
+    const fn = getToPreferredDelta({
+      groups: [{ id: 'g', sources: ['real-source'], inactive: false }],
+      excludeIdentities: new Set(['excluded-plugin'])
+    })
+    // Excluded source publishes first — should be invisible to the
+    // engine including routesPath bookkeeping.
+    emit(fn, 'excluded-plugin', 1, 0)
+    fn.routesPath(PATH, 'real-source').should.equal(false)
+    // Real source publishes — group claims the path but only one
+    // publisher is known, so routesPath stays false.
+    emit(fn, 'real-source', 2, 1)
+    fn.routesPath(PATH, 'real-source').should.equal(false)
+    // Excluded plugin emits again — must not count as a second
+    // publisher even though it shares the path.
+    emit(fn, 'excluded-plugin', 3, 2)
+    fn.routesPath(PATH, 'real-source').should.equal(false)
+  })
+
+  it('exclusion applies on non-self contexts too', () => {
+    // A plugin subscribed with context:"*" must not see its own output
+    // even when the delta is for another vessel.
+    const fn = getToPreferredDelta({
+      excludeIdentities: new Set(['c'])
+    })
+    const otherVesselDelta = {
+      context: 'vessels.urn:mrn:imo:mmsi:123',
+      updates: [
+        {
+          $source: 'c',
+          values: [{ path: PATH, value: 5 }]
+        }
+      ]
+    }
+    const result = fn(otherVesselDelta, new Date(), 'self')
+    result.updates[0].values.length.should.equal(0)
+  })
+})

--- a/test/plugin-source-exclude.ts
+++ b/test/plugin-source-exclude.ts
@@ -1,0 +1,144 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Server = require('../dist/')
+
+interface PluginInfo {
+  id: string
+}
+
+interface PluginOptions {
+  excludeSelf?: boolean
+  excludeSources?: string[]
+}
+
+const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
+const CONFIG_FILE = path.join(
+  CONFIG_DIR,
+  'plugin-config-data',
+  'sourceexcludeplugin.json'
+)
+
+const writeConfig = (options: PluginOptions) => {
+  fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true })
+  fs.writeFileSync(
+    CONFIG_FILE,
+    JSON.stringify({
+      enabled: true,
+      configuration: options
+    })
+  )
+}
+
+// Asserts the plugin wrapper resolves excludeSelf to [plugin.id] and
+// forwards a merged excludeSources to the underlying
+// subscriptionmanager. End-to-end exclude routing (per-subscription
+// engine + cache replay) is covered by test/deltaPriority.ts; here
+// we just need to prove the wrapper produces the right call.
+// Position of the excludeSources argument in subscriptionmanager.subscribe:
+// (command, unsubscribes, errorCallback, callback, user, sourcePolicy, excludeSources)
+const EXCLUDE_SOURCES_ARG_INDEX = 6
+
+describe('Plugin excludeSelf / excludeSources', () => {
+  const originalConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
+  before(() => {
+    process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
+  })
+
+  after(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.SIGNALK_NODE_CONFIG_DIR
+    } else {
+      process.env.SIGNALK_NODE_CONFIG_DIR = originalConfigDir
+    }
+    if (fs.existsSync(CONFIG_FILE)) fs.unlinkSync(CONFIG_FILE)
+  })
+
+  const captureSubscribeArgs = async (
+    options: PluginOptions
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any[]> => {
+    writeConfig(options)
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const captured: any[] = []
+    const original = server.app.subscriptionmanager
+    server.app.subscriptionmanager = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      subscribe: (...args: any[]) => {
+        captured.push(args)
+        return original.subscribe(...args)
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      unsubscribe: (...args: any[]) => original.unsubscribe(...args)
+    }
+
+    await server.start()
+    try {
+      const plugin = server.app.plugins.find(
+        (p: PluginInfo) => p.id === 'sourceexcludeplugin'
+      )
+      assert(plugin, 'sourceexcludeplugin should be loaded')
+      const ours = captured.find(
+        (args) =>
+          args[0]?.subscribe?.[0]?.path === 'environment.inside.test.pressure'
+      )
+      assert(ours, 'plugin subscribe call should be captured')
+      return ours
+    } finally {
+      await server.stop()
+    }
+  }
+
+  it('resolves excludeSelf:true to [plugin.id] as the 7th argument', async () => {
+    const args = await captureSubscribeArgs({ excludeSelf: true })
+    assert.deepStrictEqual(
+      args[EXCLUDE_SOURCES_ARG_INDEX],
+      ['sourceexcludeplugin'],
+      'excludeSelf should be expanded to [plugin.id]'
+    )
+  })
+
+  it('forwards an explicit excludeSources list', async () => {
+    const args = await captureSubscribeArgs({
+      excludeSources: ['otherPlugin']
+    })
+    assert.deepStrictEqual(
+      args[EXCLUDE_SOURCES_ARG_INDEX],
+      ['otherPlugin'],
+      'excludeSources should be forwarded as-is'
+    )
+  })
+
+  it('merges excludeSelf with an explicit excludeSources list', async () => {
+    const args = await captureSubscribeArgs({
+      excludeSelf: true,
+      excludeSources: ['otherPlugin']
+    })
+    assert(
+      Array.isArray(args[EXCLUDE_SOURCES_ARG_INDEX]),
+      'excludeSources arg should be an array'
+    )
+    const set = new Set(args[EXCLUDE_SOURCES_ARG_INDEX])
+    assert(
+      set.has('sourceexcludeplugin'),
+      "merged list should include the plugin's own id"
+    )
+    assert(set.has('otherPlugin'), 'merged list should include explicit refs')
+    assert.strictEqual(set.size, 2, 'merged list should be deduplicated')
+  })
+
+  it('omits the excludeSources argument when neither field is set', async () => {
+    const args = await captureSubscribeArgs({})
+    assert.strictEqual(
+      args[EXCLUDE_SOURCES_ARG_INDEX],
+      undefined,
+      'subscriptionmanager.subscribe should receive undefined when no excludes are set'
+    )
+  })
+})

--- a/test/plugin-test-config/node_modules/sourceexcludeplugin/index.js
+++ b/test/plugin-test-config/node_modules/sourceexcludeplugin/index.js
@@ -1,0 +1,49 @@
+module.exports = function (app) {
+  const received = []
+  let unsubscribes = []
+  return {
+    id: 'sourceexcludeplugin',
+    name: 'Source Exclude Test Plugin',
+    schema: function () {
+      return {
+        type: 'object',
+        properties: {
+          excludeSelf: { type: 'boolean' },
+          excludeSources: { type: 'array', items: { type: 'string' } }
+        }
+      }
+    },
+    start: function (options) {
+      const command = {
+        context: 'vessels.self',
+        subscribe: [{ path: 'environment.inside.test.pressure' }]
+      }
+      if (options && options.excludeSelf) {
+        command.excludeSelf = true
+      }
+      if (options && Array.isArray(options.excludeSources)) {
+        command.excludeSources = options.excludeSources
+      }
+      app.subscriptionmanager.subscribe(
+        command,
+        unsubscribes,
+        (err) => console.error(err),
+        (delta) => {
+          delta.updates.forEach((u) => {
+            if (!u.values) return
+            u.values.forEach((v) => {
+              if (v.path === 'environment.inside.test.pressure') {
+                received.push({ $source: u.$source, value: v.value })
+              }
+            })
+          })
+        }
+      )
+    },
+    stop: function () {
+      unsubscribes.forEach((f) => f())
+      unsubscribes = []
+    },
+    _received: received
+  }
+}

--- a/test/plugin-test-config/node_modules/sourceexcludeplugin/package.json
+++ b/test/plugin-test-config/node_modules/sourceexcludeplugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sourceexcludeplugin",
+  "keywords": [
+    "signalk-node-server-plugin"
+  ]
+}


### PR DESCRIPTION
## Motivation

A derived-data plugin that publishes on the same path it consumes cannot benefit from source priority today:

- `sourcePolicy: 'preferred'` returns the global engine's winner — which is the plugin's own output. Cyclic feedback.
- `sourcePolicy: 'all'` returns every source unranked. The plugin loses the user's priority cascade across the upstream sources.

This adds a per-subscription priority cascade with a source-exclusion mask so the plugin can apply the user's ranking to the upstream sources and never receive its own output. Background discussion: a plugin developer raised the gap on Discord with the canonical "plugin owns sourceC, ranking is C > B > A, plugin wants to see B with fallback to A" scenario.

## Approach

Extends `SubscribeMessage` with `excludeSources?: SourceRef[]` (explicit refs to drop) and `excludeSelf?: boolean` (plugin-API shorthand resolved server-side to `[plugin.id]`). Both apply only under `sourcePolicy: 'preferred'`; ignored under `'all'`. `excludeSelf` is plugin-only — WebSocket subscriptions should use the explicit form.

Routing reuses the existing `getToPreferredDelta` engine with a new `excludeIdentities` config field; a per-subscription engine is built on demand, fed from the unfiltered bus, and applied to the cached-delta bootstrap snapshot so the exclude mask is honoured from the very first emission. The global priority engine remains a single instance — there's no new state on the ingestion hot path. Subscribers that don't set the new fields keep the existing fast path.

## Tested

- 5 new engine unit tests in [test/deltaPriority.ts](test/deltaPriority.ts) (cascade across remaining sources, excluded source never wins, no pollution of `pathSeenPublishers`, applies on non-self contexts).
- 4 new plugin integration tests in [test/plugin-source-exclude.ts](test/plugin-source-exclude.ts) (excludeSelf resolves, explicit list forwarded, union deduped, undefined when neither set).
- Full suite: 701 passing.
- Live end-to-end against a running server: WS subscriber with `excludeSources:['sourceC']` saw only sourceA/sourceB across both live deltas and the cached bootstrap snapshot; the cached preferred winner (`sourceC`) was correctly filtered out.

## Docs

- New `#### Excluding Sources` subsection under [docs/develop/plugins/deltas.md](docs/develop/plugins/deltas.md) Source Policy section, with the canonical derived-data cascade scenario.
- Short entry in [docs/whats_new.md](docs/whats_new.md).
- JSDoc on `SubscribeMessage.excludeSources` / `excludeSelf` rides into the published `@signalk/server-api` TypeDoc reference.

No breaking changes. Additive API surface.