### PR TITLE
fix(admin-ui): clear cached paths in Data Browser after server restart

### DIFF
--- a/packages/server-admin-ui/src/services/WebSocketService.test.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { WebSocketService } from './WebSocketService'
+import { useStore } from '../store'
+import type { PathData } from '../store'
+
+// Reach into the service to drive the hello-message path without
+// opening a real WebSocket. handleMessage is private, so cast through
+// an interface that exposes just what these tests need.
+interface ServiceWithHandle {
+  handleMessage(msg: unknown): void
+}
+
+const dispatchHello = (
+  service: WebSocketService,
+  bootId: string | undefined
+): void => {
+  const msg: Record<string, unknown> = {
+    name: 'signalk-server',
+    version: '0.0.0-test',
+    self: 'vessels.urn:mrn:signalk:uuid:test-self',
+    roles: ['master', 'main'],
+    timestamp: new Date().toISOString()
+  }
+  if (bootId !== undefined) msg.bootId = bootId
+  ;(service as unknown as ServiceWithHandle).handleMessage(msg)
+}
+
+const seedPath = (path: string): void => {
+  const data: PathData = {
+    value: 1,
+    timestamp: '2024-01-15T10:30:00Z',
+    $source: 'nmea0183.0'
+  }
+  useStore.getState().updatePath('self', `${path}$nmea0183.0`, data)
+}
+
+describe('WebSocketService bootId tracking', () => {
+  beforeEach(() => {
+    useStore.getState().clearData()
+  })
+
+  it('records bootId on first hello without clearing data', () => {
+    const service = new WebSocketService()
+    seedPath('navigation.speedOverGround')
+    dispatchHello(service, 'boot-1')
+
+    expect(
+      Object.keys(useStore.getState().signalkData.self ?? {})
+    ).toHaveLength(1)
+  })
+
+  it('clears signalkData when a subsequent hello carries a new bootId', () => {
+    const service = new WebSocketService()
+    dispatchHello(service, 'boot-1')
+    seedPath('navigation.speedOverGround')
+    expect(
+      Object.keys(useStore.getState().signalkData.self ?? {})
+    ).toHaveLength(1)
+
+    dispatchHello(service, 'boot-2')
+
+    expect(useStore.getState().signalkData).toEqual({})
+  })
+
+  it('does not clear signalkData when the bootId is unchanged', () => {
+    const service = new WebSocketService()
+    dispatchHello(service, 'boot-1')
+    seedPath('navigation.speedOverGround')
+
+    dispatchHello(service, 'boot-1')
+
+    expect(
+      Object.keys(useStore.getState().signalkData.self ?? {})
+    ).toHaveLength(1)
+  })
+
+  it('does not clear signalkData when the hello has no bootId', () => {
+    const service = new WebSocketService()
+    dispatchHello(service, 'boot-1')
+    seedPath('navigation.speedOverGround')
+
+    dispatchHello(service, undefined)
+
+    expect(
+      Object.keys(useStore.getState().signalkData.self ?? {})
+    ).toHaveLength(1)
+  })
+})

--- a/packages/server-admin-ui/src/services/WebSocketService.test.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.test.ts
@@ -1,19 +1,41 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { WebSocketService } from './WebSocketService'
 import { useStore } from '../store'
 import type { PathData } from '../store'
 
