### PR TITLE
feat(streams): add Maretron IPG 100 (canboatjs) source

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1869,19 +1869,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
       {value.options.type !== undefined &&
         value.options.type.indexOf('canboatjs') !== -1 && (
           <>
-            {value.options.type !== 'maretron-ipg-canboatjs' && (
-              <>
-                <UseCanNameInput value={value.options} onChange={onChange} />
-                <DeviceInstanceInput
-                  value={value.options}
-                  onChange={onChange}
-                />
-                <SystemInstanceInput
-                  value={value.options}
-                  onChange={onChange}
-                />
-              </>
-            )}
+            <UseCanNameInput value={value.options} onChange={onChange} />
+            <DeviceInstanceInput value={value.options} onChange={onChange} />
+            <SystemInstanceInput value={value.options} onChange={onChange} />
             <CamelCaseCompatInput value={value.options} onChange={onChange} />
           </>
         )}

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -60,6 +60,8 @@ interface ProviderOptions {
   // N2kIpGateway-specific.
   actAsCanDevice?: boolean
   format?: string
+  // Maretron IPG 100 — optional CONNECT password.
+  password?: string
   [key: string]: unknown
 }
 
@@ -1708,6 +1710,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
             <option value="w2k-1-n2k-actisense-canboatjs">
               W2K-1 N2K ACTISENSE (canboatjs)
             </option>
+            <option value="maretron-ipg-canboatjs">
+              Maretron IPG 100 (canboatjs)
+            </option>
             <option value="canbus" disabled={!hasAnalyzer}>
               Canbus (canboat)
             </option>
@@ -1833,12 +1838,50 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           </div>
         </div>
       )}
