### PR TITLE
fix(discovery): suppress local server's own mDNS advertisement

### DIFF
--- a/src/discovery.js
+++ b/src/discovery.js
@@ -205,8 +205,14 @@ module.exports.runDiscovery = function (app) {
 
       browser.on('serviceUp', function onServiceUp(data) {
         try {
+          // Suppress the local server's own advertisement. data.addresses
+          // can contain a mix of IPv4 and IPv6 entries (including
+          // loopback) depending on the underlying mDNS responder, so a
+          // single address from the list is not enough — any local match
+          // anywhere in the list means this is our own service.
+          const addresses = Array.isArray(data.addresses) ? data.addresses : []
           if (
-            !isLocalIP(data.addresses[0]) &&
+            !addresses.some(isOwnAddress) &&
             data.type &&
             data.type.name === 'signalk-' + wsType &&
             !findWSProvider(data.addresses[0], wsType, data.host, data.port)
@@ -264,15 +270,19 @@ module.exports.runDiscovery = function (app) {
     }
   }
 
-  function isLocalIP(IP) {
+  // True when `addr` is an address bound to one of our own interfaces,
+  // covering IPv4 (including 127.0.0.0/8), IPv6 (including ::1 and
+  // link-local fe80::*), and the zone-ID suffix mDNS responders append
+  // to link-local IPv6 (e.g. 'fe80::1%eth0'). Used to filter the local
+  // server's own mDNS advertisement out of discovery results.
+  function isOwnAddress(addr) {
+    if (typeof addr !== 'string' || addr.length === 0) return false
+    const normalized = addr.replace(/%.*$/, '').toLowerCase()
     const nets = networkInterfaces()
-
     for (const name of Object.keys(nets)) {
-      for (const net of nets[name]) {
-        if (net.family === 'IPv4' && !net.internal) {
-          if (net.address === IP) {
-            return true
-          }
+      for (const net of nets[name] || []) {
+        if (net.address && net.address.toLowerCase() === normalized) {
+          return true
         }
       }
     }

--- a/src/discovery.js
+++ b/src/discovery.js
@@ -211,14 +211,16 @@ module.exports.runDiscovery = function (app) {
           // single address from the list is not enough — any local match
           // anywhere in the list means this is our own service.
           const addresses = Array.isArray(data.addresses) ? data.addresses : []
+          const primaryAddress = addresses[0]
           if (
+            primaryAddress &&
             !addresses.some(isOwnAddress) &&
             data.type &&
             data.type.name === 'signalk-' + wsType &&
-            !findWSProvider(data.addresses[0], wsType, data.host, data.port)
+            !findWSProvider(primaryAddress, wsType, data.host, data.port)
           ) {
             debug('discoverSignalkWs found data[' + wsType + ']:', data)
-            const providerId = `${wsType}-${data.host}:${data.port} (${data.addresses[0]})`
+            const providerId = `${wsType}-${data.host}:${data.port} (${primaryAddress})`
             app.emit('discovered', {
               id: providerId,
               enabled: false,
@@ -231,7 +233,7 @@ module.exports.runDiscovery = function (app) {
                       type: wsType,
                       host: data.host,
                       port: data.port,
-                      address: data.addresses[0],
+                      address: primaryAddress,
                       providerId
                     },
                     providerId

--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -164,4 +164,112 @@ describe('runDiscovery', () => {
     expect(wsBrowser?.stopCallCount).to.equal(1)
     expect(wssBrowser?.stopCallCount).to.equal(1)
   })
+
+  type DiscoveredPayload = {
+    id: string
+    pipeElements: Array<{
+      options: {
+        subOptions: { type: string; host: string; port: number }
+      }
+    }>
+  }
+
+  // Build a discovery run with controllable networkInterfaces and an
+  // app emit spy, then return the FakeBrowser the assertions can drive.
+  function runDiscoveryWith(interfaces: Record<string, unknown[]>): {
+    wsBrowser: FakeBrowser
+    discovered: DiscoveredPayload[]
+  } {
+    Module._load = ((request, parent, isMain) => {
+      if (request === '@astronautlabs/mdns') return { Browser: FakeBrowser }
+      if (request === '@canboat/canboatjs') return {}
+      if (request === 'dgram') return { createSocket: () => new FakeSocket() }
+      if (request === 'os') return { networkInterfaces: () => interfaces }
+      if (request === './mdnsPatch') return { patchAstronautLabsMdns: () => {} }
+      return originalLoad(request, parent, isMain)
+    }) as LoadFn
+
+    global.setTimeout = ((..._args: unknown[]) =>
+      0 as ReturnType<typeof setTimeout>) as unknown as typeof setTimeout
+
+    delete require.cache[discoveryModulePath]
+
+    const { runDiscovery } = require('../dist/discovery.js') as DiscoveryModule
+    const discovered: DiscoveredPayload[] = []
+    const app: App = {
+      config: { settings: { pipedProviders: [] } },
+      emit: (event, payload) => {
+        if (event === 'discovered')
+          discovered.push(payload as DiscoveredPayload)
+      }
+    }
+    runDiscovery(app)
+    const wsBrowser = FakeBrowser.instances.find(
+      (b) => b.serviceType === '_signalk-ws._tcp'
+    )
+    expect(wsBrowser).to.not.equal(undefined)
+    return { wsBrowser: wsBrowser as FakeBrowser, discovered }
+  }
+
+  const serviceUp = (browser: FakeBrowser, addresses: string[]) => {
+    browser.emit('serviceUp', {
+      addresses,
+      host: 'remote.local',
+      port: 3000,
+      type: { name: 'signalk-ws' }
+    })
+  }
+
+  describe('isOwnAddress filter', () => {
+    it('suppresses an advertisement whose address matches a local IPv4', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        eth0: [{ family: 'IPv4', internal: false, address: '192.168.1.50' }]
+      })
+      serviceUp(wsBrowser, ['192.168.1.50'])
+      expect(discovered).to.have.length(0)
+    })
+
+    it('suppresses an advertisement on IPv4 loopback', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        lo: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }]
+      })
+      serviceUp(wsBrowser, ['127.0.0.1'])
+      expect(discovered).to.have.length(0)
+    })
+
+    it('suppresses an advertisement on IPv6 loopback', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        lo: [{ family: 'IPv6', internal: true, address: '::1' }]
+      })
+      serviceUp(wsBrowser, ['::1'])
+      expect(discovered).to.have.length(0)
+    })
+
+    it('suppresses an advertisement on link-local IPv6 with zone id', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        eth0: [{ family: 'IPv6', internal: false, address: 'fe80::1' }]
+      })
+      serviceUp(wsBrowser, ['fe80::1%eth0'])
+      expect(discovered).to.have.length(0)
+    })
+
+    it('suppresses when any address in the list is local', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        eth0: [{ family: 'IPv4', internal: false, address: '192.168.1.50' }]
+      })
+      serviceUp(wsBrowser, ['10.0.0.5', '192.168.1.50'])
+      expect(discovered).to.have.length(0)
+    })
+
+    it('emits an advertisement whose addresses are all remote', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        eth0: [{ family: 'IPv4', internal: false, address: '192.168.1.50' }]
+      })
+      serviceUp(wsBrowser, ['192.168.1.99'])
+      expect(discovered).to.have.length(1)
+      expect(discovered[0].pipeElements[0].options.subOptions.host).to.equal(
+        'remote.local'
+      )
+    })
+  })
 })

