### PR TITLE
fix(path-metadata): resolve metadata by path independent of context root

### DIFF
--- a/packages/path-metadata/src/index.test.ts
+++ b/packages/path-metadata/src/index.test.ts
@@ -89,4 +89,78 @@ describe('getMetadata', () => {
       )
     })
   })
+
+  // Metadata is a PATH-keyed, context-INDEPENDENT namespace: a path's
+  // units/description are the same under any context root. The seed is
+  // authored as /vessels/*/<path> but must resolve under meteo.<id>,
+  // aircraft.<id>, an arbitrary root, etc.
+  describe('metadata resolves independently of the context root', () => {
+    it('resolves the same spec meta under a non-vessel context', () => {
+      const meteo = getMetadata(
+        'meteo.urn:mrn:imo:mmsi:002320001.environment.outside.temperature'
+      )
+      expect((meteo as { units?: string })?.units).to.equal('K')
+      const aircraft = getMetadata(
+        'aircraft.self.environment.outside.temperature'
+      )
+      expect((aircraft as { units?: string })?.units).to.equal('K')
+    })
+
+    it('resolves spec meta under an entirely arbitrary context root', () => {
+      const meta = getMetadata('foobar.self.environment.outside.temperature')
+      expect((meta as { units?: string })?.units).to.equal('K')
+    })
+
+    it('addMetaData under one context is visible under another', () => {
+      metadataRegistry.addMetaData(
+        'meteo.x',
+        'environment.outside.temperature',
+        { description: 'from meteo' }
+      )
+      const meta = getMetadata(self('environment.outside.temperature'))
+      expect((meta as { description?: string }).description).to.equal(
+        'from meteo'
+      )
+      // The spec unit survives because the plugin only set description.
+      expect((meta as { units?: string }).units).to.equal('K')
+    })
+
+    it('addMetaData ignores the context root for keying', () => {
+      // Identity-less context root only — must still populate the path for
+      // every context.
+      metadataRegistry.addMetaData('meteo', 'plugin.only.path', { units: 'C' })
+      const meta = getMetadata(self('plugin.only.path'))
+      expect((meta as { units?: string }).units).to.equal('C')
+    })
+
+    it('internalGetMetadata shares one clone across contexts', () => {
+      const a = metadataRegistry.internalGetMetadata(
+        'vessels.self.navigation.speedOverGround'
+      )
+      const b = metadataRegistry.internalGetMetadata(
+        'meteo.x.navigation.speedOverGround'
+      )
+      expect(a).to.not.equal(undefined)
+      expect(a).to.equal(b)
+    })
+  })
+
+  describe('the /paths view (getAllMetadata) keeps its on-disk shape', () => {
+    it('exposes only authored seed keys, not runtime adds', () => {
+      const all = metadataRegistry.getAllMetadata()
+      // Authored shape PathReference.tsx filters on is unchanged.
+      expect(all).to.have.property('/vessels/*/environment/outside/temperature')
+      expect(all).to.have.property('/self')
+      expect(all).to.have.property('/version')
+
+      // Runtime adds land in the separate runtimeClones map and must NOT
+      // leak into /paths under any key.
+      metadataRegistry.addMetaData('vessels.self', 'plugin.runtime.path', {
+        units: 'V'
+      })
+      const after = metadataRegistry.getAllMetadata()
+      expect(after).to.not.have.property('/*/plugin/runtime/path')
+      expect(after).to.not.have.property('/vessels/*/plugin/runtime/path')
+    })
+  })
 })

--- a/packages/path-metadata/src/index.test.ts
+++ b/packages/path-metadata/src/index.test.ts
@@ -163,4 +163,42 @@ describe('getMetadata', () => {
       expect(after).to.not.have.property('/vessels/*/plugin/runtime/path')
     })
   })
