### PR TITLE
fix(security): trim whitespace from username on register and login

### DIFF
--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -804,8 +804,13 @@ function tokenSecurityFactory(
         return
       }
 
+      // Trim to match the stored username, which addUser trims on
+      // registration, so a stray space typed into the login box still logs in.
+      const trimmedName = name.trim()
       const configuration = getConfiguration()
-      const user = configuration.users.find((aUser) => aUser.username === name)
+      const user = configuration.users.find(
+        (aUser) => aUser.username === trimmedName
+      )
 
       // Always run bcrypt.compare to prevent timing attacks that reveal
       // whether a username exists. Use a dummy hash if user not found.
@@ -1018,13 +1023,30 @@ function tokenSecurityFactory(
   ): void {
     assertConfigImmutability()
 
-    if (theConfig.users?.find((u) => u.username === user.userId)) {
+    // userId arrives from request bodies, so guard the type before trimming
+    // to keep malformed input on the callback error path rather than throwing.
+    if (typeof user.userId !== 'string') {
+      callback(new Error('Username is required'))
+      return
+    }
+
+    // Trim so a stray leading/trailing space (browser autofill, paste,
+    // mobile autocapitalize) doesn't get baked into the stored username,
+    // which would then never match the trimmed value typed at login.
+    const username = user.userId.trim()
+
+    if (username.length === 0) {
+      callback(new Error('Username cannot be empty'))
+      return
+    }
+
+    if (theConfig.users?.find((u) => u.username === username)) {
       callback(new Error('User already exists'))
       return
     }
 
     const newUser: User = {
-      username: user.userId,
+      username,
       type: user.type
     }
 

--- a/test/tokensecurity-adduser-trim.ts
+++ b/test/tokensecurity-adduser-trim.ts
@@ -1,0 +1,158 @@
+import { expect } from 'chai'
+import type { SecurityConfig, User } from '../src/security'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tokenSecurityFactory = require('../dist/tokensecurity.js')
+
+interface LoginResult {
+  statusCode: number
+  token?: string
+}
+
+// userId is typed unknown because addUser receives raw request bodies, where
+// a malformed value (number, missing, ...) is exactly what we want to test.
+interface NewUser {
+  userId: unknown
+  type: string
+  password?: string
+}
+
+interface AddUserStrategy {
+  addUser(
+    config: Partial<SecurityConfig>,
+    user: NewUser,
+    callback: (err: Error | null, config?: SecurityConfig) => void
+  ): void
+  login(name: string, password: string): Promise<LoginResult>
+}
+
+function makeStrategy(): AddUserStrategy {
+  // setupApp() registers express routes during construction; stub the
+  // router verbs as no-ops since this test only exercises addUser().
+  const noop = () => undefined
+  const app = {
+    config: {},
+    use: noop,
+    get: noop,
+    post: noop,
+    put: noop,
+    delete: noop
+  }
+  return tokenSecurityFactory(app, { secretKey: 'test-key' })
+}
+
+function addUser(
+  strategy: AddUserStrategy,
+  config: Partial<SecurityConfig>,
+  user: NewUser
+): Promise<SecurityConfig> {
+  return new Promise((resolve, reject) => {
+    strategy.addUser(config, user, (err, theConfig) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(theConfig as SecurityConfig)
+      }
+    })
+  })
+}
+
+const usernames = (config: { users?: User[] }): string[] =>
+  (config.users ?? []).map((u) => u.username)
+
+describe('tokensecurity addUser', () => {
+  it('trims a trailing space from the username', async () => {
+    const config: Partial<SecurityConfig> = { users: [] }
+    const result = await addUser(makeStrategy(), config, {
+      userId: 'admin ',
+      type: 'admin',
+      password: 'secret'
+    })
+    expect(usernames(result)).to.deep.equal(['admin'])
+  })
+
+  it('trims a leading space from the username', async () => {
+    const config: Partial<SecurityConfig> = { users: [] }
+    const result = await addUser(makeStrategy(), config, {
+      userId: ' admin',
+      type: 'admin',
+      password: 'secret'
+    })
+    expect(usernames(result)).to.deep.equal(['admin'])
+  })
+
+  it('rejects a username that is empty after trimming', async () => {
+    let error: Error | undefined
+    try {
+      await addUser(
+        makeStrategy(),
+        { users: [] },
+        {
+          userId: '   ',
+          type: 'admin',
+          password: 'secret'
+        }
+      )
+    } catch (err) {
+      error = err as Error
+    }
+    expect(error).to.be.an('error')
+  })
+
+  it('rejects a non-string username via the callback, not a throw', async () => {
+    let error: Error | undefined
+    try {
+      await addUser(
+        makeStrategy(),
+        { users: [] },
+        {
+          userId: 42,
+          type: 'admin',
+          password: 'secret'
+        }
+      )
+    } catch (err) {
+      error = err as Error
+    }
+    expect(error).to.be.an('error')
+  })
+
+  it('treats a padded username as a duplicate of the trimmed one', async () => {
+    const config: Partial<SecurityConfig> = { users: [] }
+    const strategy = makeStrategy()
+    await addUser(strategy, config, {
+      userId: 'admin',
+      type: 'admin',
+      password: 'secret'
+    })
+    let error: Error | undefined
+    try {
+      await addUser(strategy, config, {
+        userId: ' admin ',
+        type: 'admin',
+        password: 'secret'
+      })
+    } catch (err) {
+      error = err as Error
+    }
+    expect(error).to.be.an('error')
+    expect(config.users).to.have.length(1)
+  })
+})
+
+describe('tokensecurity login', () => {
+  it('logs in when the typed username has stray surrounding spaces', async () => {
+    const strategy = makeStrategy()
+    // addUser reassigns the strategy's live config to the object passed
+    // here, so carry the secretKey through or token signing at login fails.
+    const config: Partial<SecurityConfig> = { users: [], secretKey: 'test-key' }
+    await addUser(strategy, config, {
+      userId: 'admin',
+      type: 'admin',
+      password: 'secret'
+    })
+    const result = await strategy.login(' admin ', 'secret')
+    expect(result.statusCode).to.equal(200)
+    expect(result.token).to.be.a('string')
+  })
+})