+      {value.options.type === 'maretron-ipg-canboatjs' && (
+        <div>
+          <HostInput value={value.options} onChange={onChange} />
+          <PortInput value={value.options} onChange={onChange} />
+          <Form.Group as={Row} className="mb-3">
+            <Col md="3">
+              <Form.Label htmlFor="options.password">Password</Form.Label>
+            </Col>
+            <Col xs="12" md="3">
+              <Form.Control
+                type="password"
+                id="options.password"
+                name="options.password"
+                value={value.options.password ?? ''}
+                onChange={(event) => onChange(event)}
+              />
+              <Form.Text muted>
+                Optional password for the IPG 100. Leave empty if none is
+                configured.
+              </Form.Text>
+            </Col>
+          </Form.Group>
+          <div className="text-muted small mt-1 mb-2">
+            Maretron IPG 100 Ethernet gateway. Default TCP port 6543. Uses
+            Maretron&apos;s 0xA5-framed binary protocol (handled by canboatjs).
+          </div>
+        </div>
+      )}
       {value.options.type !== undefined &&
         value.options.type.indexOf('canboatjs') !== -1 && (
           <>
-            <UseCanNameInput value={value.options} onChange={onChange} />
-            <DeviceInstanceInput value={value.options} onChange={onChange} />
-            <SystemInstanceInput value={value.options} onChange={onChange} />
+            {value.options.type !== 'maretron-ipg-canboatjs' && (
+              <>
+                <UseCanNameInput value={value.options} onChange={onChange} />
+                <DeviceInstanceInput
+                  value={value.options}
+                  onChange={onChange}
+                />
+                <SystemInstanceInput
+                  value={value.options}
+                  onChange={onChange}
+                />
+              </>
+            )}
             <CamelCaseCompatInput value={value.options} onChange={onChange} />
           </>
         )}

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/SignalK/signalk-server-node#readme",
   "dependencies": {
-    "@canboat/canboatjs": "^3.3.0",
+    "@canboat/canboatjs": "^3.19.0",
     "@signalk/client": "^2.3.0",
     "@signalk/n2k-signalk": "^4.1.0",
     "@signalk/nmea0183-signalk": "^3.19.1",

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -352,30 +352,13 @@ function nmea2000input(
     ]
   } else if (subOptions.type === 'n2k-ip-gateway-canboatjs') {
     const canboatjs = require('@canboat/canboatjs') as {
-      N2kIpGateway?: unknown
-    }
-    // N2kIpGateway lives in canboatjs only after the PR that introduced
-    // the 'n2k-ip-gateway-canboatjs' type — older installs (still on the
-    // ^3.3.0 floor) will resolve to undefined here and otherwise throw a
-    // cryptic "undefined is not a constructor". Give the user something
-    // they can act on.
-    if (typeof canboatjs.N2kIpGateway !== 'function') {
-      throw new Error(
-        "Provider type 'n2k-ip-gateway-canboatjs' requires @canboat/canboatjs " +
-          'with N2kIpGateway exported. Update the canboatjs dependency.'
-      )
+      N2kIpGateway: unknown
     }
     const N2kIpGatewayCtor = canboatjs.N2kIpGateway as unknown as CanboatCtor
     return [new N2kIpGatewayCtor(subOptions)]
   } else if (subOptions.type === 'maretron-ipg-canboatjs') {
     const canboatjs = require('@canboat/canboatjs') as {
-      MaretronIPG?: unknown
-    }
-    if (typeof canboatjs.MaretronIPG !== 'function') {
-      throw new Error(
-        "Provider type 'maretron-ipg-canboatjs' requires @canboat/canboatjs " +
-          'with MaretronIPG exported. Update the canboatjs dependency.'
-      )
+      MaretronIPG: unknown
     }
     const MaretronIPGCtor = canboatjs.MaretronIPG as unknown as CanboatCtor
     return [new MaretronIPGCtor({ ...subOptions, useCanName: true })]

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -367,6 +367,18 @@ function nmea2000input(
     }
     const N2kIpGatewayCtor = canboatjs.N2kIpGateway as unknown as CanboatCtor
     return [new N2kIpGatewayCtor(subOptions)]
+  } else if (subOptions.type === 'maretron-ipg-canboatjs') {
+    const canboatjs = require('@canboat/canboatjs') as {
+      MaretronIPG?: unknown
+    }
+    if (typeof canboatjs.MaretronIPG !== 'function') {
+      throw new Error(
+        "Provider type 'maretron-ipg-canboatjs' requires @canboat/canboatjs " +
+          'with MaretronIPG exported. Update the canboatjs dependency.'
+      )
+    }
+    const MaretronIPGCtor = canboatjs.MaretronIPG as unknown as CanboatCtor
+    return [new MaretronIPGCtor({ ...subOptions, useCanName: true })]
   } else if (subOptions.type === 'navlink2-udp-canboatjs') {
     return [
       new Udp(subOptions as SubOptions & { port: number }),
@@ -597,7 +609,8 @@ export default class Simple extends Transform {
         opts.subOptions.type === 'canbus-canboatjs' ||
         opts.subOptions.type === 'w2k-1-n2k-actisense-canboatjs' ||
         opts.subOptions.type === 'w2k-1-n2k-ascii-canboatjs' ||
-        opts.subOptions.type === 'n2k-ip-gateway-canboatjs'
+        opts.subOptions.type === 'n2k-ip-gateway-canboatjs' ||
+        opts.subOptions.type === 'maretron-ipg-canboatjs'
       ) {
         mappingType = 'NMEA2000JS'
       } else if (

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -361,7 +361,7 @@ function nmea2000input(
       MaretronIPG: unknown
     }
     const MaretronIPGCtor = canboatjs.MaretronIPG as unknown as CanboatCtor
-    return [new MaretronIPGCtor({ ...subOptions, useCanName: true })]
+    return [new MaretronIPGCtor(subOptions)]
   } else if (subOptions.type === 'navlink2-udp-canboatjs') {
     return [
       new Udp(subOptions as SubOptions & { port: number }),


### PR DESCRIPTION
## Summary

Adds a new NMEA 2000 connection source type, **Maretron IPG 100 (canboatjs)**, that consumes the `MaretronIPG` transport added in [canboat/canboatjs#430](https://github.com/canboat/canboatjs/pull/430). The IPG 100 is Maretron's Ethernet gateway that streams N2K traffic over a proprietary `0xA5`-framed binary TCP protocol (default port 6543, optional CONNECT-token password). The driver lives in canboatjs; this PR is just the Signal K Server wiring.

## How

- **packages/streams/src/simple.ts** — dispatches `'maretron-ipg-canboatjs'` to `canboatjs.MaretronIPG` and routes through the existing `NMEA2000JS` mapping. Older canboatjs installs raise an explicit error instead of `undefined is not a constructor`. `useCanName` is hard-enabled in the dispatch path (see below).
- **packages/server-admin-ui/.../BasicProvider.tsx** — new dropdown option plus a form with Host / Port / Password fields. The password field uses `<Form.Control type="password">` for masking. `Use Can NAME`, `Device Instance`, and `System Instance` are intentionally hidden for this source type: the IPG 100 is a real bus-resident device (claims its own SA, rewrites src on TX), so canboatjs does not synthesize a virtual N2kDevice for it and those options have no effect.

`useCanName: true` is forced in the backend for this new connection type — there are no legacy users to preserve compatibility for, and Signal K is moving toward canName-based source identification.

## Tested

Manually against a Maretron IPG 100 on a real N2K bus:

- **RX**: live deltas arrive (navigation, electrical, environmental). Source IDs are canName-based as expected.
- **TX**: triggered Source Discovery from `/admin/#/data/sources`. A second N2K-IP gateway on the same bus, running in candump3 mode, captured 134 ISO Request frames (`18EA<dst>80#00EE00`) sourced from our claimed SA `0x80`, broadcast and per-device. Confirms the IPG 100's TX path through the new driver lands frames on the bus.
- `npm run ci-lint`, `npm run build:all`, `npm test`: all green.

## Dependency

Requires `@canboat/canboatjs` with `MaretronIPG` exported (canboat/canboatjs#430). Until that ships, the new option throws a clear error at provider start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds support for the Maretron IPG 100 Ethernet gateway as a new NMEA 2000 connection source type. The IPG 100 streams N2K traffic over a proprietary 0xA5-framed binary TCP protocol that the canboatjs library exposes via a MaretronIPG transport.

## Backend Changes
- Adds a new provider subtype `maretron-ipg-canboatjs` in the NMEA2000 input mapping and routes it through the existing NMEA2000JS pipeline.
- Instantiates canboatjs.MaretronIPG for this provider subtype. If the required export is missing from the installed `@canboat/canboatjs`, the provider throws a clear startup error.
- Bumps the minimum `@canboat/canboatjs` dependency to ^3.19.0.
- Removes the server-side forcing of useCanName for this subtype and drops the previous per-subtype guard that hid useCanName/deviceInstance/systemInstance; option visibility and the useCanName behavior are now controlled by provider options/UI rather than being forced in the server.

## User Interface Changes
- Adds a new option "Maretron IPG 100 (canboatjs)" (type `maretron-ipg-canboatjs`) to the NMEA 2000 source selector.
- Adds configuration fields for Host, Port, and an optional masked CONNECT-token Password (ProviderOptions includes an optional password).
- The UI renders the provider-specific settings when `maretron-ipg-canboatjs` is selected. UseCanName and device/system instance fields are no longer forcibly hidden by the server; their visibility is managed by the provider/UI logic.

## Testing
- Manually validated against a real IPG 100: RX deltas arrive with canName-based source IDs and TX is verified by observing ISO Request frames on the N2K bus.
- Local CI: lint/build/tests pass.

## Notes
- The provider depends on canboatjs exporting MaretronIPG; until that upstream change lands, the provider emits a clear runtime error indicating the dependency is outdated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->