### PR TITLE
fix(appstore): point plugin registry at signalk.org after org transfer

### DIFF
--- a/packages/server-admin-ui/src/views/appstore/Detail/IndicatorsTab.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/IndicatorsTab.tsx
@@ -34,7 +34,7 @@ interface IndicatorsTabProps {
 // Public registry that publishes the per-plugin scoring data the
 // Indicators tab attributes. Defined here so the link can be updated
 // in one place if the registry ever moves.
-const PLUGIN_REGISTRY_URL = 'https://dirkwa.github.io/signalk-plugin-registry/'
+const PLUGIN_REGISTRY_URL = 'https://signalk.org/signalk-plugin-registry/'
 
 const statusToVariant: Record<Check['status'], string> = {
   ok: 'success',

--- a/src/appstore/registry.ts
+++ b/src/appstore/registry.ts
@@ -18,7 +18,7 @@ import { type IndicatorCheck, PluginCiSchema } from './schemas'
 
 const debug = createDebug('signalk-server:appstore:registry')
 
-const DEFAULT_REGISTRY_BASE = 'https://dirkwa.github.io/signalk-plugin-registry'
+const DEFAULT_REGISTRY_BASE = 'https://signalk.org/signalk-plugin-registry'
 const INDEX_TTL_MS = 60 * 60 * 1000 // 1 hour
 const PLUGIN_TTL_MS = 6 * 60 * 60 * 1000 // 6 hours
 const FETCH_TIMEOUT_MS = 20_000


### PR DESCRIPTION
The `signalk-plugin-registry` repository was transferred to the SignalK org, and its GitHub Pages site now serves at `https://signalk.org/signalk-plugin-registry/`. The old `dirkwa.github.io` URL returns 404.

Both places the server hardcoded the old base were therefore broken: the AppStore registry fetch (`index.json` / `plugins/<name>.json`) and the "registry" link on the plugin Indicators tab. This updates both constants to the org domain.

Verified the new base serves `index.json` and `plugins/<name>.json` (HTTP 200) and that the old base now returns 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR updates the plugin registry URL to point to the new SignalK organization domain following the repository transfer. The hardcoded registry URLs were previously pointing to `dirkwa.github.io`, which now returns 404 errors. The changes redirect traffic to `https://signalk.org/signalk-plugin-registry/`, where the GitHub Pages site is now hosted.

## Changes

**src/appstore/registry.ts**
- Updates `DEFAULT_REGISTRY_BASE` from `https://dirkwa.github.io/signalk-plugin-registry` to `https://signalk.org/signalk-plugin-registry`
- This constant defines the default origin for registry requests when fetching `index.json` and plugin metadata files

**packages/server-admin-ui/src/views/appstore/Detail/IndicatorsTab.tsx**
- Updates `PLUGIN_REGISTRY_URL` from `https://dirkwa.github.io/signalk-plugin-registry/` to `https://signalk.org/signalk-plugin-registry/`
- This constant provides the outbound link labeled "Signal K Plugin Registry" in the composite score section of the AppStore detail view

## Impact

These changes resolve broken plugin registry endpoints by routing traffic to the new organization-owned domain where the registry is now hosted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->