--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -174,8 +174,6 @@ describe('runDiscovery', () => {
     }>
   }
 
-  // Build a discovery run with controllable networkInterfaces and an
-  // app emit spy, then return the FakeBrowser the assertions can drive.
   function runDiscoveryWith(interfaces: Record<string, unknown[]>): {
     wsBrowser: FakeBrowser
     discovered: DiscoveredPayload[]
@@ -270,6 +268,19 @@ describe('runDiscovery', () => {
       expect(discovered[0].pipeElements[0].options.subOptions.host).to.equal(
         'remote.local'
       )
+    })
+
+    it('does not emit when the addresses list is empty or missing', () => {
+      const { wsBrowser, discovered } = runDiscoveryWith({
+        eth0: [{ family: 'IPv4', internal: false, address: '192.168.1.50' }]
+      })
+      serviceUp(wsBrowser, [])
+      wsBrowser.emit('serviceUp', {
+        host: 'remote.local',
+        port: 3000,
+        type: { name: 'signalk-ws' }
+      })
+      expect(discovered).to.have.length(0)
     })
   })
 })


### PR DESCRIPTION
## Motivation

Since v2.27.0 the local server can appear in its own **Data → Connections → Discovered Connections** list. The IPv4-only loopback-excluding `isLocalIP` filter introduced with the mdns-js → @astronautlabs/mdns migration (#2601) does not catch advertisements whose resolved address is IPv6, IPv4 loopback, or any address with a link-local IPv6 zone suffix. mdns-js historically suppressed the local interface via `excludeInterface('0.0.0.0')`, which has no `@astronautlabs/mdns` equivalent.

## Approach

Replace `isLocalIP` with `isOwnAddress`, which matches any address bound to any local interface — loopback included — across all address families, and normalises link-local IPv6 zone IDs (`fe80::1%eth0` → `fe80::1`). Apply it to every entry in `data.addresses` rather than only `[0]`, so an advertisement that lists both a routable and a loopback address is still recognised as local.

## Tested

- New `test/discovery.ts` `isOwnAddress filter` block covers IPv4, IPv4 loopback, IPv6 loopback, link-local IPv6 with zone id, mixed-address lists, and the all-remote pass-through case (6 cases)
- `npm run format`, `npm run build:all`, `npm test` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes the local server appearing in its own Data → Connections → Discovered Connections list by robustly suppressing the server's own mDNS advertisements across address families and edge cases.

## Changes
- discoverSignalkWs in src/discovery.js replaces the old IPv4-only isLocalIP logic with isOwnAddress, which:
  - Normalizes addresses by stripping IPv6 zone-ID suffixes and lowercasing.
  - Detects any address bound to the host's network interfaces across IPv4 and IPv6 (including loopback and link-local).
- Applies the local-address check to every entry in data.addresses (addresses.some(isOwnAddress)) so mixed-address advertisements (routable + loopback) are recognized as local.
- Hoists addresses[0] to primaryAddress, gates emission on its presence, and uses the normalized primaryAddress for emitted provider subOptions.address and providerId to avoid emitting providers with undefined hosts.
- Adds defensive behavior: discovery does not emit when data.addresses is empty or missing.

## Testing
- Adds tests in test/discovery.ts covering IPv4, IPv4 loopback, IPv6 loopback, link-local IPv6 with zone id, mixed-address lists, all-remote cases, and an empty/missing addresses guard (7 cases).
- Runs formatting, build, and tests successfully in the author's verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->