### PR TITLE
fix: accept zero latitude/longitude in relativePosition subscriptions

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -469,9 +469,9 @@ function contextMatcher(
           normalizedDeltaData.context === selfContext)
     } else if ('radius' in subscribeCommand.context) {
       if (
-        !get(subscribeCommand.context, 'radius') ||
-        !get(subscribeCommand.context, 'position.latitude') ||
-        !get(subscribeCommand.context, 'position.longitude')
+        !Number.isFinite(get(subscribeCommand.context, 'radius')) ||
+        !Number.isFinite(get(subscribeCommand.context, 'position.latitude')) ||
+        !Number.isFinite(get(subscribeCommand.context, 'position.longitude'))
       ) {
         errorCallback(
           'Please specify a radius and position for relativePosition'
@@ -500,8 +500,8 @@ function checkPosition(
   return (
     position &&
     position.value &&
-    position.value.latitude &&
-    position.value.longitude &&
+    Number.isFinite(position.value.latitude) &&
+    Number.isFinite(position.value.longitude) &&
     isPointWithinRadius(position.value, origin.position, origin.radius)
   )
 }

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -152,6 +152,34 @@ function getFarPosistionDelta() {
   return delta
 }
 
+function getZeroPositionDelta() {
+  const delta = {
+    updates: [
+      {
+        source: {
+          label: 'langford-canboatjs',
+          type: 'NMEA2000',
+          pgn: 129025,
+          src: '3'
+        },
+        timestamp: '2017-04-15T14:58:01.200Z',
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude: 0,
+              latitude: 0
+            }
+          }
+        ]
+      }
+    ],
+    context: 'vessels.zeroPosition'
+  }
+
+  return delta
+}
+
 function getNullPositionDelta(overwrite) {
   const delta = {
     updates: [
@@ -501,6 +529,67 @@ describe('Subscriptions', (_) => {
         assert(delta.updates.length === 1, 'Receives just one update')
         assert(delta.updates[0].values.length === 1, 'Receives just one value')
         assert(delta.context === 'vessels.closeVessel')
+
+        return sendDelta(getFarPosistionDelta(), deltaUrl)
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getFarPosistionDelta(), deltaUrl)
+        ])
+      })
+      .then((results) => {
+        assert(results[0] === 'timeout')
+      })
+  })
+
+  it('relativePosition subscription works at zero latitude/longitude', function () {
+    let wsPromiser
+
+    return serverP
+      .then((_) => {
+        wsPromiser = new WsPromiser(
+          'ws://localhost:' +
+            port +
+            '/signalk/v1/stream?subsribe=none&metaDeltas=none'
+        )
+        return wsPromiser.nextMsg()
+      })
+      .then(() => {
+        return wsPromiser.send({
+          context: {
+            radius: 1,
+            position: {
+              longitude: 0,
+              latitude: 0
+            }
+          },
+          subscribe: [
+            {
+              path: 'navigation.position'
+            }
+          ]
+        })
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getZeroPositionDelta(), deltaUrl)
+        ])
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getZeroPositionDelta(), deltaUrl)
+        ])
+      })
+      .then((results) => {
+        assert(results[0] !== 'timeout', 'Got timeout')
+        const delta = JSON.parse(results[0])
+
+        assert(delta.updates.length === 1, 'Receives just one update')
+        assert(delta.updates[0].values.length === 1, 'Receives just one value')
+        assert(delta.context === 'vessels.zeroPosition')
 
         return sendDelta(getFarPosistionDelta(), deltaUrl)
       })


### PR DESCRIPTION
Truthy checks on coordinates rejected valid `0` values, so relativePosition subscriptions broke at the equator or prime meridian — both when `0` appeared in the subscription origin (rejected with "Please specify a radius and position") and when an incoming vessel position had a `0` coordinate (silently filtered out).

Swapped the truthy checks for `Number.isFinite`, which also keeps `NaN` and non-numeric values out. Added a test with origin and vessel at 0°,0° that fails on master and passes with the fix.

fixes #2717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes relative position subscription validation to correctly handle zero latitude and longitude coordinates. 

## Changes

**src/subscriptionmanager.ts**

Updates relative-position context validation to require finite numeric values. In `contextMatcher`, the checks for `radius`, `position.latitude`, and `position.longitude` now use `Number.isFinite(...)` instead of generic truthiness checks, rejecting missing/undefined/NaN/non-finite values with the existing error message. In `checkPosition`, the latitude/longitude validation similarly requires finite numbers before calling `isPointWithinRadius`.

**test/subscriptions.js**

Adds a new test helper `getZeroPositionDelta(overwrite)` that generates a delta with navigation position coordinates set to 0, and introduces a test case `relativePosition subscription works at zero latitude/longitude` that verifies relative-position subscriptions with radius and position at (0,0) correctly receive and filter position updates at zero coordinates.

## Rationale

The original truthy checks on coordinates incorrectly treated numeric 0 as false, preventing valid subscriptions at the equator or prime meridian. This fix allows numeric 0 values while still excluding undefined, NaN, and non-numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->