### PR TITLE
feat(admin-ui): persist sidebar nav group expansion across navigation

### DIFF
--- a/packages/server-admin-ui/scss/core/_sidebar.scss
+++ b/packages/server-admin-ui/scss/core/_sidebar.scss
@@ -63,10 +63,15 @@
       -webkit-appearance: none;
     }
 
+    // Match the sidebar background so the scrollbar track does not
+    // surface as a visibly-lighter vertical strip whenever the menu
+    // overflows (typically once the Data submenu is expanded). The
+    // thumb is still rendered darker, so the scroll affordance is
+    // preserved while the empty trough disappears.
     &::-webkit-scrollbar-track {
-      background-color: color.adjust($sidebar-bg, $lightness: 5%);
-      border-right: 1px solid color.adjust($sidebar-bg, $lightness: -5%);
-      border-left: 1px solid color.adjust($sidebar-bg, $lightness: -5%);
+      background-color: $sidebar-bg;
+      border-right: 1px solid $sidebar-bg;
+      border-left: 1px solid $sidebar-bg;
     }
 
     &::-webkit-scrollbar-thumb {

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,10 @@
-import React, { useMemo, useCallback, MouseEvent, ReactNode } from 'react'
+import React, {
+  useMemo,
+  useCallback,
+  useEffect,
+  MouseEvent,
+  ReactNode
+} from 'react'
 import { NavLink, Location } from 'react-router-dom'
 import Badge from 'react-bootstrap/Badge'
 import Nav from 'react-bootstrap/Nav'
@@ -14,7 +20,10 @@ import {
   useSourcePriorities,
   usePriorityOverrides,
   usePriorityGroups,
-  useActiveConflictCount
+  useActiveConflictCount,
+  useExpandedNavGroups,
+  useToggleNavGroup,
+  useSetNavGroupExpanded
 } from '../../store'
 import classNames from 'classnames'
 import { isOverrideDormantUnderGroups } from '../../utils/sourceGroups'
@@ -60,6 +69,9 @@ export default function Sidebar({ location }: SidebarProps) {
   const loginStatus = useLoginStatus()
   const plugins = usePlugins()
   const conflictCount = useActiveConflictCount()
+  const expandedNavGroups = useExpandedNavGroups()
+  const toggleNavGroup = useToggleNavGroup()
+  const setNavGroupExpanded = useSetNavGroupExpanded()
 
   const multiSourcePaths = useMultiSourcePaths()
   const reconciled = useReconciledGroups()
@@ -414,21 +426,45 @@ export default function Sidebar({ location }: SidebarProps) {
     overridesWithMissingSourcesCount
   ])
 
-  const handleClick = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    ;(e.target as HTMLElement).parentElement?.classList.toggle('open')
-  }, [])
+  // Persist a group as expanded the first time the user navigates into
+  // it. After this, the group stays open even when the route moves out
+  // of the group — the user can collapse it explicitly via the toggle.
+  useEffect(() => {
+    for (const item of items) {
+      if (!item.children?.length) continue
+      const routeMatch = item.children.some(
+        (child) => child.url && location.pathname.indexOf(child.url) > -1
+      )
+      if (routeMatch && expandedNavGroups[item.name] !== true) {
+        setNavGroupExpanded(item.name, true)
+      }
+    }
+  }, [items, location.pathname, expandedNavGroups, setNavGroupExpanded])
 
