### PR TITLE
fix(server-api): type app.debug as callable with .enabled

### DIFF
--- a/packages/server-api/src/serverapi.test.ts
+++ b/packages/server-api/src/serverapi.test.ts
@@ -1,0 +1,9 @@
+import type { ServerAPI } from './serverapi'
+
+// Type-check test - verify `app.debug` is callable and exposes `.enabled`, so
+// plugins can guard expensive log arguments without a local type workaround.
+const _typeCheckDebug = (app: ServerAPI): boolean => {
+  app.debug('msg')
+  return app.debug.enabled
+}
+void _typeCheckDebug

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -159,13 +159,23 @@ export interface ServerAPI
    *
    * `app.debug()` can take any type and will serialize it before outputting.
    *
+   * Use `app.debug.enabled` to guard expensive log arguments so they are not
+   * computed when the debug name is disabled:
+   *
+   * ```ts
+   * if (app.debug.enabled) app.debug('state: ' + JSON.stringify(big))
+   * ```
+   *
    * > [!note]
    * > Do not use `debug` from the debug module directly! Using `app.debug()` provided by the server ensures that the plugin taps into the server's debug logging system, including the helper switches in Admin UI's Server Log page.
    *
    * @category Status and Debugging
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug(msg: any, ...args: any[]): void
+  debug: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (msg: any, ...args: any[]): void
+    enabled: boolean
+  }
 
   /**
    * Register a function to intercept all delta messages _before_ they are processed by the server.


### PR DESCRIPTION
## What problem does this solve?

`ServerAPI` types `app.debug` as a bare function, but at runtime it is a `debug`-module `Debugger` (`createDebug` -> `coreDebug`) that exposes `.enabled`. So the recommended guard for expensive log arguments,

```ts
if (app.debug.enabled) app.debug('x ' + JSON.stringify(big))
```

(the pattern documented in `AGENTS.md` and tracked in #2582) does not type-check for plugins. Every plugin that adopts it has to add a local type workaround, e.g. [openwatersio/signalk-tides#76](https://github.com/openwatersio/signalk-tides/pull/76).

This types `debug` as a callable carrying `enabled: boolean` and documents the guard. Existing `app.debug(...)` calls are unaffected; the change only widens the type. No new dependency, so the package stays self-contained.

## How was this tested?

- `tsc -b packages/server-api` and full root `tsc --build`: pass.
- `prettier --check` and `eslint` on the changed files: clean.
- server-api mocha suite: 34 passing.
- Added a type-contract test (`serverapi.test.ts`) matching the existing `deltas.test.ts` convention; confirmed it catches regressions under `tsc` (reverting the type yields `TS2339: Property 'enabled' does not exist`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the `ServerAPI` TypeScript type definition to properly type `app.debug` as a callable object with an `enabled: boolean` property, matching the runtime interface provided by the `debug` module's `Debugger`.

**Changes in `packages/server-api/src/serverapi.ts`:**
- Refines the `debug` property type from a bare function to an object that is both callable (`(msg: any, ...args: any[]): void`) and exposes an `enabled: boolean` property
- Expands documentation to include the recommended guard pattern for expensive debug logging: `if (app.debug.enabled) app.debug('state: ' + JSON.stringify(big))`
- Adds a note directing plugins to use `app.debug()` from the server rather than importing `debug` directly to ensure logging integrates with the server's debug system and Admin UI controls

**Changes in `packages/server-api/src/serverapi.test.ts`:**
- Adds a type-contract test (`_typeCheckDebug`) that verifies the type surface of `app.debug` is correct, ensuring it can be called as a function and that the `enabled` property is accessible; this catches regressions if the type definition is inadvertently reverted

The PR enables plugins to use the documented and recommended guard pattern without requiring local workarounds, and includes a regression test to maintain type safety going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->