### PR TITLE
fix(admin-ui): collapse path-overrides table when its column is narrow

### DIFF
--- a/packages/server-admin-ui/scss/_custom.scss
+++ b/packages/server-admin-ui/scss/_custom.scss
@@ -382,6 +382,89 @@ form.rjsf {
   min-width: 0;
 }
 
+// The path-overrides column hosts a 5-column table with a long
+// "Fallback after (ms)" header. On wide viewports the surrounding
+// 3-column card grid leaves the column too narrow for the header to
+// stay on one line and for the Source dropdown to keep enough room.
+// Promote the column to a container and reuse the same card layout
+// the @media (max-width: 575.98px) block uses, but trigger it on the
+// column's own width so it kicks in whenever the column is below the
+// table's comfortable minimum, independent of viewport.
+.pg-col-overrides {
+  container-type: inline-size;
+}
+
+@mixin pg-prefs-table-card-layout {
+  thead {
+    display: none;
+  }
+  tbody,
+  tr,
+  td {
+    display: block;
+    width: 100%;
+  }
+  tr {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      'rank source actions'
+      'fallback fallback fallback'
+      'enabled order order';
+    column-gap: 0.5rem;
+    row-gap: 0.35rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+  td {
+    padding: 0;
+    border: none;
+    &::before {
+      content: attr(data-th);
+      display: block;
+      font-size: 0.7rem;
+      color: var(--bs-secondary-color, #6c757d);
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+      margin-bottom: 0.1rem;
+    }
+    &[data-th='']::before {
+      display: none;
+    }
+  }
+  td:nth-child(1) {
+    grid-area: rank;
+    align-self: center;
+    &::before {
+      display: none;
+    }
+  }
+  td:nth-child(2) {
+    grid-area: source;
+  }
+  td:nth-child(3) {
+    grid-area: fallback;
+  }
+  td:nth-child(4) {
+    grid-area: enabled;
+    text-align: left !important;
+  }
+  td:nth-child(5) {
+    grid-area: order;
+  }
+  td:nth-child(6) {
+    grid-area: actions;
+    align-self: end;
+    justify-self: end;
+  }
+}
+
+@container (max-width: 500px) {
+  .pg-col-overrides .pg-prefs-table {
+    @include pg-prefs-table-card-layout;
+  }
+}
+
 .pg-col-title {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -540,68 +623,7 @@ form.rjsf {
   // with the dropdown instead of falling off-screen behind the table's
   // horizontal overflow.
   .pg-prefs-table {
-    thead {
-      display: none;
-    }
-    tbody,
-    tr,
-    td {
-      display: block;
-      width: 100%;
-    }
-    tr {
-      display: grid;
-      grid-template-columns: auto 1fr auto;
-      grid-template-areas:
-        'rank source actions'
-        'fallback fallback fallback'
-        'enabled order order';
-      column-gap: 0.5rem;
-      row-gap: 0.35rem;
-      padding: 0.5rem 0;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-    }
-    td {
-      padding: 0;
-      border: none;
-      &::before {
-        content: attr(data-th);
-        display: block;
-        font-size: 0.7rem;
-        color: var(--bs-secondary-color, #6c757d);
-        text-transform: uppercase;
-        letter-spacing: 0.02em;
-        margin-bottom: 0.1rem;
-      }
-      &[data-th='']::before {
-        display: none;
-      }
-    }
-    td:nth-child(1) {
-      grid-area: rank;
-      align-self: center;
-      &::before {
-        display: none;
-      }
-    }
-    td:nth-child(2) {
-      grid-area: source;
-    }
-    td:nth-child(3) {
-      grid-area: fallback;
-    }
-    td:nth-child(4) {
-      grid-area: enabled;
-      text-align: left !important;
-    }
-    td:nth-child(5) {
-      grid-area: order;
-    }
-    td:nth-child(6) {
-      grid-area: actions;
-      align-self: end;
-      justify-self: end;
-    }
+    @include pg-prefs-table-card-layout;
   }
 
   // Path rows in the middle column: let the path wrap and demote the


### PR DESCRIPTION
## Motivation

In Data → Priorities, an expanded group card lays out three columns at viewports ≥ 900px. The right-most "Path overrides" column hosts a five-column edit table whose `Fallback after (ms)` header wrapped onto three lines and squeezed the Source dropdown at typical desktop widths (e.g. MacBook Pro 15" full-screen Firefox).

## Approach

Promote `.pg-col-overrides` to a CSS container (`container-type: inline-size`) and trigger the existing card layout from a `@container (max-width: 500px)` rule that keys off the column's own width rather than the viewport. The mobile `@media (max-width: 575.98px)` collapse stays in place for narrow-viewport users. Both paths share a `@mixin pg-prefs-table-card-layout` so they stay in lockstep.

Container queries are widely supported in current browsers (Firefox 110+, Chrome 105+, Safari 16+) and require no new dependencies.

## Tested

- `npm run format`, `npm run build:all`, `npm test` all green (832 server + 210 admin-ui + 128 other)
- Browser repro on the dev server: at desktop widths the table now renders the header on one line; resizing the viewport narrower flips the in-column table to the card layout when its column drops below ~500px
- Ungrouped overrides section (outside `.pg-col-overrides`) is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a layout issue in the Data → Priorities admin panel where the "Path overrides" column could not fit its five-column edit table at typical desktop widths, causing the "Fallback after (ms)" header to wrap onto multiple lines and the Source dropdown to be squeezed.

## Changes
The PR modifies `packages/server-admin-ui/scss/_custom.scss` to implement a container-based responsive mechanism:

- Promotes `.pg-col-overrides` to a CSS container by setting `container-type: inline-size`
- Introduces a `@container (max-width: 500px)` query that switches the table into a collapsed card layout when the column width drops below approximately 500px
- Extracts table-collapse rules into a new `@mixin pg-prefs-table-card-layout` that:
  - Hides the table header
  - Reshapes rows and cells into block/grid layout with named grid areas for rank, source, fallback, enabled, order, and actions
  - Uses `td::before` with `data-th` attributes to render per-cell labels, with conditional suppression for empty labels and the first column
- Replaces previously inlined card-layout styles in the existing mobile media query (`@media (max-width: 575.98px)`) with the new mixin to maintain consistency

The implementation preserves the existing mobile collapse behavior for narrow viewports while adding container-query-based responsiveness to accommodate the column's own width constraints.

## Testing
- All npm commands passed: `npm run format`, `npm run build:all`, and `npm test` (832 server + 210 admin-ui + 128 other tests)
- Manual browser verification confirms that at desktop widths the table header renders on a single line, and resizing to narrow column width properly triggers the card layout when the column drops below approximately 500px
- Ungrouped overrides outside `.pg-col-overrides` remain unchanged

## Browser Support
Container queries are supported in Firefox 110+, Chrome 105+, and Safari 16+.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->