### PR TITLE
fix(admin-ui): include selectedPlugin in handlePluginClick deps

### DIFF
--- a/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
@@ -228,7 +228,7 @@ export default function PluginConfigurationList() {
         }
       }
     },
-    [plugins, selectPlugin]
+    [plugins, selectPlugin, selectedPlugin]
   )
 
   const saveData = useCallback(


### PR DESCRIPTION
## Why

After clicking between plugin rows on `/admin/#/serverConfiguration/plugins/-`, the right pane sometimes goes blank and only a hard reload restores it. The plugin row stops showing as selected (no bold, no gear icon) even though the user clicked it.

## Cause

`handlePluginClick` was extended in 42ed8f1a to support click-to-deselect. It reads `selectedPlugin` inside the callback, but the `useCallback` dep array only includes `[plugins, selectPlugin]`. The closure refreshes only when `plugins` changes — initial fetch and `PLUGINS_CHANGED` store updates. Between those events, the closure holds a stale `selectedPlugin`.

Failure sequence after a `PLUGINS_CHANGED` event captures `selectedPlugin = A` in the closure:

1. Click plugin B → state updates to B, closure still has A.
2. Click plugin A → closure says "A is currently selected" → `selectPlugin(null)`.
3. Right pane shows the placeholder.

Plugins that emit `PLUGINS_CHANGED` frequently (self-restarting plugins like `signalk-container` that save on user edits) hit this in normal use.

## Fix

Add `selectedPlugin` to the dep array so the callback re-memoizes on every selection change.

## Tested

Manually verified on a local server with `signalk-container` installed: before the fix, clicking Container Manager → another plugin → Container Manager landed on the blank placeholder. After the fix, the same sequence selects Container Manager normally. Click-to-deselect (single plugin row twice) still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR fixes a stale closure issue in the plugin configuration UI that causes the right pane to go blank when clicking between plugin rows and loses the selected state.

## Changes

The `handlePluginClick` callback in `PluginConfigurationList` now includes `selectedPlugin` in its `useCallback` dependency array. This ensures the callback closes over the latest selected plugin value when determining whether to deselect the current selection or switch to a newly clicked plugin. Previously, the callback would only depend on `[plugins, selectPlugin]`, causing it to retain a stale reference to `selectedPlugin` between plugin fetch events, which allowed unintended deselections.

## Testing

Manual verification on a local server confirms the fix resolves the UI state issues and restores proper click-to-deselect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->