### PR TITLE
chore(prettier): ignore runtime sources-cache.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,9 @@ public
 **/*.mbtiles
 **/*.pmtiles
 **/.__mf__temp
+# Runtime cache the server writes into its config dir; the test config
+# dir is under prettier's scan, so a freshly-written cache trips
+# prettier --check during npm test.
+**/sources-cache.json
 # AssemblyScript build outputs
 packages/assemblyscript-plugin-sdk/build


### PR DESCRIPTION
## Motivation

`npm test` intermittently fails at the `prettier --check .` step (chained after the mocha run in the `test` script) with:

```
[warn] test/server-test-config/sources-cache.json
[warn] Code style issues found in the above file.
```

`sources-cache.json` is a runtime cache the server writes into its config dir via a save timer (`DeltaCache.saveSourcesCache`). The test config dir is under prettier's scan, so when that timer fires during the test run it leaves a freshly-written `{}` (no trailing newline) that `prettier --check` then rejects, failing CI even though every test passed. The file is generated and never tracked.

## Approach

Add `**/sources-cache.json` to `.prettierignore` so the generated cache is never style-checked, in any config dir.

## Tested

- Reproduced locally: a 2-byte `{}` cache file written into `test/server-test-config/` makes `prettier --check .` exit 1; with the ignore entry it passes.
- `npm run ci-lint` (eslint + prettier --check) passes with the cache file present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds `**/sources-cache.json` to `.prettierignore` to exclude the runtime-generated sources cache from Prettier checks. The `sources-cache.json` file is written by the server's delta cache save timer during tests and is never tracked in version control. When the file is generated with only `{}` content (without a trailing newline) during test execution, Prettier's formatting check rejects it, causing intermittent CI failures despite passing tests. Excluding this file from Prettier's scan prevents these spurious check failures.

## Changes

- Updates `.prettierignore` to ignore the runtime cache file across all config directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->