### PR TITLE
fix(server): also register urlencoded body parser if security is disabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ class Server {
       })
     )
     app.use(bodyParser.json({ limit: FILEUPLOADSIZELIMIT }))
+    app.use(bodyParser.urlencoded({ extended: true }))
 
     this.app = app
     app.started = false

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -28,7 +28,6 @@ import {
   Path
 } from '@signalk/server-api'
 import ms, { StringValue } from 'ms'
-import bodyParser from 'body-parser'
 import cookieParser from 'cookie-parser'
 import { createHash, randomBytes } from 'crypto'
 
@@ -637,8 +636,6 @@ function tokenSecurityFactory(
       }
       next()
     }
-
-    app.use(bodyParser.urlencoded({ extended: true }))
 
     app.use(cookieParser())
 

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -83,6 +83,7 @@ module.exports = function(app) {
     },
     registerWithRouter: (router) => {
       router.get('/demopluginGet', (req, res) => res.json({message: 'test ok'}))
+      router.post('/echoBody', (req, res) => res.json({ value: req.body.value }))
     },
     getOpenApi: () => require('./openApi'),
     app: app

--- a/test/plugin-urlencoded-body.ts
+++ b/test/plugin-urlencoded-body.ts
@@ -1,0 +1,47 @@
+import assert from 'assert'
+import path from 'path'
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Server = require('../dist/')
+
+const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
+
+describe('Plugin urlencoded POST bodies without security', () => {
+  const originalConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
+
+  before(() => {
+    process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
+  })
+
+  after(() => {
+    if (originalConfigDir === undefined) {
+      delete process.env.SIGNALK_NODE_CONFIG_DIR
+    } else {
+      process.env.SIGNALK_NODE_CONFIG_DIR = originalConfigDir
+    }
+  })
+
+  it('parses urlencoded POST bodies on plugin routes', async () => {
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+
+    await server.start()
+    try {
+      const response = await fetch(
+        `http://0.0.0.0:${port}/skServer/plugins/testplugin/echoBody`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body: 'value=hello'
+        }
+      )
+      assert.equal(response.status, 200)
+      assert.deepEqual(await response.json(), { value: 'hello' })
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/test/plugin-urlencoded-body.ts
+++ b/test/plugin-urlencoded-body.ts
@@ -29,7 +29,7 @@ describe('Plugin urlencoded POST bodies without security', () => {
     await server.start()
     try {
       const response = await fetch(
-        `http://0.0.0.0:${port}/skServer/plugins/testplugin/echoBody`,
+        `http://127.0.0.1:${port}/skServer/plugins/testplugin/echoBody`,
         {
           method: 'POST',
           headers: {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -93,6 +93,34 @@ describe('Demo plugin ', () => {
     await server.stop()
   })
 
+  it('parses urlencoded POST bodies on plugin routes without security', async () => {
+    process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
+      __dirname,
+      'plugin-test-config'
+    )
+
+    const port = await freeport()
+    const server = new Server({
+      config: { settings: { port } }
+    })
+    await server.start()
+
+    const response = await fetch(
+      `http://0.0.0.0:${port}/skServer/plugins/testplugin/echoBody`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'value=hello'
+      }
+    )
+    assert.equal(response.status, 200)
+    assert.deepEqual(await response.json(), { value: 'hello' })
+
+    await server.stop()
+  })
+
   it('loads ESM plugins', async () => {
     process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
       __dirname,

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -93,34 +93,6 @@ describe('Demo plugin ', () => {
     await server.stop()
   })
 
-  it('parses urlencoded POST bodies on plugin routes without security', async () => {
-    process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
-      __dirname,
-      'plugin-test-config'
-    )
-
-    const port = await freeport()
-    const server = new Server({
-      config: { settings: { port } }
-    })
-    await server.start()
-
-    const response = await fetch(
-      `http://0.0.0.0:${port}/skServer/plugins/testplugin/echoBody`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
-        },
-        body: 'value=hello'
-      }
-    )
-    assert.equal(response.status, 200)
-    assert.deepEqual(await response.json(), { value: 'hello' })
-
-    await server.stop()
-  })
-
   it('loads ESM plugins', async () => {
     process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
       __dirname,


### PR DESCRIPTION
## What problem does this solve?

Plugin routes registered via `plugin.registerWithRouter()` receive `req.body === {}` for POSTs with `Content-Type: application/x-www-form-urlencoded` whenever the server has no security strategy configured. The same plugin endpoints work as soon as security is enabled.

Root cause: `app.use(bodyParser.urlencoded({ extended: true }))` lived in `src/tokensecurity.ts`, so it was only registered when a real security strategy was loaded. With `dummysecurity` in place, no urlencoded parser was in the chain.

This affects any plugin using jQuery `$.post()` (default content type `application/x-www-form-urlencoded; charset=UTF-8`) or a traditional HTML form submission against a security-disabled server. Concretely surfaced via `signalk-anchor-alarm`.

This PR moves the urlencoded parser registration into `src/index.ts` next to the json parser so it is always active. The line is removed from `tokensecurity.ts` to avoid a duplicate registration. Behavior with security enabled is unchanged.

closes #2725

## How was this tested?

- Added a regression test (`test/plugins.js` + a POST handler in the test plugin) that POSTs urlencoded data to a plugin route on a server with no security configured. Test fails on master, passes with the fix.
- Manually verified with a real plugin (`signalk-anchor-alarm`) on a Raspberry Pi running with `ssl: false` and security disabled: `req.body.radius` is now populated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes a bug where plugin routes fail to parse URL-encoded request bodies (Content-Type: application/x-www-form-urlencoded) when the server has no security strategy configured. The URL-encoded body parser middleware is now registered in src/index.ts alongside the existing JSON parser so URL-encoded parsing is always active regardless of security configuration.

## Changes
- src/index.ts: Registers bodyParser.urlencoded({ extended: true }) with the Express app initialization so application/x-www-form-urlencoded request bodies are parsed even when security is disabled.
- src/tokensecurity.ts: Removes the body-parser import and the duplicate bodyParser.urlencoded() middleware registration from the token security setup.
- test/plugin-urlencoded-body.ts (regression test): Adds a test that starts a server with no security configured, POSTs URL-encoded data to a plugin endpoint, asserts a 200 response, and verifies the parsed body matches the expected values. The test uses the loopback address (127.0.0.1) to reliably connect to the local test server.

## Impact
Plugin routes registered via plugin.registerWithRouter() now correctly receive parsed req.body for URL-encoded POST requests regardless of whether security is enabled. Behavior with security enabled remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->