### PR TITLE
fix(deltacache): collapse numeric and canName refs on priority reconcile paths

### DIFF
--- a/packages/streams/src/n2k-signalk.test.ts
+++ b/packages/streams/src/n2k-signalk.test.ts
@@ -13,13 +13,15 @@ const HEADING_PGN = {
   id: 'vesselHeading'
 }
 
-/**
- * Pre-seed sourceMeta for a src so that deltas pass through without waiting
- * for CAN Name resolution (which requires PGN 60928 address claim traffic).
- */
-function markCanNameUnknown(stream: N2kToSignalK, src: number): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(stream as any).sourceMeta[src] = { unknownCanName: true }
+const WIND_PGN = {
+  prio: 2,
+  pgn: 130306,
+  dst: 255,
+  src: 35,
+  timestamp: '2024-01-01T00:00:00.000Z',
+  fields: { sid: 0, windSpeed: 5.2, windAngle: 1.1, reference: 'Apparent' },
+  description: 'Wind Data',
+  id: 'windData'
 }
 
 describe('N2kToSignalK', () => {
@@ -29,7 +31,6 @@ describe('N2kToSignalK', () => {
       app,
       providerId: 'test-n2k'
     })
-    markCanNameUnknown(stream, 204)
 
     const outputPromise = collectStreamOutput(stream)
 
@@ -76,7 +77,6 @@ describe('N2kToSignalK', () => {
       filtersEnabled: true,
       filters: [{ pgn: '999999', source: '' }]
     })
-    markCanNameUnknown(stream, 204)
 
     const outputPromise = collectStreamOutput(stream)
 
@@ -191,7 +191,6 @@ describe('N2kToSignalK', () => {
     // flow downstream — they create phantom can0.254 / ydgw02.254 devices.
     const app = createMockApp()
     const stream = new N2kToSignalK({ app, providerId: 'test-n2k' })
-    markCanNameUnknown(stream, 254)
 
     const outputPromise = collectStreamOutput(stream)
     stream.write({ ...HEADING_PGN, src: 254 })
@@ -229,7 +228,6 @@ describe('N2kToSignalK', () => {
       filtersEnabled: false,
       filters: [{ pgn: '127250', source: '204' }]
     })
-    markCanNameUnknown(stream, 204)
 
     const outputPromise = collectStreamOutput(stream)
 
@@ -238,5 +236,135 @@ describe('N2kToSignalK', () => {
 
     const results = await outputPromise
     expect(results).to.have.length(1)
+  })
+})
+
+describe('N2kToSignalK canName warmup', () => {
+  // Pre-seed the mapper so a src already has a resolved canName, as it
+  // would after a PGN 60928 address claim. toDelta then stamps the
+  // canName onto the delta source.
+  function seedCanName(stream: N2kToSignalK, src: number, canName: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(stream as any).n2kMapper.state[src] = { canName }
+  }
+
+  it('drops src-only deltas during the warmup window (useCanName on)', async () => {
+    const app = createMockApp()
+    const stream = new N2kToSignalK({
+      app,
+      providerId: 'canbus0',
+      useCanName: true,
+      canNameWarmupMs: 60000
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+    stream.write(WIND_PGN)
+    stream.end()
+
+    // Inside warmup with no canName yet — hold it back so no numeric-form
+    // ref is stamped before the address claim resolves.
+    expect(await outputPromise).to.have.length(0)
+  })
+
+  it('passes src-only deltas once warmup has elapsed (never-claiming device)', async () => {
+    const app = createMockApp()
+    const stream = new N2kToSignalK({
+      app,
+      providerId: 'canbus0',
+      useCanName: true,
+      canNameWarmupMs: 0
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+    stream.write(WIND_PGN)
+    stream.end()
+
+    const results = (await outputPromise) as Array<{
+      updates: Array<{ source: { src: string; canName?: string } }>
+    }>
+    expect(results).to.have.length(1)
+    expect(results[0]!.updates[0]!.source.src).to.equal('35')
+    expect(results[0]!.updates[0]!.source.canName).to.equal(undefined)
+  })
+
+  it('passes deltas that already carry a canName during warmup', async () => {
+    const app = createMockApp()
+    const stream = new N2kToSignalK({
+      app,
+      providerId: 'canbus0',
+      useCanName: true,
+      canNameWarmupMs: 60000
+    })
+    seedCanName(stream, 35, 'c0509635e7664732')
+
+    const outputPromise = collectStreamOutput(stream)
+    stream.write(WIND_PGN)
+    stream.end()
+
+    const results = (await outputPromise) as Array<{
+      updates: Array<{ source: { canName?: string } }>
+    }>
+    expect(results).to.have.length(1)
+    expect(results[0]!.updates[0]!.source.canName).to.equal('c0509635e7664732')
+  })
+
+  it('does not gate src-only deltas when useCanName is off', async () => {
+    const app = createMockApp()
+    const stream = new N2kToSignalK({
+      app,
+      providerId: 'canbus0',
+      canNameWarmupMs: 60000
+      // useCanName off
+    })
+
+    const outputPromise = collectStreamOutput(stream)
+    stream.write(WIND_PGN)
+    stream.end()
+
+    expect(await outputPromise).to.have.length(1)
+  })
+
+  it('an alarm dropped during warmup is delivered when it re-arrives after warmup', async () => {
+    // Answers the core question: notifications need no special-casing
+    // during warmup because N2K alarms are periodic (PGN 127489 every
+    // 500 ms). The same alarm that is held back mid-warmup flows through
+    // once the window passes.
+    const ENGINE_ALARM = {
+      prio: 2,
+      pgn: 127489,
+      dst: 255,
+      src: 50,
+      timestamp: '2024-01-01T00:00:00.000Z',
+      fields: { engineInstance: 0, discreteStatus1: ['Check Engine'] },
+      description: 'Engine Parameters, Dynamic',
+      id: 'engineParametersDynamic'
+    }
+
+    const app = createMockApp()
+    const stream = new N2kToSignalK({
+      app,
+      providerId: 'canbus0',
+      useCanName: true,
+      canNameWarmupMs: 0
+    })
+    // Force the first frame into the warmup window, then let it lapse so
+    // the periodic retransmit lands after warmup — without real timers.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(stream as any).warmupUntil = Number.MAX_SAFE_INTEGER
+
+    const outputPromise = collectStreamOutput(stream)
+    stream.write(ENGINE_ALARM)
+    // Warmup elapsed: the alarm's next periodic broadcast gets through.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(stream as any).warmupUntil = 0
+    stream.write({ ...ENGINE_ALARM, timestamp: '2024-01-01T00:00:00.500Z' })
+    stream.end()
+
+    const results = (await outputPromise) as Array<{
+      updates: Array<{ values: Array<{ path: string }> }>
+    }>
+    expect(results).to.have.length(1)
+    const paths = results[0]!.updates[0]!.values.map((v) => v.path)
+    expect(paths).to.include('notifications.propulsion.starboard.checkEngine')
   })
 })

--- a/packages/streams/src/n2k-signalk.ts
+++ b/packages/streams/src/n2k-signalk.ts
@@ -38,8 +38,23 @@ interface N2kToSignalKOptions {
   filters?: N2kFilter[]
   filtersEnabled?: boolean
   useCanName?: boolean
+  canNameWarmupMs?: number
   [key: string]: unknown
 }
+
+// When useCanName is on, a freshly seen NMEA 2000 device emits data frames
+// before its ISO Address Claim (PGN 60928) resolves, so the very first
+// deltas carry only the numeric src and no canName. Letting them through
+// stamps a numeric-form ref that the canName form then supersedes a beat
+// later, producing a transient duplicate device (the priority-reconcile
+// skew #2739 chased). Instead we hold src-only deltas back for a warmup
+// window, measured from the first frame seen, long enough for n2k-signalk's
+// broadcast metadata request cycle (PGN 59904 → 60928) to settle the canName
+// for devices that claim. After the window we let src-only deltas through
+// unchanged, so a controller/app node that never claims a canName (e.g.
+// Maretron N2KView, which re-broadcasts alarms but answers no ISO request
+// for its own address) still reports under its numeric ref.
+const CANNAME_WARMUP_MS = 10000
 
 interface N2kMessage {
   src: string | number
@@ -72,7 +87,6 @@ interface Delta {
 }
 
 interface SourceMeta {
-  unknownCanName?: boolean
   [key: string]: unknown
 }
 
@@ -91,10 +105,15 @@ export default class N2kToSignalK extends Transform {
   private readonly app: N2kToSignalKOptions['app']
   private readonly filters?: N2kFilter[]
   private readonly n2kMapper: N2kMapper & EventEmitter
+  private readonly canNameWarmupMs: number
+  // Set on the first frame; src-only deltas are held back until this time
+  // to give the canName time to resolve. Undefined until traffic starts.
+  private warmupUntil?: number
 
   constructor(options: N2kToSignalKOptions) {
     super({ objectMode: true })
     this.options = options
+    this.canNameWarmupMs = options.canNameWarmupMs ?? CANNAME_WARMUP_MS
     this.app = options.app
 
     if (options.filters && options.filtersEnabled) {
@@ -180,11 +199,6 @@ export default class N2kToSignalK extends Transform {
       (pgn: string | number, src: string | number) => {
         if (Number(pgn) === 60928) {
           console.warn(`n2k-signalk: unable to detect can name for src ${src}`)
-          const srcNum = Number(src)
-          const meta = this.sourceMeta[srcNum]
-          if (meta) {
-            meta.unknownCanName = true
-          }
         }
       }
     )
@@ -246,6 +260,10 @@ export default class N2kToSignalK extends Transform {
         return
       }
 
+      if (this.warmupUntil === undefined) {
+        this.warmupUntil = Date.now() + this.canNameWarmupMs
+      }
+
       const delta = this.n2kMapper.toDelta(chunk) as unknown as
         | Delta
         | undefined
@@ -268,10 +286,14 @@ export default class N2kToSignalK extends Transform {
 
         const canName = firstUpdate.source.canName
 
+        // Hold src-only deltas back only during the warmup window, so the
+        // canName has a chance to resolve before any numeric-form ref is
+        // stamped. Once the window passes, a device that still has no
+        // canName (slow or never-claiming) reports under its numeric ref.
         if (
           this.options.useCanName &&
           !canName &&
-          !this.sourceMeta[src]?.unknownCanName
+          Date.now() < this.warmupUntil!
         ) {
           done()
           return

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -787,10 +787,7 @@ export default class DeltaCache {
       if (!selfBranch || !selfBranch[part]) return {}
       selfBranch = selfBranch[part]
     }
-    const srcToCanonical = buildSrcToCanonicalMap(
-      (this.app.signalk as any)?.sources
-    )
-    const canonical = (ref: string): string => srcToCanonical.get(ref) ?? ref
+    const canonical = this.reconcileCanonical()
     const out: Record<string, string[]> = {}
     const walk = (node: any, pathParts: string[]) => {
       for (const key of Object.keys(node)) {
@@ -831,10 +828,7 @@ export default class DeltaCache {
       selfBranch = selfBranch[part]
     }
 
-    const srcToCanonical = buildSrcToCanonicalMap(
-      (this.app.signalk as any)?.sources
-    )
-    const canonical = (ref: string): string => srcToCanonical.get(ref) ?? ref
+    const canonical = this.reconcileCanonical()
 
     // Per-path canonical publishers observed in the cache, regardless
     // of publisher count. Multi-source paths drop in via the standard
@@ -938,6 +932,58 @@ export default class DeltaCache {
   }
 
   /**
+   * Supplementary `<conn>.<src>` → `<conn>.<canName>` translation built
+   * from the per-source delta store. `buildSrcToCanonicalMap` goes blind
+   * when `app.signalk.sources` has no `n2k.canName` for a numeric src —
+   * the cold-boot / UDP-gateway late-join window the comment at the top
+   * of this file describes — but a metadata delta carrying the resolved
+   * canName may already sit in `sourceDeltas` keyed by the same numeric
+   * src. Recovering it here lets a device that left a stale numeric leaf
+   * AND a canName leaf in the cache collapse onto one ref, so the two
+   * forms of one physical device don't land in two reconciled groups and
+   * trip the "a source may belong to at most one active group" save
+   * validator.
+   *
+   * Each `sourceDeltas` entry carries exactly one canName, so the map is
+   * single-valued per key and never merges two physically-different
+   * devices. Keys are usually numeric-form (the `setSourceDelta` key,
+   * n2k-signalk.ts) but `loadSourcesCache` can hydrate canName-form keys
+   * from disk; those map onto themselves (a harmless identity), which
+   * leaves the ref unchanged.
+   */
+  private buildSourceDeltaCanonicalMap(): Map<string, string> {
+    const out = new Map<string, string>()
+    for (const [key, delta] of Object.entries(this.sourceDeltas)) {
+      const source = (delta as any)?.updates?.[0]?.source
+      const canName = source?.canName
+      if (typeof canName !== 'string' || canName.length === 0) continue
+      const label = source?.label
+      if (typeof label !== 'string' || label.length === 0) continue
+      out.set(key, `${label}.${canName}`)
+    }
+    return out
+  }
+
+  /**
+   * Source-ref canonicaliser shared by the three cache-walk callers
+   * (getReconciledGroups, getSelfPathPublishers, getMultiSourcePaths).
+   * Prefers the live sources tree, then falls back to the canName
+   * recovered from the source-delta store for numeric refs the tree
+   * hasn't resolved yet. Routing all three through one closure keeps the
+   * reconciled groups, the engine's seenPublishersByPath seed and the
+   * multi-source UI from disagreeing about a device's ref during the
+   * late-join window.
+   */
+  private reconcileCanonical(): (ref: string) => string {
+    const srcToCanonical = buildSrcToCanonicalMap(
+      (this.app.signalk as any)?.sources
+    )
+    const srcDeltaCanonical = this.buildSourceDeltaCanonicalMap()
+    return (ref: string): string =>
+      srcToCanonical.get(ref) ?? srcDeltaCanonical.get(ref) ?? ref
+  }
+
+  /**
    * Compute reconciled priority groups for the admin UI: saved groups
    * are authoritative (composition is fixed by priorityGroups, not by
    * who is currently live), unsaved sources fall through to connected-
@@ -968,10 +1014,7 @@ export default class DeltaCache {
       selfBranch = selfBranch[part]
     }
 
-    const srcToCanonical = buildSrcToCanonicalMap(
-      (this.app.signalk as any)?.sources
-    )
-    const canonical = (ref: string): string => srcToCanonical.get(ref) ?? ref
+    const canonical = this.reconcileCanonical()
 
     // Walk once to populate two views: per-source path history, and
     // per-path live publisher set. The latter is the same set of edges

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -760,4 +760,202 @@ describe('Deltacache', () => {
         delete settings.priorityGroups
       })
   })
+
+  it('getReconciledGroups collapses a device seen under both numeric and canName refs', function () {
+    // Canonicalisation skew (cold boot / UDP gateway that missed the ISO
+    // Address Claim): one physical N2K device leaks a stale numeric-src
+    // leaf AND a canName leaf on the same path. buildSrcToCanonicalMap is
+    // blind because app.signalk.sources has no n2k.canName for the src,
+    // but the resolved canName already sits in sourceDeltas keyed by the
+    // numeric src. Reconcile must collapse the two onto the canName form
+    // so one device does not present two refs across two groups and trip
+    // the PUT validator ("a source may belong to at most one active
+    // group"). A genuinely different device on the same path must stay
+    // separable.
+    const PATH = 'environment.depth.canonSkew'
+    const NUMERIC = 'canbus0.172'
+    const CANNAME = 'canbus0.c0509635e7664732'
+    const OTHER = 'canbus0.c0788c00e7e04312'
+    const deltaCache = theServer.app.deltaCache
+    // The recovered numeric->canName association the late address claim
+    // wrote to the per-source delta store (keyed by numeric src). Set it
+    // directly rather than via setSourceDelta: setSourceDelta would
+    // app.signalk.addDelta() it, backfilling app.signalk.sources and
+    // letting the EXISTING buildSrcToCanonicalMap path collapse the ref -
+    // which would mask the gap this test exercises. Keeping it out of the
+    // sources tree forces the fix's sourceDeltas fallback to do the work.
+    deltaCache.sourceDeltas[NUMERIC] = {
+      context: 'vessels.self',
+      updates: [
+        {
+          source: {
+            label: 'canbus0',
+            type: 'NMEA2000',
+            canName: 'c0509635e7664732',
+            src: '172'
+          },
+          timestamp: '2024-04-01T10:00:00.000Z',
+          values: []
+        }
+      ]
+    }
+    return doSendADelta({
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: NUMERIC,
+          timestamp: '2024-04-01T10:00:01.000Z',
+          values: [{ path: PATH, value: 1 }]
+        }
+      ]
+    })
+      .then(() =>
+        doSendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              $source: CANNAME,
+              timestamp: '2024-04-01T10:00:02.000Z',
+              values: [{ path: PATH, value: 2 }]
+            }
+          ]
+        })
+      )
+      .then(() =>
+        doSendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              $source: OTHER,
+              timestamp: '2024-04-01T10:00:03.000Z',
+              values: [{ path: PATH, value: 3 }]
+            }
+          ]
+        })
+      )
+      .then(() => {
+        const reconciled = deltaCache.getReconciledGroups()
+        const allSources = []
+        for (const g of reconciled) {
+          for (const s of g.sources) allSources.push(s)
+        }
+        // The numeric ref must have been rewritten to its canName twin,
+        // so it never appears verbatim and the device is a single ref.
+        allSources.should.not.include(NUMERIC)
+        allSources.filter((s) => s === CANNAME).length.should.equal(1)
+        // The genuinely different device stays as its own distinct ref.
+        allSources.filter((s) => s === OTHER).length.should.equal(1)
+      })
+      .finally(() => {
+        deltaCache.removeSourceDelta(NUMERIC)
+      })
+  })
+
+  it('getReconciledGroups keeps two different canName devices separable when both have a stale numeric twin', function () {
+    // The two-different-devices invariant under the sourceDeltas fallback:
+    // TWO physically-distinct N2K devices each leak a numeric-src leaf AND
+    // a canName leaf on the SAME shared path. Each numeric ref must
+    // collapse onto ITS OWN canName twin (per-src single canName), and the
+    // two devices must remain two separate refs - a label-wide merge would
+    // force genuinely-separate devices into one group/source-list.
+    const PATH = 'environment.depth.canonSkewPair'
+    const NUMERIC_A = 'canbus0.181'
+    const CANNAME_A = 'canbus0.c0509635e7664732'
+    const NUMERIC_B = 'canbus0.182'
+    const CANNAME_B = 'canbus0.c0788c00e7e04312'
+    const deltaCache = theServer.app.deltaCache
+    deltaCache.sourceDeltas[NUMERIC_A] = {
+      context: 'vessels.self',
+      updates: [
+        {
+          source: {
+            label: 'canbus0',
+            type: 'NMEA2000',
+            canName: 'c0509635e7664732',
+            src: '181'
+          },
+          timestamp: '2024-04-02T10:00:00.000Z',
+          values: []
+        }
+      ]
+    }
+    deltaCache.sourceDeltas[NUMERIC_B] = {
+      context: 'vessels.self',
+      updates: [
+        {
+          source: {
+            label: 'canbus0',
+            type: 'NMEA2000',
+            canName: 'c0788c00e7e04312',
+            src: '182'
+          },
+          timestamp: '2024-04-02T10:00:01.000Z',
+          values: []
+        }
+      ]
+    }
+    return doSendADelta({
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: NUMERIC_A,
+          timestamp: '2024-04-02T10:00:02.000Z',
+          values: [{ path: PATH, value: 1 }]
+        }
+      ]
+    })
+      .then(() =>
+        doSendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              $source: CANNAME_A,
+              timestamp: '2024-04-02T10:00:03.000Z',
+              values: [{ path: PATH, value: 2 }]
+            }
+          ]
+        })
+      )
+      .then(() =>
+        doSendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              $source: NUMERIC_B,
+              timestamp: '2024-04-02T10:00:04.000Z',
+              values: [{ path: PATH, value: 3 }]
+            }
+          ]
+        })
+      )
+      .then(() =>
+        doSendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              $source: CANNAME_B,
+              timestamp: '2024-04-02T10:00:05.000Z',
+              values: [{ path: PATH, value: 4 }]
+            }
+          ]
+        })
+      )
+      .then(() => {
+        const reconciled = deltaCache.getReconciledGroups()
+        const allSources = []
+        for (const g of reconciled) {
+          for (const s of g.sources) allSources.push(s)
+        }
+        // Neither numeric ref survives - each collapsed onto its OWN twin.
+        allSources.should.not.include(NUMERIC_A)
+        allSources.should.not.include(NUMERIC_B)
+        // Both devices remain present as two distinct canName refs.
+        allSources.filter((s) => s === CANNAME_A).length.should.equal(1)
+        allSources.filter((s) => s === CANNAME_B).length.should.equal(1)
+      })
+      .finally(() => {
+        deltaCache.removeSourceDelta(NUMERIC_A)
+        deltaCache.removeSourceDelta(NUMERIC_B)
+      })
+  })
 })


### PR DESCRIPTION
## Motivation

A second cause of the Source Priorities **"Saving priorities settings failed!"** error (console: *"a source may belong to at most one active group"*). This is distinct from the newcomer dual-group claim fixed in #2738.

An N2K device can leak a stale numeric-src leaf (`canbus0.172`) and a canName leaf (`canbus0.c0509635e7664732`) onto the same path during the cold-boot / UDP-gateway window before its ISO Address Claim resolves. The reconcile cache-walk canonicalises refs via `buildSrcToCanonicalMap(app.signalk.sources)`, which only maps a numeric src to its canName once the sources tree carries `n2k.canName` for that src. In that window the numeric ref doesn't collapse, so one physical device is recorded as two refs, they split across priority groups, and the save validator rejects the payload.

## Approach

Recover the numeric→canName association the resolved address claim already wrote to the per-source delta store, and fall back to it when the sources tree is still blind. All three cache-walk callers (`getReconciledGroups`, `getSelfPathPublishers`, `getMultiSourcePaths`) now share one `reconcileCanonical` closure so the reconciled groups, the engine's seen-publishers seed and the multi-source UI agree on a device's ref during the late-join window. The fallback is keyed by numeric src and carries one canName per key, so it can never merge two physically-different devices.

## Tested

- Added two deltacache tests: one asserts a device seen under both its numeric and canName refs collapses to a single ref (with a genuinely different device on the same path staying separate); the other asserts two different devices, each with a stale numeric twin, remain two distinct refs (no false merge). Both fail on unmodified code and pass with the fix.
- Full `test/deltacache.js` plus `test/deltaPriority.ts`, `test/sourceref-migration.ts` and `test/canonical-source-ref.ts` pass (84 tests) — these exercise the shared canonicaliser across all three callers.
- `npm run build` and `npm run ci-lint` (eslint + prettier --check) are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents transient numeric ↔ canName source duplication for NMEA2000 devices by holding and reconciling source refs so devices do not split across priority groups or produce a source-priorities validation error. It implements both a read-side reconcile fallback (collapsing numeric refs into canName when available in the per-source delta store) and an ingest-side “canName warmup” that withholds src-only deltas for a short window to allow ISO Address Claim (PGN 60928) to resolve.

## Changes

src/deltacache.ts
- Centralizes canonical source-ref resolution into a shared reconcileCanonical() closure used by getReconciledGroups(), getSelfPathPublishers(), and getMultiSourcePaths().
- Adds buildSourceDeltaCanonicalMap() to derive numeric→canName translations from this.sourceDeltas (using each entry’s first update's source.label and source.canName).
- reconcileCanonical() prefers live app.signalk.sources mapping, falls back to the sourceDeltas-derived map when the live tree is blind, and otherwise returns the original ref. The fallback is keyed by numeric src and stores a single canName per key to avoid merging distinct devices.

packages/streams/src/n2k-signalk.ts
- Adds a configurable canNameWarmupMs option (default 10s) and implements a warmup window measured from the first non-null-address frame on a connection.
- During warmup, when useCanName is enabled, deltas that lack a canName are withheld (held back) so numeric-form device deltas do not emit before the CAN name can resolve. After the warmup window, src-only deltas pass through unchanged so nodes that never claim a canName still appear under numeric refs.
- Removes the previous unknownCanName tracking logic in favor of the warmup timing behavior.

test/deltacache.js and packages/streams/src/n2k-signalk.test.ts
- Adds deltacache tests that validate numeric+canName collapse to a single canonical ref and that distinct devices do not merge when both have stale numeric twins.
- Adds tests that verify canName warmup behavior: src-only deltas are withheld during warmup, deltas that already contain a canName pass immediately, and periodic alarms re-enter after warmup as expected.
- Removes explicit pre-seeding of unknown CAN-name metadata from several PGN-related tests since warmup replaces the previous unsticking behavior.

## Rationale & trade-offs

- The reconcile fallback recovers numeric→canName mappings already present in the per-source delta store for admin/UI/read-side operations without changing high-frequency ingest hot paths.
- The ingest-side warmup reduces transient duplicates earlier in the pipeline, avoiding many cases where numeric refs are observed before a canName claim arrives.
- The reconcile fallback is not applied on hot ingest paths (preferredSources) to avoid rebuilding the fallback map per call; routing hot paths through the fallback is deferred to a follow-up if needed.

## Testing & status

- Added unit tests for deltacache and warmup behavior; local deltacache and related suites pass.
- npm build and lint are clean.
- CI currently shows a pre-existing prettier --check flake on a test-generated file; a separate PR will fix it and a rebase should clear CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->