### PR TITLE
fix(server-api): resolve plugin source $source to bare label

### DIFF
--- a/packages/server-api/src/sourceutil.test.ts
+++ b/packages/server-api/src/sourceutil.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai'
+
+import { getSourceId } from './sourceutil'
+
+describe('getSourceId', () => {
+  it('returns no_source for a missing source', () => {
+    expect(getSourceId(undefined)).to.equal('no_source')
+    expect(getSourceId(null)).to.equal('no_source')
+  })
+
+  it('uses label.canName for an N2K source with a CAN Name', () => {
+    expect(
+      getSourceId({ label: 'canhat', canName: 'c0509635e7664732', src: '172' })
+    ).to.equal('canhat.c0509635e7664732')
+  })
+
+  it('uses label.src for an N2K source without a CAN Name', () => {
+    expect(getSourceId({ label: 'n2k-sample-data', src: '43' })).to.equal(
+      'n2k-sample-data.43'
+    )
+  })
+
+  it('uses label.talker for an NMEA 0183 source', () => {
+    expect(
+      getSourceId({ label: 'gps', type: 'NMEA0183', talker: 'GP' })
+    ).to.equal('gps.GP')
+  })
+
+  it('falls back to label.XX for an NMEA 0183 source with no talker', () => {
+    expect(getSourceId({ label: 'gps', type: 'NMEA0183' })).to.equal('gps.XX')
+  })
+
+  it('returns the bare label for a plugin source', () => {
+    // A plugin emitting `source: { label: pluginId, type: 'plugin' }` must
+    // resolve to the bare plugin id so it matches the `excludeSelf` ranking
+    // entry (which is the bare plugin id) and a correcter plugin does not
+    // see its own output back on a self-subscription.
+    expect(
+      getSourceId({ label: 'my-correcter-plugin', type: 'plugin' })
+    ).to.equal('my-correcter-plugin')
+  })
+
+  it('returns unknown_source for a plugin source without a label', () => {
+    expect(getSourceId({ type: 'plugin' })).to.equal('unknown_source')
+  })
+
+  it('passes a plain $source string through unchanged', () => {
+    expect(getSourceId('n2k-sample-data.43')).to.equal('n2k-sample-data.43')
+  })
+})

--- a/packages/server-api/src/sourceutil.ts
+++ b/packages/server-api/src/sourceutil.ts
@@ -25,6 +25,15 @@ export function getSourceId(source: any): SourceRef {
     return `${label}.${source.src}` as SourceRef
   }
   if (typeof source === 'object') {
+    // A plugin source is fully identified by its label (the plugin id):
+    // there is no talker or device address to disambiguate, and the
+    // `.XX` fallback below would make $source `<pluginId>.XX`, which no
+    // longer matches the bare plugin id that `excludeSelf` resolves to —
+    // so a plugin emitting `source: { label, type: 'plugin' }` would see
+    // its own output back. Return the bare label for plugin sources.
+    if (source.type === 'plugin') {
+      return (source.label || 'unknown_source') as SourceRef
+    }
     const label = source.label || 'unknown_source'
     return `${label}${source.talker ? '.' + source.talker : '.XX'}` as SourceRef
   }


### PR DESCRIPTION
## Motivation

A plugin that subscribes to a path it also publishes — a "correcter" reading raw data, applying a correction, and emitting on the same path — uses `excludeSelf: true` so it doesn't see its own output back. In practice the exclusion silently failed and the plugin looped, re-consuming its own corrected value.

The cause is in `getSourceId`. `excludeSelf` resolves to the bare plugin id, but when a plugin emits `source: { label: pluginId, type: 'plugin' }` (a natural, intuitive shape), `getSourceId` hit the generic-object branch and appended the `.XX` fallback suffix, producing `$source = <pluginId>.XX`. `<pluginId>` never matched `<pluginId>.XX`, so the plugin's own deltas were never excluded.

Plugins that emit with no `source` object at all (e.g. signalk-derived-data) were unaffected, because the server defaults `$source` to the bare provider id in that case — which is why the breakage was easy to miss.

## Approach

`getSourceId` returns the bare label for `type: 'plugin'` sources. A plugin is fully identified by its label (the plugin id); the `.XX` fallback exists to disambiguate generic objects that carry no talker, and a plugin has none. With this, a plugin source resolves to `<pluginId>`, matching the id that `excludeSelf` / `excludeSources` rank against.

The change is scoped to `type: 'plugin'`; NMEA 0183 sources without a talker keep their existing `<label>.XX` form.

## Tested

- New `packages/server-api/src/sourceutil.test.ts` covers every `getSourceId` branch (canName, src, talker, the NMEA-no-talker `.XX` fallback, the new plugin case, the missing-label case, and the pass-through string). `getSourceId` had no tests before.
- `npm run test:server-api` passes (42 tests).
- `npm run build:all` and `npm run ci-lint` (eslint + prettier --check) are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a plugin source resolution issue in the Signal K server. When plugins both subscribe to and publish the same path (e.g., a correcter), they use `excludeSelf: true` to prevent consuming their own output. However, this mechanism was failing due to incorrect source ID normalization.

### Root Cause
When a plugin emitted a source with `source: { label: pluginId, type: 'plugin' }`, the `getSourceId` function treated it as a generic object and appended a `.XX` fallback, producing `$source = <pluginId>.XX`. Since `excludeSelf` resolves to the bare plugin ID, the two forms did not match and self-exclusion did not work.

### Solution
The `getSourceId` function now detects plugin-origin sources by checking `source.type === 'plugin'` and returns the source's label as a bare `SourceRef`, bypassing the suffix-building logic. This ensures plugin sources use the bare `<pluginId>` form that matches the `excludeSelf` resolution. The change is scoped to plugin sources; NMEA 0183 sources without a talker retain their `<label>.XX` form, and NMEA 2000 sources continue using their respective suffixes.

### Changes
- **sourceutil.ts**: Adds a conditional branch in `getSourceId` to detect plugin sources (`type: 'plugin'`) and return the bare label (or `unknown_source` if no label exists) without appending the `.XX` fallback suffix
- **sourceutil.test.ts**: Adds comprehensive test cases covering all `getSourceId` branches: missing sources, N2K sources with and without CAN names, NMEA 0183 sources with and without talkers, plugin sources with and without labels, and plain `$source` strings

### Testing
All existing tests pass (42 tests in the server-api suite) with no build or linting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->