### PR TITLE
fix(server-api): apply meta deltas from identity-less contexts

### DIFF
--- a/packages/server-api/src/fullsignalk.ts
+++ b/packages/server-api/src/fullsignalk.ts
@@ -354,6 +354,26 @@ export class FullSignalK extends EventEmitter {
     if (context) {
       this.addUpdates(context, delta.context, delta.updates)
       this.updateLastModified(delta.context)
+    } else if (delta.context && delta.updates) {
+      // A context without an identity segment (e.g. the bare `meteo`
+      // context some plugins use to register metadata) is rejected by
+      // findContext to avoid seeding an orphan tree entry. Meta updates
+      // only populate the global metadataRegistry — keyed by contextPath,
+      // never written onto the tree — so they carry no orphan risk and
+      // must still be applied; otherwise that metadata is silently lost.
+      // Value updates are intentionally not applied here: they would seed
+      // the orphan tree entry findContext exists to prevent.
+      for (const update of delta.updates) {
+        if (update.meta) {
+          addMetas(
+            this.root,
+            delta.context,
+            update.source || update['$source'],
+            update.timestamp,
+            update.meta
+          )
+        }
+      }
     }
   }
 

--- a/test/plugin-meta.ts
+++ b/test/plugin-meta.ts
@@ -117,4 +117,47 @@ describe('Plugin meta deltas', function () {
       expect(res.status).to.equal(404)
     }
   })
+
+  it('meta registered under a context without an identity reaches values under its identified context', async function () {
+    // Some plugins (e.g. FreeboardSK) register metadata for a path under
+    // the bare context root, with no identity segment (context: 'meteo').
+    // findContext rejects identity-less contexts to avoid orphan tree
+    // entries, but that also dropped the meta delta entirely — so a value
+    // arriving under the identified context (meteo.<id>) lost its meta.
+    const id = 'urn:mrn:imo:mmsi:002655619:837976'
+    await sendADelta({
+      context: 'meteo',
+      updates: [
+        {
+          $source: 'freeboard-sk',
+          timestamp: '2026-04-24T00:00:03.000Z',
+          meta: [
+            {
+              path: 'environment.water.level',
+              value: { units: 'm', description: 'Water level.' }
+            }
+          ]
+        }
+      ]
+    })
+    await sendADelta({
+      context: `meteo.${id}`,
+      updates: [
+        {
+          $source: 'ais.AI',
+          timestamp: '2026-04-24T00:00:04.000Z',
+          values: [{ path: 'environment.water.level', value: 0.63 }]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, 80))
+
+    const res = await fetch(
+      `${host}/signalk/v1/api/meteo/${id}/environment/water/level/meta`
+    )
+    expect(res.status).to.equal(200)
+    const meta = await res.json()
+    expect(meta.units).to.equal('m')
+    expect(meta.description).to.equal('Water level.')
+  })
 })


### PR DESCRIPTION
## Problem

Reported on the 2.28.0-beta thread: metadata for some environment paths (e.g. `environment.water.level` → `{units:"m", description:"Water level."}`) disappeared from the REST API output between 2.27 and 2.28.

These metas are supplied at runtime by the FreeboardSK server plugin, which registers them under a **bare `meteo` context** (no identity segment). The value for the path then arrives under the identified context (`meteo.<id>`) and ends up with no metadata. It surfaces when security/ACLs are enabled, since REST then rebuilds the tree per request from the metadata registry.

## Cause

`FullSignalK.addDelta` routes every update through `findContext`, which rejects a context with no identity segment to avoid seeding an orphan tree entry. That early return also dropped the delta's **meta** updates, so `metadataRegistry.addMetaData` was never called and the metadata never entered the registry.

## Fix

Apply meta updates even when `findContext` returns no context. Meta updates only populate the global metadata registry — keyed by contextPath, never written onto the tree — so they carry no orphan risk. Value updates remain gated, since they would seed the orphan entry the guard exists to prevent.

The FreeboardSK plugin could also address these under `meteo.<id>`, but the server should tolerate the bare context regardless, so the fix is here.

## Tested

- Added an end-to-end test in `test/plugin-meta.ts`: a meta delta under a bare `meteo` context, then a value under `meteo.<id>`, and the meta is retrievable via REST at `/signalk/v1/api/meteo/<id>/environment/water/level/meta`. Verified it fails without the fix (404) and passes with it.
- `@signalk/server-api`, `@signalk/path-metadata`, and the server `metadata`/`plugin-meta`/`deltacache` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description

This PR fixes a regression where metadata registered under identity-less contexts (e.g., `meteo`) disappears from REST API output when values arrive under identified contexts (e.g., `meteo.<id>`). Previously, delta processing rejects contexts without an identity segment before applying metadata, which prevents metadata from reaching the metadata registry. The change ensures meta deltas on bare contexts populate the global metadata registry without creating orphan tree entries; value updates remain gated by context lookup.

## Changes

packages/server-api/src/fullsignalk.ts
- Update FullSignalK.addDelta to handle cases where findContext(...) returns no context (identity-less). Instead of dropping the delta, iterate delta.updates and apply any meta payloads via addMetas to the global metadataRegistry. Do not apply value updates or call updateLastModified in this fallback path, preserving orphan-prevention behavior while ensuring metadata is recorded.

test/plugin-meta.ts
- Add an end-to-end regression test that submits a meta delta under bare `meteo` then a value delta under `meteo.<id>`, waits for processing, and asserts the metadata (units and description) is available via the REST endpoint /signalk/v1/api/meteo/<id>/environment/water/level/meta.

## Testing

- New regression test verifies the issue reproduces before the fix and passes after.
- Relevant suites pass: `@signalk/server-api`, `@signalk/path-metadata`, and server metadata/plugin-meta/deltacache.

## Notes

- This PR is complementary to a companion change that introduces a path-keyed, context-independent metadata namespace; together they restore tolerance for bare contexts (such as those emitted by FreeboardSK) without changing how value updates guard against orphan tree entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->