### PR TITLE
ci(plugin-ci): install signalk.requires before plugin under test

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1506,7 +1506,6 @@ jobs:
         run: |
           REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "${{ github.workspace }}/package.json" 2>/dev/null || true)
           if [ -z "$REQUIRES" ]; then
-            echo "No signalk.requires entries — skipping companion install."
             exit 0
           fi
           cd /tmp/sk-test

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1501,6 +1501,22 @@ jobs:
           npm init -y
           npm install signalk-server@${{ matrix.signalk-server-version }}
 
+      - name: Install plugins declared in signalk.requires
+        shell: bash
+        run: |
+          REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "${{ github.workspace }}/package.json" 2>/dev/null || true)
+          if [ -z "$REQUIRES" ]; then
+            echo "No signalk.requires entries — skipping companion install."
+            exit 0
+          fi
+          cd /tmp/sk-test
+          while IFS= read -r pkg; do
+            [ -z "$pkg" ] && continue
+            echo "::group::npm install $pkg (signalk.requires)"
+            npm install "$pkg"
+            echo "::endgroup::"
+          done <<< "$REQUIRES"
+
       - name: Build plugin
         env:
           BUILD_CMD: ${{ inputs.build-command }}


### PR DESCRIPTION
## Motivation

Plugins whose `package.json` declares `signalk.requires` (e.g. a plugin that needs `signalk-container` running) currently fail the `/skServer/plugins` integration assertion because their `start()` bails when the companion's global hook is missing. The only workaround today is `enable-signalk-integration: false`, which removes all integration coverage.

## Change

Before installing the plugin under test, read `signalk.requires` from its `package.json` and `npm install` each entry into the test server. No new workflow input — the plugin already declares its dependencies, the CI now honors them.

Skips silently when `signalk.requires` is absent or empty (the case for the vast majority of plugins). Entries are passed verbatim to `npm install`, so version specs like `signalk-container@1.9.0` work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the Plugin CI reusable workflow to install companion packages declared by a plugin before testing the plugin under test.

What changed
- The workflow adds a bash step that, after installing the SignalK server into /tmp/sk-test and before installing the plugin under test, reads signalk.requires from the plugin’s package.json (via jq).
- If signalk.requires is present and non-empty, the step iterates each entry and runs npm install for that entry inside /tmp/sk-test. Entries are passed verbatim, so versioned specs like signalk-container@1.9.0 are supported.
- The step is silent/skipped when signalk.requires is missing or empty.

Why this matters
- Plugins that declare companion dependencies via signalk.requires no longer fail the /skServer/plugins integration assertion because required companion packages are installed before the plugin starts. This preserves integration test coverage without requiring plugins to disable integration testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->