### PR TITLE
fix(admin-ui): keep user on Installs & Removes after manual return

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { useStore } from '../../../store'
+import type { AppStoreState } from '../../../store/types'
+
+// fetchAppStore runs on mount and would try to talk to the network; stub
+// it so the tests stay deterministic and don't issue real fetches.
+vi.mock('../../../dataFetching', () => ({
+  fetchAppStore: vi.fn().mockResolvedValue(undefined)
+}))
+
+import Apps from './Apps'
+
+const emptyStore: AppStoreState = {
+  updates: [],
+  installed: [],
+  available: [],
+  installing: []
+}
+
+function setAppStore(state: AppStoreState) {
+  act(() => {
+    useStore.getState().setAppStore(state)
+  })
+}
+
+// Bootstrap's active tab variant is "secondary"; light is the inactive
+// state. Asserting on the className is the cheapest way to tell which
+// tab is selected — aria-pressed isn't set on these buttons.
+function tabIsActive(name: RegExp | string): boolean {
+  const button = screen.getByRole('button', { name })
+  return button.className.includes('btn-secondary')
+}
+
+describe('Apps auto-jump on install completion', () => {
+  beforeEach(() => {
+    setAppStore(emptyStore)
+  })
+
+  function renderApps() {
+    return render(
+      <MemoryRouter>
+        <Apps />
+      </MemoryRouter>
+    )
+  }
+
+  it('auto-jumps to Installed when the install queue drains', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a', isInstalling: true }]
+    })
+    renderApps()
+
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+    expect(tabIsActive(/Installs & Removes/)).toBe(true)
+
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a' }]
+    })
+
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+    expect(tabIsActive(/Installs & Removes/)).toBe(false)
+  })
+
+  it('lets the user manually return to Installs & Removes after the auto-jump', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a', isInstalling: true }]
+    })
+    renderApps()
+
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a' }]
+    })
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+
+    expect(tabIsActive(/Installs & Removes/)).toBe(true)
+    expect(tabIsActive(/^Installed$/)).toBe(false)
+  })
+
+  it('re-arms after a second install completes', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a', isInstalling: true }]
+    })
+    renderApps()
+
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a' }]
+    })
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+
+    setAppStore({
+      ...emptyStore,
+      installing: [
+        { name: 'plugin-a' },
+        { name: 'plugin-b', isInstalling: true }
+      ]
+    })
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+    expect(tabIsActive(/Installs & Removes/)).toBe(true)
+
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a' }, { name: 'plugin-b' }]
+    })
+
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+  })
+
+  it('does not auto-jump when an install in the batch failed', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      installing: [
+        { name: 'plugin-a', isInstalling: true },
+        { name: 'plugin-b', isInstalling: true }
+      ]
+    })
+    renderApps()
+
+    await user.click(screen.getByRole('button', { name: /Installs & Removes/ }))
+
+    setAppStore({
+      ...emptyStore,
+      installing: [
+        { name: 'plugin-a' },
+        { name: 'plugin-b', installFailed: true }
+      ]
+    })
+
+    expect(tabIsActive(/Installs & Removes/)).toBe(true)
+    expect(tabIsActive(/^Installed$/)).toBe(false)
+  })
+
+  it('does not auto-jump on first render with a stale installing array', () => {
+    setAppStore({
+      ...emptyStore,
+      installing: [{ name: 'plugin-a' }]
+    })
+    renderApps()
+
+    expect(tabIsActive(/^All$/)).toBe(true)
+    expect(tabIsActive(/^Installed$/)).toBe(false)
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useDeferredValue
 } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -270,24 +271,27 @@ const Apps: React.FC = () => {
     }
   }, [rowData])
 
-  // Once everything queued on the Installs & Removes tab has finished,
-  // jump back to Installed so the user lands on the result. Stay put
-  // when at least one install failed so the red "Install failed" pill
-  // remains in view until the user navigates away themselves.
+  // Auto-jump to Installed only on the busy→idle transition so the
+  // user lands on the result when a queued install/update finishes.
+  // appStore.installing is never cleared server-side (it drives the
+  // "Pending restart" warning), so we detect the transition via a
+  // ref rather than the array length. `view` is deliberately NOT a
+  // dep: making it one re-fires the effect when the user clicks
+  // back to "Installs & Removes" and traps them on "Installed".
+  // Suppressed on failure so the red "Install failed" pill stays
+  // in view until the user navigates away themselves.
   const busyCount = installingCount(appStore)
   const hasFailure = appStore.installing.some(
     (app) => (app as InstallingApp).installFailed
   )
+  const prevBusyCountRef = useRef(busyCount)
   useEffect(() => {
-    if (
-      view === 'Installing' &&
-      busyCount === 0 &&
-      !hasFailure &&
-      appStore.installing.length > 0
-    ) {
+    const prev = prevBusyCountRef.current
+    prevBusyCountRef.current = busyCount
+    if (prev > 0 && busyCount === 0 && !hasFailure) {
       setSelectedView('Installed')
     }
-  }, [view, busyCount, hasFailure, appStore.installing.length])
+  }, [busyCount, hasFailure])
 
   let warning: string | undefined
   if (appStore.storeAvailable === false) {


### PR DESCRIPTION
## Motivation

Reported by a user: *"App Store: once you have installed some updates, you can't get back to the 'Installs & Removes' tab, it just shows the 'Installed' tab."*

## Root cause

The auto-jump effect that lands the user on Installed when the install queue drains had `view` in its dep array and re-fired on every render where the queue was idle. Because `appStore.installing` is never cleared server-side (it drives the "Pending restart" warning), once any install had completed during the server's lifetime the user was bounced back to Installed every time they clicked the Installs & Removes tab.

## Fix

Detect the busy→idle transition via a `useRef` so the auto-jump fires once per completion rather than continuously while the queue is idle. `view` is dropped from the dep array so clicking the tab button no longer re-triggers the effect. The "auto-jump on completion" UX is preserved; the user can freely navigate back to Installs & Removes afterward; a subsequent install re-arms the detector naturally.

## Tested

- 5 new Vitest cases in `Apps.test.tsx` covering auto-jump on completion, sticky manual return, re-arm after a second install, failure-suppresses-jump, and stale-installing-on-mount.
- Full admin-ui build green; 215/215 admin-ui tests pass; root tsc build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a tab-trapping issue in the Admin UI app store where the UI auto-jumps users back to the "Installed" tab whenever installs complete, preventing them from remaining on "Installs & Removes".

## Problem

The navigation effect auto-switches based on the install queue state and includes `view` in its dependency array. Because the server preserves `appStore.installing` (used for "Pending restart"), the effect re-fires while idle and repeatedly moves users to "Installed" when they click back to "Installs & Removes". Additionally, the effect does not account for failed installs.

## Solution

The component tracks the busy→idle transition using a ref and updates `view` only when the install queue transitions from busy to idle. The effect omits `view` from its dependencies to avoid retriggering on tab clicks. The auto-jump is suppressed if any install in the batch failed. Subsequent installs re-arm the transition detector so the behavior resumes on new completions.

## Changes

- packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
  - Use `useRef` to track previous busy count and detect busy→idle transitions.
  - Replace the previous effect with a transition-aware effect that excludes `view` from deps and checks for failures before auto-jumping.

- packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
  - Add 5 Vitest + React Testing Library tests covering:
    - Auto-jump on completion
    - Sticky manual return after an auto-jump
    - Re-arming after a subsequent install
    - Suppression of auto-jump on failure
    - Handling of stale `installing` state on mount

## Tests

- Admin-ui tests: 215/215 pass.
- Root TypeScript build: green.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->