### PR TITLE
fix(streams): authenticate binary-stream WebSocket via cookie and query token

### DIFF
--- a/src/api/streams/index.ts
+++ b/src/api/streams/index.ts
@@ -7,6 +7,7 @@
 
 import Debug from 'debug'
 import WebSocket from 'ws'
+import cookie from 'cookie'
 import { IncomingMessage } from 'http'
 import { Duplex } from 'stream'
 import { Server as HttpServer } from 'http'
@@ -42,10 +43,17 @@ interface StreamApplication
 }
 
 /**
- * Extended request with SignalK principal attached by security middleware
+ * Extended request with SignalK principal attached by security middleware.
+ * `cookies` / `query` are populated here before authentication: WebSocket
+ * upgrade requests bypass the Express middleware chain, so unlike normal
+ * HTTP requests they arrive with neither parsed. authorizeWS() reads the
+ * token from query → header → cookie, so both must be filled in for cookie-
+ * and query-token auth to work.
  */
 interface AuthenticatedRequest extends IncomingMessage {
   skPrincipal?: StreamPrincipal
+  cookies?: Record<string, string>
+  query?: Record<string, string>
 }
 
 /**
@@ -109,6 +117,18 @@ export function initializeBinaryStreams(app: StreamApplication): void {
         // Authenticate the request (if security is enabled)
         let principal: StreamPrincipal = { identifier: 'unknown' }
         const authRequest = request as AuthenticatedRequest
+
+        // Upgrade requests skip Express, so parse the cookie header and query
+        // string onto the request the way the middleware chain would. Without
+        // this authorizeWS() finds no token and rejects every browser
+        // connection — the HttpOnly JAUTHENTICATION cookie the browser sends
+        // on a same-origin upgrade would otherwise be ignored. Mirrors the
+        // v1 stream path in interfaces/ws.ts.
+        const cookieHeader = request.headers.cookie
+        if (typeof cookieHeader === 'string') {
+          authRequest.cookies = cookie.parse(cookieHeader)
+        }
+        authRequest.query = Object.fromEntries(url.searchParams)
 
         // Check if security is enabled
         if (

--- a/test/binary-stream-auth.ts
+++ b/test/binary-stream-auth.ts
@@ -1,0 +1,86 @@
+import chai from 'chai'
+import { freeport } from './ts-servertestutilities'
+import { startServerP, getAdminToken } from './servertestutilities'
+import WebSocket from 'ws'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(chai as any).Should()
+
+// The radar spoke stream is served as a binary-stream WebSocket at the
+// alias path /signalk/v2/api/vessels/self/radars/:id/stream. WebSocket
+// upgrade requests bypass the Express middleware chain, so the handler
+// must parse the cookie header and query string itself before calling
+// authorizeWS() — otherwise a browser's same-origin HttpOnly
+// JAUTHENTICATION cookie is ignored and every connection is rejected.
+describe('Binary stream WebSocket authentication', function () {
+  const RADAR_STREAM = '/signalk/v2/api/vessels/self/radars/test-radar/stream'
+
+  let host: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let adminToken: string
+
+  before(async function () {
+    this.timeout(60000)
+    const port = await freeport()
+    host = `ws://0.0.0.0:${port}`
+    server = await startServerP(port, true)
+    adminToken = await getAdminToken(server)
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  // Resolve to the HTTP status on a rejected upgrade, or 101 on success.
+  function upgradeStatus(
+    path: string,
+    headers: Record<string, string> = {}
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`${host}${path}`, { headers })
+      const done = (n: number) => {
+        try {
+          ws.close()
+        } catch {
+          // ignore
+        }
+        resolve(n)
+      }
+      ws.on('open', () => done(101))
+      ws.on('unexpected-response', (_req, res) => done(res.statusCode ?? 0))
+      ws.on('error', (err) => reject(err))
+    })
+  }
+
+  it('rejects an unauthenticated connection with 401', async function () {
+    const status = await upgradeStatus(RADAR_STREAM)
+    status.should.equal(401)
+  })
+
+  it('rejects an invalid token with 401', async function () {
+    const status = await upgradeStatus(RADAR_STREAM, {
+      Cookie: 'JAUTHENTICATION=not-a-real-token'
+    })
+    status.should.equal(401)
+  })
+
+  it('accepts a valid token via the JAUTHENTICATION cookie', async function () {
+    const status = await upgradeStatus(RADAR_STREAM, {
+      Cookie: `JAUTHENTICATION=${adminToken}`
+    })
+    status.should.equal(101)
+  })
+
+  it('accepts a valid token via the ?token= query parameter', async function () {
+    const status = await upgradeStatus(`${RADAR_STREAM}?token=${adminToken}`)
+    status.should.equal(101)
+  })
+
+  it('accepts a valid token via the Authorization header', async function () {
+    const status = await upgradeStatus(RADAR_STREAM, {
+      Authorization: `Bearer ${adminToken}`
+    })
+    status.should.equal(101)
+  })
+})


### PR DESCRIPTION
closes #2753

## Motivation

The binary-stream WebSocket endpoint — radar spoke data at `/signalk/v2/api/vessels/self/radars/<id>/stream` and the generic `/signalk/v2/api/streams/<id>` — rejects authenticated **browser** clients with 401 when security is enabled. Radar overlays (e.g. Freeboard-SK) loop on "disconnected retry in 3 seconds".

The upgrade handler calls `authorizeWS()` on the raw `IncomingMessage`. WebSocket upgrades bypass the Express middleware chain, so `req.cookies` and `req.query` are never populated — `authorizeWS()` can only see the `Authorization` header, which browsers cannot set on a `WebSocket`. The `JAUTHENTICATION` cookie the browser sends on a same-origin upgrade is the only credential a web app can present, and it was being dropped.

The v1 delta stream is unaffected because its Primus authorize wrapper parses the cookie before calling `authorizeWS()` (`src/interfaces/ws.ts`). The binary-stream path simply never got the equivalent.

## Approach

Parse the cookie header and query string onto the request before `authorizeWS()`, mirroring the v1 path. The token resolution order (cookie / header / query) is unchanged — it already lives inside `authorizeWS()`; this just feeds it the inputs.

| credential | before | after |
| --- | :---: | :---: |
| none | 401 | 401 |
| invalid token | 401 | 401 |
| valid token via `JAUTHENTICATION` cookie | 401 | 101 |
| valid token via `?token=` | 401 | 101 |
| valid token via `Authorization` header | 101 | 101 |

## Tested

New `test/binary-stream-auth.ts` exercises the radar stream upgrade with no token, an invalid token, and a valid token via cookie / query / header. Confirmed the cookie and query cases fail without the fix and pass with it; `endpoint-auth.ts` still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes authentication for binary-stream WebSocket endpoints (`/signalk/v2/api/vessels/self/radars/<id>/stream` and `/signalk/v2/api/streams/<id>`) that were rejecting authenticated browser clients with HTTP 401 when security is enabled. The root cause is that WebSocket upgrades bypass Express middleware, leaving `req.cookies` and `req.query` unpopulated when the raw `IncomingMessage` is passed to `authorizeWS()`. The PR parses the Cookie header and query string onto the upgrade request before authorization, mirroring the v1 stream behavior, so `authorizeWS()` can resolve tokens from cookies, query parameters, or headers as intended.

## Changes

**src/api/streams/index.ts**
Adds cookie and query parameter parsing during WebSocket upgrade handling. Introduces an `AuthenticatedRequest` extension with optional `cookies` and `query` properties. The upgrade handler now parses the incoming Cookie header and URL search parameters into these fields before calling `authorizeWS()`, enabling the authorization logic to access tokens passed via `JAUTHENTICATION` cookie or `?token=` query parameter without modifying the token resolution order.

**test/binary-stream-auth.ts**
Introduces a comprehensive test suite validating WebSocket upgrade authentication for the binary radar stream endpoint. The suite starts the server on a free port, fetches an admin token, and exercises upgrade scenarios including rejection when no credentials are provided, rejection for invalid `JAUTHENTICATION` cookies, and acceptance when valid credentials are supplied via cookie, query parameter, or Authorization header. This ensures the fix resolves the authentication rejection issue for browser clients while maintaining security semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->