### PR TITLE
feat: wire N2kIpGateway as 'N2K IP Gateway (canboatjs)' source

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -57,6 +57,8 @@ interface ProviderOptions {
   // lower 3 bits and upper 5 bits of PGN 60928.
   deviceInstance?: number
   systemInstance?: number
+  // N2kIpGateway-specific.
+  actAsCanDevice?: boolean
   format?: string
   [key: string]: unknown
 }
@@ -1396,6 +1398,47 @@ function UseCanNameInput({
   )
 }
 
+function ActAsCanDeviceInput({
+  value,
+  onChange
+}: {
+  value: ProviderOptions
+  onChange: OnChangeHandler
+}) {
+  // Default to true when the field is unset so the switch reflects the
+  // gateway's actual runtime default (matches N2kIpGateway constructor).
+  const checked = value.actAsCanDevice !== false
+  return (
+    <Form.Group as={Row} className="mb-3">
+      <Col xs="3" md="3">
+        <Form.Label htmlFor="provider-actAsCanDevice">
+          Act as N2K device
+        </Form.Label>
+      </Col>
+      <Col xs="2" md="3">
+        <Form.Label className="switch switch-text switch-primary">
+          <input
+            type="checkbox"
+            id="provider-actAsCanDevice"
+            name="options.actAsCanDevice"
+            className="switch-input"
+            onChange={(event) => onChange(event)}
+            checked={checked}
+          />
+          <span className="switch-label" data-on="Yes" data-off="No" />
+          <span className="switch-handle" />
+        </Form.Label>
+      </Col>
+      <Col xs="7" md="6" className="form-text text-muted small">
+        Claim an N2K address and participate actively on the bus (answer ISO
+        Requests for 60928 / 126996 / 126998, send heartbeat, accept
+        commands). Defaults to <strong>on</strong>; turn off to run as a
+        read-only listener.
+      </Col>
+    </Form.Group>
+  )
+}
+
 function CreateDeviceInput({
   value,
   onChange
@@ -1724,12 +1767,11 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
               </Form.Select>
             </Col>
           </Form.Group>
+          <ActAsCanDeviceInput value={value.options} onChange={onChange} />
           <div className="text-muted small mt-1 mb-2">
             Generic source for IP-based N2K gateways that stream raw CAN
             frames over TCP in one of canboatjs's supported text formats.
-            Default port 2599, default format candump3, default
-            actAsCanDevice true (server claims an N2K address and
-            participates as a node).
+            Default port 2599, default format candump3.
           </div>
         </div>
       )}

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1431,9 +1431,9 @@ function ActAsCanDeviceInput({
       </Col>
       <Col xs="7" md="6" className="form-text text-muted small">
         Claim an N2K address and participate actively on the bus (answer ISO
-        Requests for 60928 / 126996 / 126998, send heartbeat, accept
-        commands). Defaults to <strong>on</strong>; turn off to run as a
-        read-only listener.
+        Requests for 60928 / 126996 / 126998, send heartbeat, accept commands).
+        Defaults to <strong>on</strong>; turn off to run as a read-only
+        listener.
       </Col>
     </Form.Group>
   )
