### PR TITLE
feat(serverroutes): add GET /skServer/diagnostics

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -23,6 +23,7 @@ export const TRACKED_PACKAGES = [
   '@canboat/ts-pgns',
   '@signalk/n2k-signalk',
   '@signalk/nmea0183-signalk',
+  '@signalk/path-metadata',
   '@signalk/server-admin-ui',
   '@signalk/server-api',
   '@signalk/streams',

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -26,8 +26,7 @@ export const TRACKED_PACKAGES = [
   '@signalk/path-metadata',
   '@signalk/server-admin-ui',
   '@signalk/server-api',
-  '@signalk/streams',
-  'bonjour-service'
+  '@signalk/streams'
 ] as const
 
 export interface InstalledPackage {
@@ -68,8 +67,8 @@ function readVersionAt(pkgJsonPath: string): string | undefined {
 // of only `baseDir/node_modules` misses dependencies npm has *hoisted*
 // to an ancestor `node_modules`: in the production image signalk-server
 // runs from `…/node_modules/signalk-server`, so `appPath` is that nested
-// dir, but `@canboat/*` and `bonjour-service` are hoisted one level up to
-// the outer `node_modules`. Without the walk they'd be silently dropped.
+// dir, but `@canboat/*` is hoisted one level up to the outer
+// `node_modules`. Without the walk they'd be silently dropped.
 function findPackageVersion(
   baseDir: string,
   packageName: string

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Signal K
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { Config } from './config/config'
+import { createDebug } from './debug'
+
+const debug = createDebug('signalk-server:diagnostics')
+
+// Curated list of runtime dependencies whose drift matters to the boat operator.
+// The downstream consumer (signalk-doctor-server) does not maintain its own
+// copy — it trusts whatever this list returns, so the allow-list lives here.
+export const TRACKED_PACKAGES = [
+  '@canboat/canboatjs',
+  '@canboat/ts-pgns',
+  '@signalk/n2k-signalk',
+  '@signalk/nmea0183-signalk',
+  '@signalk/server-admin-ui',
+  '@signalk/server-api',
+  '@signalk/streams',
+  'bonjour-service'
+] as const
+
+export interface InstalledPackage {
+  name: string
+  version: string
+}
+
+export interface Diagnostics {
+  packages: InstalledPackage[]
+}
+
+export type DiagnosticsConfig = Pick<Config, 'appPath' | 'configPath'>
+
+interface PackageJson {
+  version?: unknown
+}
+
+function readPackageVersion(
+  searchDirs: string[],
+  packageName: string
+): string | undefined {
+  for (const dir of searchDirs) {
+    const pkgPath = path.join(dir, packageName, 'package.json')
+    if (!fs.existsSync(pkgPath)) {
+      continue
+    }
+    try {
+      const raw = fs.readFileSync(pkgPath, 'utf8')
+      const parsed = JSON.parse(raw) as PackageJson
+      if (typeof parsed.version === 'string') {
+        return parsed.version
+      }
+    } catch (err) {
+      debug.enabled &&
+        debug(`failed reading ${pkgPath}: ${(err as Error).message}`)
+    }
+  }
+  return undefined
+}
+
+export function getDiagnostics(config: DiagnosticsConfig): Diagnostics {
+  const { appPath, configPath } = config
+  const searchDirs = (
+    appPath === configPath ? [appPath] : [configPath, appPath]
+  ).map((p) => path.join(p, 'node_modules'))
+
+  const packages: InstalledPackage[] = []
+  for (const name of TRACKED_PACKAGES) {
+    const version = readPackageVersion(searchDirs, name)
+    if (version !== undefined) {
+      packages.push({ name, version })
+    }
+  }
+  return { packages }
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -45,38 +45,66 @@ interface PackageJson {
   version?: unknown
 }
 
-function readPackageVersion(
-  searchDirs: string[],
-  packageName: string
-): string | undefined {
-  for (const dir of searchDirs) {
-    const pkgPath = path.join(dir, packageName, 'package.json')
-    if (!fs.existsSync(pkgPath)) {
-      continue
+function readVersionAt(pkgJsonPath: string): string | undefined {
+  if (!fs.existsSync(pkgJsonPath)) {
+    return undefined
+  }
+  try {
+    const raw = fs.readFileSync(pkgJsonPath, 'utf8')
+    const parsed = JSON.parse(raw) as PackageJson
+    if (typeof parsed.version === 'string') {
+      return parsed.version
     }
-    try {
-      const raw = fs.readFileSync(pkgPath, 'utf8')
-      const parsed = JSON.parse(raw) as PackageJson
-      if (typeof parsed.version === 'string') {
-        return parsed.version
-      }
-    } catch (err) {
-      debug.enabled &&
-        debug(`failed reading ${pkgPath}: ${(err as Error).message}`)
-    }
+  } catch (err) {
+    debug.enabled &&
+      debug(`failed reading ${pkgJsonPath}: ${(err as Error).message}`)
   }
   return undefined
 }
 
+// Resolve a package's version starting from `baseDir`, walking up the
+// directory tree and checking `<ancestor>/node_modules/<pkg>/package.json`
+// at each level — the same lookup Node's own resolver does. A flat check
+// of only `baseDir/node_modules` misses dependencies npm has *hoisted*
+// to an ancestor `node_modules`: in the production image signalk-server
+// runs from `…/node_modules/signalk-server`, so `appPath` is that nested
+// dir, but `@canboat/*` and `bonjour-service` are hoisted one level up to
+// the outer `node_modules`. Without the walk they'd be silently dropped.
+function findPackageVersion(
+  baseDir: string,
+  packageName: string
+): string | undefined {
+  let dir = path.resolve(baseDir)
+  for (;;) {
+    const version = readVersionAt(
+      path.join(dir, 'node_modules', packageName, 'package.json')
+    )
+    if (version !== undefined) {
+      return version
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      return undefined
+    }
+    dir = parent
+  }
+}
+
 export function getDiagnostics(config: DiagnosticsConfig): Diagnostics {
   const { appPath, configPath } = config
-  const searchDirs = (
-    appPath === configPath ? [appPath] : [configPath, appPath]
-  ).map((p) => path.join(p, 'node_modules'))
+  // configPath first so an operator's appstore-installed copy wins over a
+  // version bundled in the app image; dedupe when they coincide.
+  const baseDirs = appPath === configPath ? [appPath] : [configPath, appPath]
 
   const packages: InstalledPackage[] = []
   for (const name of TRACKED_PACKAGES) {
-    const version = readPackageVersion(searchDirs, name)
+    let version: string | undefined
+    for (const base of baseDirs) {
+      version = findPackageVersion(base, name)
+      if (version !== undefined) {
+        break
+      }
+    }
     if (version !== undefined) {
       packages.push({ name, version })
     }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -66,6 +66,7 @@ import redirects from './redirects.json'
 import rateLimit from 'express-rate-limit'
 import { execSync } from 'child_process'
 import { recommendedVersion as recommendedNodeVersion } from './version'
+import { getDiagnostics } from './diagnostics'
 import { Type } from '@sinclair/typebox'
 import { Value } from '@sinclair/typebox/value'
 
@@ -2032,6 +2033,13 @@ module.exports = function (
       recommendedNodeVersion
     })
   })
+
+  app.get(
+    `${SERVERROUTESPREFIX}/diagnostics`,
+    (_req: Request, res: Response) => {
+      res.json(getDiagnostics(app.config))
+    }
+  )
 
   app.securityStrategy.addAdminWriteMiddleware(
     `${SERVERROUTESPREFIX}/rememberDebug`

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -751,7 +751,8 @@ function tokenSecurityFactory(
       '/restore',
       '/providers',
       '/vessel',
-      '/serialports'
+      '/serialports',
+      '/diagnostics'
     ].forEach((p) =>
       app.use(`${SERVERROUTESPREFIX}${p}`, adminAuthenticationMiddleware(false))
     )

--- a/test/diagnostics.ts
+++ b/test/diagnostics.ts
@@ -93,6 +93,33 @@ describe('getDiagnostics', () => {
     }
   })
 
+  it('finds a dependency hoisted to an ancestor node_modules', () => {
+    // Mirrors the production image: signalk-server runs from a nested
+    // `.../node_modules/signalk-server` dir (appPath), but npm hoists
+    // @canboat/* and bonjour-service to the outer node_modules one level
+    // up. A flat lookup of appPath/node_modules misses them.
+    const outerNodeModules = path.join(tmpDir, 'node_modules')
+    const appPath = path.join(outerNodeModules, 'signalk-server')
+    fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true })
+
+    // Hoisted to the outer node_modules, not under appPath.
+    writeFakePackage(outerNodeModules, '@canboat/canboatjs', '3.19.0')
+    // Co-located with the app, under appPath/node_modules.
+    writeFakePackage(
+      path.join(appPath, 'node_modules'),
+      '@signalk/streams',
+      '6.6.0'
+    )
+
+    const config = { appPath, configPath: appPath }
+
+    const result = getDiagnostics(config)
+    chai.expect(result.packages).to.deep.include.members([
+      { name: '@canboat/canboatjs', version: '3.19.0' },
+      { name: '@signalk/streams', version: '6.6.0' }
+    ])
+  })
+
   it('handles malformed package.json without throwing', () => {
     const nodeModules = path.join(tmpDir, 'node_modules')
     const pkgDir = path.join(nodeModules, '@canboat/canboatjs')

--- a/test/diagnostics.ts
+++ b/test/diagnostics.ts
@@ -33,7 +33,7 @@ describe('getDiagnostics', () => {
   it('returns versions for tracked packages that are installed', () => {
     const nodeModules = path.join(tmpDir, 'node_modules')
     writeFakePackage(nodeModules, '@canboat/canboatjs', '3.18.0')
-    writeFakePackage(nodeModules, 'bonjour-service', '1.3.1')
+    writeFakePackage(nodeModules, '@canboat/ts-pgns', '1.11.0')
 
     const config = {
       appPath: tmpDir,
@@ -43,7 +43,7 @@ describe('getDiagnostics', () => {
     const result = getDiagnostics(config)
     chai.expect(result.packages).to.deep.include.members([
       { name: '@canboat/canboatjs', version: '3.18.0' },
-      { name: 'bonjour-service', version: '1.3.1' }
+      { name: '@canboat/ts-pgns', version: '1.11.0' }
     ])
   })
 
@@ -72,10 +72,10 @@ describe('getDiagnostics', () => {
     try {
       writeFakePackage(
         path.join(appPath, 'node_modules'),
-        'bonjour-service',
+        '@canboat/ts-pgns',
         '1.0.0'
       )
-      writeFakePackage(userInstall, 'bonjour-service', '1.3.1')
+      writeFakePackage(userInstall, '@canboat/ts-pgns', '1.3.1')
 
       const config = {
         appPath,
@@ -83,9 +83,9 @@ describe('getDiagnostics', () => {
       }
 
       const result = getDiagnostics(config)
-      const entry = result.packages.find((p) => p.name === 'bonjour-service')
+      const entry = result.packages.find((p) => p.name === '@canboat/ts-pgns')
       chai.expect(entry).to.deep.equal({
-        name: 'bonjour-service',
+        name: '@canboat/ts-pgns',
         version: '1.3.1'
       })
     } finally {
@@ -96,8 +96,8 @@ describe('getDiagnostics', () => {
   it('finds a dependency hoisted to an ancestor node_modules', () => {
     // Mirrors the production image: signalk-server runs from a nested
     // `.../node_modules/signalk-server` dir (appPath), but npm hoists
-    // @canboat/* and bonjour-service to the outer node_modules one level
-    // up. A flat lookup of appPath/node_modules misses them.
+    // @canboat/* to the outer node_modules one level up. A flat lookup
+    // of appPath/node_modules misses them.
     const outerNodeModules = path.join(tmpDir, 'node_modules')
     const appPath = path.join(outerNodeModules, 'signalk-server')
     fs.mkdirSync(path.join(appPath, 'node_modules'), { recursive: true })

--- a/test/diagnostics.ts
+++ b/test/diagnostics.ts
@@ -1,0 +1,115 @@
+import chai from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { getDiagnostics, TRACKED_PACKAGES } from '../src/diagnostics'
+
+const writeFakePackage = (
+  nodeModulesDir: string,
+  name: string,
+  version: string
+) => {
+  const pkgDir = path.join(nodeModulesDir, name)
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version })
+  )
+}
+
+describe('getDiagnostics', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'diagnostics-'))
+    fs.mkdirSync(path.join(tmpDir, 'node_modules'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns versions for tracked packages that are installed', () => {
+    const nodeModules = path.join(tmpDir, 'node_modules')
+    writeFakePackage(nodeModules, '@canboat/canboatjs', '3.18.0')
+    writeFakePackage(nodeModules, 'bonjour-service', '1.3.1')
+
+    const config = {
+      appPath: tmpDir,
+      configPath: tmpDir
+    }
+
+    const result = getDiagnostics(config)
+    chai.expect(result.packages).to.deep.include.members([
+      { name: '@canboat/canboatjs', version: '3.18.0' },
+      { name: 'bonjour-service', version: '1.3.1' }
+    ])
+  })
+
+  it('skips tracked packages that are not installed', () => {
+    const nodeModules = path.join(tmpDir, 'node_modules')
+    writeFakePackage(nodeModules, '@canboat/canboatjs', '3.18.0')
+
+    const config = {
+      appPath: tmpDir,
+      configPath: tmpDir
+    }
+
+    const result = getDiagnostics(config)
+    chai.expect(result.packages).to.have.lengthOf(1)
+    chai.expect(result.packages[0]).to.deep.equal({
+      name: '@canboat/canboatjs',
+      version: '3.18.0'
+    })
+  })
+
+  it('prefers configPath over appPath when both have the same package', () => {
+    const userInstall = path.join(tmpDir, 'node_modules')
+    const appPath = fs.mkdtempSync(path.join(os.tmpdir(), 'apppath-'))
+    fs.mkdirSync(path.join(appPath, 'node_modules'))
+
+    try {
+      writeFakePackage(
+        path.join(appPath, 'node_modules'),
+        'bonjour-service',
+        '1.0.0'
+      )
+      writeFakePackage(userInstall, 'bonjour-service', '1.3.1')
+
+      const config = {
+        appPath,
+        configPath: tmpDir
+      }
+
+      const result = getDiagnostics(config)
+      const entry = result.packages.find((p) => p.name === 'bonjour-service')
+      chai.expect(entry).to.deep.equal({
+        name: 'bonjour-service',
+        version: '1.3.1'
+      })
+    } finally {
+      fs.rmSync(appPath, { recursive: true, force: true })
+    }
+  })
+
+  it('handles malformed package.json without throwing', () => {
+    const nodeModules = path.join(tmpDir, 'node_modules')
+    const pkgDir = path.join(nodeModules, '@canboat/canboatjs')
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{ not json')
+
+    const config = {
+      appPath: tmpDir,
+      configPath: tmpDir
+    }
+
+    const result = getDiagnostics(config)
+    chai.expect(result.packages).to.deep.equal([])
+  })
+
+  it('exposes the curated tracked-packages list', () => {
+    chai.expect(TRACKED_PACKAGES).to.include('@canboat/canboatjs')
+    chai.expect(TRACKED_PACKAGES).to.include('@signalk/server-admin-ui')
+  })
+})


### PR DESCRIPTION
## Why

Image-pinned npm dependencies (canboatjs, @signalk/n2k-signalk, @signalk/server-admin-ui, …) drift behind upstream releases between server versions, and operators have no signal that drift is happening. Ecosystem tooling — drift detectors, observability dashboards, diagnostics plugins — needs a uniform read-only way to ask the running server what's actually inside the image.

`package.json` ranges aren't enough: deps are baked at Docker build time, so the truth is the installed version, not the range. The existing `/skServer/nodeInfo` covers Node/npm only.

## How

- New `src/diagnostics.ts`: curated allow-list of 7 runtime deps + `getDiagnostics(config)` reader. Resolves each tracked package by walking up the directory tree from `configPath` then `appPath` (preferring `configPath`), checking `<ancestor>/node_modules/<pkg>/package.json` at each level the way Node's own resolver does — so dependencies npm has **hoisted** to an ancestor `node_modules` are found, not just those sitting directly beside the app. Reads each tracked package's `package.json`, silently skips packages that aren't present, tolerates malformed JSON via debug log.
- New `GET /skServer/diagnostics` route in `serverroutes.ts` next to `/nodeInfo`, gated with `adminAuthenticationMiddleware` (same posture as `/restart`, `/plugins`, `/settings`, `/serialports`, etc.).
- Returns `{ packages: [{ name, version }] }`.

Shaped as an envelope (`{ packages: ... }`) rather than a bare array, so future diagnostic fields can land as sibling keys without new endpoints.

The package allow-list is intentionally narrow — boat-operator-relevant runtime deps only — so consumers don't have to filter noise. If the maintainers prefer it configurable rather than hardcoded, happy to change.

## Tested

- Unit tests in `test/diagnostics.ts`: present packages returned, absent skipped, configPath preferred over appPath, malformed `package.json` tolerated, allow-list export.
- `npm test` → 706 passing.
- End-to-end against a security-enabled instance: unauth → 401, admin bearer → 200 with the tracked packages.

- Verified against the production `:dirkwa` image layout (signalk-server runs from a nested `…/node_modules/signalk-server`, with `@canboat/*` hoisted to the outer `node_modules`): the endpoint now returns the `@canboat` packages alongside the `@signalk/*` ones, where the flat lookup previously dropped them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an admin-gated diagnostics endpoint and supporting module that report runtime-installed versions of a curated set of npm dependencies.

## Changes

**New module src/diagnostics.ts**
- Exports TRACKED_PACKAGES, a curated allow-list of seven runtime packages: `@canboat/canboatjs`, `@canboat/ts-pgns`, `@signalk/n2k-signalk`, `@signalk/nmea0183-signalk`, `@signalk/server-admin-ui`, `@signalk/server-api`, and `@signalk/streams`.
- Exports InstalledPackage and Diagnostics interfaces and DiagnosticsConfig type.
- Implements getDiagnostics(config) which derives candidate base directories from config.configPath and config.appPath (preferring configPath), walks upward through ancestor directories to locate hoisted node_modules, checks <ancestor>/node_modules/<pkg>/package.json for each tracked package, reads package.json to extract string versions, silently skips absent packages, and tolerates malformed JSON (logging read/parse failures via the module debug logger). Uses debug.enabled guards to avoid eager template evaluation in debug calls.
- Exports the allow-list for tests and other code.

**New GET /skServer/diagnostics route (src/serverroutes.ts)**
- Adds an admin-protected, read-only route colocated with other server admin routes that responds with JSON of shape { packages: [{ name, version }] } (an envelope for future diagnostic fields).
- Route protection is applied via the project’s admin path registration so adminAuthenticationMiddleware guards the route.

**Updated src/tokensecurity.ts**
- Registers /skServer/diagnostics in the list of admin-authenticated paths so the route is protected.

**Tests (test/diagnostics.ts)**
- Adds unit tests that verify returned packages for present installations, omission of absent packages, configPath precedence over appPath, locating packages hoisted to ancestor node_modules, tolerant handling of malformed package.json, and the exported TRACKED_PACKAGES contents.

## Commits and verification
- getDiagnostics walks ancestor node_modules to find hoisted dependencies (fixes hoisting-related misses for `@canboat` packages).
- Removes bonjour-service from TRACKED_PACKAGES and updates tests after that dependency is removed upstream.
- Unit tests pass; full test suite reports 706 passing.
- End-to-end verification with security enabled: unauthenticated requests return 401; requests with an admin bearer token return 200 and the tracked packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