+
+  describe('non-context root entries still resolve when looked up bare', () => {
+    // /self and /version are not '/<root>/*/<path>'-shaped, so the path-only
+    // matcher cannot reach them. getMetadata falls back to a literal lookup
+    // so a bare 'self'/'version' still resolves (as on the old schema).
+    it('resolves /self and /version by their literal key', () => {
+      expect(getMetadata('self')).to.not.equal(undefined)
+      expect(getMetadata('version')).to.not.equal(undefined)
+    })
+  })
+
+  describe('a per-path runtime clone wins over the generic spec wildcard', () => {
+    // A value delta clones the spec entry (internalGetMetadata); a later
+    // PUT meta override merges into that same clone (addMetaData). The
+    // clone's regex must sit ahead of the spec wildcard so getMetadata
+    // returns the override, not the untouched spec entry. Regression for
+    // the unit-preferences displayUnits override.
+    it('returns a later addMetaData override after an earlier value clone', () => {
+      const p = 'vessels.self.navigation.speedOverGround'
+      // value delta path: clone the spec entry first
+      metadataRegistry.internalGetMetadata(p)
+      // PUT meta path: merge an override into the same path
+      metadataRegistry.addMetaData(
+        'vessels.self',
+        'navigation.speedOverGround',
+        {
+          displayUnits: { category: 'speed', targetUnit: 'km/h' }
+        }
+      )
+      const meta = getMetadata(p) as {
+        units?: string
+        displayUnits?: { targetUnit?: string }
+      }
+      expect(meta.displayUnits?.targetUnit).to.equal('km/h')
+      // The spec unit is preserved through the merge.
+      expect(meta.units).to.equal('m/s')
+    })
+  })
 })

