### PR TITLE
fix: type app.debug as debug's Debugger so plugins can check debug.enabled

### DIFF
--- a/packages/server-api/package.json
+++ b/packages/server-api/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
+    "@types/debug": "^4.1.12",
     "@signalk/path-metadata": "*",
     "@sinclair/typebox": "^0.34.0",
     "baconjs": "^3.0.0"

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -1,3 +1,4 @@
+import type { Debugger } from 'debug'
 import {
   SKVersion,
   AutopilotProviderRegistry,
@@ -154,8 +155,9 @@ export interface ServerAPI
   /**
    * Log debug messages.
    *
-   * This function exposes the `debug` method from the [debug module](https://www.npmjs.com/package/debug).
-   * The npm module name is used as the debug name.
+   * This is a `debug` instance from the [debug module](https://www.npmjs.com/package/debug),
+   * created with the npm module name as the debug name, so instance properties
+   * such as `app.debug.enabled` are available for gating expensive log statements.
    *
    * `app.debug()` can take any type and will serialize it before outputting.
    *
@@ -164,8 +166,7 @@ export interface ServerAPI
    *
    * @category Status and Debugging
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug(msg: any, ...args: any[]): void
+  debug: Debugger
 
   /**
    * Register a function to intercept all delta messages _before_ they are processed by the server.


### PR DESCRIPTION
## What problem does this solve?

`ServerAPI` types `app.debug` as a bare function, but at runtime it's a debug-module instance (`createDebug(packageName)` in `interfaces/plugins.ts`). So TypeScript plugins can't write the `debug.enabled &&` guards that AGENTS.md and #2582 call for — the plugin-side follow-up planned in #2582 needs this. It already broke a real plugin build (worked around downstream in openwatersio/signalk-tides#76).

The import is type-only, so `@types/debug` goes in `dependencies` (no runtime dep) to keep the published d.ts resolvable for consumers. If you'd rather avoid the dep entirely, an inline `& { enabled: boolean }` intersection works too — happy to switch.

## How was this tested?

`npm run build:all`, the full `npm test` chain, and `npm run build:docs` pass. The one in-tree `ServerAPI` implementor already assigns a real `Debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the TypeScript typing of `ServerAPI.debug` to expose it as a `debug` module Debugger instance rather than a bare callable function. This enables plugins to check the `.enabled` property on the debug instance for conditional logging, as recommended by AGENTS.md and addressed in issue `#2582`.

## Changes

- **packages/server-api/src/serverapi.ts**: Updates the `ServerAPI.debug` member type from a function signature (`debug(msg: any, ...args: any[]): void`) to a Debugger instance type (`debug: Debugger`). Adds an import for the Debugger type from the debug module and updates the associated JSDoc.

- **packages/server-api/package.json**: Adds `@types/debug` to dependencies to ensure the published `.d.ts` files are resolvable for consumers.

The runtime implementation already uses `createDebug(packageName)` to create a real Debugger instance, making this typing change accurate for existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->