### PR TITLE
chore(deps): remove orphaned bonjour-service dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "baconjs": "^3.0.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.3",
-    "bonjour-service": "^1.3.0",
     "busboy": "^1.6.0",
     "chalk": "^3.0.0",
     "clear": "^0.1.0",


### PR DESCRIPTION
## Motivation

`bonjour-service` has been a declared dependency in `package.json` without being imported anywhere in this repository since the 2026-01-27 revert to native mdns (#2298). The 2026-05-08 migration to `@astronautlabs/mdns` (#2601) replaced both advertising and discovery and likewise does not use it.

## Approach

Drop the single `bonjour-service` line from `package.json`. `npm ls bonjour-service` afterwards reports `(empty)`; nothing else in the repo or workspace packages depends on it transitively.

## Tested

- `grep -rn bonjour --include='*.ts' --include='*.tsx' --include='*.js' --include='*.json'` returns no remaining references outside this PR
- `npm install`, `npm run format`, `npm run build:all`, `npm test` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes the orphaned `bonjour-service` dependency from `package.json`. The package remained declared as a dependency but has not been imported anywhere in the repository since being superseded by the `@astronautlabs/mdns` library migration. The change involves removing a single line from the root dependencies list, and all verification checks (grep for bonjour references, npm install, format, build, and test) pass successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->