--- a/packages/path-metadata/src/index.ts
+++ b/packages/path-metadata/src/index.ts
@@ -180,7 +180,15 @@ export class MetadataRegistry {
    * Returns the metadata entry or undefined if no match.
    */
   getMetadata(path: string): PathMetadataEntry | undefined {
-    return this.getMetadataForLookupPath(toLookupPath(path))
+    // Context-independent lookup first (strip context root + identity).
+    // Fall back to the literal path so non-context root entries — /self,
+    // /version — still resolve when looked up bare; those keys are not
+    // '/<root>/*/<tail>'-shaped, so they never participate in the
+    // path-only matcher.
+    return (
+      this.getMetadataForLookupPath(toLookupPath(path)) ??
+      this.getMetadataForLookupPath('/' + path.replace(/\./g, '/'))
+    )
   }
 
   // Match an already-normalized '/*/<tail>' lookup path against the regex
@@ -233,9 +241,12 @@ export class MetadataRegistry {
     // silently change every other path that matches the same wildcard.
     const cloned: PathMetadataEntry = structuredClone(result.metadata)
     this.runtimeClones[key] = cloned
-    // Escape special chars first, then replace wildcard
+    // Escape special chars first, then replace wildcard. Front of the
+    // array so this per-path clone wins over the generic spec wildcard —
+    // and so a later addMetaData that merges into this same clone (e.g. a
+    // PUT meta displayUnits override) is found ahead of the spec entry.
     const escaped = key.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
-    this.regexEntries.push({
+    this.regexEntries.unshift({
       pattern: new RegExp(`^${escaped.replace(/\*/g, '[^/]+')}$`),
       key,
       metadata: cloned

--- a/packages/path-metadata/src/index.ts
+++ b/packages/path-metadata/src/index.ts
@@ -68,28 +68,67 @@ interface RegexEntry {
   metadata: PathMetadataEntry
 }
 
+// Metadata is a PATH-keyed, context-INDEPENDENT namespace: a path's units /
+// description are identical no matter which context root it appears under
+// (vessels.<id>, meteo.<id>, aircraft.<id>, a bare 'meteo', ...). The four
+// entity families share one data model, so their identity-scoped seed keys
+// (/vessels/*/<path> and the /aircraft|/aton|/sar expansions) reduce to a
+// single path-keyed matcher '/*/<path>'. Non-context keys (/self, /version,
+// the /resources/* tree) are not '/<root>/*/<path>'-shaped and pass through
+// unchanged, so they keep literal matching and cannot leak across roots.
+const CONTEXT_ROOT_PREFIX = /^\/(?:vessels|aircraft|aton|sar)\/\*\//
+function toMatchKey(key: string): string {
+  return key.replace(CONTEXT_ROOT_PREFIX, '/*/')
+}
+
+// Strip the context root + identity (first two dot segments) so a lookup
+// resolves the same meta under ANY context, yielding the '/*/<tail>' shape
+// the re-keyed matcher expects. Callers only ever pass context-prefixed
+// paths (vessels.self.<path>, <context>.<identity>.<path>); resources are
+// served by ResourceProvider and never reach getMetadata (rest.js next()s
+// on the 'resources' prefix before any getMetadata call), so the
+// unconditional two-segment strip is safe.
+function toLookupPath(path: string): string {
+  return '/*/' + path.split('.').slice(2).join('/')
+}
+
 function buildRegexArray(
   allEntries: Record<string, PathMetadataEntry>
 ): RegexEntry[] {
   const result: RegexEntry[] = []
+  const seen = new Set<string>()
   for (const [key, metadata] of Object.entries(allEntries)) {
-    // Convert path wildcards to regex: * → [^/]+ and RegExp → [^/]+
-    const pattern = key
-      .replace(/\*/g, '[^/]+')
-      .replace(/RegExp/g, '[^/]+')
-      .replace(/\(([^)]+)\)/g, '($1)') // preserve regex groups like (single)|([A-C])
     // Skip entries whose key ends in a bare wildcard. These are container
     // shapes (e.g. /vessels/*/electrical/ac/RegExp defines "an AC bus",
     // not "any child of electrical.ac"). Letting them match would attach
     // the container description to plugin-invented siblings — matches the
-    // old @signalk/signalk-schema behaviour.
+    // old @signalk/signalk-schema behaviour. Evaluated on the ORIGINAL key,
+    // before re-keying.
     if (key.endsWith('/*') || key.endsWith('/RegExp')) {
       continue
     }
+    // Re-key to the path-only matcher. The /aircraft|/aton|/sar expansions
+    // collapse onto the same '/*/<tail>' matcher as their /vessels/* source;
+    // the seen-Set drops the duplicates so the hot-path .find() stays short.
+    // Object.entries preserves insertion order and expandContextPrefixes
+    // emits the /vessels/* key before its expansions, so the first (and only
+    // retained) entry carries the /vessels/* metadata — identical object,
+    // so dropping the rest is harmless.
+    const matchKey = toMatchKey(key)
+    if (seen.has(matchKey)) {
+      continue
+    }
+    seen.add(matchKey)
+    // Convert path wildcards to regex on the re-keyed matcher:
+    // * → [^/]+ and RegExp → [^/]+
+    const pattern = matchKey
+      .replace(/\*/g, '[^/]+')
+      .replace(/RegExp/g, '[^/]+')
+      .replace(/\(([^)]+)\)/g, '($1)') // preserve regex groups like (single)|([A-C])
     try {
       result.push({
         pattern: new RegExp(`^${pattern}$`),
-        key,
+        key: matchKey,
         metadata
       })
     } catch (e) {
@@ -108,13 +147,20 @@ function buildRegexArray(
 }
 
 export class MetadataRegistry {
+  // allMetadata stays keyed by the original on-disk keys (/vessels/*/...,
+  // /resources/*, /self, /version) and backs getAllMetadata() -> /paths, so
+  // the endpoint and PathReference.tsx (which filters on '/vessels/*/') keep
+  // the exact same JSON shape. Runtime per-path clones live in a separate
+  // path-only map so they never reshape that /paths view.
   private allMetadata: Record<string, PathMetadataEntry>
+  private runtimeClones: Record<string, PathMetadataEntry>
   private regexEntries: RegexEntry[]
   private readonly seedEntries: Record<string, PathMetadataEntry>
 
   constructor(entries: Record<string, PathMetadataEntry>) {
     this.seedEntries = entries
     this.allMetadata = { ...entries }
+    this.runtimeClones = {}
     this.regexEntries = buildRegexArray(this.allMetadata)
   }
 
@@ -125,6 +171,7 @@ export class MetadataRegistry {
    */
   reset(): void {
     this.allMetadata = { ...this.seedEntries }
+    this.runtimeClones = {}
     this.regexEntries = buildRegexArray(this.allMetadata)
   }
 
@@ -133,7 +180,15 @@ export class MetadataRegistry {
    * Returns the metadata entry or undefined if no match.
    */
   getMetadata(path: string): PathMetadataEntry | undefined {
-    const slashPath = '/' + path.replace(/\./g, '/')
+    return this.getMetadataForLookupPath(toLookupPath(path))
+  }
+
+  // Match an already-normalized '/*/<tail>' lookup path against the regex
+  // array. Shared by getMetadata and addMetaData's seed lookup so the
+  // path-only normalization lives in exactly one place.
+  private getMetadataForLookupPath(
+    slashPath: string
+  ): PathMetadataEntry | undefined {
     const result = this.regexEntries.find((entry) =>
       entry.pattern.test(slashPath)
     )
@@ -149,26 +204,24 @@ export class MetadataRegistry {
    * so runtime metadata additions don't pollute the template.
    */
   internalGetMetadata(path: string): PathMetadataEntry | undefined {
-    const slashPath = '/' + path.replace(/\./g, '/')
     const parts = path.split('.')
     // Need at least context root + identity + one path segment to
     // produce a meaningful per-path key. Anything shorter would yield
-    // keys like "/vessels/*/" that match nothing.
+    // keys like "/*/" that match nothing.
     if (parts.length < 3) {
       return undefined
     }
-    // Use wildcard key so all identities share the same cloned entry
-    const key = `/${parts[0]}/*/${parts.slice(2).join('/')}`
+    // Key by PATH alone so a value first seen under any context
+    // (vessels.self, meteo.<id>, ...) shares one cloned per-path entry.
+    const key = `/*/${parts.slice(2).join('/')}`
 
-    // Check for existing wildcard entry first
-    if (this.allMetadata[key]) {
-      return this.allMetadata[key]
+    // Check for an existing per-path clone first
+    if (this.runtimeClones[key]) {
+      return this.runtimeClones[key]
     }
 
-    // Find via regex against the full path
-    const result = this.regexEntries.find((entry) =>
-      entry.pattern.test(slashPath)
-    )
+    // Find via regex against the path-only lookup form
+    const result = this.regexEntries.find((entry) => entry.pattern.test(key))
     if (!result || Object.keys(result.metadata).length === 0) {
       return undefined
     }
@@ -179,7 +232,7 @@ export class MetadataRegistry {
     // the template, so a plugin tweaking displayScale on one path would
     // silently change every other path that matches the same wildcard.
     const cloned: PathMetadataEntry = structuredClone(result.metadata)
-    this.allMetadata[key] = cloned
+    this.runtimeClones[key] = cloned
     // Escape special chars first, then replace wildcard
     const escaped = key.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
     this.regexEntries.push({
@@ -202,33 +255,36 @@ export class MetadataRegistry {
    *    generic spec wildcard.
    */
   addMetaData(
-    context: string,
+    _context: string,
     path: string,
     meta: Record<string, unknown>
   ): void {
-    // An empty path would key the entry at "/vessels/*/" (no tail) and
-    // mask every per-vessel entry under the same context root.
+    // An empty path would key the entry at "/*/" (no tail) and mask every
+    // per-path entry. The context is intentionally ignored: metadata is a
+    // path-keyed, context-independent namespace, so a meta delta under ANY
+    // context (including an identity-less 'meteo') populates the path for
+    // all contexts.
     if (!path) {
       return
     }
-    // Use wildcard key pattern so lookups with any identity match
-    const root = context.split('.')[0]
-    const key = `/${root}/*/${path.replace(/\./g, '/')}`
-    const existing = this.allMetadata[key]
+    const key = `/*/${path.replace(/\./g, '/')}`
+    const existing = this.runtimeClones[key]
     if (existing) {
       Object.assign(existing, meta)
       return
     }
 
-    // Seed from the matching spec template, if any, so untouched fields
-    // like units / enum survive when a plugin only updates description.
-    const seed = this.getMetadata(`${context}.${path}`)
+    // Seed from the matching spec template by PATH, if any, so untouched
+    // fields like units / enum survive when a plugin only updates
+    // description. The key is already the normalized '/*/<tail>' form.
+    const seed = this.getMetadataForLookupPath(key)
     const entry: PathMetadataEntry = { description: '' }
     if (seed) Object.assign(entry, seed)
     Object.assign(entry, meta)
-    this.allMetadata[key] = entry
+    this.runtimeClones[key] = entry
 
-    // Escape special chars first, then replace wildcard
+    // Escape special chars first, then replace wildcard. The entry fronts
+    // the generic spec wildcard for EVERY context, not just one root.
     const escaped = key.replace(/[.+?^${}()|[\]\\]/g, '\\$&')
     this.regexEntries.unshift({
       pattern: new RegExp(`^${escaped.replace(/\*/g, '[^/]+')}$`),

--- a/packages/path-metadata/src/index.ts
+++ b/packages/path-metadata/src/index.ts
@@ -83,11 +83,14 @@ function toMatchKey(key: string): string {
 
 // Strip the context root + identity (first two dot segments) so a lookup
 // resolves the same meta under ANY context, yielding the '/*/<tail>' shape
-// the re-keyed matcher expects. Callers only ever pass context-prefixed
-// paths (vessels.self.<path>, <context>.<identity>.<path>); resources are
-// served by ResourceProvider and never reach getMetadata (rest.js next()s
-// on the 'resources' prefix before any getMetadata call), so the
-// unconditional two-segment strip is safe.
+// the re-keyed matcher expects. This is the FIRST of getMetadata's two
+// lookup stages and assumes a context-prefixed path
+// (vessels.self.<path>, <context>.<identity>.<path>) — the common case.
+// It is not safe for every input: a bare singleton or short-segment path
+// (self, version, meteo.environment.outside.temperature) has no context
+// root + identity to strip, so the two-segment slice produces a '/*/...'
+// form that matches nothing. getMetadata falls back to a literal-path
+// lookup for those, so this strip does not need to handle them.
 function toLookupPath(path: string): string {
   return '/*/' + path.split('.').slice(2).join('/')
 }


### PR DESCRIPTION
Implements the path-keyed, context-independent metadata namespace per maintainer direction (Teppo, on the 2.28.0-beta thread): metadata should be keyed by path and applied across all contexts, with `@signalk/path-metadata` as the master for well-known paths and units.

## Problem

The registry keyed runtime and spec metadata by **context root**. A path's units/description were only resolvable under the context root they were authored or registered under. So metadata registered under one context (e.g. the FreeboardSK plugin registers environment metas under `meteo`) was invisible to a value at the same path under another context (`vessels.<id>`, `aircraft.<id>`, …) — even though a path's physical meaning (units) is identical regardless of context.

## Approach

Treat metadata as a **path-keyed, context-independent namespace**:

- Re-key the identity-scoped seed entries (`/vessels|/aircraft|/aton|/sar/*/<path>`) to a single path-only matcher `/*/<path>` when building the lookup array, so a lookup under any context root resolves the same spec metadata. The bare-wildcard container-shape skip is evaluated on the original key first, so it is preserved.
- Normalise lookups (`getMetadata`, `internalGetMetadata`) and runtime additions (`addMetaData`) to the path-only form; `addMetaData` ignores the context root for keying.
- Keep `allMetadata` on the original on-disk keys and move runtime per-path clones to a separate map, so `getAllMetadata()` / the `/paths` endpoint keep their exact shape and the admin Path Reference UI is unchanged.

This matches the behaviour of the old `@signalk/signalk-schema` implementation, where path metadata was effectively context-independent.

## Companion

A separate change is also needed so meta deltas under an identity-less context (e.g. a bare `meteo`) reach the registry at all — `FullSignalK.addDelta`'s `findContext` rejects such contexts before the meta is applied. That is #2742.

## Tested

- Added tests: spec meta resolves under non-vessel and arbitrary context roots; `addMetaData` under one context is visible under another and ignores the context root for keying; `internalGetMetadata` shares one per-path clone across contexts; `getAllMetadata()`/`/paths` exposes only the authored seed keys (runtime adds do not leak).
- All pre-existing `@signalk/path-metadata` tests pass unchanged; `getAllMetadata()` output is byte-identical to before (same 2377 keys).
- `@signalk/server-api` and the server `metadata`/`plugin-meta` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors metadata resolution in the path-metadata package so metadata is path-keyed and context-independent: metadata keyed to a given path resolves the same under any context root (vessels, aircraft, aton, sar, bare contexts, etc.).

## Key Changes

- Normalize matching and runtime updates to a path-only namespace by mapping identity-scoped seed keys (e.g., /vessels, /aircraft, /aton, /sar/*/<path>) to a single path-only matcher form (`/*/<tail>`) when building the lookup array, while preserving authored on-disk keys for getAllMetadata() and the /paths endpoint.
- Introduce a runtimeClones map that separates on-disk seed templates from runtime per-path clones; reset() clears runtimeClones.
- Update getMetadata() to normalize lookups via toLookupPath() and delegate to getMetadataForLookupPath(); add a literal-path fallback to preserve resolution for bare singleton and short-segment paths (e.g., /self, /version, meteo.environment.outside.temperature).
- Update internalGetMetadata() to key clones by the normalized path-only form, require a minimum segment depth, match templates using the normalized form, deep-clone matched templates into runtimeClones, and unshift per-path regex entries so runtime clones take precedence.
- Update addMetaData() to ignore the provided context for keying, merge updates into the normalized per-path clone (seeding from a matched spec template when needed), and unshift the clone into the lookup array so runtime additions override generic spec wildcards.
- Deduplicate re-keyed entries and preserve original container-shape skip behavior when compiling regex templates.

## Behavioral fixes & rationale

- Implement a two-stage getMetadata lookup (normalized lookup then literal-path fallback) to avoid over-normalization and preserve expected literal resolutions.
- Ensure runtime per-path clones are unshifted to the front of the lookup order so runtime overrides are not shadowed by generic spec wildcards (fixes a bug where clones previously were appended and could be shadowed).
- Keep authored seed key shapes intact in getAllMetadata() and the /paths view; runtime-added clones do not leak into the authored /paths view.

## Tests

- Add tests validating that authored spec metadata resolves under non-vessel and arbitrary contexts.
- Add tests verifying addMetaData ignores context for keying and runtime additions under one context are visible under another.
- Add tests confirming internalGetMetadata shares per-path clones across contexts and that runtime overrides win over generic spec wildcards.
- Add tests verifying getAllMetadata() and the /paths endpoint expose only authored on-disk keys and that literal-path fallback and clone-vs-wildcard precedence regressions are fixed.

## Impact

- Metadata resolution is consistent across contexts; runtime metadata additions are shared across contexts while authored seed metadata shape and getAllMetadata() output remain unchanged (byte-identical /paths view).
- Behavior aligns with prior `@signalk/signalk-schema` semantics where path metadata is effectively context-independent.

## Notes

- A companion change (PR `#2742`) is required so meta deltas under identity-less contexts reach the registry; combined, the changes allow plugin metadata registered under any context to resolve for the same path under any context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->