### PR TITLE
feature(admin-ui): show restart banner after server settings change

### DIFF
--- a/packages/server-admin-ui/src/components/Header/Header.tsx
+++ b/packages/server-admin-ui/src/components/Header/Header.tsx
@@ -11,6 +11,7 @@ import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTrian
 import {
   useLoginStatus,
   useRestarting,
+  useRestartRequired,
   useBackpressureWarning
 } from '../../store'
 import { logoutAction, restartAction } from '../../actions'
@@ -20,6 +21,7 @@ export default function Header() {
 
   const loginStatus = useLoginStatus()
   const restarting = useRestarting()
+  const restartRequired = useRestartRequired()
   const backpressureWarning = useBackpressureWarning()
 
   const handleSidebarHide = useCallback(() => {
@@ -62,15 +64,44 @@ export default function Header() {
     restartAction()
   }
 
+  const showRestartBanner =
+    restartRequired &&
+    loginStatus.status === 'loggedIn' &&
+    loginStatus.userLevel === 'admin'
+
   return (
     <header className="app-header navbar">
+      {showRestartBanner && (
+        <Alert
+          variant="warning"
+          className="restart-required-warning"
+          style={{
+            position: 'absolute',
+            top: '55px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 1050,
+            margin: 0,
+            padding: '8px 16px',
+            fontSize: '14px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)'
+          }}
+        >
+          <FontAwesomeIcon icon={faTriangleExclamation} /> Server settings
+          changed –{' '}
+          <Alert.Link href="#/" onClick={handleRestart}>
+            restart the server
+          </Alert.Link>{' '}
+          for them to take effect.
+        </Alert>
+      )}
       {backpressureWarning && (
         <Alert
           variant="warning"
           className="backpressure-warning"
           style={{
             position: 'absolute',
-            top: '55px',
+            top: showRestartBanner ? '100px' : '55px',
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 1050,

--- a/packages/server-admin-ui/src/components/Header/Header.tsx
+++ b/packages/server-admin-ui/src/components/Header/Header.tsx
@@ -16,6 +16,11 @@ import {
 } from '../../store'
 import { logoutAction, restartAction } from '../../actions'
 
+// Header banners are absolutely positioned just below the navbar. The
+// stacked offset places a second banner below the first when both show.
+const BANNER_TOP = '55px'
+const BANNER_TOP_STACKED = '100px'
+
 export default function Header() {
   const [dropdownOpen, setDropdownOpen] = useState(false)
 
@@ -77,7 +82,7 @@ export default function Header() {
           className="restart-required-warning"
           style={{
             position: 'absolute',
-            top: '55px',
+            top: BANNER_TOP,
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 1050,
@@ -101,7 +106,7 @@ export default function Header() {
           className="backpressure-warning"
           style={{
             position: 'absolute',
-            top: showRestartBanner ? '100px' : '55px',
+            top: showRestartBanner ? BANNER_TOP_STACKED : BANNER_TOP,
             left: '50%',
             transform: 'translateX(-50%)',
             zIndex: 1050,

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -69,6 +69,7 @@ export class WebSocketService {
       if (isReconnect) {
         fetchAllData()
         useStore.getState().setRestarting(false)
+        useStore.getState().setRestartRequired(false)
       }
     }
 

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -68,8 +68,15 @@ export class WebSocketService {
 
       if (isReconnect) {
         fetchAllData()
-        useStore.getState().setRestarting(false)
-        useStore.getState().setRestartRequired(false)
+        const store = useStore.getState()
+        const wasRestarting = store.restarting
+        store.setRestarting(false)
+        // Only clear the settings restart banner when this reconnect
+        // followed an actual restart; a transient disconnect must not
+        // hide a still-pending restart reminder.
+        if (wasRestarting) {
+          store.setRestartRequired(false)
+        }
       }
     }
 

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -192,6 +192,10 @@ export function useRestarting() {
   return useStore((s) => s.restarting)
 }
 
+export function useRestartRequired() {
+  return useStore((s) => s.restartRequired)
+}
+
 export function useNodeInfo() {
   return useStore((s) => s.nodeInfo)
 }

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -42,6 +42,7 @@ export interface AppSliceState {
   loginStatus: LoginStatus
   serverSpecification: ServerSpecification
   restarting: boolean
+  restartRequired: boolean
   accessRequests: AccessRequest[]
   devices: DeviceInfo[]
   discoveredProviders: DiscoveredProvider[]
@@ -117,6 +118,7 @@ export interface AppSliceActions {
   setServerStatistics: (stats: ServerStatistics) => void
   setProviderStatus: (status: ProviderStatus[]) => void
   setRestarting: (restarting: boolean) => void
+  setRestartRequired: (restartRequired: boolean) => void
   setAccessRequests: (requests: AccessRequest[]) => void
   setDevices: (devices: DeviceInfo[]) => void
   setDiscoveredProviders: (providers: DiscoveredProvider[]) => void
@@ -192,6 +194,7 @@ const initialAppState: AppSliceState = {
   loginStatus: {},
   serverSpecification: {},
   restarting: false,
+  restartRequired: false,
   accessRequests: [],
   devices: [],
   discoveredProviders: [],
@@ -273,6 +276,10 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
 
   setRestarting: (restarting) => {
     set({ restarting })
+  },
+
+  setRestartRequired: (restartRequired) => {
+    set({ restartRequired })
   },
 
   setAccessRequests: (accessRequests) => {

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -11,6 +11,7 @@ import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
 
 import VesselConfiguration from './VesselConfiguration'
 import Logging from './Logging'
+import { useStore } from '../../store'
 
 interface ServerSettingsData {
   hasData?: boolean
@@ -125,11 +126,11 @@ const ServerSettings: React.FC = () => {
       },
       body: JSON.stringify(settings),
       credentials: 'include'
+    }).then((response) => {
+      if (response.ok) {
+        useStore.getState().setRestartRequired(true)
+      }
     })
-      .then((response) => response.text())
-      .then((response) => {
-        alert(response)
-      })
   }, [settings])
 
   const fieldColWidthMd = 10

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import Badge from 'react-bootstrap/Badge'
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -413,10 +412,7 @@ const ServerSettings: React.FC = () => {
         <Card.Footer>
           <Button size="sm" variant="primary" onClick={handleSaveSettings}>
             <FontAwesomeIcon icon={faFloppyDisk} /> Save
-          </Button>{' '}
-          <Badge bg="danger" className="float-end">
-            Restart Required
-          </Badge>
+          </Button>
         </Card.Footer>
       </Card>
     </div>


### PR DESCRIPTION
## Motivation

Changes made in the Server Settings card only take effect after a server restart, but saving them gave no persistent reminder — just a transient alert popup that's gone the moment you dismiss it. Users could easily save settings and forget to restart, then wonder why nothing changed.

## Solution

Surface a global yellow "restart required" banner in the admin header, mirroring the existing app-store restart warning:

- Saving Server Settings (on a 2xx response) sets a `restartRequired` flag in the store.
- The header renders a banner (admin users only, since only they can restart) with an inline link that triggers the existing restart action.
- The flag auto-clears when the WebSocket reconnects after the restart, so the banner disappears on its own — same lifecycle as the existing `restarting` flag.
- When the backpressure warning is also visible, it offsets downward so the two banners don't overlap.

The redundant save-confirmation alert popup is removed, since the banner now communicates the result persistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a persistent restart reminder banner to the admin interface when server settings change. Instead of a transient alert popup, the UI displays a persistent yellow banner until the server actually restarts.

## Changes

### Store State Management
- Adds a `restartRequired: boolean` field to the application store (`appSlice`), initialized to `false`.
- Adds a `setRestartRequired(restartRequired: boolean)` action to update the flag.
- Adds a `useRestartRequired()` selector hook (alongside the existing `useRestarting()` hook) to read the flag.

### Settings Save Flow
- The ServerConfig Settings view marks a restart as required on successful saves (2xx responses) by calling `useStore.getState().setRestartRequired(true)`.
- Removes the redundant save-confirmation alert popup and the inline "Restart Required" Badge from the settings footer.

### Admin Header Banner
- The Header component uses `useRestartRequired()` and, when the current user is an admin and a restart is required, renders a global yellow "restart required" Alert with an inline link that triggers the existing restart action.
- When the backpressure (network congestion) banner is also visible, the restart banner uses a stacked top offset so the two banners do not overlap; banner top offsets are exposed as named constants.

### Automatic Flag Clearing
- WebSocketService.connect() clears `restartRequired` only when a reconnect corresponds to an actual server restart (i.e., the `restarting` flag was true prior to reconnect), preventing ordinary reconnects from hiding the banner. The `restarting` flag lifecycle remains aligned with the banner.

## Affected Files
- packages/server-admin-ui/src/components/Header/Header.tsx
- packages/server-admin-ui/src/services/WebSocketService.ts
- packages/server-admin-ui/src/store/index.ts
- packages/server-admin-ui/src/store/slices/appSlice.ts
- packages/server-admin-ui/src/views/ServerConfig/Settings.tsx

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->