### PR TITLE
docs: document TypeBox source-of-truth and API doc-sync conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,26 +45,26 @@ Do not add error handling, fallbacks, or validation for scenarios that cannot ha
 
 ## v2 API Conventions
 
-The v2 APIs (`src/api/<name>/`) follow the provider pattern (Course, Autopilot, Weather, Radar, Notifications, BLE). A new or modified API has several documentation surfaces; most are generated from one source, so keep that source authoritative and update the hand-written surface that drifts.
+The v2 APIs (`src/api/<name>/`) follow the provider pattern (Course, Autopilot, Weather, Radar, Notifications, BLE). A new or modified API has several documentation surfaces; most use the data shapes from one source, so keep that source authoritative and update the hand-written surface that drifts.
 
 ### TypeBox is the single source of truth
 
 - Define every request/response data shape as a **TypeBox schema** in `packages/server-api/src/typebox/<name>-schemas.ts`, each with a unique `$id`. These schemas — not hand-written interfaces or hand-written OpenAPI — are the source of truth.
 - Derive the TypeScript types plugins program against from the schemas with `Static<typeof XSchema>`. Do not hand-maintain a parallel `interface` that duplicates a schema; the two will drift. Only types TypeBox cannot express (anything with methods — `XApi`, `XProvider`, connection handles) are hand-written interfaces.
-- Generate OpenAPI `components.schemas` from the schemas via `typeboxToOpenApiSchemas()` (`src/api/openApiSchemas.ts`) and reference them from paths with `$ref: '#/components/schemas/<id>'`. Do not inline data shapes into the OpenAPI doc.
+- Create the OpenAPI `components.schemas` at runtime from the schemas via `typeboxToOpenApiSchemas()` (`src/api/openApiSchemas.ts`) and reference them from paths with `$ref: '#/components/schemas/<id>'`. Do not inline data shapes into the OpenAPI doc.
 - Validate request input against the schemas with `Value.Check` / `Value.Errors` (from `@sinclair/typebox/value`) — bodies **and** path/query parameters. See `src/api/ble/index.ts` and `src/api/course/index.ts`.
 
 ### Keep documentation surfaces in sync
 
-For one API, its shape is described in several places. When you change an API's shape, update each surface that is not auto-generated:
+For one API, its shape is described in several places. When you change an API's shape, update each hand-written surface — the others follow the schemas by themselves:
 
-| Surface                                                                                           | Source                                                         | Drift                        |
-| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
-| TypeBox schema (`packages/server-api/src/typebox/<name>-schemas.ts`)                              | authored                                                       | — (the source)               |
-| OpenAPI (`src/api/<name>/openApi.ts`, served at `/doc/openapi/`)                                  | generated from TypeBox; only the path/summary text is authored | low                          |
-| AsyncAPI for WebSocket channels (`src/api/<name>/asyncApi.ts`, served under `/skServer/asyncapi`) | references TypeBox schemas                                     | low                          |
-| TypeDoc types (served at `/documentation/`)                                                       | generated from `Static<>` types + JSDoc                        | —                            |
-| **Narrative markdown** (`docs/develop/rest-api/<name>_api.md`)                                    | **authored**                                                   | **high — update it by hand** |
+| Surface                                                                                           | Source                                                              | Drift                        |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------- |
+| TypeBox schema (`packages/server-api/src/typebox/<name>-schemas.ts`)                              | authored                                                            | — (the source)               |
+| OpenAPI (`src/api/<name>/openApi.ts`, served at `/doc/openapi/`)                                  | uses TypeBox schema objects; only the path/summary text is authored | low                          |
+| AsyncAPI for WebSocket channels (`src/api/<name>/asyncApi.ts`, served under `/skServer/asyncapi`) | references TypeBox schemas                                          | low                          |
+| TypeDoc types (served at `/documentation/`)                                                       | generated from `Static<>` types + JSDoc                             | —                            |
+| **Narrative markdown** (`docs/develop/rest-api/<name>_api.md`)                                    | **authored**                                                        | **high — update it by hand** |
 
 - Register each API's OpenAPI record in `src/api/swagger.ts` (`apiDocs`) and each AsyncAPI doc in the `asyncApiDocs` map.
 - `/admin/#/documentation/paths` is the live **Path Reference** (driven by the metadata registry), not the OpenAPI spec — an API-shape change does not flow through it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,37 @@ Do not add error handling, fallbacks, or validation for scenarios that cannot ha
 - Unit tests for business logic; integration tests for boundaries
 - Aim for meaningful coverage, not arbitrary percentages
 
