### PR TITLE
Preserve app store view and search filter when returning from plugin detail

### DIFF
--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -120,6 +120,17 @@ export function useAppStore() {
   return useStore((s) => s.appStore)
 }
 
+export function useAppstoreFilter() {
+  return useStore(
+    useShallow((s) => ({
+      view: s.appstoreView,
+      search: s.appstoreSearch,
+      setView: s.setAppstoreView,
+      setSearch: s.setAppstoreSearch
+    }))
+  )
+}
+
 export function useServerStats() {
   return useStore((s) => s.serverStatistics)
 }

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -34,6 +34,8 @@ function nameCollator<T extends { name: string; displayName?: string }>(
   return a.localeCompare(b, undefined, { sensitivity: 'base' })
 }
 
+export type AppstoreView = 'All' | 'Installed' | 'Updates' | 'Installing'
+
 export interface AppSliceState {
   plugins: Plugin[]
   webapps: Webapp[]
@@ -106,6 +108,14 @@ export interface AppSliceState {
   n2kDeviceStatusLoaded: boolean
   sourceStatus: Record<string, { online: boolean; lastSeen?: number }>
   sourceStatusLoaded: boolean
+  /**
+   * App Store list view filter (All/Installed/Updates/Installing) and search
+   * text. Held in the store rather than component state so they survive the
+   * unmount/remount when the user opens a plugin detail page and returns via
+   * "Back to Store".
+   */
+  appstoreView: AppstoreView
+  appstoreSearch: string
 }
 
 export interface AppSliceActions {
@@ -177,6 +187,8 @@ export interface AppSliceActions {
       { sourceRef: string; timeout: string | number }[]
     >
   ) => void
+  setAppstoreView: (view: AppstoreView) => void
+  setAppstoreSearch: (search: string) => void
 }
 
 export type AppSlice = AppSliceState & AppSliceActions
@@ -225,7 +237,9 @@ const initialAppState: AppSliceState = {
   n2kOutAvailable: false,
   n2kDeviceStatusLoaded: false,
   sourceStatus: {},
-  sourceStatusLoaded: false
+  sourceStatusLoaded: false,
+  appstoreView: 'All',
+  appstoreSearch: ''
 }
 
 export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
@@ -483,5 +497,13 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
       },
       sourcePrioritiesLoaded: true
     }))
+  },
+
+  setAppstoreView: (appstoreView) => {
+    set({ appstoreView })
+  },
+
+  setAppstoreSearch: (appstoreSearch) => {
+    set({ appstoreSearch })
   }
 })

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -37,6 +37,12 @@ function tabIsActive(name: RegExp | string): boolean {
 describe('Apps auto-jump on install completion', () => {
   beforeEach(() => {
     setAppStore(emptyStore)
+    // View/search now live in the store (singleton across tests), so reset
+    // them between cases or a tab switched in one test leaks into the next.
+    act(() => {
+      useStore.getState().setAppstoreView('All')
+      useStore.getState().setAppstoreSearch('')
+    })
   })
 
   function renderApps() {
@@ -155,5 +161,61 @@ describe('Apps auto-jump on install completion', () => {
 
     expect(tabIsActive(/^All$/)).toBe(true)
     expect(tabIsActive(/^Installed$/)).toBe(false)
+  })
+})
+
+describe('Apps view/search state survives the detail round trip', () => {
+  beforeEach(() => {
+    setAppStore(emptyStore)
+    act(() => {
+      useStore.getState().setAppstoreView('All')
+      useStore.getState().setAppstoreSearch('')
+    })
+  })
+
+  function renderApps() {
+    return render(
+      <MemoryRouter>
+        <Apps />
+      </MemoryRouter>
+    )
+  }
+
+  it('restores the selected view after an unmount/remount', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      installed: [
+        { name: 'plugin-a', installedVersion: '1.0.0', version: '1.0.0' }
+      ]
+    })
+    const { unmount } = renderApps()
+
+    await user.click(screen.getByRole('button', { name: /^Installed$/ }))
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+
+    // Opening a plugin detail page unmounts Apps; returning remounts it.
+    unmount()
+    renderApps()
+
+    expect(tabIsActive(/^Installed$/)).toBe(true)
+    expect(tabIsActive(/^All$/)).toBe(false)
+  })
+
+  it('restores the search term after an unmount/remount', async () => {
+    const user = userEvent.setup()
+    const { unmount } = renderApps()
+
+    await user.type(screen.getByRole('textbox', { name: /Search/ }), 'anchor')
+    expect(screen.getByRole('textbox', { name: /Search/ })).toHaveValue(
+      'anchor'
+    )
+
+    unmount()
+    renderApps()
+
+    expect(screen.getByRole('textbox', { name: /Search/ })).toHaveValue(
+      'anchor'
+    )
   })
 })

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -11,7 +11,7 @@ import React, {
   useDeferredValue
 } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useAppStore } from '../../../store'
