### PR TITLE
fix(course): handle external navigation updates

### DIFF
--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -21,7 +21,6 @@ import {
   RouteDestination,
   CourseInfo,
   COURSE_POINT_TYPES,
-  Update,
   Delta,
   hasValues,
   SourceRef,
@@ -38,6 +37,7 @@ import { Store } from '../../serverstate/store'
 
 import { buildSchemaSync } from 'api-schema-builder'
 import { courseApiDoc } from './openApi'
+import { crossTrackDistance, rebasePreviousPointFromXte } from './xteGeometry'
 import { ResourcesApi } from '../resources'
 import { ConfigApp, writeSettingsFile } from '../../config/config'
 
@@ -79,12 +79,67 @@ const NO_COURSE_INFO: CourseInfo = {
   previousPoint: null
 }
 
+const EXTERNAL_COURSE_SOURCE_TYPES = new Set(['NMEA0183', 'NMEA2000'])
+const EXTERNAL_NAV_MAX_AGE_MS = 15000
+const XTE_REBASE_THRESHOLD_M = 10
+const XTE_REBASE_CONFIRMATIONS = 3
+
+const EXTERNAL_NEXT_POINT_PATHS = new Set([
+  'navigation.courseRhumbline.nextPoint.position',
+  'navigation.courseGreatCircle.nextPoint.position'
+])
+
+const EXTERNAL_PREVIOUS_POINT_PATHS = new Set([
+  'navigation.courseRhumbline.previousPoint.position',
+  'navigation.courseGreatCircle.previousPoint.position'
+])
+
+const EXTERNAL_XTE_PATHS = new Set([
+  'navigation.courseRhumbline.crossTrackError',
+  'navigation.courseGreatCircle.crossTrackError'
+])
+
+const EXTERNAL_NAV_TOUCH_PATHS = [
+  'navigation.courseRhumbline.nextPoint.distance',
+  'navigation.courseGreatCircle.nextPoint.distance',
+  'navigation.courseRhumbline.nextPoint.bearingTrue',
+  'navigation.courseGreatCircle.nextPoint.bearingTrue',
+  'navigation.courseRhumbline.nextPoint.bearingMagnetic',
+  'navigation.courseGreatCircle.nextPoint.bearingMagnetic',
+  'navigation.courseRhumbline.bearingTrackTrue',
+  'navigation.courseGreatCircle.bearingTrackTrue',
+  'navigation.courseRhumbline.bearingTrackMagnetic',
+  'navigation.courseGreatCircle.bearingTrackMagnetic'
+]
+
+const EXTERNAL_NAV_PATHS = [
+  ...EXTERNAL_NEXT_POINT_PATHS,
+  ...EXTERNAL_PREVIOUS_POINT_PATHS,
+  ...EXTERNAL_XTE_PATHS,
+  ...EXTERNAL_NAV_TOUCH_PATHS
+]
+
+const orderExternalNavigationValues = (values: PathValue[]) => [
+  ...values.filter((pathValue) =>
+    EXTERNAL_NEXT_POINT_PATHS.has(pathValue.path)
+  ),
+  ...values.filter(
+    (pathValue) => !EXTERNAL_NEXT_POINT_PATHS.has(pathValue.path)
+  )
+]
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+
 export class CourseApi {
   private courseInfo = NO_COURSE_INFO
 
   private store: Store
   private cmdSource: CommandSource | null = null // source which set the destination
   private unsubscribes: Unsubscribes = []
+  private externalNavTimer: ReturnType<typeof setTimeout> | null = null
+  private externalNavLastUpdate = 0
+  private xteRebaseMismatchCount = 0
 
   constructor(
     private app: CourseApplication,
@@ -120,23 +175,22 @@ export class CourseApi {
       this.app.subscriptionmanager?.subscribe(
         {
           context: 'vessels.self' as Context,
-          subscribe: [
-            {
-              path: 'navigation.courseRhumbline.nextPoint.position' as Path,
-              period: 500
-            },
-            {
-              path: 'navigation.courseGreatCircle.nextPoint.position' as Path,
-              period: 500
-            }
-          ]
+          subscribe: EXTERNAL_NAV_PATHS.map((path) => ({
+            path: path as Path,
+            period: 500
+          }))
         },
         this.unsubscribes,
         (err) => {
           console.log(`Course API: Subscribe failed: ${err}`)
         },
         (msg: Delta) => {
-          this.processV1DestinationDeltas(msg)
+          void this.processV1DestinationDeltas(msg).catch((error) => {
+            debug(
+              'Course API: external navigation delta processing failed',
+              error
+            )
+          })
         }
       )
       this.app.subscriptionmanager?.subscribe(
@@ -300,37 +354,41 @@ export class CourseApi {
     ) {
       return
     }
-    delta.updates.forEach((update: Update) => {
+    for (const update of delta.updates) {
       if (hasValues(update)) {
-        update.values.forEach((pathValue: PathValue) => {
-          if (
-            update.source &&
-            update.source.type &&
-            ['NMEA0183', 'NMEA2000'].includes(update.source.type)
-          ) {
-            this.parseStreamValue(
-              {
-                type: update.source.type,
-                $source: update.$source || getSourceId(update.source),
-                msg:
-                  update.source.type === 'NMEA0183'
-                    ? `${update.source.sentence}`
-                    : `${update.source.pgn}`,
-                path: pathValue.path
-              },
-              pathValue.value as Position
-            )
-          }
-        })
+        if (!update.source?.type) {
+          continue
+        }
+
+        if (!EXTERNAL_COURSE_SOURCE_TYPES.has(update.source.type)) {
+          continue
+        }
+
+        for (const pathValue of orderExternalNavigationValues(update.values)) {
+          await this.parseStreamValue(
+            {
+              type: update.source.type,
+              $source:
+                (update.$source as SourceRef | undefined) ||
+                getSourceId(update.source),
+              msg:
+                update.source.type === 'NMEA0183'
+                  ? `${update.source.sentence}`
+                  : `${update.source.pgn}`,
+              path: pathValue.path
+            },
+            pathValue.value
+          )
+        }
       }
-    })
+    }
   }
 
   /** Test for valid Signal K position */
   private isValidPosition(position: Position): boolean {
     return (
       typeof position?.latitude === 'number' &&
-      typeof position?.latitude === 'number' &&
+      typeof position?.longitude === 'number' &&
       position?.latitude >= -90 &&
       position?.latitude <= 90 &&
       position?.longitude >= -180 &&
@@ -340,30 +398,57 @@ export class CourseApi {
 
   /** Process stream value and take action
    * @param cmdSource Object describing the source of the update
-   * @param pos Destination location value in the update
+   * @param value Destination position or external navigation value in the update
    */
-  private async parseStreamValue(cmdSource: CommandSource, pos: Position) {
+  private async parseStreamValue(cmdSource: CommandSource, value: unknown) {
+    const isNextPoint = EXTERNAL_NEXT_POINT_PATHS.has(cmdSource.path ?? '')
+    const isPreviousPoint = EXTERNAL_PREVIOUS_POINT_PATHS.has(
+      cmdSource.path ?? ''
+    )
+    const isXte = EXTERNAL_XTE_PATHS.has(cmdSource.path ?? '')
+
     if (!this.cmdSource) {
       // New source
-      if (!this.isValidPosition(pos)) {
+      if (!isNextPoint || !this.isValidPosition(value as Position)) {
         return
       }
       debug('parseStreamValue:', 'Setting Destination...')
-      const result = await this.setDestination({ position: pos }, cmdSource)
+      const result = await this.setDestination(
+        { position: value as Position },
+        cmdSource
+      )
       debug('parseStreamValue: Source set...', this.cmdSource)
       if (result) {
+        this.markExternalNavigationUpdate()
         this.emitCourseInfo()
         return
       }
     }
 
-    if (this.isCurrentCmdSource(cmdSource)) {
+    if (this.isCurrentNavigationSource(cmdSource)) {
+      this.markExternalNavigationUpdate()
+
+      if (isPreviousPoint) {
+        this.updateExternalPreviousPoint(value)
+        return
+      }
+
+      if (isXte) {
+        this.maybeRebaseExternalPreviousPoint(value)
+        return
+      }
+
+      if (!isNextPoint) {
+        return
+      }
+
+      const pos = value as Position
       if (!this.isValidPosition(pos)) {
         debug(
           'parseStreamValue:',
           'No or invalid position... Clear Destination...'
         )
-        this.clearDestination()
+        this.clearDestination(true)
         return
       }
 
@@ -383,6 +468,135 @@ export class CourseApi {
     }
   }
 
+  private markExternalNavigationUpdate() {
+    this.externalNavLastUpdate = Date.now()
+    this.scheduleExternalNavigationTimeout()
+  }
+
+  private scheduleExternalNavigationTimeout() {
+    if (!this.cmdSource || !isExternalCmdSource(this.cmdSource)) {
+      return
+    }
+
+    if (this.externalNavTimer) {
+      clearTimeout(this.externalNavTimer)
+    }
+
+    const age = Date.now() - this.externalNavLastUpdate
+    const delay = Math.max(EXTERNAL_NAV_MAX_AGE_MS - age, 0)
+    this.externalNavTimer = setTimeout(() => {
+      const elapsed = Date.now() - this.externalNavLastUpdate
+      if (
+        this.cmdSource &&
+        isExternalCmdSource(this.cmdSource) &&
+        elapsed >= EXTERNAL_NAV_MAX_AGE_MS
+      ) {
+        debug('External navigation stale; clearing course')
+        this.clearDestination(true)
+      } else {
+        this.scheduleExternalNavigationTimeout()
+      }
+    }, delay)
+    this.externalNavTimer.unref?.()
+  }
+
+  private clearExternalNavigationState() {
+    if (this.externalNavTimer) {
+      clearTimeout(this.externalNavTimer)
+      this.externalNavTimer = null
+    }
+    this.externalNavLastUpdate = 0
+    this.xteRebaseMismatchCount = 0
+  }
+
+  private updateExternalPreviousPoint(value: unknown) {
+    const position = value as Position
+    if (!this.isValidPosition(position)) {
+      return
+    }
+
+    if (
+      this.courseInfo.previousPoint?.position?.latitude === position.latitude &&
+      this.courseInfo.previousPoint?.position?.longitude === position.longitude
+    ) {
+      return
+    }
+
+    this.xteRebaseMismatchCount = 0
+    this.courseInfo.previousPoint = {
+      position,
+      type: RoutePoint,
+      name: this.courseInfo.previousPoint?.name ?? 'WP0'
+    }
+    this.emitCourseInfo(true, 'previousPoint')
+  }
+
+  private maybeRebaseExternalPreviousPoint(externalXte: unknown) {
+    if (!isFiniteNumber(externalXte)) {
+      return
+    }
+
+    const vesselPositionValue: any = this.getVesselPosition()
+    const vesselPosition = vesselPositionValue?.value as Position | undefined
+    const previousPoint = this.courseInfo.previousPoint?.position
+    const destination = this.courseInfo.nextPoint?.position
+
+    if (
+      !vesselPosition ||
+      !previousPoint ||
+      !destination ||
+      !this.isValidPosition(vesselPosition) ||
+      !this.isValidPosition(previousPoint) ||
+      !this.isValidPosition(destination)
+    ) {
+      return
+    }
+
+    const calculatedXte = crossTrackDistance(
+      vesselPosition,
+      previousPoint,
+      destination
+    )
+
+    if (
+      calculatedXte === undefined ||
+      Math.abs(calculatedXte - externalXte) <= XTE_REBASE_THRESHOLD_M
+    ) {
+      this.xteRebaseMismatchCount = 0
+      return
+    }
+
+    this.xteRebaseMismatchCount += 1
+    if (this.xteRebaseMismatchCount < XTE_REBASE_CONFIRMATIONS) {
+      return
+    }
+
+    const rebasedPreviousPoint = rebasePreviousPointFromXte(
+      vesselPosition,
+      destination,
+      externalXte
+    )
+    if (!rebasedPreviousPoint) {
+      return
+    }
+
+    debug(
+      'External XTE mismatch; rebasing previousPoint',
+      calculatedXte,
+      externalXte,
+      rebasedPreviousPoint
+    )
+    this.xteRebaseMismatchCount = 0
+    this.courseInfo.previousPoint = {
+      position: rebasedPreviousPoint,
+      type: VesselPosition,
+      name: 'VP'
+    }
+    this.courseInfo.activeRoute = null
+    this.courseInfo.startTime = new Date().toISOString()
+    this.emitCourseInfo(true, 'activeRoute', 'nextPoint', 'previousPoint')
+  }
+
   /** Get course (exposed to plugins) */
   async getCourse(): Promise<CourseInfo> {
     debug(`** getCourse()`)
@@ -391,6 +605,7 @@ export class CourseApi {
 
   /** Clear destination / route (exposed to plugins) */
   async clearDestination(persistState?: boolean): Promise<void> {
+    this.clearExternalNavigationState()
     this.courseInfo = {
       ...NO_COURSE_INFO,
       arrivalCircle: this.courseInfo.arrivalCircle
@@ -950,6 +1165,7 @@ export class CourseApi {
     }
     this.courseInfo = newCourse
     this.cmdSource = src
+    this.clearExternalNavigationState()
     return true
   }
 
@@ -1035,6 +1251,10 @@ export class CourseApi {
     }
     this.courseInfo = newCourse
     this.cmdSource = src
+    this.clearExternalNavigationState()
+    if (isExternalCmdSource(src)) {
+      this.markExternalNavigationUpdate()
+    }
     return true
   }
 
@@ -1332,12 +1552,18 @@ export class CourseApi {
     (this.cmdSource.type !== newSource.type ||
       this.cmdSource.$source !== newSource.$source)
 
-  private isCurrentCmdSource = (cmdSource: CommandSource) =>
+  private isCurrentNavigationSource = (cmdSource: CommandSource) =>
     this.cmdSource?.type === cmdSource.type &&
-    this.cmdSource?.$source === cmdSource.$source &&
+    this.cmdSource?.$source === cmdSource.$source
+
+  private isCurrentCmdSource = (cmdSource: CommandSource) =>
+    this.isCurrentNavigationSource(cmdSource) &&
     this.cmdSource?.path === cmdSource.path &&
     this.cmdSource?.msg === cmdSource.msg
 }
+
+const isExternalCmdSource = (cmdSource: CommandSource) =>
+  EXTERNAL_COURSE_SOURCE_TYPES.has(cmdSource.type)
 
 const hasAllProperties = (info: CourseInfo, propNames: string[]) => {
   return !propNames.find((propName) => !(propName in info))

--- a/src/api/course/xteGeometry.ts
+++ b/src/api/course/xteGeometry.ts
@@ -1,0 +1,157 @@
+import { Position } from '@signalk/server-api'
+
+const EARTH_RADIUS_M = 6371000
+const XTE_ZERO_EPSILON_M = 1
+
+const toRadians = (degrees: number) => (degrees * Math.PI) / 180
+const toDegrees = (radians: number) => (radians * 180) / Math.PI
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+
+const angularDistance = (a: Position, b: Position) => {
+  const lat1 = toRadians(a.latitude)
+  const lat2 = toRadians(b.latitude)
+  const deltaLat = lat2 - lat1
+  const deltaLon = toRadians(b.longitude - a.longitude)
+  const sinDeltaLat = Math.sin(deltaLat / 2)
+  const sinDeltaLon = Math.sin(deltaLon / 2)
+  return (
+    2 *
+    Math.asin(
+      Math.sqrt(
+        sinDeltaLat * sinDeltaLat +
+          Math.cos(lat1) * Math.cos(lat2) * sinDeltaLon * sinDeltaLon
+      )
+    )
+  )
+}
+
+const initialBearing = (a: Position, b: Position) => {
+  const lat1 = toRadians(a.latitude)
+  const lat2 = toRadians(b.latitude)
+  const deltaLon = toRadians(b.longitude - a.longitude)
+  return Math.atan2(
+    Math.sin(deltaLon) * Math.cos(lat2),
+    Math.cos(lat1) * Math.sin(lat2) -
+      Math.sin(lat1) * Math.cos(lat2) * Math.cos(deltaLon)
+  )
+}
+
+export const crossTrackDistance = (
+  position: Position,
+  start: Position,
+  destination: Position
+): number | undefined => {
+  const distanceStartToPosition = angularDistance(start, position)
+  const bearingStartToPosition = initialBearing(start, position)
+  const bearingStartToDestination = initialBearing(start, destination)
+  const value =
+    Math.asin(
+      Math.sin(distanceStartToPosition) *
+        Math.sin(bearingStartToPosition - bearingStartToDestination)
+    ) * EARTH_RADIUS_M
+  return Number.isFinite(value) ? value : undefined
+}
+
+const localPoint = (
+  position: Position,
+  origin: Position
+): { x: number; y: number } => {
+  const lat0 = toRadians(origin.latitude)
+  const lat = toRadians(position.latitude)
+  return {
+    x:
+      toRadians(position.longitude - origin.longitude) *
+      EARTH_RADIUS_M *
+      Math.cos((lat + lat0) / 2),
+    y: (lat - lat0) * EARTH_RADIUS_M
+  }
+}
+
+const geographicPoint = (
+  point: { x: number; y: number },
+  origin: Position
+): Position => {
+  const lat = toRadians(origin.latitude)
+  const latitude = lat + point.y / EARTH_RADIUS_M
+  return {
+    latitude: toDegrees(latitude),
+    longitude:
+      origin.longitude +
+      toDegrees(point.x / (EARTH_RADIUS_M * Math.cos((latitude + lat) / 2)))
+  }
+}
+
+const candidateStartFromTangent = (
+  vesselPosition: Position,
+  destination: Position,
+  xteRadius: number,
+  side: 1 | -1
+): Position | undefined => {
+  const destinationLocal = localPoint(destination, vesselPosition)
+  const distanceSquared =
+    destinationLocal.x * destinationLocal.x +
+    destinationLocal.y * destinationLocal.y
+  const radiusSquared = xteRadius * xteRadius
+
+  if (distanceSquared <= radiusSquared) {
+    return undefined
+  }
+
+  const scale = radiusSquared / distanceSquared
+  const offset =
+    (side * xteRadius * Math.sqrt(distanceSquared - radiusSquared)) /
+    distanceSquared
+  const tangent = {
+    x: scale * destinationLocal.x - offset * destinationLocal.y,
+    y: scale * destinationLocal.y + offset * destinationLocal.x
+  }
+  const dx = tangent.x - destinationLocal.x
+  const dy = tangent.y - destinationLocal.y
+  const length = Math.hypot(dx, dy)
+
+  if (!Number.isFinite(length) || length === 0) {
+    return undefined
+  }
+
+  const extension = xteRadius
+  return geographicPoint(
+    {
+      x: tangent.x + (dx / length) * extension,
+      y: tangent.y + (dy / length) * extension
+    },
+    vesselPosition
+  )
+}
+
+export const rebasePreviousPointFromXte = (
+  vesselPosition: Position,
+  destination: Position,
+  xte: number
+): Position | undefined => {
+  if (Math.abs(xte) <= XTE_ZERO_EPSILON_M) {
+    return vesselPosition
+  }
+
+  const radius = Math.abs(xte)
+  const candidates = (
+    [
+      candidateStartFromTangent(vesselPosition, destination, radius, 1),
+      candidateStartFromTangent(vesselPosition, destination, radius, -1)
+    ] as Array<Position | undefined>
+  ).filter((candidate): candidate is Position => candidate !== undefined)
+
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      calculatedXte: crossTrackDistance(vesselPosition, candidate, destination)
+    }))
+    .filter((item): item is { candidate: Position; calculatedXte: number } =>
+      isFiniteNumber(item.calculatedXte)
+    )
+    .sort(
+      (a, b) =>
+        Math.abs(a.calculatedXte - xte) - Math.abs(b.calculatedXte - xte)
+    )[0]?.candidate
+}

--- a/test/course.ts
+++ b/test/course.ts
@@ -5,7 +5,8 @@ import {
   deltaHasPathValue,
   startServer
 } from './ts-servertestutilities'
-import { CourseInfo } from '@signalk/server-api'
+import { CourseInfo, Position } from '@signalk/server-api'
+import { crossTrackDistance } from '../src/api/course/xteGeometry'
 chai.should()
 
 describe('Course Api', () => {
@@ -487,6 +488,139 @@ describe('Course Api', () => {
     data = (await selfGetJson('navigation/course')) as CourseInfo
     expect(data.previousPoint?.position?.latitude).to.equal(60.0)
     expect(data.previousPoint?.position?.longitude).to.equal(10.0)
+
+    stop()
+  })
+
+  it('clears an external course when navigation updates stop', async function () {
+    this.timeout(30000)
+
+    const { server, selfGetJson, sendDelta, stop } = await startServer()
+    const vesselPosition = { latitude: 43.02, longitude: 7.84 }
+    await sendDelta('navigation.position', vesselPosition)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const courseApi = server.app.courseApi as any
+    const cmdSource = {
+      type: 'NMEA0183',
+      $source: 'nmea.external',
+      msg: 'RMB',
+      path: 'navigation.courseRhumbline.nextPoint.position'
+    }
+
+    await courseApi.parseStreamValue(cmdSource, {
+      latitude: 43.03,
+      longitude: 7.94
+    })
+
+    let data = (await selfGetJson('navigation/course')) as CourseInfo
+    expect(data.nextPoint?.position).to.deep.equal({
+      latitude: 43.03,
+      longitude: 7.94
+    })
+
+    courseApi.externalNavLastUpdate = Date.now() - 16000
+    courseApi.scheduleExternalNavigationTimeout()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    data = (await selfGetJson('navigation/course')) as CourseInfo
+    data.should.deep.equal({
+      startTime: null,
+      targetArrivalTime: null,
+      activeRoute: null,
+      arrivalCircle: 0,
+      nextPoint: null,
+      previousPoint: null
+    })
+
+    stop()
+  })
+
+  it('rebases external NMEA0183 previousPoint using Signal K XTE sign', async function () {
+    const { server, selfGetJson, sendDelta, stop } = await startServer()
+    const vesselPosition = { latitude: 43.02, longitude: 7.84 }
+    const destination = {
+      latitude: 43.03,
+      longitude: 7.94
+    }
+    const externalXte = 50
+    await sendDelta('navigation.position', vesselPosition)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const courseApi = server.app.courseApi as any
+    const source = {
+      type: 'NMEA0183',
+      $source: 'nmea.external',
+      msg: 'RMB',
+      path: 'navigation.courseRhumbline.nextPoint.position'
+    }
+
+    await courseApi.parseStreamValue(source, destination)
+
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+
+    const data = (await selfGetJson('navigation/course')) as CourseInfo
+    expect(data.previousPoint?.type).to.equal('VesselPosition')
+    expect(
+      crossTrackDistance(
+        vesselPosition,
+        data.previousPoint?.position as Position,
+        destination
+      )
+    ).to.be.closeTo(externalXte, 0.1)
+    expect(data.previousPoint?.position).to.not.deep.equal(vesselPosition)
+
+    stop()
+  })
+
+  it('uses external previousPoint position when provided', async function () {
+    const { server, selfGetJson, sendDelta, stop } = await startServer()
+    const vesselPosition = { latitude: 43.02, longitude: 7.84 }
+    const previousPoint = { latitude: 43.01, longitude: 7.75 }
+    const destination = {
+      latitude: 43.03,
+      longitude: 7.94
+    }
+    await sendDelta('navigation.position', vesselPosition)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const courseApi = server.app.courseApi as any
+    const source = {
+      type: 'NMEA2000',
+      $source: 'n2k.external',
+      msg: '129285',
+      path: 'navigation.courseRhumbline.nextPoint.position'
+    }
+
+    await courseApi.parseStreamValue(source, destination)
+    await courseApi.parseStreamValue(
+      {
+        ...source,
+        path: 'navigation.courseRhumbline.previousPoint.position'
+      },
+      previousPoint
+    )
+
+    let data = (await selfGetJson('navigation/course')) as CourseInfo
+    expect(data.previousPoint?.type).to.equal('RoutePoint')
+    expect(data.previousPoint?.position).to.deep.equal(previousPoint)
+
+    const externalXte = crossTrackDistance(
+      vesselPosition,
+      previousPoint,
+      destination
+    )
+    if (typeof externalXte !== 'number') {
+      throw new Error('Expected a finite external XTE')
+    }
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+    courseApi.maybeRebaseExternalPreviousPoint(externalXte)
+
+    data = (await selfGetJson('navigation/course')) as CourseInfo
+    expect(data.previousPoint?.position).to.deep.equal(previousPoint)
 
     stop()
   })


### PR DESCRIPTION
## Summary

This updates the Course API so courses driven by external navigation sources stay coherent when the source changes or stops navigation.

Previously, the Course API used externally supplied next waypoint positions, but it still derived parts of the course state from its own stored previous point. This caused stale course state in common external navigation workflows.

For example, when an external navigation app resets XTE by telling the boat to steer directly to the target waypoint from the current position, the NMEA XTE becomes zero or near-zero. Signal K, however, could continue calculating XTE from the old previous point, so Course API consumers still saw the old cross-track error. Downstream consumers using Course API data could therefore continue steering as if the original route leg was still active.

This change compares externally supplied XTE with the XTE calculated from the Course API course geometry. If they diverge consistently, the Course API rebases the previous point so its calculated course state matches the externally supplied navigation state.

The Course API now also handles external route cancellation more cleanly. If an external navigation source stops sending course/navigation updates, the Course API clears the active course using the same Course API state transition as a normal route stop. This prevents a route cancelled on the external device from remaining active indefinitely in Signal K.

When an external source provides previousPoint.position directly, such as via NMEA2000 route data, the Course API now uses that value instead of reconstructing it from XTE.

## Details

- Subscribe to external course next point, previous point, XTE, distance, and bearing updates.
- Treat NMEA0183 and NMEA2000 course updates as external course sources.
- Clear an externally driven course when no external navigation updates are received for 15 seconds.
- Use externally supplied previousPoint.position when available.
- Rebase previousPoint from XTE when external XTE and calculated XTE differ by more than 10 meters for 3 consecutive updates.
- Move XTE geometry helpers into a dedicated module.
- Fix position validation so longitude type is checked correctly.

## Testing

- npm run build
- prettier --check src/api/course/index.ts src/api/course/xteGeometry.ts test/course.ts
- eslint src/api/course/index.ts src/api/course/xteGeometry.ts test/course.ts
- Manual validation with external NMEA navigation input


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR updates the Course API to keep courses driven by external navigation sources coherent when the external source changes or stops navigation. The implementation subscribes to external course updates (nextPoint, previousPoint, XTE, distance, and bearing), treats NMEA0183 and NMEA2000 course updates as external sources, and introduces timeout-based clearing of stale external navigation state along with intelligent previousPoint rebasing.

## Changes

### Core API Updates (src/api/course/index.ts)
- Centralizes handling of external navigation inputs and generalizes subscriptions to a precomputed set of external navigation paths.
- Refactors delta processing to asynchronous iteration, filters incoming deltas by allowed external source types, and constructs a normalized CommandSource for per-value handling.
- Adds a source-aware parser that separates setting a destination from ongoing external navigation updates and updates previousPoint/next-point destination only when updates come from the current navigation source.
- Implements stale external-nav clearing: tracks the last external update timestamp and schedules a timeout to clear externally driven courses after 15 seconds of inactivity.
- Uses externally supplied previousPoint.position when available (e.g., NMEA2000 route data) instead of reconstructing it from XTE.
- Detects persistent XTE divergence (difference > 10 meters for 3 consecutive updates) and rebases previousPoint from XTE when appropriate.
- Clears external navigation state on destination clear, route activation, or new destination set; setting a destination from an external command starts the external-nav stale lifecycle.
- Refines command-source helpers (isCurrentNavigationSource, isCurrentCmdSource) and adds an isExternalCmdSource predicate used for external-nav state logic.

### XTE Geometry Helpers (src/api/course/xteGeometry.ts)
- Adds dedicated XTE geometry utilities: spherical helpers for angular distance and initial bearing, cross-track distance computation, local tangent-plane conversions, and candidate generation for previousPoint rebasing.
- Exports crossTrackDistance(position, start, destination): signed XTE in meters (or undefined if not finite).
- Exports rebasePreviousPointFromXte(vesselPosition, destination, xte): returns a candidate previousPoint on the local tangent plane whose computed XTE best matches the target XTE (or undefined if no valid candidate exists).

### Tests (test/course.ts)
- Adds tests validating external-course behaviors:
  - Stale course timeout: verifies external courses clear after navigation updates stop.
  - NMEA0183 XTE rebasing: verifies rebasing of previousPoint from provided XTE values.
  - External previousPoint persistence: verifies externally supplied previousPoint.position (e.g., from NMEA2000) remains unchanged when provided.

## Technical Details
- Fixes position validation to correctly check longitude type.
- Significant code changes in the Course API and new geometry helpers extracted to a separate module.
- Lines changed (per PR summary): src/api/course/index.ts +269/-43; src/api/course/xteGeometry.ts +157/-0; test/course.ts +135/-1.
- Estimated review complexity: High for main API and geometry module; Medium for tests.

## Testing
- Build and lint: npm run build; prettier --check and eslint on src/api/course/index.ts, src/api/course/xteGeometry.ts, test/course.ts.
- Manual validation with external NMEA navigation input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->