### PR DESCRIPTION
## Why

On a fresh security setup, creating the admin account with a stray leading or trailing space in the username (easily introduced by browser autofill, paste, or mobile autocapitalize) locks the account out permanently. `enableSecurity` returns 200 and `security.json` is written, but the username is stored verbatim (e.g. `"admin "`), while `login` does an exact byte-for-byte match. Typing `admin` then never matches, and every login fails with "Invalid username/password" with no obvious cause.

## How

In `tokensecurity`:

- `addUser` trims the username before the duplicate check and before storing it, and rejects a username that is empty after trimming.
- `login` trims the typed name before lookup, so a stray space typed into the login box still matches the stored (trimmed) username.

The JWT identity continues to use the stored `user.username`, so tokens carry the clean value. Authentication is otherwise unchanged — a wrong password still fails.

## Tested

- New unit tests in `test/tokensecurity-adduser-trim.ts`: trailing/leading-space trim on register, empty-after-trim rejection, padded-name treated as duplicate, and login with a padded username.
- Reproduced the original lockout and verified the fix end-to-end against a running server image: registering a padded username stores it trimmed, logging in with a padded username returns 200, and logging in with a wrong password still returns 401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a security issue where creating user accounts with leading or trailing whitespace in the username causes permanent lockout. The `enableSecurity` flow stores usernames verbatim while `login` performs exact byte-for-byte matching, causing logins with the intended username to fail.

## Changes

**src/tokensecurity.ts**
- `addUser` trims surrounding whitespace from the incoming username before validation and persistence.
- `addUser` rejects usernames that are empty after trimming.
- Duplicate detection uses the trimmed username.
- `login` trims the provided username before lookup so padded input matches stored (trimmed) usernames.
- JWT identity continues to use the stored `user.username`; password verification and other authentication behavior remain unchanged.

**test/tokensecurity-adduser-trim.ts**
- Adds tests that validate username normalization by trimming surrounding whitespace on register.
- Tests verify rejection of usernames that are empty after trimming and that non-string usernames are reported via the callback.
- Tests confirm a padded username is treated as a duplicate of the trimmed one.
- Login test verifies that providing a username with surrounding spaces succeeds and returns a token.

## Verification

- Unit tests cover trimming on register, rejection of empty-after-trim usernames, duplicate detection with padded names, and login with a padded username.
- End-to-end verification against a running server image reproduces the original lockout and confirms:
  - Registering a padded username stores it trimmed.
  - Logging in with a padded username returns 200 and a token.
  - Logging in with a wrong password still returns 401 (authentication behavior unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->