### PR TITLE
fix(admin-ui): pivot to Login on 401 from authenticated REST

### DIFF
--- a/packages/server-admin-ui/src/dataFetching.test.ts
+++ b/packages/server-admin-ui/src/dataFetching.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useStore } from './store'
+import { authFetch } from './dataFetching'
+import type { LoginStatus } from './store/types'
+
+function mockFetchStatus(status: number) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve({})
+    } as Response)
+  )
+}
+
+const loggedIn: LoginStatus = {
+  status: 'loggedIn',
+  authenticationRequired: true,
+  username: 'admin',
+  oidcEnabled: true,
+  oidcLoginUrl: '/signalk/v1/auth/oidc/login'
+}
+
+describe('authFetch 401 handling', () => {
+  beforeEach(() => {
+    useStore.setState({ loginStatus: { ...loggedIn } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('flips loggedIn -> notLoggedIn on 401 from a non-login URL', async () => {
+    mockFetchStatus(401)
+    await authFetch('/signalk/v1/plugins')
+    const ls = useStore.getState().loginStatus
+    expect(ls.status).toBe('notLoggedIn')
+    expect(ls.username).toBeUndefined()
+    // Server settings preserved across the credential expiry.
+    expect(ls.authenticationRequired).toBe(true)
+    expect(ls.oidcEnabled).toBe(true)
+    expect(ls.oidcLoginUrl).toBe('/signalk/v1/auth/oidc/login')
+  })
+
+  it('does not touch loginStatus on 401 from /signalk/v1/auth/login', async () => {
+    mockFetchStatus(401)
+    await authFetch('/signalk/v1/auth/login', { method: 'POST' })
+    const ls = useStore.getState().loginStatus
+    expect(ls.status).toBe('loggedIn')
+    expect(ls.username).toBe('admin')
+  })
+
+  it('does not touch loginStatus on 200', async () => {
+    mockFetchStatus(200)
+    await authFetch('/signalk/v1/plugins')
+    const ls = useStore.getState().loginStatus
+    expect(ls.status).toBe('loggedIn')
+    expect(ls.username).toBe('admin')
+  })
+
+  it('is a no-op when already notLoggedIn (dedup under parallel 401 storm)', async () => {
+    const seed: LoginStatus = {
+      status: 'notLoggedIn',
+      authenticationRequired: true
+    }
+    useStore.setState({ loginStatus: seed })
+    mockFetchStatus(401)
+
+    await Promise.all([
+      authFetch('/signalk/v1/plugins'),
+      authFetch('/signalk/v1/webapps'),
+      authFetch('/signalk/v1/addons')
+    ])
+
+    const ls = useStore.getState().loginStatus
+    expect(ls.status).toBe('notLoggedIn')
+    expect(ls.username).toBeUndefined()
+    // No stale fields leaked in from the spread path (which only runs
+    // when status was 'loggedIn').
+    expect(Object.keys(ls).sort()).toEqual(
+      ['authenticationRequired', 'status'].sort()
+    )
+  })
+})

--- a/packages/server-admin-ui/src/dataFetching.ts
+++ b/packages/server-admin-ui/src/dataFetching.ts
@@ -7,14 +7,41 @@ declare global {
   }
 }
 
-export const authFetch = (
+const LOGIN_URL = '/signalk/v1/auth/login'
+
+// A 401 from any authenticated REST call means the server no longer
+// recognises our cookie — typically after a reinstall regenerates
+// `secretKey`. Flip the store into `notLoggedIn` so ProtectedRoute
+// auto-renders <Login />. Skipped for the login endpoint itself so
+// a bad-password attempt propagates as a normal 401 to loginAction.
+// Other LoginStatus fields (authenticationRequired, oidc*, etc.) are
+// server settings, not credential state — preserve them.
+export const authFetch = async (
   url: string,
   options?: RequestInit
 ): Promise<Response> => {
-  return fetch(url, {
+  const response = await fetch(url, {
     ...options,
     credentials: 'include'
   })
+
+  if (response.status === 401 && !isLoginUrl(url)) {
+    const { loginStatus, setLoginStatus } = useStore.getState()
+    if (loginStatus.status === 'loggedIn') {
+      setLoginStatus({
+        ...loginStatus,
+        status: 'notLoggedIn',
+        username: undefined
+      })
+    }
+  }
+
+  return response
+}
+
+function isLoginUrl(url: string): boolean {
+  const path = url.split('?')[0].split('#')[0]
+  return path === LOGIN_URL || path.endsWith(LOGIN_URL)
 }
 
 export async function fetchLoginStatus(): Promise<void> {


### PR DESCRIPTION
## Motivation

closes #2718

After a signalk-server reinstall regenerates `security.json` (and the random `secretKey`), a browser that previously logged in to the same origin gets stuck in a 401 loop in the admin UI. The dashboard renders, but every `/skServer/*` and `/signalk/*` REST call returns 401 because the stored JWT was signed with the old key. Entering correct credentials doesn't visibly recover; the only user-side fix today is manually clearing site data or using incognito mode.

## Root cause

Every authenticated REST call in the admin UI goes through `authFetch` in `packages/server-admin-ui/src/dataFetching.ts`, which had no 401 handling — it just returned the raw `Response`. Callers all gate on `status === 200` and silently drop the payload on anything else. The server's auth middleware already clears the stale cookie on the first 401 (`tokensecurity.ts:1673`), so the loop isn't infinite cookie-replay — the UI just never learns the credential is dead. `loginStatus.status` stays at whatever was loaded at mount, `ProtectedRoute` keeps rendering the app, and the app keeps firing fetches → 401 flood.

## Fix

`authFetch` now flips `loginStatus.status` to `'notLoggedIn'` when any non-login authenticated request returns 401. The existing `ProtectedRoute` in `Full.tsx` already swaps in `<Login />` on that state, so the UI self-heals into a normal login without any navigation hacks. Server settings on `LoginStatus` (`authenticationRequired`, `oidc*`, etc.) are preserved across the credential expiry. The login endpoint itself is excluded so a bad-password attempt still propagates as a normal 401 to `loginAction`. A current-state guard dedups the handler under `fetchAllData`'s ~18-parallel-fetch storm.

## Tested

- 4 new Vitest cases in `dataFetching.test.ts`: 401 from a non-login URL flips state; 401 from `/signalk/v1/auth/login` does not; 200 does not; idempotent / no-op when already `notLoggedIn`.
- Full admin-ui test suite (214 tests) and root `tsc --build` green.
- Manual repro of the bug scenario end-to-end with the patched build: enable security on a throwaway data dir, log in via the admin UI, stop the server, rotate `secretKey` in `security.json` on disk, restart, reload the still-open admin tab. Result with this fix: the UI immediately pivots to the Login screen. Re-authenticating with the same credentials lands cleanly on the dashboard.