### PR TITLE
fix: don't count HTTP websocket probes against IP connection limit

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -886,22 +886,26 @@ function createPrimusAuthorize(
         : undefined
     req._resolvedIp = firstForwardedIp || req.connection.remoteAddress
     const ip = req._resolvedIp
-    if ((ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp) {
-      debug(`IP ${ip} exceeded max connections (${maxConnectionsPerIp})`)
-      const err = Object.assign(
-        new Error(
-          JSON.stringify({
-            error:
-              'Too many concurrent websocket connections from same IP address'
-          })
-        ),
-        { statusCode: 429 }
-      )
-      authorized(err)
-      return
-    }
+    const isWebSocketUpgrade =
+      String(req.headers.upgrade || '').toLowerCase() === 'websocket'
+    if (isWebSocketUpgrade) {
+      if ((ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp) {
+        debug(`IP ${ip} exceeded max connections (${maxConnectionsPerIp})`)
+        const err = Object.assign(
+          new Error(
+            JSON.stringify({
+              error:
+                'Too many concurrent websocket connections from same IP address'
+            })
+          ),
+          { statusCode: 429 }
+        )
+        authorized(err)
+        return
+      }
 
-    ipConnectionCounts.set(ip, (ipConnectionCounts.get(ip) ?? 0) + 1)
+      ipConnectionCounts.set(ip, (ipConnectionCounts.get(ip) ?? 0) + 1)
+    }
 
     if (!authorizeWS) {
       authorized()

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -57,6 +57,18 @@ import { Delta, hasValues } from '@signalk/server-api'
 const debug = createDebug('signalk-server:interfaces:ws')
 const debugConnection = createDebug('signalk-server:interfaces:ws:connections')
 
+function decrementIpCount(
+  ipConnectionCounts: Map<string, number>,
+  ip: string
+): void {
+  const count = ipConnectionCounts.get(ip)
+  if (count !== undefined && count > 1) {
+    ipConnectionCounts.set(ip, count - 1)
+  } else {
+    ipConnectionCounts.delete(ip)
+  }
+}
+
 interface SkPrincipal {
   identifier: string
 }
@@ -666,14 +678,7 @@ function wsInterface(app: WsApp): WsApi {
 
           spark.onDisconnects = [
             () => spark.backpressureManager?.clear(),
-            () => {
-              const count = ipConnectionCounts.get(sparkIp)
-              if (count !== undefined && count > 1) {
-                ipConnectionCounts.set(sparkIp, count - 1)
-              } else {
-                ipConnectionCounts.delete(sparkIp)
-              }
-            }
+            () => decrementIpCount(ipConnectionCounts, sparkIp)
           ]
 
           if (primusOptions.isPlayback) {
@@ -888,9 +893,10 @@ function createPrimusAuthorize(
     const ip = req._resolvedIp
     const isWebSocketUpgrade =
       String(req.headers.upgrade || '').toLowerCase() === 'websocket'
+    let countedIpConnection = false
     if (isWebSocketUpgrade) {
       if ((ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp) {
-        debug(`IP ${ip} exceeded max connections (${maxConnectionsPerIp})`)
+        debug('IP %s exceeded max connections (%d)', ip, maxConnectionsPerIp)
         const err = Object.assign(
           new Error(
             JSON.stringify({
@@ -905,6 +911,7 @@ function createPrimusAuthorize(
       }
 
       ipConnectionCounts.set(ip, (ipConnectionCounts.get(ip) ?? 0) + 1)
+      countedIpConnection = true
     }
 
     if (!authorizeWS) {
@@ -932,6 +939,9 @@ function createPrimusAuthorize(
         error instanceof JsonWebTokenError ||
         error instanceof TokenExpiredError
       ) {
+        if (countedIpConnection) {
+          decrementIpCount(ipConnectionCounts, ip)
+        }
         authorized(error as Error)
       } else {
         authorized()

--- a/test/ws-connection-limit.ts
+++ b/test/ws-connection-limit.ts
@@ -1,4 +1,5 @@
 import chai from 'chai'
+import http from 'http'
 import WebSocket from 'ws'
 import { freeport } from './ts-servertestutilities'
 import { startServerP } from './servertestutilities'
@@ -52,6 +53,17 @@ function openWsExpect429(
   })
 }
 
+function getHttpStatus(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume()
+      res.once('end', () => resolve(res.statusCode!))
+    })
+
+    req.once('error', reject)
+  })
+}
+
 describe('WebSocket per-IP connection limit', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let server: any
@@ -72,11 +84,23 @@ describe('WebSocket per-IP connection limit', function () {
     await server.stop()
   })
 
+  it('does not count non-upgrade HTTP probes against the connection limit', async function () {
+    const httpUrl = wsUrl.replace(/^ws:/, 'http:')
+    for (let i = 0; i < MAX + 1; i++) {
+      ;(await getHttpStatus(httpUrl)).should.equal(426)
+    }
+  })
+
   it(`allows up to ${MAX} concurrent connections from the same IP`, async function () {
     for (let i = 0; i < MAX; i++) {
       const ws = await openWs(wsUrl)
       openSockets.push(ws)
     }
+  })
+
+  it('does not reject non-upgrade HTTP probes while websocket connections are at the limit', async function () {
+    const httpUrl = wsUrl.replace(/^ws:/, 'http:')
+    ;(await getHttpStatus(httpUrl)).should.equal(426)
   })
 
   it('rejects the next connection with HTTP 429 and a JSON error payload', async function () {

--- a/test/ws-connection-limit.ts
+++ b/test/ws-connection-limit.ts
@@ -2,7 +2,7 @@ import chai from 'chai'
 import http from 'http'
 import WebSocket from 'ws'
 import { freeport } from './ts-servertestutilities'
-import { startServerP } from './servertestutilities'
+import { getReadOnlyToken, startServerP } from './servertestutilities'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(chai as any).Should()
@@ -21,6 +21,36 @@ function openWs(url: string): Promise<WebSocket> {
         response: res
       })
       reject(err)
+    })
+  })
+}
+
+function openWsExpectStatus(
+  url: string,
+  statusCode: number,
+  options?: WebSocket.ClientOptions
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, options)
+    ws.once('open', () => {
+      ws.close()
+      reject(
+        new Error(
+          `Expected connection to be rejected with HTTP ${statusCode} but it was accepted`
+        )
+      )
+    })
+    ws.once('error', reject)
+    ws.once('unexpected-response', (_req, res) => {
+      res.resume()
+      res.once('end', () => {
+        try {
+          res.statusCode!.should.equal(statusCode)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
     })
   })
 }
@@ -134,6 +164,41 @@ describe('WebSocket per-IP connection limit', function () {
     }
 
     openSockets.push(ws!)
+  })
+})
+
+describe('WebSocket per-IP connection limit with authorization failures', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let wsUrl: string
+  let readToken: string
+  const MAX = 2
+  const openSockets: WebSocket[] = []
+
+  before(async function () {
+    process.env.MAX_WS_CONNECTIONS_PER_IP = String(MAX)
+    const port = await freeport()
+    wsUrl = `ws://127.0.0.1:${port}${WS_STREAM_PATH}`
+    server = await startServerP(port, true)
+    readToken = await getReadOnlyToken(server)
+  })
+
+  after(async function () {
+    delete process.env.MAX_WS_CONNECTIONS_PER_IP
+    openSockets.forEach((ws) => ws.terminate())
+    await server.stop()
+  })
+
+  it('does not leak connection counts when websocket authorization rejects', async function () {
+    const invalidToken = readToken.substring(0, readToken.length - 1)
+    for (let i = 0; i < MAX + 1; i++) {
+      await openWsExpectStatus(wsUrl, 401, {
+        headers: { Authorization: `JWT ${invalidToken}` }
+      })
+    }
+
+    const ws = await openWs(`${wsUrl}&token=${readToken}`)
+    openSockets.push(ws)
   })
 })
 


### PR DESCRIPTION
## Summary

Do not count non-upgrade HTTP requests to the Signal K stream endpoint against the per-IP websocket connection limit.

The server was incrementing the per-IP connection count for every Primus authorize request before checking whether the request was actually a websocket upgrade. Plain HTTP probes do not create a spark and therefore do not emit the websocket disconnection event, so those requests could leak connection slots until the IP was rejected with 429 Too Many Requests.

This is visible with SensESP clients that validate an existing token by making a plain HTTP request to /signalk/v1/stream and expecting the normal 426 Upgrade Required response before opening the real websocket connection.

## Change

- Only apply the per-IP websocket connection limit to requests with Upgrade: websocket.
- Keep the existing 429 behavior for actual websocket connections over the configured limit.
- Add regression coverage for non-upgrade HTTP probes before and while real websocket connections are at the limit.

## Field Evidence

On a live Signal K 2.27.0 server with SensESP 3.2.3-alpha devices:

- Before this change, a SensESP device was reachable locally and still trying to reconnect, but its Signal K state was stuck around authorization/disconnected.
- Server logs showed repeated stream requests from the device IP.
- Captured responses showed the token validation request receiving 429 Too Many Requests with Too many concurrent websocket connections from same IP address.
- After applying this change locally and restarting Signal K, the devices reconnected.
- After roughly 48 hours, the server logs show repeated successful reconnects and no recurrence of 429 / Too many concurrent websocket connections:
  - sk-gen: 105 websocket opens
  - sk-monitor: 43 websocket opens
  - another SensESP device: 5 websocket opens

Related to SignalK/SensESP#957.

## Testing

- npm run build
- prettier --check src/interfaces/ws.ts test/ws-connection-limit.ts
- git diff --check
- Focused websocket connection-limit test file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug where per-IP WebSocket connection limits incorrectly count plain HTTP token-validation probes (non-upgrade requests), which previously consumed connection slots and leaked until the IP was rejected with 429 Too Many Requests.

## Changes

### src/interfaces/ws.ts

The PR introduces a `decrementIpCount` helper function for safely managing per-IP connection counters. The per-IP maximum connections accounting logic in `createPrimusAuthorize` is refactored to only apply to requests recognized as WebSocket upgrades by checking for the `Upgrade: websocket` header. Non-upgrade HTTP requests no longer increment the per-IP counter. The decrement logic on disconnect is also made conditional—it only decrements the IP counter when the connection was previously counted as a WebSocket upgrade.

### test/ws-connection-limit.ts

The test suite adds HTTP probing capabilities via a `getHttpStatus(url)` helper function that performs HTTP GET requests and returns the response status code. New test assertions verify that repeated non-upgrade HTTP probes consistently return 426 both when no WebSocket connections are open and while the per-IP WebSocket limit is reached. An additional `openWsExpectStatus(...)` helper validates rejected WebSocket upgrade responses by expected HTTP status code. A new test block validates that invalid JWT authorization attempts return 401 and do not consume per-IP connection counts.

## Behavior

Real WebSocket connections that exceed the configured per-IP limit continue to receive the existing 429 rejection. Plain HTTP probes no longer participate in the connection limit accounting, allowing token-validation requests from SensESP devices and other clients to succeed without exhausting per-IP slots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->