+## v2 API Conventions
+
+The v2 APIs (`src/api/<name>/`) follow the provider pattern (Course, Autopilot, Weather, Radar, Notifications, BLE). A new or modified API has several documentation surfaces; most are generated from one source, so keep that source authoritative and update the hand-written surface that drifts.
+
+### TypeBox is the single source of truth
+
+- Define every request/response data shape as a **TypeBox schema** in `packages/server-api/src/typebox/<name>-schemas.ts`, each with a unique `$id`. These schemas — not hand-written interfaces or hand-written OpenAPI — are the source of truth.
+- Derive the TypeScript types plugins program against from the schemas with `Static<typeof XSchema>`. Do not hand-maintain a parallel `interface` that duplicates a schema; the two will drift. Only types TypeBox cannot express (anything with methods — `XApi`, `XProvider`, connection handles) are hand-written interfaces.
+- Generate OpenAPI `components.schemas` from the schemas via `typeboxToOpenApiSchemas()` (`src/api/openApiSchemas.ts`) and reference them from paths with `$ref: '#/components/schemas/<id>'`. Do not inline data shapes into the OpenAPI doc.
+- Validate request input against the schemas with `Value.Check` / `Value.Errors` (from `@sinclair/typebox/value`) — bodies **and** path/query parameters. See `src/api/ble/index.ts` and `src/api/course/index.ts`.
+
+### Keep documentation surfaces in sync
+
+For one API, its shape is described in several places. When you change an API's shape, update each surface that is not auto-generated:
+
+| Surface                                                                                           | Source                                                         | Drift                        |
+| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
+| TypeBox schema (`packages/server-api/src/typebox/<name>-schemas.ts`)                              | authored                                                       | — (the source)               |
+| OpenAPI (`src/api/<name>/openApi.ts`, served at `/doc/openapi/`)                                  | generated from TypeBox; only the path/summary text is authored | low                          |
+| AsyncAPI for WebSocket channels (`src/api/<name>/asyncApi.ts`, served under `/skServer/asyncapi`) | references TypeBox schemas                                     | low                          |
+| TypeDoc types (served at `/documentation/`)                                                       | generated from `Static<>` types + JSDoc                        | —                            |
+| **Narrative markdown** (`docs/develop/rest-api/<name>_api.md`)                                    | **authored**                                                   | **high — update it by hand** |
+
+- Register each API's OpenAPI record in `src/api/swagger.ts` (`apiDocs`) and each AsyncAPI doc in the `asyncApiDocs` map.
+- `/admin/#/documentation/paths` is the live **Path Reference** (driven by the metadata registry), not the OpenAPI spec — an API-shape change does not flow through it.
+- **Avoid hard-coded values in markdown** (timeouts, limits) that will fall out of sync as the code changes; describe behaviour, not specific numbers.
+
+### TypeDoc treats warnings as errors
+
+`typedoc.json` sets `treatWarningsAsErrors: true`, so `npm run build:docs` (part of `build:all`) fails on any warning. The common trap: a documented type that references a symbol TypeDoc cannot reach (e.g. a `Static<typeof XSchema>` whose schema module is not exported from `packages/server-api/src/index.ts`) emits "referenced but not included in the documentation". Make the referenced schema reachable from the documented entry point (the typebox schemas are exported via `export * as typebox`). Run `npm run build:docs` before pushing.
+
 ## Performance
 
 Signal K Server runs on Raspberry Pi 3-5 hardware, often on battery power. CPU cycles cost watts. Treat the delta ingestion and fanout path as allocation-sensitive.

--- a/docs/develop/rest-api/conventions.md
+++ b/docs/develop/rest-api/conventions.md
@@ -11,6 +11,7 @@ This document outlines the conventions used when defining Signal K REST APIs.
 - Managing Configuration
 - Multiple Devices
 - Multiple Providers
+- Schemas and Documentation
 
 ---
 
@@ -95,5 +96,18 @@ _Example: Create a new waypoint using the specified provider._
 ```shell
 HTTP POST "/signalk/v2/api/resources/waypoints?provider=my-plugin-id"
 ```
+
+---
+
+### Schemas and Documentation
+
+An API's data shapes are described by **TypeBox schemas**, which are the single source of truth. Each request / response shape is defined once in `packages/server-api/src/typebox/<name>-schemas.ts` and reused everywhere else:
+
+- The **OpenAPI** specification (`src/api/<name>/openApi.ts`, browsable at `/doc/openapi/`) is generated from the schemas — paths reference them, the shapes are not written out by hand.
+- The **AsyncAPI** specification for any WebSocket channels (`src/api/<name>/asyncApi.ts`) references the same schemas.
+- Incoming request bodies and path / query parameters are **validated** against the schemas at runtime.
+- The TypeScript types that plugins program against are derived from the schemas, so they cannot drift from what the server validates.
+
+Because the OpenAPI and AsyncAPI specifications are generated, they stay in step with the schemas automatically. The one surface that is written by hand — and therefore the one to update whenever an API changes — is the **narrative documentation** for the API under `docs/develop/rest-api/`. Keep it describing current behaviour, and avoid hard-coding values (timeouts, limits) that will fall out of sync as the implementation evolves.
 
 ---

