### PR TITLE
fix: count websocket connections on lifecycle events

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -57,6 +57,25 @@ import { Delta, hasValues } from '@signalk/server-api'
 const debug = createDebug('signalk-server:interfaces:ws')
 const debugConnection = createDebug('signalk-server:interfaces:ws:connections')
 
+function incrementIpCount(
+  ipConnectionCounts: Map<string, number>,
+  ip: string
+): void {
+  ipConnectionCounts.set(ip, (ipConnectionCounts.get(ip) ?? 0) + 1)
+}
+
+function decrementIpCount(
+  ipConnectionCounts: Map<string, number>,
+  ip: string
+): void {
+  const count = ipConnectionCounts.get(ip)
+  if (count !== undefined && count > 1) {
+    ipConnectionCounts.set(ip, count - 1)
+  } else {
+    ipConnectionCounts.delete(ip)
+  }
+}
+
 interface SkPrincipal {
   identifier: string
 }
@@ -502,6 +521,9 @@ function wsInterface(app: WsApp): WsApi {
 
         primus.on('connection', function (primusSpark: unknown) {
           const spark = primusSpark as Spark
+          const sparkIp = spark.request._resolvedIp
+          incrementIpCount(ipConnectionCounts, sparkIp)
+
           let principalId: string | undefined
           if (spark.request.skPrincipal) {
             principalId = spark.request.skPrincipal.identifier
@@ -662,18 +684,9 @@ function wsInterface(app: WsApp): WsApi {
             })
           })
 
-          const sparkIp = spark.request._resolvedIp
-
           spark.onDisconnects = [
             () => spark.backpressureManager?.clear(),
-            () => {
-              const count = ipConnectionCounts.get(sparkIp)
-              if (count !== undefined && count > 1) {
-                ipConnectionCounts.set(sparkIp, count - 1)
-              } else {
-                ipConnectionCounts.delete(sparkIp)
-              }
-            }
+            () => decrementIpCount(ipConnectionCounts, sparkIp)
           ]
 
           if (primusOptions.isPlayback) {
@@ -886,8 +899,13 @@ function createPrimusAuthorize(
         : undefined
     req._resolvedIp = firstForwardedIp || req.connection.remoteAddress
     const ip = req._resolvedIp
-    if ((ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp) {
-      debug(`IP ${ip} exceeded max connections (${maxConnectionsPerIp})`)
+    const isWebSocketUpgrade =
+      String(req.headers.upgrade || '').toLowerCase() === 'websocket'
+    if (
+      isWebSocketUpgrade &&
+      (ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp
+    ) {
+      debug('IP %s exceeded max connections (%d)', ip, maxConnectionsPerIp)
       const err = Object.assign(
         new Error(
           JSON.stringify({
@@ -900,8 +918,6 @@ function createPrimusAuthorize(
       authorized(err)
       return
     }
-
-    ipConnectionCounts.set(ip, (ipConnectionCounts.get(ip) ?? 0) + 1)
 
     if (!authorizeWS) {
       authorized()

--- a/test/ws-connection-limit.ts
+++ b/test/ws-connection-limit.ts
@@ -1,7 +1,8 @@
 import chai from 'chai'
+import http from 'http'
 import WebSocket from 'ws'
 import { freeport } from './ts-servertestutilities'
-import { startServerP } from './servertestutilities'
+import { getReadOnlyToken, startServerP } from './servertestutilities'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(chai as any).Should()
@@ -20,6 +21,36 @@ function openWs(url: string): Promise<WebSocket> {
         response: res
       })
       reject(err)
+    })
+  })
+}
+
+function openWsExpectStatus(
+  url: string,
+  statusCode: number,
+  options?: WebSocket.ClientOptions
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, options)
+    ws.once('open', () => {
+      ws.close()
+      reject(
+        new Error(
+          `Expected connection to be rejected with HTTP ${statusCode} but it was accepted`
+        )
+      )
+    })
+    ws.once('error', reject)
+    ws.once('unexpected-response', (_req, res) => {
+      res.resume()
+      res.once('end', () => {
+        try {
+          res.statusCode!.should.equal(statusCode)
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
     })
   })
 }
@@ -52,6 +83,17 @@ function openWsExpect429(
   })
 }
 
+function getHttpStatus(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume()
+      res.once('end', () => resolve(res.statusCode!))
+    })
+
+    req.once('error', reject)
+  })
+}
+
 describe('WebSocket per-IP connection limit', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let server: any
@@ -72,11 +114,23 @@ describe('WebSocket per-IP connection limit', function () {
     await server.stop()
   })
 
+  it('does not count non-upgrade HTTP probes against the connection limit', async function () {
+    const httpUrl = wsUrl.replace(/^ws:/, 'http:')
+    for (let i = 0; i < MAX + 1; i++) {
+      ;(await getHttpStatus(httpUrl)).should.equal(426)
+    }
+  })
+
   it(`allows up to ${MAX} concurrent connections from the same IP`, async function () {
     for (let i = 0; i < MAX; i++) {
       const ws = await openWs(wsUrl)
       openSockets.push(ws)
     }
+  })
+
+  it('does not reject non-upgrade HTTP probes while websocket connections are at the limit', async function () {
+    const httpUrl = wsUrl.replace(/^ws:/, 'http:')
+    ;(await getHttpStatus(httpUrl)).should.equal(426)
   })
 
   it('rejects the next connection with HTTP 429 and a JSON error payload', async function () {
@@ -110,6 +164,41 @@ describe('WebSocket per-IP connection limit', function () {
     }
 
     openSockets.push(ws!)
+  })
+})
+
+describe('WebSocket per-IP connection limit with authorization failures', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let wsUrl: string
+  let readToken: string
+  const MAX = 2
+  const openSockets: WebSocket[] = []
+
+  before(async function () {
+    process.env.MAX_WS_CONNECTIONS_PER_IP = String(MAX)
+    const port = await freeport()
+    wsUrl = `ws://127.0.0.1:${port}${WS_STREAM_PATH}`
+    server = await startServerP(port, true)
+    readToken = await getReadOnlyToken(server)
+  })
+
+  after(async function () {
+    delete process.env.MAX_WS_CONNECTIONS_PER_IP
+    openSockets.forEach((ws) => ws.terminate())
+    await server.stop()
+  })
+
+  it('does not count rejected websocket authorization attempts', async function () {
+    const invalidToken = readToken.substring(0, readToken.length - 1)
+    for (let i = 0; i < MAX + 1; i++) {
+      await openWsExpectStatus(wsUrl, 401, {
+        headers: { Authorization: `JWT ${invalidToken}` }
+      })
+    }
+
+    const ws = await openWs(`${wsUrl}&token=${readToken}`)
+    openSockets.push(ws)
   })
 })
 