+  const handleDropdownClick = useCallback(
+    (name: string) => (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault()
+      toggleNavGroup(name)
+    },
+    [toggleNavGroup]
+  )
+
+  // A dropdown is "open" when either the current route lives inside it
+  // (so the user can see where they are) or the user has expanded it
+  // explicitly. The expanded preference persists in localStorage so the
+  // group stays open after navigating away.
   const activeRoute = useCallback(
-    (routeName: string, children?: NavItemData[]) => {
-      const isActive = children?.length
-        ? children.some(
+    (item: NavItemData) => {
+      const routeName = item.url || ''
+      const routeMatch = item.children?.length
+        ? item.children.some(
             (child) => child.url && location.pathname.indexOf(child.url) > -1
           )
         : location.pathname.indexOf(routeName) > -1
-      return isActive ? 'nav-item nav-dropdown open' : 'nav-item nav-dropdown'
+      const isOpen = routeMatch || expandedNavGroups[item.name] === true
+      return isOpen ? 'nav-item nav-dropdown open' : 'nav-item nav-dropdown'
     },
-    [location.pathname]
+    [location.pathname, expandedNavGroups]
   )
 
   const renderBadge = (badgeData?: BadgeData | null): ReactNode => {
@@ -539,11 +575,11 @@ export default function Sidebar({ location }: SidebarProps) {
 
   const navDropdown = (item: NavItemData, key: number): ReactNode => {
     return (
-      <li key={key} className={activeRoute(item.url || '', item.children)}>
+      <li key={key} className={activeRoute(item)}>
         <a
           className="nav-link nav-dropdown-toggle"
           href="#"
-          onClick={handleClick}
+          onClick={handleDropdownClick(item.name)}
         >
           {renderIcon(item.icon)}
           {item.name}

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -362,3 +362,10 @@ export function usePreferredSourceByPath(): Map<string, string> {
 }
 
 export * from './types'
+
+export {
+  useUiPrefs,
+  useExpandedNavGroups,
+  useToggleNavGroup,
+  useSetNavGroupExpanded
+} from './slices/uiSlice'

--- a/packages/server-admin-ui/src/store/slices/uiSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/uiSlice.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUiPrefs } from './uiSlice'
+
+describe('uiSlice', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useUiPrefs.setState({ expandedNavGroups: {} })
+  })
+
+  it('toggleNavGroup flips the named group', () => {
+    useUiPrefs.getState().toggleNavGroup('Data')
+    expect(useUiPrefs.getState().expandedNavGroups.Data).toBe(true)
+
+    useUiPrefs.getState().toggleNavGroup('Data')
+    expect(useUiPrefs.getState().expandedNavGroups.Data).toBe(false)
+  })
+
+  it('setNavGroupExpanded sets explicit state', () => {
+    useUiPrefs.getState().setNavGroupExpanded('Security', true)
+    expect(useUiPrefs.getState().expandedNavGroups.Security).toBe(true)
+
+    useUiPrefs.getState().setNavGroupExpanded('Security', false)
+    expect(useUiPrefs.getState().expandedNavGroups.Security).toBe(false)
+  })
+
+  it('keeps groups independent', () => {
+    useUiPrefs.getState().setNavGroupExpanded('Data', true)
+    useUiPrefs.getState().setNavGroupExpanded('Server', true)
+    useUiPrefs.getState().toggleNavGroup('Data')
+
+    expect(useUiPrefs.getState().expandedNavGroups).toEqual({
+      Data: false,
+      Server: true
+    })
+  })
+
+  it('persists expanded groups to localStorage', () => {
+    useUiPrefs.getState().setNavGroupExpanded('Data', true)
+    const raw = localStorage.getItem('signalk-admin-ui-prefs')
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw as string)
+    expect(parsed.state.expandedNavGroups.Data).toBe(true)
+  })
+})

--- a/packages/server-admin-ui/src/store/slices/uiSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/uiSlice.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+export interface UiPrefsState {
+  expandedNavGroups: Record<string, boolean>
+  toggleNavGroup: (name: string) => void
+  setNavGroupExpanded: (name: string, expanded: boolean) => void
+}
+
+export const useUiPrefs = create<UiPrefsState>()(
+  persist(
+    (set) => ({
+      expandedNavGroups: {},
+      toggleNavGroup: (name) =>
+        set((s) => ({
+          expandedNavGroups: {
+            ...s.expandedNavGroups,
+            [name]: !s.expandedNavGroups[name]
+          }
+        })),
+      setNavGroupExpanded: (name, expanded) =>
+        set((s) => ({
+          expandedNavGroups: { ...s.expandedNavGroups, [name]: expanded }
+        }))
+    }),
+    {
+      name: 'signalk-admin-ui-prefs',
+      storage: createJSONStorage(() => localStorage),
+      version: 1
+    }
+  )
+)
+
+export function useExpandedNavGroups() {
+  return useUiPrefs((s) => s.expandedNavGroups)
+}
+
+export function useToggleNavGroup() {
+  return useUiPrefs((s) => s.toggleNavGroup)
+}
+
+export function useSetNavGroupExpanded() {
+  return useUiPrefs((s) => s.setNavGroupExpanded)
+}


### PR DESCRIPTION
## Motivation

As more items are added under sidebar groups (Data, Server, Apps & Plugins, …), users have to re-open the parent group on every navigation. Even after expanding "Data" to pick "Connections", a click to "Dashboard" collapses the group, costing two extra clicks to get back.

This is the low-magic option from the recent discussion: persist the expansion state. No "auto-jump to last visited child", no inferred intent — just remember which groups the user has opened.

## Approach

- New `uiSlice` using `zustand/middleware`'s `persist` keeps `expandedNavGroups: Record<string, boolean>` in `localStorage` under `signalk-admin-ui-prefs`.
- `Sidebar` drives each dropdown's open state from `routeMatch || expandedNavGroups[name]`, so the active route still force-opens its group.
- The first time a child route activates, the parent is marked persisted-expanded — so navigating away no longer collapses the group, while the user can still collapse it explicitly via the toggle.
- Click handler now updates the store instead of toggling a DOM class, removing the previous render/DOM tug-of-war.

If users still want "open the last-visited child for me", that can land as a separate change on top of this; easier to add magic than to take it away.

## Tested

- New `uiSlice.test.ts` covers toggle/set/independence and verifies the localStorage payload.
- Full admin-ui suite (174 tests) and full repo `npm test` green.
- Manual: expand "Data", navigate to Dashboard → group stays open; collapse → stays collapsed across navigation and full reload; navigating directly into a child auto-persists the parent as open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds persistent expansion state for admin-ui sidebar navigation groups so expanded groups remain open across route changes and page reloads.

## Implementation Details

### New UI state store
- Adds `uiSlice.ts`, a Zustand store persisted to localStorage under the key `signalk-admin-ui-prefs` (with version).
- Tracks `expandedNavGroups: Record<string, boolean>`.
- Exposes actions: `toggleNavGroup(name)` and `setNavGroupExpanded(name, boolean)`.
- Exports selector hooks: `useUiPrefs`, `useExpandedNavGroups`, `useToggleNavGroup`, `useSetNavGroupExpanded`.

### Sidebar component changes
- `Sidebar.tsx` uses the new store hooks instead of DOM class toggling.
- Dropdown open state is driven by `routeMatch || expandedNavGroups[name]`, so an active route still force-opens its parent group.
- On navigation, parent groups whose child route matches `location.pathname` are auto-marked persisted-expanded the first time (so navigating away no longer collapses them); users can still collapse explicitly.
- Clicks call `toggleNavGroup(item.name)` via a `handleDropdownClick` callback, removing prior render/DOM conflicts.

### Store exports
- `packages/server-admin-ui/src/store/index.ts` re-exports the new UI prefs hooks for consuming code.

### Styling tweak
- Adjusts `.sidebar-nav` ::-webkit-scrollbar-track to use the raw sidebar background color so the scrollbar track matches the sidebar.

## Testing
- Adds `uiSlice.test.ts` (Vitest) verifying toggle/set behavior, independence of groups, and correct localStorage payload shape.
- Full admin-ui test suite (174 tests) and full repo npm test pass.
- Manual verification confirms persistence across navigation and reloads; collapsing persists; navigating directly to a child auto-persists its parent as open.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->