### PR TITLE
fix(admin-ui): show webapp app icons on a transparent background

### DIFF
--- a/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import Webapp from './Webapp'
+
+describe('Webapp', () => {
+  describe('app icon box', () => {
+    it('renders a transparent box with the app icon as background when appIcon is set', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{ name: 'test-app', signalk: { appIcon: 'icon.png' } }}
+        />
+      )
+
+      const iconBox = container.querySelector('.float-start') as HTMLElement
+      expect(iconBox).toBeInTheDocument()
+      expect(iconBox.style.backgroundImage).toContain('test-app/icon.png')
+      // No background colour, so the icon's transparent regions show the card.
+      expect(iconBox).not.toHaveClass('bg-primary')
+    })
+
+    it('renders a blue placeholder box with a grid icon when neither appIcon nor displayName is set', () => {
+      const { container } = render(<Webapp webAppInfo={{ name: 'test-app' }} />)
+
+      const iconBox = container.querySelector('.float-start') as HTMLElement
+      expect(iconBox).toHaveClass('bg-primary')
+      expect(
+        container.querySelector('[data-icon="table-cells"]')
+      ).toBeInTheDocument()
+    })
+
+    it('renders an empty blue box when displayName is set but appIcon is not', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{
+            name: 'test-app',
+            signalk: { displayName: 'Test App' }
+          }}
+        />
+      )
+
+      const iconBox = container.querySelector('.float-start') as HTMLElement
+      expect(iconBox).toHaveClass('bg-primary')
+      expect(
+        container.querySelector('[data-icon="table-cells"]')
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -5,6 +5,8 @@ import { faTableCells } from '@fortawesome/free-solid-svg-icons/faTableCells'
 import classNames from 'classnames'
 import { toSafeModuleId } from './dynamicutilities'
 
+const ICON_BOX_SIZE = '72px'
+
 interface SignalKInfo {
   displayName?: string
   appIcon?: string
@@ -45,11 +47,14 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
   )
   const header = webAppInfo?.signalk?.displayName || webAppInfo.name
   const url = urlToWebapp(webAppInfo)
+  const appIcon = webAppInfo?.signalk?.appIcon
   const hasDisplayName = !!webAppInfo?.signalk?.displayName
 
-  const blockIcon = function (appIcon: string | null = null) {
+  const blockIcon = function () {
+    // A real icon renders on a transparent box so the card shows through its
+    // transparent areas; the primary colour is reserved for the placeholder.
     const classes = classNames(
-      'bg-primary',
+      !appIcon && 'bg-primary',
       padding.icon,
       'font-2xl me-3 float-start'
     )
@@ -63,7 +68,7 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
       justifyContent: 'center'
     }
     if (appIcon) {
-      style.width = style.height = '72px'
+      style.width = style.height = ICON_BOX_SIZE
     }
     return (
       <span className={classes} style={style}>
@@ -76,7 +81,7 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
     <a href={url}>
       <Card>
         <Card.Body className={card.style} {...attributes}>
-          {blockIcon(webAppInfo?.signalk?.appIcon || null)}
+          {blockIcon()}
           <div className={lead.classes}>{header}</div>
           <div className="text-muted font-xs">{webAppInfo.description}</div>
         </Card.Body>


### PR DESCRIPTION
## Motivation

App icons with transparent regions showed the primary (blue) colour behind them, because the webapp icon box always used `bg-primary`.

## Approach

The icon box drops its background colour when an app icon is present, so transparent areas show the card through. When no app icon is set the box keeps the blue placeholder (with the grid-icon fallback when there is also no display name).

Tests cover all three cases: icon present (transparent box, icon as background), no icon and no display name (blue box with grid icon), and display name only (empty blue box).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes the display of webapp app icons by making the icon box background transparent when an icon is present, allowing transparent regions of the icon to show the card background through. When no icon is present, the box retains a blue placeholder background with an optional grid icon fallback.

## Changes

### Webapp Component (`Webapp.tsx`)

The component introduces an `ICON_BOX_SIZE` constant and refactors icon rendering logic:

- Extracts `appIcon` from `webAppInfo?.signalk?.appIcon` and computes `hasDisplayName` to control styling
- Refactors the `blockIcon` helper into a closure-based function that captures `appIcon` and `hasDisplayName` variables
- Conditionally applies the `bg-primary` class only when `appIcon` is absent, ensuring transparent icons don't show a colored background
- When an icon is present, sets the icon box dimensions to `ICON_BOX_SIZE` and applies the icon URL as a background image
- Displays a grid icon fallback only when both `appIcon` and `displayName` are absent

### Test Suite (`Webapp.test.tsx`)

Adds comprehensive test coverage for the icon box rendering with three scenarios:

- **Icon present**: Verifies the icon box renders without the `bg-primary` class and displays the app icon as a background image
- **No icon and no display name**: Confirms the blue placeholder renders with a grid icon fallback
- **Display name only**: Validates that the blue placeholder renders without the grid icon when an icon is not provided

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SignalK/signalk-server/pull/2733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->