@@ -1487,7 +1487,9 @@ function DeviceInstanceInput({
   return (
     <Form.Group as={Row} className="mb-3">
       <Col xs="3" md="3">
-        <Form.Label htmlFor="provider-deviceInstance">Device Instance</Form.Label>
+        <Form.Label htmlFor="provider-deviceInstance">
+          Device Instance
+        </Form.Label>
       </Col>
       <Col xs="2" md="3">
         <Form.Control
@@ -1499,7 +1501,7 @@ function DeviceInstanceInput({
           value={
             typeof value.deviceInstance === 'number'
               ? value.deviceInstance
-              : value.deviceInstance ?? ''
+              : (value.deviceInstance ?? '')
           }
           onChange={(event) => onChange(event)}
         />
@@ -1522,7 +1524,9 @@ function SystemInstanceInput({
   return (
     <Form.Group as={Row} className="mb-3">
       <Col xs="3" md="3">
-        <Form.Label htmlFor="provider-systemInstance">System Instance</Form.Label>
+        <Form.Label htmlFor="provider-systemInstance">
+          System Instance
+        </Form.Label>
       </Col>
       <Col xs="2" md="3">
         <Form.Control
@@ -1534,7 +1538,7 @@ function SystemInstanceInput({
           value={
             typeof value.systemInstance === 'number'
               ? value.systemInstance
-              : value.systemInstance ?? ''
+              : (value.systemInstance ?? '')
           }
           onChange={(event) => onChange(event)}
         />
@@ -1769,9 +1773,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           </Form.Group>
           <ActAsCanDeviceInput value={value.options} onChange={onChange} />
           <div className="text-muted small mt-1 mb-2">
-            Generic source for IP-based N2K gateways that stream raw CAN
-            frames over TCP in one of canboatjs's supported text formats.
-            Default port 2599, default format candump3.
+            Generic source for IP-based N2K gateways that stream raw CAN frames
+            over TCP in one of canboatjs's supported text formats. Default port
+            2599, default format candump3.
           </div>
         </div>
       )}
@@ -1779,14 +1783,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
         value.options.type.indexOf('canboatjs') !== -1 && (
           <>
             <UseCanNameInput value={value.options} onChange={onChange} />
-            <DeviceInstanceInput
-              value={value.options}
-              onChange={onChange}
-            />
-            <SystemInstanceInput
-              value={value.options}
-              onChange={onChange}
-            />
+            <DeviceInstanceInput value={value.options} onChange={onChange} />
+            <SystemInstanceInput value={value.options} onChange={onChange} />
             <CamelCaseCompatInput value={value.options} onChange={onChange} />
           </>
         )}

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1523,6 +1523,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
               Yacht Devices RAW USB (canboatjs)
             </option>
             <option value="canbus-canboatjs">Canbus (canboatjs)</option>
+            <option value="n2k-ip-gateway-canboatjs">
+              N2K IP Gateway (canboatjs)
+            </option>
             <option value="w2k-1-n2k-ascii-canboatjs">
               W2K-1 N2K ASCII (canboatjs)
             </option>
@@ -1617,6 +1620,42 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
             value={value.options}
             onChange={onChange}
           />
+        </div>
+      )}
+      {value.options.type === 'n2k-ip-gateway-canboatjs' && (
+        <div>
+          <HostInput value={value.options} onChange={onChange} />
+          <PortInput value={value.options} onChange={onChange} />
+          <Form.Group as={Row} className="mb-2">
+            <Col xs="12" md="3">
+              <Form.Label htmlFor="n2k-ip-gateway-format">
+                Text Format
+              </Form.Label>
+            </Col>
+            <Col xs="12" md="3">
+              <Form.Select
+                id="n2k-ip-gateway-format"
+                name="options.format"
+                value={value.options.format || 'candump3'}
+                onChange={(event) => onChange(event)}
+              >
+                <option value="candump3">candump3 (default)</option>
+                <option value="candump2">candump2</option>
+                <option value="candump1">candump1</option>
+                <option value="ydraw">YDRAW</option>
+                <option value="actisense">Actisense (comma)</option>
+                <option value="actisense-n2k-ascii">Actisense N2K ASCII</option>
+                <option value="pcdin">PCDIN</option>
+              </Form.Select>
+            </Col>
+          </Form.Group>
+          <div className="text-muted small mt-1 mb-2">
+            Generic source for IP-based N2K gateways that stream raw CAN
+            frames over TCP in one of canboatjs's supported text formats.
+            Default port 2599, default format candump3, default
+            actAsCanDevice true (server claims an N2K address and
+            participates as a node).
+          </div>
         </div>
       )}
       {value.options.type !== undefined &&

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1477,6 +1477,44 @@ function CreateDeviceInput({
   )
 }
 
+// NMEA 2000 PGN 60928 instance-field widths. canboatjs validates these
+// server-side and falls back to 0 for anything out of range, but we
+// still clamp here so settings.json never persists a value the user
+// typed that the bus can't actually carry.
+const MIN_DEVICE_INSTANCE = 0
+const MAX_DEVICE_INSTANCE = 255
+const MIN_SYSTEM_INSTANCE = 0
+const MAX_SYSTEM_INSTANCE = 15
+
+function clampedInstanceChange(
+  event: ChangeEvent<HTMLInputElement>,
+  onChange: OnChangeHandler,
+  min: number,
+  max: number
+) {
+  // Empty input clears the field so it falls back to the default. Any
+  // non-numeric input mirrors that — we'd rather store nothing than
+  // `NaN` or a string the server has to coerce.
+  const raw = event.target.value
+  if (raw === '') {
+    onChange({
+      target: { name: event.target.name, value: '', type: 'number' }
+    })
+    return
+  }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) {
+    onChange({
+      target: { name: event.target.name, value: '', type: 'number' }
+    })
+    return
+  }
+  const clamped = Math.min(max, Math.max(min, Math.trunc(parsed)))
+  onChange({
+    target: { name: event.target.name, value: clamped, type: 'number' }
+  })
+}
+
 function DeviceInstanceInput({
   value,
   onChange
@@ -1495,20 +1533,28 @@ function DeviceInstanceInput({
         <Form.Control
           id="provider-deviceInstance"
           type="number"
-          min={0}
-          max={255}
+          min={MIN_DEVICE_INSTANCE}
+          max={MAX_DEVICE_INSTANCE}
           name="options.deviceInstance"
           value={
             typeof value.deviceInstance === 'number'
               ? value.deviceInstance
               : (value.deviceInstance ?? '')
           }
-          onChange={(event) => onChange(event)}
+          onChange={(event) =>
+            clampedInstanceChange(
+              event,
+              onChange,
+              MIN_DEVICE_INSTANCE,
+              MAX_DEVICE_INSTANCE
+            )
+          }
         />
       </Col>
       <Col xs="7" md="6" className="form-text text-muted small">
-        0–255. Identifies this signalk-server among multiple N2K nodes (split
-        into PGN 60928's lower 3 bits and upper 5 bits). Defaults to 0.
+        {MIN_DEVICE_INSTANCE}–{MAX_DEVICE_INSTANCE}. Identifies this
+        signalk-server among multiple N2K nodes (split into PGN 60928's lower 3
+        bits and upper 5 bits). Defaults to 0.
       </Col>
     </Form.Group>
   )
@@ -1532,19 +1578,27 @@ function SystemInstanceInput({
         <Form.Control
           id="provider-systemInstance"
           type="number"
-          min={0}
-          max={15}
+          min={MIN_SYSTEM_INSTANCE}
+          max={MAX_SYSTEM_INSTANCE}
           name="options.systemInstance"
           value={
             typeof value.systemInstance === 'number'
               ? value.systemInstance
               : (value.systemInstance ?? '')
           }
-          onChange={(event) => onChange(event)}
+          onChange={(event) =>
+            clampedInstanceChange(
+              event,
+              onChange,
+              MIN_SYSTEM_INSTANCE,
+              MAX_SYSTEM_INSTANCE
+            )
+          }
         />
       </Col>
       <Col xs="7" md="6" className="form-text text-muted small">
-        0–15. Defaults to 0; rarely changed.
+        {MIN_SYSTEM_INSTANCE}–{MAX_SYSTEM_INSTANCE}. Defaults to 0; rarely
+        changed.
       </Col>
     </Form.Group>
   )

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -52,6 +52,12 @@ interface ProviderOptions {
   gpioInvert?: boolean
   filtersEnabled?: boolean
   filters?: Array<{ source: string; pgn: string }>
+  // PGN 60928 Address Claim instance fields. Forwarded to
+  // canboatjs N2kDevice; canboatjs splits deviceInstance into the
+  // lower 3 bits and upper 5 bits of PGN 60928.
+  deviceInstance?: number
+  systemInstance?: number
+  format?: string
   [key: string]: unknown
 }
 
@@ -1428,6 +1434,75 @@ function CreateDeviceInput({
   )
 }
 
+function DeviceInstanceInput({
+  value,
+  onChange
+}: {
+  value: ProviderOptions
+  onChange: OnChangeHandler
+}) {
+  return (
+    <Form.Group as={Row} className="mb-3">
+      <Col xs="3" md="3">
+        <Form.Label htmlFor="provider-deviceInstance">Device Instance</Form.Label>
+      </Col>
+      <Col xs="2" md="3">
+        <Form.Control
+          id="provider-deviceInstance"
+          type="number"
+          min={0}
+          max={255}
+          name="options.deviceInstance"
+          value={
+            typeof value.deviceInstance === 'number'
+              ? value.deviceInstance
+              : value.deviceInstance ?? ''
+          }
+          onChange={(event) => onChange(event)}
+        />
+      </Col>
+      <Col xs="7" md="6" className="form-text text-muted small">
+        0–255. Identifies this signalk-server among multiple N2K nodes (split
+        into PGN 60928's lower 3 bits and upper 5 bits). Defaults to 0.
+      </Col>
+    </Form.Group>
+  )
+}
+
+function SystemInstanceInput({
+  value,
+  onChange
+}: {
+  value: ProviderOptions
+  onChange: OnChangeHandler
+}) {
+  return (
+    <Form.Group as={Row} className="mb-3">
+      <Col xs="3" md="3">
+        <Form.Label htmlFor="provider-systemInstance">System Instance</Form.Label>
+      </Col>
+      <Col xs="2" md="3">
+        <Form.Control
+          id="provider-systemInstance"
+          type="number"
+          min={0}
+          max={15}
+          name="options.systemInstance"
+          value={
+            typeof value.systemInstance === 'number'
+              ? value.systemInstance
+              : value.systemInstance ?? ''
+          }
+          onChange={(event) => onChange(event)}
+        />
+      </Col>
+      <Col xs="7" md="6" className="form-text text-muted small">
+        0–15. Defaults to 0; rarely changed.
+      </Col>
+    </Form.Group>
+  )
+}
+
 function CamelCaseCompatInput({
   value,
   onChange
@@ -1662,6 +1737,14 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
         value.options.type.indexOf('canboatjs') !== -1 && (
           <>
             <UseCanNameInput value={value.options} onChange={onChange} />
+            <DeviceInstanceInput
+              value={value.options}
+              onChange={onChange}
+            />
+            <SystemInstanceInput
+              value={value.options}
+              onChange={onChange}
+            />
             <CamelCaseCompatInput value={value.options} onChange={onChange} />
           </>
         )}

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -352,7 +352,18 @@ function nmea2000input(
     ]
   } else if (subOptions.type === 'n2k-ip-gateway-canboatjs') {
     const canboatjs = require('@canboat/canboatjs') as {
-      N2kIpGateway: unknown
+      N2kIpGateway?: unknown
+    }
+    // N2kIpGateway lives in canboatjs only after the PR that introduced
+    // the 'n2k-ip-gateway-canboatjs' type — older installs (still on the
+    // ^3.3.0 floor) will resolve to undefined here and otherwise throw a
+    // cryptic "undefined is not a constructor". Give the user something
+    // they can act on.
+    if (typeof canboatjs.N2kIpGateway !== 'function') {
+      throw new Error(
+        "Provider type 'n2k-ip-gateway-canboatjs' requires @canboat/canboatjs " +
+          'with N2kIpGateway exported. Update the canboatjs dependency.'
+      )
     }
     const N2kIpGatewayCtor = canboatjs.N2kIpGateway as unknown as CanboatCtor
     return [new N2kIpGatewayCtor(subOptions)]

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -350,6 +350,12 @@ function nmea2000input(
       }),
       new W2k01Ctor(subOptions, 'actisense', 'w2k-1-out')
     ]
+  } else if (subOptions.type === 'n2k-ip-gateway-canboatjs') {
+    const canboatjs = require('@canboat/canboatjs') as {
+      N2kIpGateway: unknown
+    }
+    const N2kIpGatewayCtor = canboatjs.N2kIpGateway as unknown as CanboatCtor
+    return [new N2kIpGatewayCtor(subOptions)]
   } else if (subOptions.type === 'navlink2-udp-canboatjs') {
     return [
       new Udp(subOptions as SubOptions & { port: number }),
@@ -579,7 +585,8 @@ export default class Simple extends Transform {
         opts.subOptions.type === 'ngt-1-canboatjs' ||
         opts.subOptions.type === 'canbus-canboatjs' ||
         opts.subOptions.type === 'w2k-1-n2k-actisense-canboatjs' ||
-        opts.subOptions.type === 'w2k-1-n2k-ascii-canboatjs'
+        opts.subOptions.type === 'w2k-1-n2k-ascii-canboatjs' ||
+        opts.subOptions.type === 'n2k-ip-gateway-canboatjs'
       ) {
         mappingType = 'NMEA2000JS'
       } else if (


### PR DESCRIPTION
## Summary

Wires up the new generic IP-based N2K gateway source from **canboat/canboatjs#437** so users can connect a candump-over-TCP gateway (e.g. an ESP32-based SensESP gateway) without misconfiguring the W2K-1 ASCII source as a stand-in.

Three things land here:

1. **packages/streams/src/simple.ts** — route `subOptions.type === 'n2k-ip-gateway-canboatjs'` through `new N2kIpGateway(subOptions)` and map it to the `NMEA2000JS` data type path (CanboatJs + N2kToSignalK), the same pipeline `canbus-canboatjs` uses.
2. **packages/server-admin-ui BasicProvider.tsx — new source dropdown entry** — adds *N2K IP Gateway (canboatjs)* as a selectable NMEA 2000 source with Host, Port, Text Format (candump3 default, plus candump2/candump1, YDRAW, Actisense, Actisense N2K ASCII, PCDIN), and an *Act as N2K device* toggle (defaults to on).
3. **packages/server-admin-ui BasicProvider.tsx — shared canboatjs inputs** — adds **Device Instance** (0–255) and **System Instance** (0–15) number fields alongside the existing *Use CAN NAME* and *CamelCase Compat* toggles for every `*-canboatjs` source type. Forwarded to canboatjs's `N2kDevice` so multiple signalk-server nodes on the same N2K bus can be told apart by the PGN 60928 instance fields.

### Note on scope of the instance fields

Point 3 explicitly covers **every** `*-canboatjs` source type, not just the new N2K IP Gateway. The gating in the UI is `value.options.type.indexOf('canboatjs') !== -1`, which matches `canbus-canboatjs` (Linux SocketCAN), `ngt-1-canboatjs` (Actisense NGT-1), `ydwg02-canboatjs` (Yacht Devices YDWG-02), `ikonvert-canboatjs`, `w2k-1-n2k-ascii-canboatjs`, `n2k-ip-gateway-canboatjs`, etc. The settings flow downstream is identical for all of them — the stream factory spreads `subOptions` into the stream constructor, the stream forwards its options to `new CanDevice(this, this.options)`, and canboatjs's `N2kDevice` constructor (in canboatjs#438) reads `deviceInstance` / `systemInstance` from there. So a single change in this PR gives the instance fields to every canboatjs-based connection — SocketCAN included — without per-source plumbing.

## Why bother with a new source

Without this, the closest fit for a candump-over-TCP gateway was the W2K-1 ASCII source — but the parsers are incompatible (W2K-1 ASCII parser silently rejects candump3 lines), so users were getting partial decoding (only the PGNs that happened to land in malformed-fallback paths) without realising it. Switching to the new source on the same bus showed real differences:

- **279 decoded PGN paths** vs **90** on the W2K-1 ASCII path (same gateway, same bus).
- **Full AIS reassembly** — fast-packet completion rate 100% over 60s for PGN 129038/129039/129809/129810; phantom-vessel count dropped from 552 to 0 once a related canboatjs reassembly bug was fixed (see canboatjs#437 commit 3).
- **Working bidirectional discovery** — `POST /skServer/n2kDiscoverDevices` produced 430 response frames from 18 bus devices in 25 seconds, populating 42 of 42 active bus devices in `/skServer/deviceIdentities`.

## Dependencies

This PR depends on two canboatjs PRs being merged and a release published:

- **canboat/canboatjs#437** — exports `N2kIpGateway`. Used by part 1 of this PR (stream factory).
- **canboat/canboatjs#438** — adds `deviceInstance` / `systemInstance` options to `N2kDevice`, plus numeric-string coercion for those options and a fix for the silent `uniqueNumber → 0x1FFFFF` sentinel emission. Used by part 3 (instance UI fields).

Reviewers can read and comment on this PR in parallel; the actual merge has to wait for the canboatjs side.

A related but independent PR — **#2693 (fix(deltacache): drop cached sources from removed providers on load)** — was opened to fix zombie devices showing up in the Data Browser after removing a connection. It's mergeable now, separate from this work.

## Test plan

- [x] `npm run format`, `npm run build` clean in both `packages/streams` and `packages/server-admin-ui`.
- [x] **Live tested on a real bus with 47+ NMEA 2000 devices.** Connected `n2k-ip-gateway-canboatjs` to a SensESP candump-over-TCP gateway at 192.168.0.120:2599 with `actAsCanDevice: true`, `useCanName: true`, `deviceInstance: 3`, `systemInstance: 3`.
- [x] Verified the new admin UI fields render correctly under the source-type dropdown and saved correctly to `settings.json`.
- [x] Confirmed `POST /skServer/n2kDiscoverDevices` works end-to-end through the new source: 430 response frames received from 18 bus devices.
- [x] Verified on a Maretron N2K analyzer that signalk-server appears in the bus device list with the configured Device Instance / System Instance and a non-sentinel unique number (the Maretron-visibility fix lives in canboatjs#438).
- [x] Verified end-to-end on a `canbus-canboatjs` (SocketCAN) connection in a node harness that the same `deviceInstance` / `systemInstance` options on `subOptions` flow through `CanbusStream → CanDevice → PGN 60928 fields` — no per-source code change needed.
