### PR TITLE
fix(admin-ui): keep priority group cards mounted across reconciles

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -621,13 +621,24 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
     setSelectedPath(path)
   }
 
+  // Stable reference for the items dnd-kit's SortableContext registers.
+  // group.sources is a fresh array on every RECONCILEDGROUPS push even
+  // when the contents are unchanged; without this memo dnd-kit's
+  // internal registry sees the items reference flicker between drag
+  // start and drag end and onDragEnd's `over` can land on a stale node.
+  const stableSources = useMemo(
+    () => group.sources,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [group.sources.join('|')]
+  )
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
-    const from = group.sources.indexOf(String(active.id))
-    const to = group.sources.indexOf(String(over.id))
+    const from = stableSources.indexOf(String(active.id))
+    const to = stableSources.indexOf(String(over.id))
     if (from === -1 || to === -1 || from === to) return
-    const sources = [...group.sources]
+    const sources = [...stableSources]
     const [moved] = sources.splice(from, 1)
     sources.splice(to, 0, moved)
     setGroupSources(group.id, sources)
@@ -787,7 +798,7 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                       onDragEnd={handleDragEnd}
                     >
                       <SortableContext
-                        items={group.sources}
+                        items={stableSources}
                         strategy={verticalListSortingStrategy}
                       >
                         <ul className="pg-source-list">

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
@@ -869,8 +869,16 @@ const SourcePriorities: React.FC = () => {
           )}
 
           {displayed.map((group) => (
+            // Key by matchedSavedId when the group is persisted, falling
+            // back to a path-set fingerprint for unsaved residue groups.
+            // The reconciled id for an unsaved group is sortedSources.join(''),
+            // which flips every time a source joins or leaves the
+            // connected component; using it as a React key unmounts the
+            // card mid-drag and dnd-kit's onDragEnd loses its `over`
+            // target so a reorder silently does nothing. Path-set is the
+            // stable structural identity of the group.
             <PriorityGroupCard
-              key={group.id}
+              key={group.matchedSavedId ?? [...group.paths].sort().join('|')}
               group={group}
               hasLocalEdit={savedIds.has(group.id)}
               multiSourcePaths={multiSourcePaths}

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
@@ -430,17 +430,28 @@ const SourcePriorities: React.FC = () => {
   const displayed = useMemo(() => {
     const savedById = new Map(savedGroups.map((g) => [g.id, g]))
     return reconciled.map((g) => {
+      // Stable identity for the group: persisted saved id when present,
+      // otherwise a path-set fingerprint. The reconciled live id for an
+      // unsaved group is sortedSources.join(''), which flips whenever a
+      // source joins or leaves the connected component; using it as the
+      // storage key for local edits would orphan a pending drag the
+      // moment a newcomer arrives. The path-set is the structural
+      // identity reconcile uses to define a group cluster and is stable
+      // across source flux.
+      const effectiveId = g.matchedSavedId ?? [...g.paths].sort().join('|')
       const saved =
         g.matchedSavedId !== null ? savedById.get(g.matchedSavedId) : undefined
-      // For an unranked group the user might still have toggled
-      // Deactivate, which writes a stub saved entry under the live id
-      // (sources: [], inactive: true). reconcileGroups can't match that
-      // to anything via overlap, so fall back to a direct live-id
-      // lookup to surface the pending inactive state.
+      // Unsaved group with a pending local edit: the user has dragged
+      // (setGroupSources) or toggled Deactivate (setGroupInactive). Both
+      // write under effectiveId via the callbacks below, so the lookup
+      // also goes via effectiveId.
       const stub =
-        !saved && g.matchedSavedId === null ? savedById.get(g.id) : undefined
+        !saved && g.matchedSavedId === null
+          ? savedById.get(effectiveId)
+          : undefined
       const inactive = saved?.inactive ?? stub?.inactive ?? false
-      if (!saved) return { ...g, inactive }
+      const editSource = saved ?? stub
+      if (!editSource) return { ...g, id: effectiveId, inactive }
       // editedOrder respects the user's local edit; newcomers come
       // straight from the server's live-publisher view (not derived
       // from `g.sources \ editedOrder`). Otherwise trashing a source
@@ -448,14 +459,15 @@ const SourcePriorities: React.FC = () => {
       // since g.sources still echoes sg.sources from the on-disk
       // config until the user clicks Save.
       const liveSet = new Set(g.sources)
-      const editedOrder = saved.sources.filter((src) => liveSet.has(src))
+      const editedOrder = editSource.sources.filter((src) => liveSet.has(src))
       const editedSet = new Set(editedOrder)
-      const suppressed = new Set(suppressedNewcomersByGroup[g.id] ?? [])
+      const suppressed = new Set(suppressedNewcomersByGroup[effectiveId] ?? [])
       const newcomers = g.newcomerSources.filter(
         (src) => !editedSet.has(src) && !suppressed.has(src)
       )
       return {
         ...g,
+        id: effectiveId,
         // Hide suppressed newcomers from the ordering reported back
         // to the rest of the page, too — otherwise the dirty-by-group
         // calculation and buildSavePayload below would still see them.
@@ -869,16 +881,12 @@ const SourcePriorities: React.FC = () => {
           )}
 
           {displayed.map((group) => (
-            // Key by matchedSavedId when the group is persisted, falling
-            // back to a path-set fingerprint for unsaved residue groups.
-            // The reconciled id for an unsaved group is sortedSources.join(''),
-            // which flips every time a source joins or leaves the
-            // connected component; using it as a React key unmounts the
-            // card mid-drag and dnd-kit's onDragEnd loses its `over`
-            // target so a reorder silently does nothing. Path-set is the
-            // stable structural identity of the group.
+            // group.id is normalised in the displayed memo: matchedSavedId
+            // when persisted, path-set fingerprint otherwise. That gives a
+            // single stable identity for the React key, slice writes
+            // (setGroupSources, setGroupInactive), and savedById lookups.
             <PriorityGroupCard
-              key={group.matchedSavedId ?? [...group.paths].sort().join('|')}
+              key={group.id}
               group={group}
               hasLocalEdit={savedIds.has(group.id)}
               multiSourcePaths={multiSourcePaths}


### PR DESCRIPTION
## Motivation

On Data → Priorities, drag-drop reordering of sources inside a priority group does nothing on first page load. After the user saves any unrelated change, drag-drop suddenly starts working for the rest of the session.

## Root cause

`getReconciledGroups` emits unsaved residue groups with `id: sortedSources.join('')`, which changes the moment a source joins or leaves the connected component. `SourcePriorities` used that id as the React key on `PriorityGroupCard`, so each RECONCILEDGROUPS push (debounced to 2s, fires on every multi-source-paths shift) could unmount and remount the card under an in-flight drag. dnd-kit's `onDragEnd` then saw a null `over` target and silently dropped the reorder. Once a save promoted the group to a saved-matched id (`matchedSavedId === sg.id`, persisted), the key stabilised and drag worked.

## Approach

Two narrow changes:

- `SourcePriorities.tsx` — key each `PriorityGroupCard` by `matchedSavedId ?? sorted-path-set`. The path-set is the structural identity reconcile uses to define a group cluster, so it is stable across source flux while the group conceptually remains the same card.
- `PriorityGroupCard.tsx` — memoise a `stableSources` array keyed on its joined contents, used by `SortableContext.items` and by `handleDragEnd`'s index lookups. Defends against `group.sources` reference flicker within a single mounted card.

No server changes. No protocol changes. No slice changes. No dnd-kit reconfiguration.

## Tested

- `npm run format`, `npm run build:all`, `npm test` all green (832 server + 210 admin-ui + 128 other)
- Local browser repro on the dev server: on first load, dragging a source up or down inside an unsaved group reorders the row and marks the card dirty — no preceding save required
- Saved-matched groups still key by `matchedSavedId` (no regression path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Problem

Drag-and-drop reordering of sources within a priority group on the Data → Priorities page does not work on initial page load. After an unrelated save, drag-drop works for the remainder of the session.

## Root cause

Reconciled groups emit unsaved groups with an unstable id derived from live reconciled sources (sortedSources.join('')), which changes when sources join/leave the connected component. The UI used that id as the React key for PriorityGroupCard, causing cards to unmount/remount across reconciles (debounced 2s) while a drag is in flight. dnd-kit's onDragEnd then observes a null over target and drops the reorder. Saved groups use matchedSavedId which stabilizes the key, hiding the issue after a save.

## Solution

This PR applies two targeted fixes:

1. SourcePriorities.tsx — assign each displayed group a stable identity (effective id) used across UI, slice writes, and local edits: matchedSavedId ?? [...g.paths].sort().join('|') (path-set fingerprint). The displayed memo normalizes group.id to matchedSavedId when available, otherwise to the sorted path-set fingerprint, and routes unsaved edits through the same editedOrder + newcomers shape the saved branch uses. This stabilizes the React key, local-edit storage key, savedById lookups, dirty tracking, and save payloads.

2. PriorityGroupCard.tsx — memoize a stableSources array (keyed on joined contents) and use it for SortableContext.items and handleDragEnd index lookups. This defends against group.sources reference flicker while the card remains mounted so DnD target resolution and index calculations remain correct during reconciles.

## Impact

- Drag-and-drop reordering works correctly for unsaved priority groups on first load and marks the card dirty.
- Saving persists under the stable id; existing saved groups keep their behaviour.
- No server, protocol, or slice changes; no dnd-kit reconfiguration.
- Tests and build pass locally (832 server + 210 admin-ui + 128 other).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->