### PR TITLE
fix: read plugin response Content-Type case-insensitively

### DIFF
--- a/src/wasm/loader/plugin-routes.ts
+++ b/src/wasm/loader/plugin-routes.ts
@@ -441,9 +441,11 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
           // Send body - try to parse as JSON if it's a string, otherwise send as-is
           let body = response.body
           if (typeof body === 'string') {
-            // Check if Content-Type is JSON
-            const contentType = response.headers?.['Content-Type'] || ''
-            if (contentType.includes('application/json')) {
+            const contentType = res.getHeader('content-type')
+            if (
+              typeof contentType === 'string' &&
+              contentType.includes('application/json')
+            ) {
               try {
                 // Try to parse the string as JSON - if it's double-escaped, this will fix it
                 body = JSON.parse(body)


### PR DESCRIPTION
The WASM plugin HTTP route handler at `src/wasm/loader/plugin-routes.ts:445` reads the response `Content-Type` like this:

```ts
const contentType = response.headers?.['Content-Type'] || ''
if (contentType.includes('application/json')) {
```

This is a case-sensitive object-key lookup. A WASM plugin author who returns headers as `'content-type': 'application/json'` (lowercase — the form HTTP/2 mandates and what `fetch`/`undici` produce by default) gets `undefined` here, and the body is never re-parsed as JSON. The endpoint then returns the raw double-escaped JSON string.

The fix reads the header back through `res.getHeader('content-type')`, which Node normalises case-insensitively. The headers were just set on `res` a few lines above (the loop at L436-438), so this is equivalent to reading from `response.headers` without the case fragility.

The existing `.includes('application/json')` already handles media-type parameters (`charset=utf-8`, etc.) correctly, so that part is unchanged. The `typeof contentType === 'string'` guard replaces the `|| ''` fallback because `res.getHeader` returns `string | number | string[] | undefined`.

No regression test is included: the existing `test/wasm-plugins.ts` integration coverage uses the `example-hello-assemblyscript` plugin which emits `'Content-Type'` (uppercase), so this path isn't exercised in either form today. Adding a regression test would require either modifying the example plugin or factoring the post-processing into a unit-testable helper — happy to do either if a maintainer prefers.