### PR TITLE
fix: accept Content-Type with charset on login endpoint

### DIFF
--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -664,14 +664,14 @@ function tokenSecurityFactory(
 
         login(name, password, remember)
           .then((reply) => {
-            const requestType = req.get('Content-Type')
+            const wantsJson = req.is('application/json')
 
             if (reply.statusCode === 200 && reply.token && reply.user) {
               setSessionCookie(res, req, reply.token, reply.user, {
                 rememberMe: remember
               })
 
-              if (requestType === 'application/json') {
+              if (wantsJson) {
                 res.json({
                   timeToLive: reply.timeToLive,
                   token: reply.token
@@ -680,7 +680,7 @@ function tokenSecurityFactory(
                 res.redirect(getSafeDestination(req.body.destination))
               }
             } else {
-              if (requestType === 'application/json') {
+              if (wantsJson) {
                 res.status(reply.statusCode).send(reply)
               } else {
                 res.status(reply.statusCode).send(reply.message)

--- a/test/security.js
+++ b/test/security.js
@@ -213,6 +213,28 @@ describe('Security', () => {
     limitedUserToken.length.should.equal(149)
   })
 
+  it('login with Content-Type charset parameter returns JSON', async function () {
+    // Clients like .NET StringContent, Java HttpClient and Python
+    // requests(json=...) send "application/json; charset=utf-8".
+    // The server must treat that the same as "application/json"
+    // and return the JSON token body rather than redirecting.
+    const result = await fetch(`${url}/signalk/v1/auth/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      },
+      body: JSON.stringify({
+        username: WRITE_USER_NAME,
+        password: WRITE_USER_PASSWORD
+      }),
+      redirect: 'manual'
+    })
+    result.status.should.equal(200)
+    const json = await result.json()
+    json.should.have.property('token')
+    json.token.length.should.be.greaterThan(0)
+  })
+
   it('websocket login works', async function () {
     const ws = new WebSocket(
       `ws://0.0.0.0:${port}/signalk/v1/stream?subscribe=none`


### PR DESCRIPTION
The `/login` and `/signalk/v1/auth/login` handlers check the request `Content-Type` with strict string equality against `'application/json'`. Any client that sends the equivalent `'application/json; charset=utf-8'` (the spec-conformant form) gets routed into the browser-form redirect branch and receives a 302 + HttpOnly cookie instead of the JSON token body.

This breaks clients that emit the charset parameter by default — .NET `StringContent`, Java `HttpClient`, Python `requests(json=...)`, and others — since they cannot read the cookie and cannot follow the redirect to a usable token.

Replaces the strict equality with `req.is('application/json')`, which parses the media type and ignores parameters, so both header forms reach the JSON branch.

A regression test in `test/security.js` posts with `Content-Type: application/json; charset=utf-8` and asserts the JSON token body is returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes response-format detection in the /login and /signalk/v1/auth/login handlers so requests with Content-Type parameters (for example, application/json; charset=utf-8) are treated as JSON requests. Clients that send Content-Type with charset now receive the JSON token body instead of being redirected with a 302 and an HttpOnly cookie.

## Changes

src/tokensecurity.ts
- Replaces strict equality check of the Content-Type header with Express’s req.is('application/json') to match media type irrespective of parameters.
- Introduces a wantsJson variable and uses it on both success and error paths to decide whether to return a JSON payload (token + timeToLive) or perform a browser redirect.

test/security.js
- Adds a regression test that POSTs to the login endpoint with Content-Type: application/json; charset=utf-8 and asserts a 200 response containing a non-empty token in the JSON body (using redirect: 'manual' to avoid following redirects).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->