### PR TITLE
test(subscriptions): wait for ws subscribe before posting delta

### DIFF
--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -314,6 +314,12 @@ describe('Subscriptions', (_) => {
         })
       })
       .then(() => {
+        // Give the server a tick to process the WS subscribe before the
+        // POST races it on a separate connection — otherwise the delta can
+        // be ingested under the default (self) subscription.
+        return new Promise((resolve) => setTimeout(resolve, 30))
+      })
+      .then(() => {
         return Promise.all([
           wsPromiser.nextMsg(),
           sendDelta(


### PR DESCRIPTION
## Motivation

The test `unsubscribe all plus navigation.logTrip subscription serves correct data` in [test/subscriptions.js](test/subscriptions.js) is flaky on CI — fails intermittently with:

```
AssertionError [ERR_ASSERTION]: Receives navigation.logTrip
+ expected - actual
-false
+true
  at test/subscriptions.js:329:9
```

## Root cause

`wsPromiser.send(subscribe)` resolves when the WS frame is written to the client socket, not when the server has finished processing it. The next step issues an HTTP POST on a separate connection. Under load, the POST can be ingested by the server before the WS subscribe takes effect, so the test client receives a delta filtered against the previous default (`self`) subscription — that delta contains multiple updates/values, breaking the single-path assertion at line 329.

## Approach

Add a 30 ms barrier between the subscribe send and the POST. This matches the pattern already used by the sibling `?subscribe=all subscription serves all data` test in the same file.

## Tested

- `npm run format && npm run build:all && npm test` on node 22 — 832 + 34 + 86 + 8 = 960 tests pass, target test passes (176 ms vs 146 ms baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a 30 millisecond delay in the "unsubscribe all plus navigation.logTrip subscription serves correct data" test case to fix a race condition. The delay is introduced between sending the WebSocket subscribe request and posting the subsequent delta via HTTP, ensuring the server processes the subscription before the delta arrives on a separate connection.

## Changes

**test/subscriptions.js**: Inserts a `setTimeout(30ms)` wrapped in a Promise after the WS subscribe message is sent, preventing the delta from being filtered against the default subscription and ensuring the test receives the expected data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->