### PR TITLE
fix(docker): restore "new version available" footer notice in containers

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -40,6 +40,11 @@ fi
 # Set IS_IN_DOCKER for Admin UI (disables "Update Server" button in container)
 export IS_IN_DOCKER=true
 
+# The server is installed locally (not at a system path), so enable the
+# update check explicitly. This restores the footer "new version
+# available" notice; the self-update button stays hidden via IS_IN_DOCKER.
+export SIGNALK_SERVER_IS_UPDATABLE=true
+
 # Check if host D-Bus socket is mounted (rootless container scenario)
 # If mounted, we use the host's D-Bus/Avahi instead of starting our own
 if [ -S /run/dbus/system_bus_socket ] && dbus-send --system --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames >/dev/null 2>&1; then


### PR DESCRIPTION
## Motivation

A user reported that the Docker image no longer shows the "a new version is available" notice in the footer info bar, so containerized users are never told when a server update exists. This regressed silently and has been gone for several versions.

## Root cause

The footer notice is driven by `appStore.serverUpdate`, which the backend only computes when a gate passes (`src/interfaces/appstore.js`): the server must be launched from a path in `npmServerInstallLocations`, **or** `SIGNALK_SERVER_IS_UPDATABLE` must be set.

`refactor(docker): switch from global to local npm install` (#2220, v2.20.0) changed the launch path from `/usr/lib/node_modules/signalk-server/bin/signalk-server` (which is in the list) to `/home/node/signalk/node_modules/signalk-server/bin/signalk-server` (which is not). With `SIGNALK_SERVER_IS_UPDATABLE` never set, the gate stopped passing in containers and the notice disappeared.

## Fix

Export `SIGNALK_SERVER_IS_UPDATABLE=true` from `docker/startup.sh` (shared by both `Dockerfile` and the release `Dockerfile_rel`) so the update check runs again. The self-update **button** stays hidden in containers, since that is gated separately on `IS_IN_DOCKER` (`canUpdateServer = !isInDocker`).

Container-only change; non-Docker installs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR restores the "a new version is available" footer notice for Docker container users by exporting `SIGNALK_SERVER_IS_UPDATABLE=true` from `docker/startup.sh`.

## Context

The update notice is driven by `appStore.serverUpdate`, which the backend computes only when the server launches from a path in `npmServerInstallLocations` or when the `SIGNALK_SERVER_IS_UPDATABLE` environment variable is set. A previous refactor changed the container launch path from `/usr/lib/node_modules/signalk-server/...` (in the allowed list) to `/home/node/signalk/node_modules/signalk-server/...` (not in the list), causing the update check gate to fail and the notice to disappear.

## Changes

Sets the `SIGNALK_SERVER_IS_UPDATABLE=true` environment variable in `docker/startup.sh`, applied to both `Dockerfile` and `Dockerfile_rel`. This restores the update check without enabling the in-container self-update button, which remains hidden through the separate `IS_IN_DOCKER` gate (`canUpdateServer = !isInDocker`).

The change is container-only and does not affect non-Docker installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->