### PR TITLE
fix(admin-ui): show version arrow and align tags column in app store list view

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -401,13 +401,15 @@
   transition: background 0.1s;
   padding: 8px 12px;
 
-  // Narrow layout (< md): two visual lines.
-  // Line 1: icon + title/badges/desc on the left, action button on the right
-  // Line 2: author / category / version indented under the title
+  // Narrow layout (< md): three visual lines.
+  // Line 1: icon + title/desc on the left, action button on the right
+  // Line 2: tags indented under the title
+  // Line 3: author / category / version indented under the title
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-areas:
     'title   action'
+    'tags    tags'
     'meta    meta';
   column-gap: 12px;
   row-gap: 4px;
@@ -441,6 +443,18 @@
   margin-left: 40px;
 }
 
+.plugin-row__tags {
+  grid-area: tags;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+
+  // Line up under the title text: 28px icon + 12px column gap = 40px.
+  margin-left: 40px;
+}
+
 .plugin-row__action-slot {
   grid-area: action;
   min-width: 160px;
@@ -449,16 +463,20 @@
 }
 
 // md+ (>= 768px): collapse to a single dense row for classic desktop
-// density. Same grid, just one template row with three columns.
+// density. Same grid, just one template row with four columns.
 @media (min-width: 768px) {
   .plugin-row {
-    grid-template-columns: minmax(0, 1fr) auto auto;
-    grid-template-areas: 'title meta action';
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    grid-template-areas: 'title tags meta action';
     padding: 6px 12px;
     row-gap: 0;
   }
   .plugin-row__meta {
     margin-left: 0;
+  }
+  .plugin-row__tags {
+    margin-left: 0;
+    flex-wrap: nowrap;
   }
 }
 

--- a/packages/server-admin-ui/src/views/appstore/components/PluginRow.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginRow.tsx
@@ -12,6 +12,18 @@ interface PluginRowProps {
   detailLinkBase?: string
 }
 
+const formatVersionLabel = (app: AppInfo): string => {
+  if (
+    app.installedVersion &&
+    app.newVersion &&
+    app.installedVersion !== app.newVersion
+  ) {
+    return `v${app.installedVersion} → v${app.newVersion}`
+  }
+  const version = app.installedVersion || app.version
+  return version ? `v${version}` : '—'
+}
+
 const PluginRow: React.FC<PluginRowProps> = ({
   app,
   detailLinkBase = '/apps/store/plugin'
@@ -50,27 +62,29 @@ const PluginRow: React.FC<PluginRowProps> = ({
             >
               {app.displayName || app.name}
             </NavLink>
-            <RecencyBadge recent={app.recent} className="plugin-row__badge" />
-            <UpdateAvailableBadge
-              installedVersion={app.installedVersion}
-              newVersion={app.newVersion}
-              className="plugin-row__badge"
-            />
-            {app.official && (
-              <Badge bg="primary" className="plugin-row__badge">
-                OFFICIAL
-              </Badge>
-            )}
-            {showDeprecated && (
-              <Badge bg="danger" className="plugin-row__badge">
-                DEPRECATED
-              </Badge>
-            )}
             <span className="text-muted small text-truncate plugin-row__desc">
               {app.description}
             </span>
           </div>
         </div>
+      </div>
+      <div className="plugin-row__tags">
+        <RecencyBadge recent={app.recent} className="plugin-row__badge" />
+        <UpdateAvailableBadge
+          installedVersion={app.installedVersion}
+          newVersion={app.newVersion}
+          className="plugin-row__badge"
+        />
+        {app.official && (
+          <Badge bg="primary" className="plugin-row__badge">
+            OFFICIAL
+          </Badge>
+        )}
+        {showDeprecated && (
+          <Badge bg="danger" className="plugin-row__badge">
+            DEPRECATED
+          </Badge>
+        )}
       </div>
       <div className="plugin-row__meta">
         {app.author ? (
@@ -89,9 +103,7 @@ const PluginRow: React.FC<PluginRowProps> = ({
           {app.categories?.[0] ?? null}
         </div>
         <div className="text-muted small font-monospace text-nowrap">
-          {app.installedVersion || app.version
-            ? `v${app.installedVersion || app.version}`
-            : '—'}
+          {formatVersionLabel(app)}
         </div>
       </div>
       <div className="plugin-row__action-slot">


### PR DESCRIPTION
## Why

Two regressions in the new app-store **list view** vs. the older tile view:

1. The list view shows only the installed version on a plugin that has an update, while the tile view shows `v{installed} → v{newVersion}`. Users couldn't see the target version without switching layout.
2. The badges (`RECENT` / `UPDATE` / `OFFICIAL` / `DEPRECATED`) were rendered inline between the plugin name and the description, so each row's description started at a different x-position. Reported as visually noisy and hard to scan.

## How

- `PluginRow.tsx`: version cell now renders `v{old} → v{new}` when an update is available (same gate as `UpdateAvailableBadge`), otherwise falls back to `v{installed||available}` or `—`. Logic extracted into a `formatVersionLabel` helper.
- Badges moved out of the title flex row into a sibling `plugin-row__tags` grid child. Desktop (≥768px) grid is now `'title tags meta action'` so badges occupy their own column and line up vertically across rows. Narrow (<768px) folds tags to their own indented row under the title.

Tile view (`PluginCard`) is unchanged.

## Tested

- `npm run format && npm run build:all && npm test` all green
- `vite build` for `server-admin-ui` clean, 218 unit tests pass
- Verified in the running admin UI at `/apps/store` in List view: version cell shows `v1.0.0 → v1.1.0` for plugins with updates, badges align in their own column across rows, tile view unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two regressions in the app store list view compared to the earlier tile view:

**Issue 1: Hidden target version for updates**
The list view was only showing the installed version for plugins with available updates, hiding the target/new version entirely.

**Issue 2: Misaligned badge columns**
Status badges (RECENT / UPDATE / OFFICIAL / DEPRECATED) were rendered inline between the plugin name and description, causing inconsistent description alignment across rows.

## Changes

**PluginRow.tsx**
- Introduces a `formatVersionLabel` helper function that renders version information contextually:
  - When both an installed and new version exist and differ: displays `v{installed} → v{new}` format
  - Otherwise: displays `v{installed||available}` or `—` as fallback
  - Uses the same gate as `UpdateAvailableBadge` to show version transitions
- Reorganizes badge/meta rendering into a dedicated `plugin-row__tags` section separate from the title area

**appStore.scss**
- Restructures the `.plugin-row` grid layout to accommodate tags as a distinct column
- Desktop layout (≥768px): Changes from 3-column to 4-column grid (`title / tags / meta / action`), allowing badges to occupy their own column and align vertically
- Narrow/mobile layout (<768px): Creates a `plugin-row__tags` grid area with proper indentation beneath the title
- Adds `.plugin-row__tags` styles with flex wrapping configuration and spacing adjustments

## Testing

- `npm run format && npm run build:all && npm test` all pass
- `vite build` for server-admin-ui completes cleanly
- 218 unit tests pass
- Verified in running admin UI: version cell correctly displays updates as `v1.0.0 → v1.1.0`, badges align in their own column on desktop, tile view remains unaffected

**Lines changed:** +55/-25 across both files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->