### PR TITLE
chore(deps-dev): bump @types/uuid to 10 and ansi-to-html to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@types/split": "^1.0.0",
     "@types/swagger-ui-express": "^4.1.3",
     "@types/unzipper": "^0.10.5",
-    "@types/uuid": "^8.3.1",
+    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "assemblyscript-prettier": "^3.0.2",
     "chai": "^4.3.0",

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -56,7 +56,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.2",
-    "ansi-to-html": "^0.6.14",
+    "ansi-to-html": "^0.7.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "bootstrap": "^5.3.3",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Bundles two low-risk dev-dependency bumps, verified against the latest master.

- `@types/uuid` 8.3.1 -> 10.0.0: types only. The codebase uses just `v4`/`validate`, both present in v10; `tsc --build` passes.
- `ansi-to-html` 0.6.14 -> 0.7.2: used in the admin-ui log view; admin-ui vitest (226 tests) passes.

Closes #1963. Closes #1951.

The remaining open Dependabot dev-dep PRs are no longer applicable and can be closed:
- #1986 (webpack-bundle-analyzer): admin-ui moved to Vite, so the package is no longer used.
- #2060 (mocha): master is already on mocha 11.
- #2062 (chai 5): ESM-only, needs a separate test-setup migration rather than a drop-in bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR bundles development dependency updates to `@types/uuid` and ansi-to-html, both verified against the current master branch.

## Changes

- Updates `@types/uuid` from `^8.3.1` to `^10.0.0` in `package.json`
- Updates `ansi-to-html` from `^0.6.14` to `^0.7.2` in `packages/server-admin-ui/package.json`

## Verification

- **`@types/uuid`**: Type-only change; the codebase uses `v4` and `validate` utilities, both of which are present in v10. Type-checking with `tsc --build` passes.
- **ansi-to-html**: Used by the admin-ui log view; the admin-ui vitest suite (226 tests) passes with the updated version.

## Related Issues

Closes issues `#1963` and `#1951`.

## Notes on Other Dependabot PRs

The PR notes that the following open Dependabot dev-dependency PRs can be closed as no longer applicable:
- `#1986` (webpack-bundle-analyzer) — admin-ui migrated to Vite
- `#2060` (mocha) — master already on mocha 11
- `#2062` (chai 5) — ESM-only and requires separate test-setup migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->