### PR TITLE
test(applicationData): raise before() timeout and guard after()

### DIFF
--- a/test/applicationData.ts
+++ b/test/applicationData.ts
@@ -69,6 +69,7 @@ describe('Application Data', () => {
   let adminHeaders: Record<string, string>
 
   before(async function () {
+    this.timeout(60000)
     port = await freeport()
     url = `http://0.0.0.0:${port}`
 
@@ -92,7 +93,9 @@ describe('Application Data', () => {
   })
 
   after(async () => {
-    await server.stop()
+    if (server) {
+      await server.stop()
+    }
   })
 
   async function post(globalOrUser: boolean, token: string, expected: number) {


### PR DESCRIPTION
## Motivation

`test/applicationData.ts` can fail intermittently on slower machines: the `before()` hook calls `startServerP(port, true)` to boot a full server with security setup, which can exceed the 20s mocha default. When that times out, `after()` then throws `TypeError: Cannot read properties of undefined (reading 'stop')`, masking the original failure.

## Approach

- Raise the `before()` hook timeout to 60s, matching the pattern already used in `test/sliding-session.ts` (which boots a server the same way).
- Guard `after()` with `if (server)` so a `before()` failure surfaces the real error instead of the undefined-server TypeError.

No behavioral changes to the tests themselves; CI continues to pass within the existing time budget.

## Tested

- `npm run format` clean
- `npm run build:all` clean
- `npx mocha test/applicationData.ts` — 11 passing in 18s