### PR TITLE
fix(path-metadata): resolve runtime meta across contexts

### DIFF
--- a/packages/path-metadata/src/index.test.ts
+++ b/packages/path-metadata/src/index.test.ts
@@ -89,4 +89,80 @@ describe('getMetadata', () => {
       )
     })
   })
+
+  describe('runtime meta is resolvable across contexts (path-keyed)', () => {
+    // Regression: the FreeboardSK server plugin registers environment-path
+    // metas under context 'meteo', but values for the same path can arrive
+    // under a different context — e.g. an AIS target under vessels.<mmsi>.
+    // Metadata describes the path, not the vessel, so it must resolve
+    // regardless of which context registered it.
+    it('meta added under "meteo" resolves for a value under "vessels"', () => {
+      metadataRegistry.addMetaData('meteo', 'environment.water.level', {
+        units: 'm',
+        description: 'Water level.'
+      })
+
+      // via getMetadata (used by the WS meta channel and /paths)
+      const viaGet = getMetadata(
+        'vessels.urn:mrn:imo:mmsi:123456789.environment.water.level'
+      )
+      expect(viaGet).to.not.equal(undefined)
+      expect((viaGet as { units?: string }).units).to.equal('m')
+      expect((viaGet as { description?: string }).description).to.equal(
+        'Water level.'
+      )
+
+      // via internalGetMetadata (used by FullSignalK on the first value)
+      const viaInternal = metadataRegistry.internalGetMetadata(
+        'vessels.urn:mrn:imo:mmsi:123456789.environment.water.level'
+      )
+      expect(viaInternal).to.not.equal(undefined)
+      expect((viaInternal as { units?: string }).units).to.equal('m')
+    })
+
+    it('also resolves under the original "meteo" context', () => {
+      metadataRegistry.addMetaData('meteo', 'environment.water.level', {
+        units: 'm',
+        description: 'Water level.'
+      })
+      const meta = getMetadata(
+        'meteo.urn:mrn:signalk:uuid:abc.environment.water.level'
+      )
+      expect((meta as { units?: string }).units).to.equal('m')
+    })
+
+    it('does not bleed onto a different path', () => {
+      metadataRegistry.addMetaData('meteo', 'environment.water.level', {
+        units: 'm',
+        description: 'Water level.'
+      })
+      // A different path under the same context root is unaffected.
+      expect(
+        getMetadata('vessels.self.environment.depth.belowTransducer')
+      ).to.not.have.property('description', 'Water level.')
+      // A truncated path (bare water.level) must not match the full path.
+      expect(getMetadata('vessels.self.water.level')).to.equal(undefined)
+    })
+
+    it('a description-only foreign-context meta keeps the spec units', () => {
+      // The path-keyed /*/*/ entry sits at the front of the lookup array,
+      // so a foreign-context (e.g. 'meteo') meta that only sets description
+      // must still seed from the vessel spec template — otherwise it would
+      // shadow the /vessels/*/ spec wildcard and strip the spec units from
+      // the same path under every context.
+      metadataRegistry.addMetaData(
+        'meteo',
+        'electrical.batteries.0.capacity.stateOfCharge',
+        { description: 'state of charge (from meteo plugin)' }
+      )
+      const meta = getMetadata(
+        self('electrical.batteries.0.capacity.stateOfCharge')
+      )
+      expect(meta).to.not.equal(undefined)
+      expect((meta as { units?: string }).units).to.equal('ratio')
+      expect((meta as { description?: string }).description).to.equal(
+        'state of charge (from meteo plugin)'
+      )
+    })
+  })
 })

