### PR TITLE
feat: add dataSize unit category for byte values

### DIFF
--- a/unitpreferences/categories.json
+++ b/unitpreferences/categories.json
@@ -24,7 +24,8 @@
     "dateTime": "RFC 3339 (UTC)",
     "epoch": "Epoch Seconds",
     "unitless": "tr",
-    "boolean": "bool"
+    "boolean": "bool",
+    "dataSize": "B"
   },
   "coreCategories": [
     "speed",
@@ -51,6 +52,7 @@
     "dateTime",
     "epoch",
     "unitless",
-    "boolean"
+    "boolean",
+    "dataSize"
   ]
 }

--- a/unitpreferences/presets/imperial-uk.json
+++ b/unitpreferences/presets/imperial-uk.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MiB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/presets/imperial-us.json
+++ b/unitpreferences/presets/imperial-us.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MiB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/presets/metric.json
+++ b/unitpreferences/presets/metric.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/presets/nautical-imperial-uk.json
+++ b/unitpreferences/presets/nautical-imperial-uk.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MiB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/presets/nautical-imperial-us.json
+++ b/unitpreferences/presets/nautical-imperial-us.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MiB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/presets/nautical-metric.json
+++ b/unitpreferences/presets/nautical-metric.json
@@ -118,6 +118,11 @@
       "baseUnit": "bool",
       "targetUnit": "bool",
       "displayFormat": "boolean"
+    },
+    "dataSize": {
+      "baseUnit": "B",
+      "targetUnit": "MB",
+      "displayFormat": "0.0"
     }
   }
 }

--- a/unitpreferences/standard-units-definitions.json
+++ b/unitpreferences/standard-units-definitions.json
@@ -875,5 +875,64 @@
         "longName": "ISO-8601 (UTC) format"
       }
     }
+  },
+  "B": {
+    "longName": "bytes",
+    "conversions": {
+      "B": {
+        "formula": "value * 1",
+        "inverseFormula": "value * 1",
+        "symbol": "B",
+        "longName": "bytes"
+      },
+      "KB": {
+        "formula": "value / 1000",
+        "inverseFormula": "value * 1000",
+        "symbol": "KB",
+        "longName": "kilobytes"
+      },
+      "MB": {
+        "formula": "value / 1000000",
+        "inverseFormula": "value * 1000000",
+        "symbol": "MB",
+        "longName": "megabytes"
+      },
+      "GB": {
+        "formula": "value / 1000000000",
+        "inverseFormula": "value * 1000000000",
+        "symbol": "GB",
+        "longName": "gigabytes"
+      },
+      "TB": {
+        "formula": "value / 1000000000000",
+        "inverseFormula": "value * 1000000000000",
+        "symbol": "TB",
+        "longName": "terabytes"
+      },
+      "KiB": {
+        "formula": "value / 1024",
+        "inverseFormula": "value * 1024",
+        "symbol": "KiB",
+        "longName": "kibibytes"
+      },
+      "MiB": {
+        "formula": "value / 1048576",
+        "inverseFormula": "value * 1048576",
+        "symbol": "MiB",
+        "longName": "mebibytes"
+      },
+      "GiB": {
+        "formula": "value / 1073741824",
+        "inverseFormula": "value * 1073741824",
+        "symbol": "GiB",
+        "longName": "gibibytes"
+      },
+      "TiB": {
+        "formula": "value / 1099511627776",
+        "inverseFormula": "value * 1099511627776",
+        "symbol": "TiB",
+        "longName": "tebibytes"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation

Plugins that surface byte-typed values via path metadata (e.g. a backup plugin reporting last-snapshot size, a logger reporting buffered bytes, a download UI reporting transferred bytes) have no way to opt into the unitpreferences conversion pipeline today. `units: 'B'` lands in the data browser as raw bytes — `62834975` instead of `~63 MB` — and users have to extend `custom-units-definitions.json` themselves to get readable values.

This is the first such plugin in the wild ([signalk-backup](https://github.com/dirkwa/signalk-backup) emitting `vessels.self.server.backup.lastRunBytes`), and the workaround already in this repo's `custom-units-definitions.json` (a hand-rolled `MB → GB/TB` entry) shows the gap is real.

## Solution

- `standard-units-definitions.json` gains a `B` (bytes) base unit with both decimal conversions (`KB/MB/GB/TB`) and binary conversions (`KiB/MiB/GiB/TiB`).
- `categories.json` adds a `dataSize` category whose SI base unit is `B`.
- All six built-in presets gain a `dataSize` entry: metric → `MB` (decimal, matches `df --si`); imperial → `MiB` (binary, matches typical OS file-size display).

## Notes

- I chose `B` as the symbol over `byte`/`bytes` because it matches the [Signal K spec's units pattern](https://signalk.org/specification/1.7.0/doc/data_model_metadata.html#meta-properties) (single-letter or abbreviation, e.g. `m`, `Pa`, `K`).
- Both decimal and binary conversions are included because user expectations differ: download speeds and storage marketing use decimal, OS file managers use binary. Per-preset default keeps the simple case simple.
- Existing user customizations in `custom-units-definitions.json` continue to work — those override standard definitions per the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds support for displaying byte values in human-readable units within the unit preferences system. Currently, plugins that expose byte-typed values via path metadata (with units: 'B') bypass the unit conversion pipeline, resulting in raw byte counts displayed instead of human-readable sizes like MB or GiB.

## Changes

**unitpreferences/standard-units-definitions.json**
Adds a new `B` (bytes) base unit definition with conversion formulas for both decimal (KB, MB, GB, TB) and binary (KiB, MiB, GiB, TiB) prefixed units, plus an identity conversion for bytes.

**unitpreferences/categories.json**
Extends the `categoryToBaseUnit` mapping to include `dataSize: "B"` and adds `dataSize` to the `coreCategories` list. Also adds `boolean: "bool"` to both mappings.

**Unit Presets**
Adds a new `dataSize` category to all six built-in presets:
- **Metric presets** (metric.json, nautical-metric.json): Set `dataSize` to target `MB` (decimal), matching tools like `df --si`
- **Imperial presets** (imperial-us.json, imperial-uk.json, nautical-imperial-us.json, nautical-imperial-uk.json): Set `dataSize` to target `MiB` (binary), matching typical OS file-size displays

Each preset entry specifies `baseUnit: "B"`, appropriate `targetUnit`, and `displayFormat: "0.0"`.

## Notes

Existing customizations in custom-units-definitions.json continue to override standard definitions, providing backward compatibility for users with custom configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->