--- a/docs/develop/rest-api/conventions.md
+++ b/docs/develop/rest-api/conventions.md
@@ -103,11 +103,11 @@ HTTP POST "/signalk/v2/api/resources/waypoints?provider=my-plugin-id"
 
 An API's data shapes are described by **TypeBox schemas**, which are the single source of truth. Each request / response shape is defined once in `packages/server-api/src/typebox/<name>-schemas.ts` and reused everywhere else:
 
-- The **OpenAPI** specification (`src/api/<name>/openApi.ts`, browsable at `/doc/openapi/`) is generated from the schemas — paths reference them, the shapes are not written out by hand.
+- The **OpenAPI** specifications (`src/api/<name>/openApi.ts`, browsable at `/doc/openapi/`) use data shapes from TypeBox schemas instead of manually created & updated literal descriptions, thus keeping OpenAPI and TypeBox in sync.
 - The **AsyncAPI** specification for any WebSocket channels (`src/api/<name>/asyncApi.ts`) references the same schemas.
 - Incoming request bodies and path / query parameters are **validated** against the schemas at runtime.
 - The TypeScript types that plugins program against are derived from the schemas, so they cannot drift from what the server validates.
 
-Because the OpenAPI and AsyncAPI specifications are generated, they stay in step with the schemas automatically. The one surface that is written by hand — and therefore the one to update whenever an API changes — is the **narrative documentation** for the API under `docs/develop/rest-api/`. Keep it describing current behaviour, and avoid hard-coding values (timeouts, limits) that will fall out of sync as the implementation evolves.
+Because the OpenAPI and AsyncAPI specifications use the schema objects directly at runtime, they stay in step with the schemas automatically. The one surface that is written by hand — and therefore the one to update whenever an API changes — is the **narrative documentation** for the API under `docs/develop/rest-api/`. Keep it describing current behaviour, and avoid hard-coding values (timeouts, limits) that will fall out of sync as the implementation evolves.
 
 ---


### PR DESCRIPTION
## Summary

Records the v2 API conventions in `AGENTS.md` and the contributor-facing `conventions.md` so future API work keeps the various documentation surfaces in sync.

- **TypeBox is the single source of truth** — request/response shapes are defined as TypeBox schemas; OpenAPI `components.schemas`, AsyncAPI payloads, runtime validation (`Value.Check` on bodies and path/query params) and the plugin-facing TypeScript types are all derived from them rather than hand-maintained in parallel.
- **Which surfaces drift** — a table marks each surface as generated or hand-written. The OpenAPI/AsyncAPI/TypeDoc surfaces regenerate automatically; the narrative markdown under `docs/develop/rest-api/<name>_api.md` is hand-written and is the one to update on every API change. Notes that `/admin/#/documentation/paths` is the live Path Reference (metadata registry), not the OpenAPI spec.
- **TypeDoc `treatWarningsAsErrors`** — documents the trap where deriving a type via `Static<typeof XSchema>` fails `build:docs` unless the schema is reachable from the documented entry point.

## Motivation

These conventions were applied and validated in the BLE Provider API PR (#2588) after maintainer feedback that TypeBox should be the source of truth for OpenAPI and validation. Capturing them here keeps the next API contributions consistent without rediscovering the same gotchas.

## Tested

- `prettier --check` passes on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR establishes and documents TypeBox schema conventions for Signal K v2 API implementations, defining TypeBox schemas as the single source of truth for API definitions and specifying how related documentation surfaces stay synchronized.

## Changes

**AGENTS.md**
- Adds a new “v2 API Conventions” section.
- Defines TypeBox schemas as the single source of truth for request and response shapes.
- Documents how conventions derive OpenAPI `components.schemas` (via `typeboxToOpenApiSchemas` and `$ref` usage), AsyncAPI payloads, runtime validation (`Value.Check` / `Value.Errors`) for request bodies and path/query parameters, and plugin-facing TypeScript types from TypeBox schemas.
- Lists which documentation surfaces are generated versus hand-written, and requires keeping TypeBox, generated OpenAPI, AsyncAPI channel docs, TypeDoc, and the authored narrative markdown files in sync.
- Records the `treatWarningsAsErrors` TypeDoc constraint and advises ensuring schema modules are reachable/exported from the documented entry points to avoid `build:docs` failures.

**docs/develop/rest-api/conventions.md**
- Adds a “Schemas and Documentation” section.
- States that API request/response shapes are defined once using TypeBox schemas and that OpenAPI/AsyncAPI specs derive from those schemas.
- Specifies that runtime validation and plugin-facing TypeScript types derive from the TypeBox definitions.
- Requires the hand-written REST API narrative markdown under `docs/develop/rest-api/` to match current server behavior and avoid drifting hard-coded limits (e.g., timeouts).

## Tests

- Runs `prettier --check` on the changed files (passes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->