-// Reach into the service to drive the hello-message path without
-// opening a real WebSocket. handleMessage is private, so cast through
-// an interface that exposes just what these tests need.
-interface ServiceWithHandle {
-  handleMessage(msg: unknown): void
+// A minimal stand-in for the global WebSocket used by WebSocketService:
+// captures the most recent instance so the test can fire onopen/onmessage
+// to drive the public connect()/handleMessage path without a real socket.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  static lastInstance(): FakeWebSocket {
+    return FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+  }
+  static OPEN = 1
+
+  readyState = 0
+  onopen: (() => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor() {
+    FakeWebSocket.instances.push(this)
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  close(): void {}
 }
 
-const dispatchHello = (
-  service: WebSocketService,
-  bootId: string | undefined
-): void => {
+const helloMessage = (bootId: string | undefined): Record<string, unknown> => {
   const msg: Record<string, unknown> = {
     name: 'signalk-server',
     version: '0.0.0-test',
@@ -22,7 +44,7 @@ const dispatchHello = (
     timestamp: new Date().toISOString()
   }
   if (bootId !== undefined) msg.bootId = bootId
-  ;(service as unknown as ServiceWithHandle).handleMessage(msg)
+  return msg
 }
 
 const seedPath = (path: string): void => {
@@ -35,14 +57,23 @@ const seedPath = (path: string): void => {
 }
 
 describe('WebSocketService bootId tracking', () => {
+  let service: WebSocketService
+  let ws: FakeWebSocket
+
   beforeEach(() => {
+    // setup.ts's beforeAll installs a different WebSocket stub; reinstall
+    // FakeWebSocket here so connect() captures *our* instance.
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    FakeWebSocket.instances = []
     useStore.getState().clearData()
+    service = new WebSocketService()
+    service.connect()
+    ws = FakeWebSocket.lastInstance()
   })
 
   it('records bootId on first hello without clearing data', () => {
-    const service = new WebSocketService()
     seedPath('navigation.speedOverGround')
-    dispatchHello(service, 'boot-1')
+    ws.receive(helloMessage('boot-1'))
 
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
@@ -50,24 +81,22 @@ describe('WebSocketService bootId tracking', () => {
   })
 
   it('clears signalkData when a subsequent hello carries a new bootId', () => {
-    const service = new WebSocketService()
-    dispatchHello(service, 'boot-1')
+    ws.receive(helloMessage('boot-1'))
     seedPath('navigation.speedOverGround')
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
     ).toHaveLength(1)
 
-    dispatchHello(service, 'boot-2')
+    ws.receive(helloMessage('boot-2'))
 
     expect(useStore.getState().signalkData).toEqual({})
   })
 
   it('does not clear signalkData when the bootId is unchanged', () => {
-    const service = new WebSocketService()
-    dispatchHello(service, 'boot-1')
+    ws.receive(helloMessage('boot-1'))
     seedPath('navigation.speedOverGround')
 
-    dispatchHello(service, 'boot-1')
+    ws.receive(helloMessage('boot-1'))
 
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
@@ -75,11 +104,10 @@ describe('WebSocketService bootId tracking', () => {
   })
 
   it('does not clear signalkData when the hello has no bootId', () => {
-    const service = new WebSocketService()
-    dispatchHello(service, 'boot-1')
+    ws.receive(helloMessage('boot-1'))
     seedPath('navigation.speedOverGround')
 
-    dispatchHello(service, undefined)
+    ws.receive(helloMessage(undefined))
 
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})

--- a/packages/server-admin-ui/src/services/WebSocketService.test.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.test.ts
@@ -35,7 +35,9 @@ class FakeWebSocket {
   close(): void {}
 }
 
-const helloMessage = (bootId: string | undefined): Record<string, unknown> => {
+const helloMessage = (
+  serverStartId: string | undefined
+): Record<string, unknown> => {
   const msg: Record<string, unknown> = {
     name: 'signalk-server',
     version: '0.0.0-test',
@@ -43,7 +45,7 @@ const helloMessage = (bootId: string | undefined): Record<string, unknown> => {
     roles: ['master', 'main'],
     timestamp: new Date().toISOString()
   }
-  if (bootId !== undefined) msg.bootId = bootId
+  if (serverStartId !== undefined) msg.serverStartId = serverStartId
   return msg
 }
 
@@ -56,7 +58,7 @@ const seedPath = (path: string): void => {
   useStore.getState().updatePath('self', `${path}$nmea0183.0`, data)
 }
 
-describe('WebSocketService bootId tracking', () => {
+describe('WebSocketService serverStartId tracking', () => {
   let service: WebSocketService
   let ws: FakeWebSocket
 
@@ -71,40 +73,40 @@ describe('WebSocketService bootId tracking', () => {
     ws = FakeWebSocket.lastInstance()
   })
 
-  it('records bootId on first hello without clearing data', () => {
+  it('records serverStartId on first hello without clearing data', () => {
     seedPath('navigation.speedOverGround')
-    ws.receive(helloMessage('boot-1'))
+    ws.receive(helloMessage('start-1'))
 
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
     ).toHaveLength(1)
   })
 
-  it('clears signalkData when a subsequent hello carries a new bootId', () => {
-    ws.receive(helloMessage('boot-1'))
+  it('clears signalkData when a subsequent hello carries a new serverStartId', () => {
+    ws.receive(helloMessage('start-1'))
     seedPath('navigation.speedOverGround')
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
     ).toHaveLength(1)
 
-    ws.receive(helloMessage('boot-2'))
+    ws.receive(helloMessage('start-2'))
 
     expect(useStore.getState().signalkData).toEqual({})
   })
 
-  it('does not clear signalkData when the bootId is unchanged', () => {
-    ws.receive(helloMessage('boot-1'))
+  it('does not clear signalkData when the serverStartId is unchanged', () => {
+    ws.receive(helloMessage('start-1'))
     seedPath('navigation.speedOverGround')
 
-    ws.receive(helloMessage('boot-1'))
+    ws.receive(helloMessage('start-1'))
 
     expect(
       Object.keys(useStore.getState().signalkData.self ?? {})
     ).toHaveLength(1)
   })
 
-  it('does not clear signalkData when the hello has no bootId', () => {
-    ws.receive(helloMessage('boot-1'))
+  it('does not clear signalkData when the hello has no serverStartId', () => {
+    ws.receive(helloMessage('start-1'))
     seedPath('navigation.speedOverGround')
 
     ws.receive(helloMessage(undefined))

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -39,11 +39,11 @@ export class WebSocketService {
   private maxReconnectAttempts = Infinity
   private reconnectInterval = 5000
   private zustandSetState: ZustandStateSetter | null = null
-  // Last hello.bootId we saw, used to detect that the server has been
-  // restarted between connections. On change, the client's signalkData
-  // mirror is wiped so paths the new boot no longer publishes don't
-  // linger as ghost rows in the Data Browser.
-  private lastBootId: string | null = null
+  // Last hello.serverStartId we saw, used to detect that the server has
+  // been restarted between connections. On change, the client's
+  // signalkData mirror is wiped so paths the new server instance no
+  // longer publishes don't linger as ghost rows in the Data Browser.
+  private lastServerStartId: string | null = null
 
   setZustandState(setState: ZustandStateSetter): void {
     this.zustandSetState = setState
@@ -186,18 +186,22 @@ export class WebSocketService {
 
     // Hello message — extract skSelf and check for server restart
     if (msg.name) {
-      const bootId =
-        typeof msg.bootId === 'string' ? (msg.bootId as string) : null
-      // A different bootId than last seen means the server process has
-      // restarted; the new boot has none of the old delta cache, so
-      // wipe our mirror to drop paths it will never re-publish. First
-      // hello on a freshly-loaded page just records the id (no clear,
-      // there is nothing cached yet).
-      if (bootId && this.lastBootId && bootId !== this.lastBootId) {
+      const serverStartId =
+        typeof msg.serverStartId === 'string' ? msg.serverStartId : null
+      // A different serverStartId than last seen means the server
+      // process has restarted; the new instance has none of the old
+      // delta cache, so wipe our mirror to drop paths it will never
+      // re-publish. First hello on a freshly-loaded page just records
+      // the id (no clear, there is nothing cached yet).
+      if (
+        serverStartId &&
+        this.lastServerStartId &&
+        serverStartId !== this.lastServerStartId
+      ) {
         useStore.getState().clearData()
       }
-      if (bootId) {
-        this.lastBootId = bootId
+      if (serverStartId) {
+        this.lastServerStartId = serverStartId
       }
       this.updateState({ skSelf: msg.self as string })
       return

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -39,6 +39,11 @@ export class WebSocketService {
   private maxReconnectAttempts = Infinity
   private reconnectInterval = 5000
   private zustandSetState: ZustandStateSetter | null = null
+  // Last hello.bootId we saw, used to detect that the server has been
+  // restarted between connections. On change, the client's signalkData
+  // mirror is wiped so paths the new boot no longer publishes don't
+  // linger as ghost rows in the Data Browser.
+  private lastBootId: string | null = null
 
   setZustandState(setState: ZustandStateSetter): void {
     this.zustandSetState = setState
@@ -179,8 +184,21 @@ export class WebSocketService {
       return
     }
 
-    // Hello message — extract skSelf
+    // Hello message — extract skSelf and check for server restart
     if (msg.name) {
+      const bootId =
+        typeof msg.bootId === 'string' ? (msg.bootId as string) : null
+      // A different bootId than last seen means the server process has
+      // restarted; the new boot has none of the old delta cache, so
+      // wipe our mirror to drop paths it will never re-publish. First
+      // hello on a freshly-loaded page just records the id (no clear,
+      // there is nothing cached yet).
+      if (bootId && this.lastBootId && bootId !== this.lastBootId) {
+        useStore.getState().clearData()
+      }
+      if (bootId) {
+        this.lastBootId = bootId
+      }
       this.updateState({ skSelf: msg.self as string })
       return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -548,14 +548,14 @@ class Server {
     // and flip routesPath on for already-contended paths at boot.
     app.activateSourcePriorities()
 
-    const bootId = randomUUID()
+    const serverStartId = randomUUID()
     app.getHello = () => ({
       name: app.config.name,
       version: app.config.version,
       self: `vessels.${app.selfId}`,
       roles: ['master', 'main'],
       timestamp: new Date(),
-      bootId
+      serverStartId
     })
 
     app.isNmea2000OutAvailable = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   Update,
   WithFeatures
 } from '@signalk/server-api'
+import { randomUUID } from 'crypto'
 import express, { IRouter, Request, Response } from 'express'
 import http from 'http'
 import https from 'https'
@@ -547,12 +548,14 @@ class Server {
     // and flip routesPath on for already-contended paths at boot.
     app.activateSourcePriorities()
 
+    const bootId = randomUUID()
     app.getHello = () => ({
       name: app.config.name,
       version: app.config.version,
       self: `vessels.${app.selfId}`,
       roles: ['master', 'main'],
-      timestamp: new Date()
+      timestamp: new Date(),
+      bootId
     })
 
     app.isNmea2000OutAvailable = false

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,13 @@ export interface HelloMessage {
   self: string
   roles: string[]
   timestamp: Date
+  /**
+   * Stable identifier for the server process. Regenerated each boot so
+   * clients reconnecting after a restart can detect that server-side
+   * state (delta cache, source registry) has been wiped and drop their
+   * own mirrors of paths the new boot may never re-publish.
+   */
+  bootId: string
 }
 
 export type ICallback<T> = (error?: Error | null, result?: T) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,12 @@ export interface HelloMessage {
   roles: string[]
   timestamp: Date
   /**
-   * Stable identifier for the server process. Regenerated each boot so
-   * clients reconnecting after a restart can detect that server-side
-   * state (delta cache, source registry) has been wiped and drop their
-   * own mirrors of paths the new boot may never re-publish.
+   * Unique identifier for this server-process start. A fresh value each
+   * time the server starts lets reconnecting clients detect that
+   * server-side state (delta cache, source registry) has been wiped and
+   * drop their own mirrors of paths the new instance may never re-publish.
    */
-  bootId: string
+  serverStartId: string
 }
 
 export type ICallback<T> = (error?: Error | null, result?: T) => void


### PR DESCRIPTION
## Motivation

After a server restart, the Data Browser keeps showing paths the new server boot no longer publishes. The client's `signalkData` mirror is never cleared on WS reconnect, so any path the page ever saw lingers until manual reload. Reported by Scott Bender.

## Approach

Add a stable `bootId` to the WS hello payload (regenerated once per server process via `crypto.randomUUID()`). The admin UI's `WebSocketService` remembers the last-seen value; when a new hello carries a different `bootId`, the client wipes its `signalkData`/`signalkMeta` mirror via the existing `clearData()` action. Subscriptions resubscribe through the existing reconnect path, so paths still present on the new boot repopulate naturally.

A reconnect within the same boot (network blip) leaves the mirror untouched, so the table does not visibly empty while the WS recovers. Old clients ignore the unknown field; new clients against an older server just never trigger the clear (no regression).

## Tested

- New `WebSocketService.test.ts` covers: first hello records, bootId change clears, unchanged bootId preserves, missing bootId preserves
- `npm run format`, `npm run build:all`, `npm test` all green (214 admin-ui tests, 832 server tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes an issue where the Data Browser retains stale paths from a previous server process after a restart. The server now includes a stable bootId in the hello payload, enabling the Admin UI to detect server restarts and clear its cached signalkData/signalkMeta accordingly.

## Changes

**Server-side (src/types.ts, src/index.ts)**
- Adds a bootId: string to the HelloMessage type.
- app.getHello() generates and includes a per-boot bootId using crypto.randomUUID().

**Admin UI (packages/server-admin-ui/src/services/WebSocketService.ts)**
- WebSocketService records the last-seen hello.bootId and compares it to newly received hello messages.
- When a new bootId differs from the previously seen one (and a prior bootId exists), the service dispatches clearData() to wipe the local signalkData and signalkMeta, preventing ghost paths from a prior server process.
- A reconnect within the same bootId does not clear data (avoids visible emptying on transient reconnects).
- Missing bootId (older servers) does not trigger a clear, preserving backward compatibility.

**Tests (packages/server-admin-ui/src/services/WebSocketService.test.ts)**
- Rewrites tests to exercise the public WebSocket boundary using a FakeWebSocket installed as global WebSocket.
- Tests verify: first hello records bootId without clearing; different bootId clears signalkData; same bootId preserves data; missing bootId does not clear data.
- Tests drive service.connect() → ws.open() → ws.receive() and assert via public store state.

## Behavior

On WebSocket reconnect, the client clears its local mirror only when it detects a different server bootId, allowing subscriptions to naturally repopulate current paths; transient reconnects within the same boot do not clear the mirror.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->