### PR TITLE
fix(test): make discovery.ts type-check under CommonJS

### DIFF
--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -87,6 +87,12 @@ describe('runDiscovery', () => {
   it('does not stop a browser twice after an internal error stop', () => {
     const scheduledCallbacks: Array<() => void> = []
 
+    const makeFakeTimeoutHandle = (): ReturnType<typeof setTimeout> => {
+      const handle = originalSetTimeout(() => {}, 0)
+      clearTimeout(handle)
+      return handle
+    }
+
     global.setTimeout = ((...args: unknown[]) => {
       const callback = args[0]
 
@@ -94,7 +100,7 @@ describe('runDiscovery', () => {
         scheduledCallbacks.push(callback as () => void)
       }
 
-      return 0 as unknown as ReturnType<typeof setTimeout>
+      return makeFakeTimeoutHandle()
     }) as unknown as typeof setTimeout
 
     Module._load = ((request, parent, isMain) => {

--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import { EventEmitter } from 'node:events'
-import { createRequire } from 'node:module'
 
 type LoadFn = (
   request: string,
@@ -21,7 +20,7 @@ type DiscoveryModule = {
   runDiscovery: (app: App) => void
 }
 
-const require = createRequire(import.meta.url)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const Module = require('node:module') as typeof import('node:module') & {
   _load: LoadFn
 }
@@ -92,10 +91,10 @@ describe('runDiscovery', () => {
       const callback = args[0]
 
       if (typeof callback === 'function') {
-        scheduledCallbacks.push(callback)
+        scheduledCallbacks.push(callback as () => void)
       }
 
-      return 0 as ReturnType<typeof setTimeout>
+      return 0 as unknown as ReturnType<typeof setTimeout>
     }) as unknown as typeof setTimeout
 
     Module._load = ((request, parent, isMain) => {
@@ -130,6 +129,7 @@ describe('runDiscovery', () => {
 
     delete require.cache[discoveryModulePath]
 
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { runDiscovery } = require('../dist/discovery.js') as DiscoveryModule
 
     const app: App = {


### PR DESCRIPTION
## Motivation

`test/discovery.ts` fails to type-check with `tsc` under the project's nodenext/CommonJS module mode, producing four errors:

- **TS1470**: `import.meta` is not allowed in files that build into CommonJS output
- **TS2441**: `const require = createRequire(...)` collides with the CJS-reserved `require` global
- **TS2345**: `typeof callback === 'function'` narrows to `Function`, not `() => void`
- **TS2352**: `ReturnType<typeof setTimeout>` is `Timeout` in Node — can't be assigned directly from `number`

`npm test` masks these because `mocha` + `ts-node` transpile permissively, so CI stays green even though `tsc` rejects the file.

## Approach

Drop the `createRequire(import.meta.url)` shim — it's unnecessary in a CommonJS package where `require` is already available. Use the CJS-global `require` with localized `eslint-disable-next-line @typescript-eslint/no-require-imports` directives at the two call sites that need CJS semantics, matching the existing pattern in `test/mdnsPatch.ts`. Tighten the two `setTimeout` fake casts to satisfy strict mode.

## Tested

- `tsc --noEmit` over `test/discovery.ts` under nodenext/CommonJS — clean
- `npm run format && npm run build:all && npm test` on node 22 and node 24 — all 960 tests pass, `runDiscovery` test still runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes TypeScript type-checking errors in test/discovery.ts under the repository's CommonJS/nodenext configuration so the file type-checks with tsc --noEmit.

## Changes

- Remove the createRequire(import.meta.url) shim and use the CommonJS global require directly, adding localized eslint-disable-next-line `@typescript-eslint/no-require-imports` comments at the two call sites (require.resolve and dynamic require('../dist/discovery.js')).
- Replace an unsafe "as unknown as" timeout cast with a helper makeFakeTimeoutHandle() that creates a real Timeout via the originalSetTimeout, clears it, and returns it (typed as ReturnType<typeof setTimeout>).
- Tighten the global.setTimeout stub to push callbacks typed as () => void into scheduledCallbacks.
- Preserve existing discovery-module mocking, restoration of Module._load and global.setTimeout, clearing FakeBrowser.instances, and deleting the discovery module cache after each test.
- Omit an unnecessary NO_DELAY_MS constant (use literal 0).

All repository tests pass (960), and tsc --noEmit succeeds for test/discovery.ts under CommonJS/nodenext.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->