### PR TITLE
fix(deltacache): drop cached sources from removed providers on load

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -73,7 +73,9 @@ export function buildSrcToCanonicalMap(sources: unknown): Map<string, string> {
 }
 
 /**
- * Collect the provider IDs declared in `settings.pipedProviders`.
+ * Collect the IDs of providers in `settings.pipedProviders` that are
+ * currently enabled. Skips entries with `enabled: false` (matching the
+ * convention in `pipedproviders.ts`: undefined is treated as enabled).
  *
  * Returns an empty Set when the settings tree is missing or empty —
  * callers must skip the prune in that case so a fresh install (or a
@@ -84,6 +86,8 @@ export function collectProviderIds(pipedProviders: unknown): Set<string> {
   if (!Array.isArray(pipedProviders)) return out
   for (const p of pipedProviders) {
     if (p && typeof p === 'object') {
+      const enabled = (p as { enabled?: unknown }).enabled
+      if (enabled === false) continue
       const id = (p as { id?: unknown }).id
       if (typeof id === 'string' && id.length > 0) {
         out.add(id)
@@ -622,19 +626,22 @@ export default class DeltaCache {
       const data = readFileSync(cachePath, 'utf-8')
       const cached = JSON.parse(data)
       if (cached && typeof cached === 'object') {
-        // Prune cached entries whose provider has been removed from
-        // settings.pipedProviders. Without this, deleting (or even just
-        // renaming) a connection leaves its devices stuck in the Data
-        // Browser and skServer/deviceIdentities forever — they get
-        // hydrated from sources-cache.json on every restart, never get
-        // a fresh `lastSeen` because the producer is gone, and survive
-        // because Reset Stale only runs on user click.
+        // Prune cached entries whose provider has been removed from (or
+        // disabled in) settings.pipedProviders. Without this, deleting,
+        // renaming, or disabling a connection leaves its devices stuck
+        // in the Data Browser and skServer/deviceIdentities forever —
+        // they get hydrated from sources-cache.json on every restart,
+        // never get a fresh `lastSeen` because the producer is gone,
+        // and survive because Reset Stale only runs on user click.
         const knownProviderIds = collectProviderIds(
           (this.app as any)?.config?.settings?.pipedProviders
         )
         const droppedCount = pruneSourcesByProvider(cached, knownProviderIds)
         if (droppedCount > 0) {
-          debug('Pruned %d cache entries from removed providers', droppedCount)
+          debug(
+            'Pruned %d cache entries from removed or disabled providers',
+            droppedCount
+          )
         }
 
         // Deduplicate by canName: when the same device appears under

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -72,6 +72,52 @@ export function buildSrcToCanonicalMap(sources: unknown): Map<string, string> {
   return out
 }
 
+/**
+ * Collect the provider IDs declared in `settings.pipedProviders`.
+ *
+ * Returns an empty Set when the settings tree is missing or empty —
+ * callers must skip the prune in that case so a fresh install (or a
+ * settings file we can't read) doesn't wipe out the entire cache.
+ */
+export function collectProviderIds(pipedProviders: unknown): Set<string> {
+  const out = new Set<string>()
+  if (!Array.isArray(pipedProviders)) return out
+  for (const p of pipedProviders) {
+    if (p && typeof p === 'object') {
+      const id = (p as { id?: unknown }).id
+      if (typeof id === 'string' && id.length > 0) {
+        out.add(id)
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Remove cache entries whose `<providerId>.<rest>` key prefix is not in
+ * `knownProviderIds`. Mutates the input object and returns the number
+ * of entries removed.
+ *
+ * If `knownProviderIds` is empty, leaves the cache untouched so a
+ * misread settings file can't drop the user's whole history.
+ */
+export function pruneSourcesByProvider(
+  cached: Record<string, unknown>,
+  knownProviderIds: Set<string>
+): number {
+  if (knownProviderIds.size === 0) return 0
+  let dropped = 0
+  for (const key of Object.keys(cached)) {
+    const dotIdx = key.indexOf('.')
+    const providerId = dotIdx > 0 ? key.slice(0, dotIdx) : key
+    if (!knownProviderIds.has(providerId)) {
+      delete cached[key]
+      dropped++
+    }
+  }
+  return dropped
+}
+
 export default class DeltaCache {
   cache: StringKeyed = {}
   lastModifieds: StringKeyed = {}
@@ -576,6 +622,21 @@ export default class DeltaCache {
       const data = readFileSync(cachePath, 'utf-8')
       const cached = JSON.parse(data)
       if (cached && typeof cached === 'object') {
+        // Prune cached entries whose provider has been removed from
+        // settings.pipedProviders. Without this, deleting (or even just
+        // renaming) a connection leaves its devices stuck in the Data
+        // Browser and skServer/deviceIdentities forever — they get
+        // hydrated from sources-cache.json on every restart, never get
+        // a fresh `lastSeen` because the producer is gone, and survive
+        // because Reset Stale only runs on user click.
+        const knownProviderIds = collectProviderIds(
+          (this.app as any)?.config?.settings?.pipedProviders
+        )
+        const droppedCount = pruneSourcesByProvider(cached, knownProviderIds)
+        if (droppedCount > 0) {
+          debug('Pruned %d cache entries from removed providers', droppedCount)
+        }
+
         // Deduplicate by canName: when the same device appears under
         // multiple addresses (e.g. from address 254 claim cycling),
         // keep only the entry with the lower non-254 address.

--- a/test/prune-sources-by-provider.ts
+++ b/test/prune-sources-by-provider.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai'
+import { collectProviderIds, pruneSourcesByProvider } from '../src/deltacache'
+
+// When a connection is deleted from settings.pipedProviders, its
+// devices used to remain in the Data Browser and skServer/deviceIdentities
+// after every restart, because loadSourcesCache() blindly re-hydrates
+// every key in ~/.signalk/sources-cache.json. The helper exercised here
+// is what makes the load drop entries belonging to providers that no
+// longer exist.
+
+describe('collectProviderIds', function () {
+  it('returns the ids of every provider in pipedProviders', function () {
+    const ids = collectProviderIds([
+      { id: 'sensESP', enabled: true },
+      { id: 'YDEN02', enabled: false }
+    ])
+    expect(ids.size).to.equal(2)
+    expect(ids.has('sensESP')).to.equal(true)
+    expect(ids.has('YDEN02')).to.equal(true)
+  })
+
+  it('returns an empty set when input is not an array', function () {
+    expect(collectProviderIds(undefined).size).to.equal(0)
+    expect(collectProviderIds(null).size).to.equal(0)
+    expect(collectProviderIds({}).size).to.equal(0)
+  })
+
+  it('skips entries without an id', function () {
+    const ids = collectProviderIds([
+      { id: 'sensESP' },
+      { enabled: true },
+      { id: '' }
+    ])
+    expect(ids.size).to.equal(1)
+    expect(ids.has('sensESP')).to.equal(true)
+  })
+})
+
+describe('pruneSourcesByProvider', function () {
+  it('removes entries whose provider id is not in the known set', function () {
+    const cached: Record<string, unknown> = {
+      'sensESP.131': { foo: 1 },
+      'sensESP.c078c30936a14904': { foo: 2 },
+      'YDEN02.131': { foo: 3 },
+      'YDEN02.c078c30936a14904': { foo: 4 }
+    }
+    const known = new Set(['sensESP'])
+    const dropped = pruneSourcesByProvider(cached, known)
+    expect(dropped).to.equal(2)
+    expect(Object.keys(cached).sort()).to.deep.equal([
+      'sensESP.131',
+      'sensESP.c078c30936a14904'
+    ])
+  })
+
+  it('leaves the cache untouched when no providers are known', function () {
+    // Guard against wiping the cache on a misread settings file.
+    const cached: Record<string, unknown> = {
+      'sensESP.131': { foo: 1 },
+      'YDEN02.131': { foo: 2 }
+    }
+    const dropped = pruneSourcesByProvider(cached, new Set())
+    expect(dropped).to.equal(0)
+    expect(Object.keys(cached).length).to.equal(2)
+  })
+
+  it('handles keys without a dot separator', function () {
+    // Defensive: a cache key written by an older server version, or
+    // some non-provider machinery, should not throw.
+    const cached: Record<string, unknown> = {
+      sensESP: { foo: 1 },
+      'YDEN02.131': { foo: 2 }
+    }
+    const known = new Set(['sensESP'])
+    const dropped = pruneSourcesByProvider(cached, known)
+    expect(dropped).to.equal(1)
+    expect('sensESP' in cached).to.equal(true)
+    expect('YDEN02.131' in cached).to.equal(false)
+  })
+})

--- a/test/prune-sources-by-provider.ts
+++ b/test/prune-sources-by-provider.ts
@@ -1,22 +1,35 @@
 import { expect } from 'chai'
 import { collectProviderIds, pruneSourcesByProvider } from '../src/deltacache'
 
-// When a connection is deleted from settings.pipedProviders, its
-// devices used to remain in the Data Browser and skServer/deviceIdentities
-// after every restart, because loadSourcesCache() blindly re-hydrates
-// every key in ~/.signalk/sources-cache.json. The helper exercised here
-// is what makes the load drop entries belonging to providers that no
-// longer exist.
+// When a connection is deleted from (or disabled in) settings.pipedProviders,
+// its devices used to remain in the Data Browser and skServer/deviceIdentities
+// after every restart, because loadSourcesCache() blindly re-hydrates every
+// key in ~/.signalk/sources-cache.json. The helper exercised here is what
+// makes the load drop entries belonging to providers that no longer exist
+// or are no longer enabled.
 
 describe('collectProviderIds', function () {
-  it('returns the ids of every provider in pipedProviders', function () {
+  it('returns the ids of enabled providers', function () {
+    const ids = collectProviderIds([
+      { id: 'sensESP', enabled: true },
+      { id: 'NMEA0183' }
+    ])
+    expect(ids.size).to.equal(2)
+    expect(ids.has('sensESP')).to.equal(true)
+    expect(ids.has('NMEA0183')).to.equal(true)
+  })
+
+  it('skips providers with enabled: false', function () {
+    // A disabled provider has the same staleness shape as a deleted one:
+    // it stops producing fresh deltas, so its cached devices never get a
+    // fresh lastSeen and would otherwise linger forever.
     const ids = collectProviderIds([
       { id: 'sensESP', enabled: true },
       { id: 'YDEN02', enabled: false }
     ])
-    expect(ids.size).to.equal(2)
+    expect(ids.size).to.equal(1)
     expect(ids.has('sensESP')).to.equal(true)
-    expect(ids.has('YDEN02')).to.equal(true)
+    expect(ids.has('YDEN02')).to.equal(false)
   })
 
   it('returns an empty set when input is not an array', function () {


### PR DESCRIPTION
## Summary

Deleting, renaming, or disabling a connection in `settings.pipedProviders` leaves its devices stuck in the Data Browser and `/skServer/deviceIdentities` forever. `loadSourcesCache()` rehydrates every key in `~/.signalk/sources-cache.json` on startup without consulting which providers still exist or are still enabled. The entries never get a fresh `lastSeen` (the producer is gone), and Reset Stale only runs on user click — so zombies accumulate.

This PR makes `loadSourcesCache()` collect the IDs of providers in `settings.pipedProviders` that are currently enabled (matching `pipedproviders.ts`: undefined treated as enabled, only `enabled: false` is skipped) and drop any cached `sourceDeltas` whose `<providerId>.<rest>` prefix is no longer in that set. The cache is left untouched when the provider list is empty or unreadable, so a fresh install or a misread settings file can't wipe the user's history.

The filtering is extracted into two pure helpers (`collectProviderIds`, `pruneSourcesByProvider`) with unit tests.

## Test plan

- [x] `npm test` — added unit test passes (7/7 in `test/prune-sources-by-provider.ts`, including the new "skips providers with enabled: false" case).
- [x] Full `npm run test-only` — 700 passing.
- [x] Reproduced end-to-end on a live server: `settings.json` had `YDEN02` with `enabled: false` and `~/.signalk/sources-cache.json` had 52 `YDEN02.*` entries. With at least one enabled provider in the same settings file, on restart the deltacache debug log emits `Pruned 52 cache entries from removed or disabled providers` and `/skServer/deviceIdentities` returns 0 devices (was 52 before the fix). With only-disabled providers in settings, the safety guard correctly leaves the cache untouched (same misread-settings safety as before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR improves cache management in Signal K by preventing stale provider data from persisting when providers are removed or disabled.

## Changes

The PR adds two new helper functions to `src/deltacache.ts`:

- `collectProviderIds(pipedProviders)` — collects provider IDs from the enabled providers in `settings.pipedProviders`, excluding entries marked with `enabled: false`, and returns an empty Set for invalid/missing input
- `pruneSourcesByProvider(cached, knownProviderIds)` — removes cache entries whose provider ID prefix is not in the known set of enabled providers, returning the count of dropped entries and performing no pruning when the known set is empty

The `loadSourcesCache()` function is modified to prune cached `sources-cache.json` entries based on the current set of enabled providers before applying existing deduplication logic. A debug log is emitted when entries are dropped.

## Testing

Unit tests are added in `test/prune-sources-by-provider.ts` with coverage for:
- `collectProviderIds` returning only enabled provider IDs and handling edge cases
- `pruneSourcesByProvider` removing entries for unknown providers, preserving the cache when the known set is empty, and safely handling malformed cache keys

## Behavior

On startup, the cache no longer unconditionally rehydrates all keys from `~/.signalk/sources-cache.json`. Cached source deltas from removed providers are dropped. If the provider list is empty or unreadable, the cache is left untouched to avoid data loss on fresh installs or misconfigured settings. The pruning also extends to providers with `enabled: false`, treating undefined as enabled to match existing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->