### PR TITLE
fix(server-api): apply meta deltas to existing value leaves in the full model

### DIFF
--- a/packages/server-api/src/fullsignalk.test.ts
+++ b/packages/server-api/src/fullsignalk.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { metadataRegistry } from '@signalk/path-metadata'
 import { FullSignalK } from './fullsignalk'
 
 describe('FullSignalK', function () {
@@ -74,6 +75,104 @@ describe('FullSignalK', function () {
     expect(sog).to.have.property('$source')
     expect(sog.values['n2kFromFile.43']).to.have.property('value', 7.09)
     expect(sog.values['n2kFromFile.48']).to.have.property('value', 8)
+  })
+
+  it('applies a meta delta to an existing value-only leaf', function () {
+    // A value-only source (e.g. an N2K device echoing a path a plugin also
+    // owns) creates the leaf, then a meta delta arrives for the same path
+    // with no further value. The leaf must carry the metadata.
+    metadataRegistry.reset()
+    const path = 'electrical.displays.raymarine.helm1.brightness'
+    const ctx = 'vessels.foo'
+    const fullSignalK = new FullSignalK()
+    fullSignalK.addDelta({
+      context: ctx,
+      updates: [
+        {
+          source: { label: 'can0', type: 'NMEA2000', pgn: 126720, src: '1' },
+          timestamp: '2017-04-15T15:50:48.664Z',
+          values: [{ path, value: 0.98 }]
+        }
+      ]
+    })
+    const leaf = () =>
+      fullSignalK.retrieve().vessels.foo.electrical.displays.raymarine.helm1
+        .brightness
+    expect(leaf().meta?.supportsPut).to.equal(undefined)
+
+    fullSignalK.addDelta({
+      context: ctx,
+      updates: [
+        {
+          $source: 'a-plugin',
+          timestamp: '2017-04-15T15:50:49.664Z',
+          meta: [{ path, value: { supportsPut: true } }]
+        }
+      ]
+    })
+    expect(leaf().meta?.supportsPut).to.equal(true)
+    expect(leaf().value).to.equal(0.98)
+    metadataRegistry.reset()
+  })
+
+  it('lets a later meta delta overwrite an existing field on the leaf', function () {
+    // Last-writer-wins, consistent with the metadata registry: a second meta
+    // delta that changes the value of a field the leaf already carries must
+    // replace it, not be dropped in favour of the existing value.
+    metadataRegistry.reset()
+    const path = 'electrical.displays.raymarine.helm1.brightness'
+    const ctx = 'vessels.foo'
+    const fullSignalK = new FullSignalK()
+    fullSignalK.addDelta({
+      context: ctx,
+      updates: [
+        {
+          source: { label: 'can0', type: 'NMEA2000', pgn: 126720, src: '1' },
+          timestamp: '2017-04-15T15:50:48.664Z',
+          values: [{ path, value: 0.98 }]
+        }
+      ]
+    })
+    const leaf = () =>
+      fullSignalK.retrieve().vessels.foo.electrical.displays.raymarine.helm1
+        .brightness
+    const sendMeta = (value: object, ts: string) =>
+      fullSignalK.addDelta({
+        context: ctx,
+        updates: [
+          { $source: 'a-plugin', timestamp: ts, meta: [{ path, value }] }
+        ]
+      })
+
+    sendMeta({ supportsPut: true, description: 'old' }, '2017-04-15T15:50:49Z')
+    expect(leaf().meta?.supportsPut).to.equal(true)
+    expect(leaf().meta?.description).to.equal('old')
+
+    sendMeta({ supportsPut: false, description: 'new' }, '2017-04-15T15:50:50Z')
+    expect(leaf().meta?.supportsPut).to.equal(false)
+    expect(leaf().meta?.description).to.equal('new')
+    expect(leaf().value).to.equal(0.98)
+    metadataRegistry.reset()
+  })
+
+  it('does not seed an orphan tree entry for an identity-less context', function () {
+    metadataRegistry.reset()
+    const fullSignalK = new FullSignalK()
+    fullSignalK.addDelta({
+      context: 'meteo',
+      updates: [
+        {
+          $source: 'a-plugin',
+          timestamp: '2017-04-15T15:50:48.664Z',
+          meta: [
+            { path: 'environment.outside.temperature', value: { units: 'K' } }
+          ]
+        }
+      ]
+    })
+    expect(fullSignalK.retrieve()).to.not.have.property('environment')
+    expect(fullSignalK.retrieve()).to.not.have.property('meteo')
+    metadataRegistry.reset()
   })
 
   it('AIS delta produces Signal K tree with expected shape', function () {

--- a/packages/server-api/src/fullsignalk.ts
+++ b/packages/server-api/src/fullsignalk.ts
@@ -276,17 +276,47 @@ function addValues(
 }
 
 function addMeta(
-  _context: AnyObject,
+  context: AnyObject,
   contextPath: string,
   _source: AnyObject | string,
   _timestamp: string,
-  pathValue: AnyObject
+  pathValue: AnyObject,
+  applyToTree: boolean
 ): void {
   if (pathValue.path === undefined || pathValue.value === undefined) {
     console.error('Illegal value in delta:' + JSON.stringify(pathValue))
     return
   }
   metadataRegistry.addMetaData(contextPath, pathValue.path, pathValue.value)
+  if (applyToTree) {
+    mergeLeafMeta(context, pathValue.path, pathValue.value)
+  }
+}
+
+// Merge metadata onto an existing value-bearing leaf so a meta delta that
+// arrives after the value (e.g. an N2K device echoes a path a plugin also
+// owns and the plugin registers supportsPut afterwards) still reaches the
+// leaf. Only existing value leaves are updated: a meta-only path is left to
+// the registry alone, so no phantom tree node is created that DELETE-meta
+// could not later clear. The new fields win, mirroring last-writer-wins.
+function mergeLeafMeta(
+  context: AnyObject,
+  path: string,
+  meta: AnyObject
+): void {
+  if (path.length === 0) {
+    return
+  }
+  let node = context
+  for (const part of path.split('.')) {
+    node = node[part]
+    if (!node) {
+      return
+    }
+  }
+  if (node.value !== undefined) {
+    node.meta = { ...node.meta, ...meta }
+  }
 }
 
 function addMetas(
@@ -294,10 +324,11 @@ function addMetas(
   contextPath: string,
   source: AnyObject | string,
   timestamp: string,
-  metas: AnyObject[]
+  metas: AnyObject[],
+  applyToTree: boolean
 ): void {
   for (const meta of metas) {
-    addMeta(context, contextPath, source, timestamp, meta)
+    addMeta(context, contextPath, source, timestamp, meta, applyToTree)
   }
 }
 
@@ -370,7 +401,8 @@ export class FullSignalK extends EventEmitter {
             delta.context,
             update.source || update['$source'],
             update.timestamp,
-            update.meta
+            update.meta,
+            false
           )
         }
       }
@@ -454,7 +486,8 @@ export class FullSignalK extends EventEmitter {
         contextPath,
         update.source || update['$source'],
         update.timestamp,
-        update.meta
+        update.meta,
+        true
       )
     }
   }

--- a/src/put.ts
+++ b/src/put.ts
@@ -107,6 +107,18 @@ let putNotificationHandler: (
   value: unknown
 ) => ActionResult
 
+// Drop a deleted metadata field from the live self leaf. Metadata is merged
+// onto value-bearing leaves in the full model, so deleting it from the
+// registry alone would leave the field stuck on the tree leaf.
+function removeLeafMetaField(app: PutApp, metaPath: string, name: string) {
+  const leaf = _get(app.signalk.self, metaPath) as
+    | { meta?: Record<string, unknown> }
+    | undefined
+  if (leaf?.meta) {
+    delete leaf.meta[name]
+  }
+}
+
 export function start(app: PutApp): void {
   app.registerActionHandler = registerActionHandler
   app.deRegisterActionHandler = deRegisterActionHandler
@@ -325,6 +337,8 @@ export function start(app: PutApp): void {
       >
       delete full_meta[name]
 
+      removeLeafMetaField(app, metaPath, name)
+
       app.config.baseDeltaEditor.setMeta(context, metaPath, metaValue)
 
       if (Object.keys(metaValue).length === 0) {
@@ -345,6 +359,7 @@ export function start(app: PutApp): void {
 
       Object.keys(metaValue).forEach((key) => {
         delete full_meta[key]
+        removeLeafMetaField(app, metaPath, key)
       })
 
       app.config.baseDeltaEditor.removeMeta(context, metaPath)


### PR DESCRIPTION
## Problem

A meta delta only updated the metadata registry, never the leaf in the full-model tree. So when a leaf already exists from a value-only source and a meta delta arrives afterwards, the metadata never reaches that leaf.

This surfaces when two sources write the same path: an N2K device echoes a path a plugin also owns (e.g. a Raymarine display broadcasting PGN 126720, which `@signalk/n2k-signalk` maps to `electrical.displays.raymarine.*`). The device's value creates the leaf, the plugin then registers `supportsPut`, and that flag never lands on the leaf — even though the registry has it. Clients reading the leaf (e.g. KIP, whose PUT widgets filter on `meta.supportsPut === true`) then hide the path.

## Approach

When a meta delta arrives for an existing value-bearing leaf, merge the metadata onto that leaf. The incoming fields win — last-writer-wins, mirroring the metadata registry's `Object.assign(existing, meta)` — so a later meta delta that updates a field already on the leaf is stored, not dropped. Meta-only paths and identity-less contexts are left to the registry alone, so no orphan or phantom tree node is created. `DELETE` of metadata also clears the field from the leaf, keeping the full model consistent with the registry.

## Tested

- Added regression tests in `fullsignalk.test.ts`: a meta delta reaches an existing value-only leaf; a later meta delta overwrites a field already on the leaf (last-writer-wins); an identity-less context does not seed an orphan tree entry. The first two fail without the change / under existing-wins precedence.
- `npm run format` and `npm test` pass (including `test/delete.js`, which covers the metadata-delete path).

## Scope note

This is a general full-model metadata-consistency fix; it is independent of any one plugin. (It is not the cause of the recently-reported display `supportsPut` case, which traced to a third-party plugin throwing on meta-only deltas in its delta-input handler — handled separately.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR applies incoming metadata deltas to existing value-bearing leaves in the Signal K live full-model tree, so metadata properly attaches whether metadata arrives before or after the corresponding value. Previously, meta deltas updated only the metadata registry, leaving existing live leaves without metadata and causing clients that filter on leaf metadata to hide those paths.

## Changes

### fullsignalk.ts
The metadata flow adds an `applyToTree` flag to control whether metadata is merged into the live Signal K state tree. `addMeta` always updates `metadataRegistry` and merges metadata onto the live tree only when `applyToTree` is `true`. It introduces a `mergeLeafMeta` helper that traverses to the target metadata path and merges into `node.meta` only when an existing `node.value` is present, using `{...node.meta, ...meta}` (last-writer-wins) and avoiding creation of tree nodes for meta-only updates. `addMetas` forwards this flag so `FullSignalK.addDelta` uses `applyToTree = false` for identity-less contexts (preventing orphan nodes) while `FullSignalK.addUpdate` uses `applyToTree = true` when context exists (allowing metadata to reach existing value-bearing leaves).

### fullsignalk.test.ts
The PR adds regression coverage for full-model metadata consistency:
1. A later meta delta for an existing value-only leaf updates `leaf.meta` (e.g., `supportsPut`) without changing the stored `leaf.value`.
2. A later meta delta overwrites an existing metadata field on the same leaf while preserving the leaf’s value (last-writer-wins).
3. A meta delta sent for an identity-less context does not create an orphan entry in the retrieved full tree, and the test asserts absence of the context/path.

### put.ts
A new `removeLeafMetaField(app, metaPath, name)` helper removes named metadata fields from the live `app.signalk.self` leaf. `deleteMetaHandler` calls it so metadata deletions clear the corresponding fields from both the registry and the live full-model tree.

## Summary
The PR keeps the live full-model tree and the metadata registry consistent by merging metadata into existing value-bearing leaves when meta deltas arrive (in either ordering) and by clearing live leaf metadata fields when metadata is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
