### PR TITLE
fix(backup): stop appending .zip to backup filename and accept .backup.zip on restore

### DIFF
--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -2199,7 +2199,10 @@ module.exports = function (
           { filename }
         ) => {
           try {
-            if (!filename.endsWith('.backup')) {
+            if (
+              !filename.endsWith('.backup') &&
+              !filename.endsWith('.backup.zip')
+            ) {
               res
                 .status(400)
                 .send('the backup file does not have the .backup extension')

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -15,12 +15,16 @@ interface ZipOptions {
 /**
  * Send a zip file as a download response.
  * Replacement for express-easy-zip using archiver directly.
+ *
+ * Note: `filename` is used verbatim in the Content-Disposition header, so the
+ * caller is responsible for including any desired extension. This function
+ * intentionally does not append `.zip`.
  */
 export function sendZip(res: Response, options: ZipOptions): void {
   const { files, filename } = options
 
   res.setHeader('Content-Type', 'application/zip')
-  res.setHeader('Content-Disposition', `attachment; filename="${filename}.zip"`)
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
 
   const archive = archiver('zip', {
     zlib: { level: 9 }


### PR DESCRIPTION
## Problem

A backup produced by the server cannot be restored by the server without manually renaming the file.

The backup download route passes a filename of `signalk-<date>.backup` to `sendZip`, but `sendZip` appends `.zip` to the `Content-Disposition` header, so the file is actually downloaded as `signalk-<date>.backup.zip`. The `validateBackup` (restore) endpoint, however, only accepts filenames ending in `.backup`, so restoring the just-downloaded file fails with:

> the backup file does not have the .backup extension

Example failing filename: `signalk-May-26-2026-13T34.backup.zip`

## Fix

Two small changes:

1. **`src/zip.ts`** — `sendZip` no longer appends `.zip`. The `filename` is used verbatim in the `Content-Disposition` header, and the caller owns the extension. The backup route already passes a `.backup` name, so downloads are now `signalk-<date>.backup`. `sendZip` has a single caller in the repo (the backup route), so no other download is affected. The `Content-Type` remains `application/zip`.

2. **`src/serverroutes.ts`** — `validateBackup` now accepts filenames ending in either `.backup` or `.backup.zip`. This keeps backwards compatibility: backups already downloaded under the old `.backup.zip` name can still be restored without renaming.

## Result

- New backups download as `signalk-<date>.backup` and restore cleanly.
- Legacy `signalk-<date>.backup.zip` files still restore.

## Notes

- The admin-ui upload control lives in the separate `@signalk/server-admin-ui` package; if it does any client-side filename validation on the restore upload, a matching tweak may be needed there too. This PR covers the server side only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Backup File Extension Handling Fix

This PR addresses a mismatch in backup filename validation where downloaded backups were saved with a `.backup.zip` extension but the server's restore function only accepted `.backup` files.

## Changes

**src/zip.ts**
The `sendZip` function now uses the provided `options.filename` verbatim in the `Content-Disposition` header instead of automatically appending a `.zip` extension. Documentation is updated to clarify that callers are responsible for including any desired file extension.

**src/serverroutes.ts**
The `validateBackup` upload handler now accepts backup filenames ending in either `.backup` or `.backup.zip`, replacing the previous validation that only accepted `.backup`.

## Result

New backup downloads use the `.backup` extension and can be restored immediately without renaming. Previously downloaded `.backup.zip` files remain restorable for backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->