--- a/packages/path-metadata/src/index.ts
+++ b/packages/path-metadata/src/index.ts
@@ -157,8 +157,13 @@ export class MetadataRegistry {
     if (parts.length < 3) {
       return undefined
     }
-    // Use wildcard key so all identities share the same cloned entry
-    const key = `/${parts[0]}/*/${parts.slice(2).join('/')}`
+    // Key runtime meta by path alone: a wildcard stands in for both the
+    // context root and the identity, so meta registered for a path under
+    // one context (e.g. 'meteo') is found by a value at the same path
+    // under any context (e.g. 'vessels'). Metadata describes the path
+    // semantics, not the vessel — mirroring how the spec entries are
+    // shared across contexts by expandContextPrefixes.
+    const key = `/*/*/${parts.slice(2).join('/')}`
 
     // Check for existing wildcard entry first
     if (this.allMetadata[key]) {
@@ -211,9 +216,11 @@ export class MetadataRegistry {
     if (!path) {
       return
     }
-    // Use wildcard key pattern so lookups with any identity match
-    const root = context.split('.')[0]
-    const key = `/${root}/*/${path.replace(/\./g, '/')}`
+    // Key by path alone (wildcard for both context root and identity) so
+    // meta registered under one context (e.g. 'meteo', as the FreeboardSK
+    // plugin does) is resolvable by a value at the same path under any
+    // context (e.g. 'vessels' for an AIS target). See internalGetMetadata.
+    const key = `/*/*/${path.replace(/\./g, '/')}`
     const existing = this.allMetadata[key]
     if (existing) {
       Object.assign(existing, meta)
@@ -222,7 +229,15 @@ export class MetadataRegistry {
 
     // Seed from the matching spec template, if any, so untouched fields
     // like units / enum survive when a plugin only updates description.
-    const seed = this.getMetadata(`${context}.${path}`)
+    // The /*/*/ key is shared across all context roots, so fall back to
+    // the vessel spec template when the registering context (e.g. 'meteo')
+    // has no spec entry of its own. Without this, a foreign-context meta
+    // that only sets `description` would store a /*/*/ entry with no
+    // `units`, and its front-of-array regex would shadow the /vessels/*/
+    // spec wildcard and strip units from the same path under every context.
+    const seed =
+      this.getMetadata(`${context}.${path}`) ??
+      this.getMetadata(`vessels.*.${path}`)
     const entry: PathMetadataEntry = { description: '' }
     if (seed) Object.assign(entry, seed)
     Object.assign(entry, meta)


### PR DESCRIPTION
**Draft — proposed approach for discussion, not a merge request.** I'd like maintainer input on the keying approach (see Open questions) before this is finalised.

## Problem

Runtime metadata (supplied by plugins via meta deltas) is lost in the REST tree for values whose context root differs from the context the meta was registered under. Concretely: the FreeboardSK server plugin registers ~30 environment-path metas (e.g. `environment.water.level` → `{units:"m", description:"Water level."}`) under **`context: 'meteo'`**. A value for the same path arriving under a **`vessels.<mmsi>`** context (e.g. an AIS target) gets no meta.

This is a regression from 2.27, reported on the 2.28.0-beta thread. In 2.27 runtime meta was applied to tree leaves directly, without context partitioning, so it didn't matter which context registered it.

## Cause

The new `@signalk/path-metadata` registry keys runtime meta by **context root**: `addMetaData('meteo', 'environment.water.level')` stores `/meteo/*/environment/water/level`, while `internalGetMetadata('vessels.<mmsi>.environment.water.level')` looks up `/vessels/*/environment/water/level`. Different roots → no match → meta dropped.

## Proposed approach

Key runtime meta by the **path** rather than the context root — wildcard both the context root and the identity (`/*/*/<path>`) in `addMetaData` and `internalGetMetadata`. Metadata is path-semantic (units are physical), so the same path tail means the same thing under any context.

Also seed a path's runtime entry from the vessel spec template when the registering context has no spec entry of its own — otherwise a description-only foreign-context meta would store an entry with no units and, sitting at the front of the lookup array, shadow the `/vessels/*/` spec wildcard and strip spec units from that path under every context. (This second part fixes an edge case the first part would otherwise introduce.)

## Open questions for maintainers

- **Open vs. closed context set.** `expandContextPrefixes` deliberately shares spec meta across a *closed* set (`/vessels/*/` → `/aircraft/*/`, `/aton/*/`, `/sar/*/`). `/*/*/` is an *open* set (any root). It's not wrong for correctness — a path tail's physical meaning is context-independent — but it's the opposite of the existing closed-enumeration stance. Acceptable, or would you prefer runtime meta resolved only across the known set (which would mean hardcoding `meteo`)?
- **Admin UI visibility.** The PathReference doc view filters on `/vessels/*/` keys, so `/*/*/` runtime keys drop out of `/documentation/paths` (live tree, REST, and the WS meta channel are unaffected — catalog-view-only). Trivial to patch in the UI; flagging as a side effect, and would be a separate PR.
- **Is the registry the right home for runtime meta** at all, vs. applying it to the tree leaf as 2.27 did? The registry approach is what makes the per-request ACL/`buildFull` path work, but it's a larger architectural question than this one-path fix.

## Tested

- Added cross-context tests in `packages/path-metadata/src/index.test.ts`: meta registered under `meteo` resolves for a value under `vessels.<mmsi>`; still resolves under `meteo`; does not bleed onto a different path; a description-only foreign-context meta keeps the spec units. Verified each fails without the corresponding change.
- All pre-existing `@signalk/path-metadata` tests pass unchanged, as do `@signalk/server-api` and the server `metadata`/`plugin-meta` suites.
- An end-to-end check through `FullSignalK` confirms a `meteo`-registered meta attaches to a `vessels.<mmsi>` value.