### PR DESCRIPTION
## Summary

Alternative implementation to #2728.

Move per-IP websocket connection counting onto the Primus connection lifecycle. The authorize hook still rejects real websocket upgrades when the current count is already at the per-IP limit, but it no longer mutates the counter.

This keeps IP connection counting tied to actual websocket connections:

- increment in `primus.on('connection')`
- decrement from the existing `primus.on('disconnection')` path
- no counter changes for plain HTTP probes
- no rollback needed for failed token authorization

## Background

SensESP clients validate an existing token by making a plain HTTP request to `/signalk/v1/stream` and expecting the normal `426 Upgrade Required` response before opening the real websocket connection.

The previous implementation counted every Primus authorize request before a websocket connection existed. Plain HTTP probes and some rejected authorization paths could therefore consume per-IP connection slots without a matching websocket disconnection event, eventually causing `429 Too Many Requests` with `Too many concurrent websocket connections from same IP address`.

## Field Evidence

This branch was deployed as a live hotfix on a Signal K 2.27.0 server with SensESP 3.2.3-alpha devices.

In the last 36 hours of logs:

- `sk-gen`: 85 websocket opens
- `sk-monitor`: 10 websocket opens
- another SensESP device: 11 websocket opens
- total websocket opens: 127
- no `Too many concurrent websocket connections` log entries
- no `429` responses on `/signalk/v1/stream`

Since deploying this lifecycle-counting variant:

- `sk-gen`: 58 websocket opens
- `sk-monitor`: 3 websocket opens
- another SensESP device: 4 websocket opens
- total websocket opens: 78
- websocket heartbeat timeouts occurred and recovered
- both `sk-gen` and `sk-monitor` currently report `Connected`

Related to SignalK/SensESP#957.

## Testing

- `npm exec -- prettier --check src/interfaces/ws.ts test/ws-connection-limit.ts`
- `npm run build`
- `git diff --check`
- Focused websocket connection-limit test file
