### PR TITLE
fix(plugin-ci): add EventEmitter methods to lifecycle mock app

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -617,6 +617,13 @@ jobs:
           }
 
           // ── Mock app with delta capture ─────────────────────────
+          // The real server app extends EventEmitter, so plugins that
+          // app.on(...) in start() and app.removeListener(...) in stop()
+          // rely on the full emitter surface. Back the mock with a real
+          // emitter so register/remove stay mutually consistent.
+          const { EventEmitter } = require('node:events');
+          const mockEmitter = new EventEmitter();
+          mockEmitter.setMaxListeners(0);
           const mockApp = {
             // ── Server configuration ──────────────────────────────
             config: { configPath: '/tmp', version: '0.0.0' },
@@ -665,8 +672,15 @@ jobs:
             registerActionHandler: () => {},
 
             // ── Event system ──────────────────────────────────────
-            on: () => ({ unsubscribe: () => {} }),
-            emit: () => {},
+            // Delegate to a real EventEmitter so on()/once()/addListener()
+            // and removeListener()/removeAllListeners() share one registry,
+            // matching the server app (which extends EventEmitter).
+            on: (...args) => mockEmitter.on(...args),
+            addListener: (...args) => mockEmitter.addListener(...args),
+            once: (...args) => mockEmitter.once(...args),
+            removeListener: (...args) => mockEmitter.removeListener(...args),
+            removeAllListeners: (...args) => mockEmitter.removeAllListeners(...args),
+            emit: (...args) => mockEmitter.emit(...args),
             emitPropertyValue: () => {},
             onPropertyValues: () => () => {},
 


### PR DESCRIPTION
The reusable Plugin CI lifecycle test builds a mock `app` whose event system only stubbed `on` and `emit`. The real server app extends `EventEmitter`, so plugins that register listeners in `start()` and call `app.removeListener()` in `stop()` failed under CI with `app.removeListener is not a function` — surfaced to plugin authors as a "missing CI mock method" warning (seen on signalk-n2k-switching).

Back the mock's event methods with a real `EventEmitter` so `on`, `once`, `addListener`, `removeListener` and `removeAllListeners` share one registry, matching the server's behaviour.

## Tested

- `npm run format`, `npm run build:all`, and the full `npm test` suite pass
- Verified the previously-failing pattern (register a listener in `start()`, `app.removeListener()` in `stop()`, plus the restart cycle) now succeeds with listeners cleaned up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the CI "Test plugin stop()/start() lifecycle" mock app in `.github/workflows/plugin-ci.yml` to back its event-related APIs with a real Node `EventEmitter`. 

The mock app now creates an `EventEmitter` instance and delegates all event methods (`on`, `addListener`, `once`, `removeListener`, `removeAllListeners`, and `emit`) to it, ensuring that listeners registered through any method share a single registry. This matches the behavior of the real SignalK server app, which extends `EventEmitter`.

Previously, the mock only stubbed `on` and `emit`, causing plugins that registered listeners in `start()` and called `app.removeListener()` in `stop()` to fail with "app.removeListener is not a function".

The emitter is configured with unlimited listeners via `setMaxListeners(0)` to prevent warnings during testing.

**Changes:**
- Added `const { EventEmitter } = require('node:events')` and created a `mockEmitter` instance with `setMaxListeners(0)`
- Updated event method definitions to delegate to the emitter: `on`, `addListener`, `once`, `removeListener`, `removeAllListeners`, and `emit`

**Testing:**
- The full plugin lifecycle test (start → stop → restart → stop) now succeeds for plugins using removeListener
- Listeners are properly cleaned up across the restart cycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->