### PR TITLE
fix(test): unbreak discovery.ts under node 24 ESM fallback

### DIFF
--- a/test/discovery.ts
+++ b/test/discovery.ts
@@ -193,11 +193,15 @@ describe('runDiscovery', () => {
       return originalLoad(request, parent, isMain)
     }) as LoadFn
 
-    global.setTimeout = ((..._args: unknown[]) =>
-      0 as ReturnType<typeof setTimeout>) as unknown as typeof setTimeout
+    global.setTimeout = ((..._args: unknown[]) => {
+      const handle = originalSetTimeout(() => {}, 0)
+      clearTimeout(handle)
+      return handle
+    }) as unknown as typeof setTimeout
 
     delete require.cache[discoveryModulePath]
 
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { runDiscovery } = require('../dist/discovery.js') as DiscoveryModule
     const discovered: DiscoveredPayload[] = []
     const app: App = {


### PR DESCRIPTION
## Motivation

Master CI has been red on every push since #2708 landed. The `CI test` workflow fails before any test gets to run:

```
Exception during run: ReferenceError: require is not defined in ES module scope
    at file:///.../test/discovery.ts:24:16
```

## Root cause

The `runDiscoveryWith` helper added in #2708 contains:

```ts
global.setTimeout = ((..._args: unknown[]) =>
  0 as ReturnType<typeof setTimeout>) as unknown as typeof setTimeout
```

`0 as ReturnType<typeof setTimeout>` violates TS2352 (no overlap between `number` and `Timeout`). ts-node's CJS transform refuses to compile the file, so mocha falls back to `import()`, which under node 24 uses the native TypeScript loader that treats `.ts` files as ESM. Once the file is ESM, the top-level `require()` calls have no defined symbol and the whole file aborts before any test runs. The pre-existing `eslint-disable` comments do nothing because eslint never sees a successful parse either way — `npm run ci-lint` was already failing on the same lines.

## Fix

Reuse the `originalSetTimeout` / `clearTimeout` pattern the first test in the file already uses to produce a real `Timeout` handle. Also add the missing `eslint-disable-next-line @typescript-eslint/no-require-imports` comment to the second `require('../dist/discovery.js')` call that #2708 introduced — matching the convention the rest of the file already follows — so `ci-lint` stops flagging it.

## Tested

- `NODE_ENV=test npx mocha 'test/discovery.ts'` — all 8 tests pass locally.
- `npm run test-only` — full server suite (848 tests) passes locally.
- `npm run ci-lint` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a test-time failure in `test/discovery.ts` that prevented tests from running during CI. The root cause was a type-unsafe cast in a `global.setTimeout` mock that violated TypeScript's strict type checking rules. Since ts-node refused to compile the file due to the type violation, mocha fell back to using Node's native TypeScript loader, which treated the file as ESM under Node 24. This caused top-level `require()` calls to fail with "require is not defined".

## Changes

**test/discovery.ts:**
- Replaces the `global.setTimeout` mock in the `runDiscoveryWith` helper with a type-safe implementation that produces a real timeout handle. The mock now calls the original `originalSetTimeout` with a no-op callback, immediately clears the returned handle via `clearTimeout`, and returns it—instead of casting the literal `0` to `ReturnType<typeof setTimeout>`
- Adds `eslint-disable-next-line `@typescript-eslint/no-require-imports`` comment to the second `require('../dist/discovery.js')` statement to satisfy linting requirements

These changes restore TypeScript compiler compatibility while maintaining the existing mock behavior and allow the tests to run successfully under Node 24's ESM fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->