### PR TITLE
Pass container arguments to signalk-server startup command

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -52,4 +52,4 @@ else
     service bluetooth restart
 fi
 
-/home/node/signalk/node_modules/signalk-server/bin/signalk-server --securityenabled
+exec /home/node/signalk/node_modules/signalk-server/bin/signalk-server --securityenabled "$@"


### PR DESCRIPTION
## What problem does this solve?

When the Signal K Docker image is started with arguments passed through `docker run ... signalk/signalk-server <args>` or Docker Compose `command:`, those arguments are currently received by `docker/startup.sh` but are not forwarded to the `signalk-server` process.

This prevents container users from passing supported server command-line options at startup.

## How was this tested?

- Ran `sh -n docker/startup.sh`.
- Tested the modified container startup locally and confirmed arguments are forwarded to `signalk-server`.
