### PR TITLE
fix(server): isolate throwing delta input handlers

### DIFF
--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -32,9 +32,18 @@ export default class DeltaChain {
       dispatch(msg, now, version)
       return
     }
-    this.chain[index](msg, (forwarded: Delta) =>
-      this.doProcess(index + 1, forwarded, dispatch, now, version)
-    )
+    // Isolate handlers: a plugin's delta input handler that throws must not
+    // abort the chain, or the delta (and any later handler's work, including
+    // metadata registration) is silently dropped for every input. Log and
+    // pass the unmodified delta to the next handler.
+    try {
+      this.chain[index](msg, (forwarded: Delta) =>
+        this.doProcess(index + 1, forwarded, dispatch, now, version)
+      )
+    } catch (err) {
+      console.error('Delta input handler threw, skipping it:', err)
+      this.doProcess(index + 1, msg, dispatch, now, version)
+    }
   }
 
   register(handler: DeltaInputHandler) {

--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -35,14 +35,21 @@ export default class DeltaChain {
     // Isolate handlers: a plugin's delta input handler that throws must not
     // abort the chain, or the delta (and any later handler's work, including
     // metadata registration) is silently dropped for every input. Log and
-    // pass the unmodified delta to the next handler.
+    // pass the unmodified delta to the next handler. `continued` guards
+    // against advancing twice when a handler calls next() and then throws.
+    let continued = false
+    const next = (nextMsg: Delta) => {
+      if (continued) {
+        return
+      }
+      continued = true
+      this.doProcess(index + 1, nextMsg, dispatch, now, version)
+    }
     try {
-      this.chain[index](msg, (forwarded: Delta) =>
-        this.doProcess(index + 1, forwarded, dispatch, now, version)
-      )
+      this.chain[index](msg, next)
     } catch (err) {
       console.error('Delta input handler threw, skipping it:', err)
-      this.doProcess(index + 1, msg, dispatch, now, version)
+      next(msg)
     }
   }
 

--- a/test/deltachain.ts
+++ b/test/deltachain.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai'
+import DeltaChain from '../src/deltachain'
+import { Context, Delta, Path, SKVersion, Value } from '@signalk/server-api'
+
+const delta = (id: string): Delta => ({
+  context: 'vessels.self' as Context,
+  updates: [{ values: [{ path: id as Path, value: 1 as Value }] }]
+})
+
+const now = new Date(0)
+
+const collector = () => {
+  const dispatched: Delta[] = []
+  const dispatch = (msg: Delta) => dispatched.push(msg)
+  return { dispatched, dispatch }
+}
+
+describe('DeltaChain', function () {
+  it('dispatches a delta through to the end when there are no handlers', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    const msg = delta('a')
+    chain.process(msg, dispatch, now, SKVersion.v1)
+    expect(dispatched).to.deep.equal([msg])
+  })
+
+  it('passes the delta along the chain and dispatches it', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    const seen: string[] = []
+    chain.register((msg, next) => {
+      seen.push('first')
+      next(msg)
+    })
+    chain.register((msg, next) => {
+      seen.push('second')
+      next(msg)
+    })
+    const msg = delta('a')
+    chain.process(msg, dispatch, now, SKVersion.v1)
+    expect(seen).to.deep.equal(['first', 'second'])
+    expect(dispatched).to.deep.equal([msg])
+  })
+
+  it('lets a handler drop a delta by not calling next', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    chain.register(() => {
+      // swallow the delta
+    })
+    chain.process(delta('a'), dispatch, now, SKVersion.v1)
+    expect(dispatched).to.be.empty
+  })
+
+  it('skips a throwing handler and still runs later handlers and dispatch', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    const seen: string[] = []
+    chain.register(() => {
+      throw new Error('boom')
+    })
+    chain.register((msg, next) => {
+      seen.push('after')
+      next(msg)
+    })
+    const msg = delta('a')
+    chain.process(msg, dispatch, now, SKVersion.v1)
+    expect(seen).to.deep.equal(['after'])
+    expect(dispatched).to.deep.equal([msg])
+  })
+})

--- a/test/deltachain.ts
+++ b/test/deltachain.ts
@@ -68,4 +68,22 @@ describe('DeltaChain', function () {
     expect(seen).to.deep.equal(['after'])
     expect(dispatched).to.deep.equal([msg])
   })
+
+  it('does not continue twice when a handler calls next and then throws', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    const seen: string[] = []
+    chain.register((msg, next) => {
+      next(msg)
+      throw new Error('boom after next')
+    })
+    chain.register((msg, next) => {
+      seen.push('after')
+      next(msg)
+    })
+    const msg = delta('a')
+    chain.process(msg, dispatch, now, SKVersion.v1)
+    expect(seen).to.deep.equal(['after'])
+    expect(dispatched).to.deep.equal([msg])
+  })
 })


### PR DESCRIPTION
## Problem

A delta input handler (registered via `registerDeltaInputHandler`) that throws aborts the entire `DeltaChain`. The delta then never reaches the full model or the metadata registry, and no later handler in the chain runs. So a single misbehaving plugin silently breaks delta processing — including metadata registration — for every input on the server.

This was hit in the field: a plugin whose handler did `update.values.forEach(...)` without guarding for meta-only deltas threw on the `supportsPut` metadata emitted by `registerPutHandler`, which prevented `supportsPut` from ever being registered for affected paths.

## Approach

Wrap each handler invocation in `DeltaChain.doProcess` in try/catch. A throwing handler is logged and skipped, and the chain continues with the unmodified delta, so one bad plugin can no longer drop deltas (or metadata) for everyone.

## Tested

- Added `test/deltachain.ts`: a throwing handler is skipped while later handlers and final dispatch still run; existing pass-through and drop-by-not-calling-next behavior is preserved. The throwing-handler test fails without the change.
- `npm run format` and `npm test` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR isolates exceptions thrown by individual delta input handlers so a handler registered via `registerDeltaInputHandler` that throws is caught and logged instead of aborting the `DeltaChain`. The chain continues with the original (unmodified) delta, allowing later handlers and the final dispatch (and any downstream metadata registration) to still run.

## Changes

**src/deltachain.ts**
- Wraps each handler invocation in `try/catch` inside `doProcess`; when a handler throws, it logs the error (`console.error`) and continues by forwarding the original delta to the next handler.
- Guards each handler’s `next` callback with a `continued` flag so a handler that calls `next()` and then throws cannot advance the chain twice.
- Removes the precomputed per-handler `next`/`updateNexts` wiring, using a per-invocation `next` function instead.
- Types the handler `next` callback parameter as `Delta`.

**test/deltachain.ts**
- Adds test coverage for `DeltaChain` including:
  - dispatching to the end when no handlers are registered;
  - running handlers in registration order and dispatching after all handlers call `next`;
  - dropping a delta when a handler does not call `next`;
  - skipping a throwing handler while later handlers still run and dispatch still happens;
  - regression coverage that a handler calling `next()` and then throwing does not continue the chain twice.

## Typing and formatting

- Tightens `next` callback typing to accept `Delta`.
- Runs formatting and the test suite successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->