+import { useAppStore, useAppstoreFilter, useStore } from '../../../store'
 import { fetchAppStore } from '../../../dataFetching'
 import Button from 'react-bootstrap/Button'
 import ButtonGroup from 'react-bootstrap/ButtonGroup'
@@ -110,16 +110,26 @@ function writeString(key: string, value: string) {
 const Apps: React.FC = () => {
   const appStore = useAppStore() as AppStoreState
   const [searchParams, setSearchParams] = useSearchParams()
-  const [view, setSelectedView] = useState('All')
+  // View and search live in the store so they survive the unmount/remount
+  // when the user opens a plugin detail page and returns via "Back to Store".
+  const {
+    view,
+    search,
+    setView: setSelectedView,
+    setSearch
+  } = useAppstoreFilter()
   const [category, setSelectedCategory] = useState('All')
-  const [search, setSearch] = useState(() => searchParams.get('q') || '')
 
-  // When the URL ?q= changes (e.g. user clicked an author link from the
-  // detail page or another card), reflect it back into the search box.
+  // An explicit ?q= in the URL (author link from a card/detail page, or a
+  // reloaded/bookmarked search) wins over the remembered store value. Runs
+  // only on URL changes; reads the current search from the store at call
+  // time so it does not also re-fire on every keystroke.
   useEffect(() => {
-    const q = searchParams.get('q') || ''
-    setSearch((current) => (current === q ? current : q))
-  }, [searchParams])
+    const q = searchParams.get('q')
+    if (q !== null && q !== useStore.getState().appstoreSearch) {
+      setSearch(q)
+    }
+  }, [searchParams, setSearch])
 
   // Re-fetch the App Store list on mount. The server's npm-metadata
   // hydrator and icon probe populate signalk.appIcon / displayName
@@ -269,7 +279,7 @@ const Apps: React.FC = () => {
       }
       setSelectedView('Installing')
     }
-  }, [rowData])
+  }, [rowData, setSelectedView])
 
   // Auto-jump to Installed only on the busy→idle transition so the
   // user lands on the result when a queued install/update finishes.
@@ -291,7 +301,7 @@ const Apps: React.FC = () => {
     if (prev > 0 && busyCount === 0 && !hasFailure) {
       setSelectedView('Installed')
     }
-  }, [busyCount, hasFailure])
+  }, [busyCount, hasFailure, setSelectedView])
 
   let warning: string | undefined
   if (appStore.storeAvailable === false) {


### PR DESCRIPTION
## Motivation

Opening a plugin's detail card and pressing **Back to Store** discarded the selected view (All/Installed/Updates) and the search term, always resetting to the All view with no search in effect. This is the bug reported in #2750: the user expects to return to the same view they came from.

The detail page is a separate route, so the app list component unmounts when it opens. The view and search were component-local state, so they were destroyed on unmount and reinitialised to defaults on the return.

## Solution

Hold the app store view filter and search text in the shared store instead of component state, so both survive the unmount/remount round trip. An explicit `?q=` in the URL still wins (author links and reloaded/bookmarked searches), so existing URL behaviour is unchanged.

closes #2750

## Tested

- Manually: open App Store, switch to Installed/Updates or enter a search term, open a plugin, press Back to Store — the previous view and search are restored.
- Added unit tests covering view and search restoration across an unmount/remount; full admin UI suite passes (228 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR preserves the app store's selected view (All/Installed/Updates/Installing) and search filter when navigating to a plugin's detail page and returning via "Back to Store." It moves view and search state out of local component state into the global store so they survive the Apps component unmount/remount that happens when opening plugin details.

## Changes

### Store State Management
- Adds AppstoreView type and two new store fields to the app slice: appstoreView (defaults to 'All') and appstoreSearch (defaults to '').
- Adds setter actions setAppstoreView(view) and setAppstoreSearch(search) to the app slice.
- Exposes a new hook useAppstoreFilter() from the main store index that selects view, search, and their setters using a shallow selector to avoid unnecessary re-renders.

### Component Integration
- Updates the Apps component to read and write the view/search from the store via useAppstoreFilter() instead of local useState.
- Keeps the explicit ?q= URL parameter semantics: a ?q= query parameter overrides the remembered store search when the URL differs from the stored value (preserving bookmarked/reload behavior).
- Adjusts effects and callbacks (including auto-jump and update handlers) to use the store-backed setters and include them in dependency arrays.

### Tests
- Updates existing tests to reset the singleton store view/search before each case to avoid cross-test leakage.
- Adds new tests verifying that the selected view and search term persist across an unmount/remount (simulating navigation to/from plugin detail).
- Confirms full admin UI test suite passes (228 tests) and manual verification reproduces restored state when returning from a plugin detail.

## Result
The app store now maintains its selected view and search text across navigation to plugin details and back, while preserving explicit URL query precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->