### PR TITLE
fix(server): run delta input handlers before priority and caching

### DIFF
--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -1,44 +1,49 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Delta, DeltaInputHandler, SKVersion } from '@signalk/server-api'
 
-import { Delta, DeltaInputHandler } from '@signalk/server-api'
+type Dispatch = (msg: Delta, now: Date, version: SKVersion) => void
 
 export default class DeltaChain {
-  chain: any
-  next: any
-  constructor(private dispatchMessage: any) {
-    this.chain = []
-    this.next = []
+  private chain: DeltaInputHandler[] = []
+
+  // Run every registered input handler over `msg`, then hand the result
+  // to `dispatch`. Each handler gets (delta, next); calling next forwards
+  // the (possibly modified) delta to the next handler, and `dispatch`
+  // runs only once the chain is exhausted. A handler that never calls
+  // next drops the delta — `dispatch` is not invoked.
+  //
+  // The caller supplies `dispatch` rather than the chain owning a fixed
+  // terminal, so handlers run BEFORE source-priority filtering and
+  // caching (the registerDeltaInputHandler contract) while that
+  // downstream pipeline stays in handleMessage. `dispatch` is a single
+  // hoisted function; the per-message context it needs (timestamp, sk
+  // version) is threaded as arguments so nothing is allocated per delta.
+  process(msg: Delta, dispatch: Dispatch, now: Date, version: SKVersion) {
+    this.doProcess(0, msg, dispatch, now, version)
   }
 
-  process(msg: Delta) {
-    return this.doProcess(0, msg)
-  }
-
-  doProcess(index: number, msg: any) {
+  private doProcess(
+    index: number,
+    msg: Delta,
+    dispatch: Dispatch,
+    now: Date,
+    version: SKVersion
+  ) {
     if (index >= this.chain.length) {
-      this.dispatchMessage(msg)
+      dispatch(msg, now, version)
       return
     }
-    this.chain[index](msg, this.next[index])
+    this.chain[index](msg, (forwarded: Delta) =>
+      this.doProcess(index + 1, forwarded, dispatch, now, version)
+    )
   }
 
   register(handler: DeltaInputHandler) {
     this.chain.push(handler)
-    this.updateNexts()
     return () => {
       const handlerIndex = this.chain.indexOf(handler)
       if (handlerIndex >= 0) {
         this.chain.splice(handlerIndex, 1)
-        this.updateNexts()
       }
     }
-  }
-
-  updateNexts() {
-    this.next = this.chain.map((chainElement: any, index: number) => {
-      return (msg: any) => {
-        this.doProcess(index + 1, msg)
-      }
-    })
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,8 @@ class Server {
 
     app.propertyValues = new PropertyValues()
 
-    const deltachainV1 = new DeltaChain(app.signalk.addDelta.bind(app.signalk))
-    const deltachainV2 = new DeltaChain((delta: Delta) =>
-      app.signalk.emit('delta', delta)
-    )
+    const deltachainV1 = new DeltaChain()
+    const deltachainV2 = new DeltaChain()
     app.registerDeltaInputHandler = (handler: DeltaInputHandler) => {
       const unRegisterHandlers = [
         deltachainV1.register(handler),
@@ -327,6 +325,25 @@ class Server {
       delta) as unknown as ToPreferredDelta
     initialPassthrough.routesPath = () => false
     let toPreferredDelta: ToPreferredDelta = initialPassthrough
+
+    // Terminal of the delta input handler chain: once every handler has
+    // run on the raw delta, cache it, fan it out unfiltered, apply
+    // source-priority filtering and dispatch the result. Defined once
+    // (not per delta) and reads `toPreferredDelta` through the closure so
+    // it picks up engine rebuilds. now / version are passed in by the
+    // chain so this stays a single hoisted function on the hot path.
+    const dispatchDelta = (handled: Delta, now: Date, version: SKVersion) => {
+      if (app.deltaCache) {
+        app.deltaCache.ingestDelta(handled)
+      }
+      app.signalk.emit('unfilteredDelta', cloneDelta(handled))
+      const preferred = toPreferredDelta(handled, now, app.selfContext)
+      if (version === SKVersion.v1) {
+        app.signalk.addDelta(preferred)
+      } else {
+        app.signalk.emit('delta', preferred)
+      }
+    }
     // Translate `<label>.<numeric>` deltas to their `<label>.<canName>`
     // form so a saved canName-form ranking matches incoming refs from
     // providers that have useCanName off. The cache is keyed by the
@@ -546,20 +563,17 @@ class Server {
         try {
           // data.updates was just rebuilt above, so the resulting Partial<Delta>
           // is in practice a full Delta by the time it reaches the chain.
-          let delta = filterStaticSelfData(data, app.selfContext) as Delta
-          if (app.deltaCache) {
-            app.deltaCache.ingestDelta(delta)
-          }
-          if (app.signalk.listenerCount('unfilteredDelta') > 0) {
-            app.signalk.emit('unfilteredDelta', cloneDelta(delta))
-          }
-          delta = toPreferredDelta(delta, now, app.selfContext)
+          const delta = filterStaticSelfData(data, app.selfContext) as Delta
 
-          if (skVersion === SKVersion.v1) {
-            deltachainV1.process(delta)
-          } else {
-            deltachainV2.process(delta)
-          }
+          // Input handlers intercept the raw delta first, per the
+          // registerDeltaInputHandler contract ("before they are
+          // processed by the server"). Whatever a handler passes to
+          // next() — modified or original — is what the cache, the
+          // unfiltered bus, source-priority filtering and the full
+          // model then see. A handler that never calls next() drops
+          // the delta here, before any of that runs.
+          const chain = skVersion === SKVersion.v1 ? deltachainV1 : deltachainV2
+          chain.process(delta, dispatchDelta, now, skVersion)
         } catch (err) {
           console.error(err)
         }

--- a/test/delta-input-handler-ordering.ts
+++ b/test/delta-input-handler-ordering.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai'
+import { startServer } from './ts-servertestutilities'
+import { WsPromiser } from './servertestutilities'
+import { Delta, hasValues, Path, Value } from '@signalk/server-api'
+
+// Allow the per-message delivery to settle before asserting on the model.
+const DELTA_SETTLE_MS = 200
+
+const stwValuesIn = (delta: Delta, path: string): Value[] =>
+  (delta.updates ?? [])
+    .flatMap((u) => ('values' in u ? u.values : []))
+    .filter((v) => v.path === (path as Path))
+    .map((v) => v.value)
+
+// registerDeltaInputHandler must intercept a delta BEFORE the server
+// processes it — before source-priority filtering, before the delta is
+// cached, and before it reaches the full data model. These tests assert
+// that a handler's modifications are what the rest of the server sees.
+describe('registerDeltaInputHandler ordering', () => {
+  it('a handler modification reaches the full model and the unfiltered stream', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { server, sendADelta, getV1, stop } = (await startServer()) as any
+
+    // Rewrite every speedThroughWater value to a sentinel.
+    server.app.registerDeltaInputHandler(
+      (delta: Delta, next: (d: Delta) => void) => {
+        for (const u of delta.updates ?? []) {
+          if (!('values' in u)) continue
+          for (const v of u.values) {
+            if (v.path === ('navigation.speedThroughWater' as Path)) {
+              v.value = 42
+            }
+          }
+        }
+        next(delta)
+      }
+    )
+
+    // The unfiltered stream must carry the handler's output (42), never
+    // the original input value (1): handlers run before the
+    // unfilteredDelta emission.
+    const unfilteredValues: Value[] = []
+    server.app.signalk.on('unfilteredDelta', (delta: Delta) => {
+      unfilteredValues.push(
+        ...stwValuesIn(delta, 'navigation.speedThroughWater')
+      )
+    })
+
+    await sendADelta({
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'test.src',
+          values: [{ path: 'navigation.speedThroughWater', value: 1 }]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, DELTA_SETTLE_MS))
+
+    // Full model reflects the handler's rewrite (not the raw 1).
+    const full = await getV1('/vessels/self/navigation/speedThroughWater').then(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (r: any) => r.json()
+    )
+    expect(full.value).to.equal(42)
+
+    // Unfiltered stream saw the rewrite, never the raw value.
+    expect(unfilteredValues).to.include(42)
+    expect(unfilteredValues).to.not.include(1)
+
+    await stop()
+  })
+
+  it('dropping a delta (not calling next) keeps it out of the model', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { server, sendADelta, getV1, stop } = (await startServer()) as any
+
+    server.app.registerDeltaInputHandler(
+      (delta: Delta, next: (d: Delta) => void) => {
+        const drop = (delta.updates ?? []).some(
+          (u) =>
+            'values' in u &&
+            u.values.some(
+              (v) => v.path === ('environment.outside.temperature' as Path)
+            )
+        )
+        if (drop) return // do not call next -> delta dropped
+        next(delta)
+      }
+    )
+
+    await sendADelta({
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'test.src',
+          values: [{ path: 'environment.outside.temperature', value: 290 }]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, DELTA_SETTLE_MS))
+
+    const res = await getV1('/vessels/self/environment/outside/temperature')
+    expect(res.status).to.equal(404)
+
+    await stop()
+  })
+})
+
+// End-to-end over a real WebSocket connection: a registered handler
+// rewrites the raw value, a priority group ranks the sources, and a WS
+// client on the default (priority-resolved) stream must receive the
+// handler's rewritten value — proving the handler runs ahead of both
+// source-priority filtering and the WebSocket fan-out.
+describe('registerDeltaInputHandler ordering (WebSocket e2e)', () => {
+  let stop: () => Promise<void>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let sendADelta: (delta: any) => Promise<Response>
+  let host: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+
+  before(async () => {
+    const s = await startServer()
+    stop = s.stop
+    sendADelta = s.sendADelta
+    host = s.host
+    server = s.server
+
+    server.app.registerDeltaInputHandler(
+      (delta: Delta, next: (d: Delta) => void) => {
+        for (const u of delta.updates ?? []) {
+          if (!('values' in u)) continue
+          for (const v of u.values) {
+            if (v.path === ('navigation.speedThroughWater' as Path)) {
+              // Mark the value so the assertion can prove the handler
+              // touched it before anything downstream saw it.
+              v.value = (v.value as number) + 1000
+            }
+          }
+        }
+        next(delta)
+      }
+    )
+  })
+
+  after(async () => {
+    await stop()
+  })
+
+  it('a sourcePolicy=all WS client receives the handler-rewritten value over the wire', async () => {
+    // A group ranks the corrected source above the raw one. A
+    // sourcePolicy=all client reads the unfiltered stream, which is fed
+    // ahead of source-priority filtering — so it must still carry the
+    // handler's rewrite. Before the fix the unfiltered stream was emitted
+    // before the handler ran and carried the raw value instead.
+    server.app.config.settings.priorityGroups = [
+      { id: 'g1', sources: ['stw.preferred', 'stw.backup'] }
+    ]
+    server.app.activateSourcePriorities()
+
+    const wsUrl =
+      host.replace('http', 'ws') +
+      '/signalk/v1/stream?subscribe=self&sourcePolicy=all&metaDeltas=none&sendCachedValues=false'
+    const ws = new WsPromiser(wsUrl)
+    await ws.nthMessage(1) // hello
+
+    await sendADelta({
+      context: 'vessels.self',
+      updates: [
+        {
+          $source: 'stw.preferred',
+          timestamp: '2024-01-15T10:00:00.000Z',
+          values: [{ path: 'navigation.speedThroughWater', value: 5 }]
+        }
+      ]
+    })
+    await ws.nthMessage(2)
+
+    const stw = ws
+      .parsedMessages()
+      .slice(1)
+      .flatMap((m: Delta) => m.updates ?? [])
+      .flatMap((u) =>
+        hasValues(u)
+          ? u.values
+              .filter(
+                (v) => v.path === ('navigation.speedThroughWater' as Path)
+              )
+              .map((v) => ({ value: v.value, $source: u.$source }))
+          : []
+      )
+
+    expect(stw.length).to.be.greaterThan(0)
+    // 5 + 1000 from the handler, delivered over the wire.
+    expect(stw[0].value).to.equal(1005)
+    expect(stw[0].$source).to.equal('stw.preferred')
+
+    ws.close()
+  })
+})


### PR DESCRIPTION
## Motivation

`registerDeltaInputHandler` is documented to intercept deltas "before they are processed by the server", but `handleMessage` ran the handler chain **last** — after `ingestDelta`, the `unfilteredDelta` emit, and `toPreferredDelta`. So a handler saw values that source-priority filtering had already stripped, and a handler's modifications never reached the unfiltered stream or the cache's non-preferred freshness stamping.

This ordering predates the recent source-priority work — since priority was first introduced (#1074) the call has been `deltachain.process(toPreferredDelta(...))`. It only became observable once `toPreferredDelta` became a real stateful filter and the cache/unfiltered emits were added ahead of it. Raised by @tkurki on #2746.

## Approach

Make `DeltaChain` a pure handler runner: `process(msg, dispatch)` runs the registered handlers and hands the result to a caller-supplied `dispatch`. `handleMessage` now runs the chain first on the raw delta and performs `ingestDelta`, the `unfilteredDelta` emit, `toPreferredDelta` and the final fan-out in the dispatch callback, so every downstream step sees the post-handler delta. A handler that does not call `next()` still drops the delta before any of that runs.

## Tested

- New `test/delta-input-handler-ordering.ts`: a handler's rewrite reaches the full model and the unfiltered stream; a dropped delta (no `next()`) stays out of the model; and end-to-end over a WebSocket, a `sourcePolicy=all` client receives the handler-rewritten value with a priority group active. The two ordering assertions fail on `master` and pass with this change.
- Existing `registerDeltaInputHandler` behaviour (notifications filter, the plugins.js path-rewrite handler) and the source-priority / exclude suites pass unchanged.
- `npm test` and `npm run ci-lint` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes delta input handler ordering so registered handlers run before server processing steps (ingestDelta, unfilteredDelta emit, source-priority filtering via toPreferredDelta, and cache freshness stamping). Handlers therefore see raw deltas and their modifications reach the unfiltered stream and cache stamping; a handler that does not call next() drops the delta before downstream processing.

## Changes

- src/deltachain.ts
  - Refactors DeltaChain to hold a typed list of DeltaInputHandler and exposes process(msg, dispatch, now, version).
  - Implements a recursive doProcess that invokes each handler with a next callback; when the chain is exhausted it calls the supplied dispatch.
  - Removes the precomputed next-array approach and the constructor-held dispatch; unregistering simply splices the handler list.

- src/index.ts
  - Constructs deltachainV1/v2 without embedded dispatch callbacks.
  - Rewrites app.handleMessage to run the chosen DeltaChain first on the raw, filtered delta and supply a dispatch callback that:
    - ingests the handled delta into the delta cache,
    - emits unfilteredDelta,
    - computes preferred via toPreferredDelta(handled, now, app.selfContext),
    - and performs final model fan-out (v1 addDelta or v2 emit).
  - Ensures handler-modified deltas flow into cache, unfiltered events, and preferred processing in the intended order.

- test/delta-input-handler-ordering.ts
  - Adds tests verifying:
    - a handler rewrite reaches the v1 REST model endpoint and the unfilteredDelta stream,
    - a handler that omits next() drops the delta so it never reaches the model/cache,
    - end-to-end WebSocket with sourcePolicy=all observes handler-rewritten values on the wire even when source-priority groups are active.

## Impact

registerDeltaInputHandler now intercepts raw deltas before server processing and can modify or drop them upstream of caching, unfiltered emission, and source-priority logic. Existing behaviors and test suites mentioned remain passing with the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->