### PR TITLE
ci(plugin-ci): retry npm install once on transient failure

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -221,12 +221,27 @@ jobs:
           node /tmp/validate-pkg.js
 
       - name: Install dependencies
+        # Retry once on transient failure. npm install / npm ci occasionally
+        # exits 127 from Git Bash on Windows + Node 24 (child-process PATH
+        # resolution race); a clean retry usually succeeds.
         run: |
+          npm_install_with_retry() {
+            local cmd="$1"
+            local attempts=2
+            for i in $(seq 1 $attempts); do
+              if $cmd; then return 0; fi
+              if [ "$i" -lt "$attempts" ]; then
+                echo "::warning::$cmd failed (attempt $i/$attempts), retrying in 5s..."
+                sleep 5
+              fi
+            done
+            return 1
+          }
           if [ -f package-lock.json ]; then
-            npm ci
+            npm_install_with_retry "npm ci"
           else
             echo "No package-lock.json found — using npm install instead of npm ci"
-            npm install
+            npm_install_with_retry "npm install"
           fi
         shell: bash
 


### PR DESCRIPTION
## Motivation

The Install dependencies step in plugin-ci.yml exits 127 occasionally on \`windows-2025\` + Node 24 + Git Bash — a known npm-on-Windows child-process PATH resolution race. We see it as random \`Windows / Node 24\` job failures across multiple plugins using this reusable workflow; the very next push of identical code succeeds.

Concrete recent example from [dirkwa/signalk-container PR #80](https://github.com/dirkwa/signalk-container/pull/80):

| Run | Result | Note |
|---|---|---|
| 26252915635 | success | docs commit |
| 26252917432 | **failure** | Windows / Node 24 only, exit 127 from \`npm install\` |
| 26252338055 | success | next commit, same install path |

9/10 jobs passed in 26252917432 — only Windows/Node24 hit the flake. The failure log shows \`npm install\` exiting 127 from \`C:\\Program Files\\Git\\bin\\bash.EXE\` without any meaningful error before it.

## Solution

Wrap both \`npm ci\` and \`npm install\` in a tiny shell retry helper:
- 2 attempts total, 5s sleep between
- emits a GitHub Actions \`::warning::\` on the first failure so the flake stays visible in the run summary without breaking the build
- pure bash, no new tooling, no compose actions

## Scope

This patch only touches the **desktop** install step (line 223-230) — that's where the Windows matrix runs. The \`signalk-integration\` job (line ~1509) uses the same idiom but runs only on \`ubuntu-latest\`, so it's not part of the observed flake surface. The \`armv7\` install (line ~1408) runs under QEMU on Linux too. Keeping the diff scoped to where the symptom actually fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Made

This PR adds retry logic to the plugin-ci workflow's desktop "Install dependencies" step to handle transient npm failures on Windows with Node 24.

## Implementation Details

The change wraps npm package installation in a bash retry helper that:
- Attempts the npm command up to 2 times (1 retry maximum)
- Sleeps 5 seconds between attempts on failure
- Emits a GitHub Actions warning message before retrying to surface the flake without failing the workflow

The logic conditionally uses `npm ci` when a `package-lock.json` exists, falling back to `npm install` with an informative message otherwise.

## Rationale

The Windows Node 24 environment occasionally encounters transient exit 127 failures from npm commands running under Git Bash, caused by child-process PATH resolution race conditions. These failures are non-deterministic; identical subsequent runs typically succeed. The retry mechanism mitigates this without adding external dependencies or composite actions.

## Scope

The change is limited to the desktop installation step (lines 223-245) where the Windows matrix runs. The signalk-integration and armv7 installation steps on Linux remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->