### PR TITLE
feat(history): add sourceRef filtering to History API

### DIFF
--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -1,4 +1,4 @@
-import { Context, Path, Timestamp } from '.'
+import { Context, Path, SourceRef, Timestamp } from '.'
 import { Temporal } from '@js-temporal/polyfill'
 
 /**
@@ -28,6 +28,7 @@ export type AggregateMethod =
 export type ValueList = {
   path: Path
   method: AggregateMethod
+  sourceRef?: SourceRef
 }[]
 
 /**
@@ -251,6 +252,7 @@ export interface PathSpec {
   path: Path
   aggregate: AggregateMethod
   parameter: string[]
+  sourceRef?: SourceRef
 }
 
 export type ValuesRequest = TimeRangeParams & {

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -16,7 +16,7 @@ import {
 } from '@signalk/server-api/history'
 import { IRouter } from 'express'
 import { Temporal } from '@js-temporal/polyfill'
-import { Context, Path } from '@signalk/server-api'
+import { Context, Path, SourceRef } from '@signalk/server-api'
 import { createDebug } from '../../debug'
 import { Request, Response } from 'express'
 import { WithSecurityStrategy } from '../../security'
@@ -286,7 +286,7 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
   }
 
   const pathExpressions = ((query.paths as string) || '')
-    .replace(/[^0-9a-z.,_:]/gi, '')
+    .replace(/[^0-9a-z.,_:|]/gi, '')
     .split(',')
   const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression)
 
@@ -335,11 +335,15 @@ export const parseResolution = (value: unknown): number | undefined => {
 
 // Parses a path expression into a PathSpec.
 // Input examples and what they parse into:
-//   'navigation.speedOverGround'         -> { path, aggregate: 'average', parameter: [] }
-//   'navigation.speedOverGround:max'     -> { path, aggregate: 'max',     parameter: [] }
-//   'navigation.speedOverGround:sma:5'   -> { path, aggregate: 'sma',     parameter: ['5'] }
-//   'navigation.position'                -> { path, aggregate: 'first',   parameter: [] }
-//   'navigation.position:last'           -> { path, aggregate: 'last',    parameter: [] }
+//   'navigation.speedOverGround'                    -> { path, aggregate: 'average', parameter: [] }
+//   'navigation.speedOverGround:max'                -> { path, aggregate: 'max',     parameter: [] }
+//   'navigation.speedOverGround:sma:5'              -> { path, aggregate: 'sma',     parameter: ['5'] }
+//   'navigation.speedOverGround|n2k-on-ve.can0.115' -> { path, aggregate: 'average', parameter: [], sourceRef }
+//   'navigation.speedOverGround:max|n2k-on-ve.can0.115' -> { path, aggregate: 'max', parameter: [], sourceRef }
+//   'navigation.position'                           -> { path, aggregate: 'first',   parameter: [] }
+//   'navigation.position:last'                      -> { path, aggregate: 'last',    parameter: [] }
+//
+// The `|` separator is used to specify a sourceRef after the path and aggregate.
 //
 // `navigation.position` is object-valued (lat/lon), so numeric aggregates
 // like `average` are not meaningful. When the caller does not specify an
@@ -347,7 +351,17 @@ export const parseResolution = (value: unknown): number | undefined => {
 // explicit aggregate is always honored so callers can still ask for
 // `last` or `middle_index` when that matches their intent.
 export const splitPathExpression = (pathExpression: string): PathSpec => {
-  const parts = pathExpression.split(':')
+  const pipeIdx = pathExpression.indexOf('|')
+  let sourceRef: SourceRef | undefined
+  let expr: string
+  if (pipeIdx >= 0) {
+    sourceRef = pathExpression.substring(pipeIdx + 1) as SourceRef
+    expr = pathExpression.substring(0, pipeIdx)
+  } else {
+    expr = pathExpression
+  }
+
+  const parts = expr.split(':')
   const aggregateMethod = (parts[1] ||
     (parts[0] === 'navigation.position'
       ? 'first'
@@ -355,11 +369,15 @@ export const splitPathExpression = (pathExpression: string): PathSpec => {
 
   const parameters: string[] = parts.slice(2).filter((p) => p.length > 0)
 
-  return {
+  const spec: PathSpec = {
     path: parts[0] as Path,
     aggregate: aggregateMethod,
     parameter: parameters
   }
+  if (sourceRef) {
+    spec.sourceRef = sourceRef
+  }
+  return spec
 }
 
 // Exported for unit testing.

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -129,9 +129,9 @@ historyApiDoc.paths = {
           name: 'paths',
           in: 'query',
           description:
-            "Comma separated list of Signal K paths whose data should be retrieved, optional aggregation methods for each path as postfix separated by a colon. Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index' | 'sma' | 'ema'. The 'sma' (simple moving average) and 'ema' (exponential moving average) methods accept an optional numeric parameter separated by colon: for sma it is the number of samples, for ema it is the alpha value (0-1). If not provided, implementations should use sensible defaults.",
+            "Comma separated list of Signal K paths whose data should be retrieved, optional aggregation methods for each path as postfix separated by a colon, and optional source reference separated by a pipe (|). Aggregation methods: 'average' | 'min' | 'max' | 'first' | 'last' | 'mid' | 'middle_index' | 'sma' | 'ema'. The 'sma' (simple moving average) and 'ema' (exponential moving average) methods accept an optional numeric parameter separated by colon: for sma it is the number of samples, for ema it is the alpha value (0-1). If not provided, implementations should use sensible defaults. The source reference after | filters data to that specific source.",
           example:
-            'navigation.speedOverGround:sma:5,navigation.speedThroughWater:max',
+            'navigation.speedOverGround:sma:5|n2k-on-ve.can0.115,navigation.speedThroughWater:max',
           schema: { type: 'string' },
           required: true
         },
@@ -197,6 +197,11 @@ historyApiDoc.paths = {
                         method: {
                           type: 'string',
                           description: 'Aggregation method'
+                        },
+                        sourceRef: {
+                          type: 'string',
+                          description:
+                            'Source reference, present when the query specified a source filter for this path'
                         }
                       }
                     }


### PR DESCRIPTION
    Add optional sourceRef to PathSpec, allowing callers to filter
    historical data by source. The source is specified inline in the
    paths query parameter using | as separator, e.g.
    `navigation.speedOverGround:average|n2k-on-ve.can0.115`.
    
    - Add `sourceRef?: SourceRef` to PathSpec interface
    - Add `sourceRef?: SourceRef` to ValueList entries in ValuesResponse
    - Parse | separator in splitPathExpression
    - Update OpenAPI documentation for the paths parameter
    
    Fixes #2706.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds support for filtering historical data by source reference (sourceRef) in the History API. It enables callers to specify which source produced each historical value, addressing the need for applications to distinguish data from multiple devices publishing the same path (e.g., multiple heading sensors, GPS receivers).

## Changes

### Type Extensions
- Adds optional `sourceRef?: SourceRef` field to the `ValueList` type in `packages/server-api/src/history.ts`, allowing historical values to carry source metadata.
- Adds optional `sourceRef?: SourceRef` field to the `PathSpec` interface in `packages/server-api/src/history.ts`, enabling path specifications to include source filters.

### Path Expression Parsing
- Updates path-expression parsing in `src/api/history/index.ts` to support an optional sourceRef segment separated by the `|` character (e.g., `navigation.speedOverGround:average|n2k-on-ve.can0.115`).
- Modifies `parseValuesQuery` to retain the `|` character in the `paths` query parameter instead of stripping it.
- Extends the `splitPathExpression` function to detect and parse the `|` separator, extracting the right side as `sourceRef` and preserving the existing left-side parsing of path, aggregate, and parameters.

### API Documentation
- Updates OpenAPI documentation in `src/api/history/openApi.ts` to reflect support for the new `path:aggregation|sourceRef` format in the `/values` endpoint's `paths` parameter.
- Documents the new optional `sourceRef` field in the response schema, indicating it appears only when a source filter was specified in the request.

## Use Case

This enables applications such as compass calibration plugins to distinguish historical data from multiple sources publishing the same signal path, allowing them to select and compare data from specific devices over time without mixing values from different sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->