### PR TITLE
Add settings switch to disable core notification management

### DIFF
--- a/docs/develop/rest-api/notifications_api.md
+++ b/docs/develop/rest-api/notifications_api.md
@@ -598,3 +598,20 @@ Updates notification `state` & `status` properties as follows:
 | Source | Condition         | State    | silenced | acknowledged |
 | ------ | ----------------- | -------- | -------- | ------------ |
 | API    | `canClear = true` | `normal` | false    | false        |
+
+## Disabling Core Notification Management
+
+By default the server manages the lifecycle of all notifications as described
+above. Setting `notifications.manageNotifications` to `false` in the server
+settings (Server -> Settings in the admin UI, restart required) takes the core
+notification manager out of the notification path so an external handler can
+own the lifecycle instead. `notifications.*` deltas then flow to the data
+model unmodified — no server-assigned `id` or `status` is embedded in values.
+
+With management disabled the API surface stays mounted but behaves as follows:
+
+| Operation                                                                                                | Behavior when disabled                                                                                                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /notifications`                                                                                     | Served from the data model (`self` context only). Keys are the source-supplied `value.id` when present, otherwise the notification path. No `status` enrichment.                                                                                         |
+| `POST /notifications` (raise), `POST /notifications/mob`                                                 | Emit the notification delta directly. `path` is required for raise (no `notifications.{id}` fallback) and `context` is ignored. The returned `id` is embedded in the emitted value but not tracked by the server.                                        |
+| `GET/PUT/DELETE /notifications/{id}`, `{id}/silence`, `{id}/acknowledge`, `silenceAll`, `acknowledgeAll` | Respond `501` with `{"state": "FAILED", "statusCode": 501, "message": ...}`. The matching `app.notifications.*` plugin methods throw `NotificationManagerDisabledError` (identify via `instanceof` or `error.code === 'NOTIFICATION_MANAGER_DISABLED'`). |

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -26,6 +26,9 @@ interface ServerSettingsData {
   courseApi?: {
     apiOnly?: boolean
   }
+  notifications?: {
+    manageNotifications?: boolean
+  }
 }
 
 const SettableInterfaces: Record<string, string> = {
@@ -76,6 +79,23 @@ const ServerSettings: React.FC = () => {
         ...prev,
         courseApi: {
           ...prev.courseApi,
+          [event.target.name]: value
+        }
+      }))
+    },
+    []
+  )
+
+  const handleNotificationsChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value =
+        event.target.type === 'checkbox'
+          ? event.target.checked
+          : event.target.value
+      setSettings((prev) => ({
+        ...prev,
+        notifications: {
+          ...prev.notifications,
           [event.target.name]: value
         }
       }))
@@ -404,6 +424,46 @@ const ServerSettings: React.FC = () => {
                 <Form.Text muted>
                   Accept course operations only via HTTP requests. Destination
                   data from NMEA sources is not used.
+                </Form.Text>
+              </Col>
+            </Form.Group>
+            <Form.Group as={Row}>
+              <Col md="2">
+                <Form.Label htmlFor="manageNotifications">
+                  Manage Notifications
+                  <br />
+                  <i>(restart required)</i>
+                </Form.Label>
+              </Col>
+              <Col xs="12" md={fieldColWidthMd}>
+                <div className="d-flex align-items-center mb-2">
+                  <Form.Label
+                    style={{ marginRight: '15px', marginBottom: 0 }}
+                    className="switch switch-text switch-primary"
+                  >
+                    <input
+                      type="checkbox"
+                      name="manageNotifications"
+                      id="manageNotifications"
+                      className="switch-input"
+                      onChange={handleNotificationsChange}
+                      checked={
+                        settings.notifications?.manageNotifications ?? true
+                      }
+                    />
+                    <span
+                      className="switch-label"
+                      data-on="On"
+                      data-off="Off"
+                    />
+                    <span className="switch-handle" />
+                  </Form.Label>
+                </div>
+                <Form.Text muted>
+                  Run the built-in notification manager. Turn off to let an
+                  external notification handler own notification lifecycle and
+                  avoid conflicts. Disabling stops core silence/acknowledge
+                  handling; those operations return 501.
                 </Form.Text>
               </Col>
             </Form.Group>

--- a/packages/server-api/src/notificationsapi.ts
+++ b/packages/server-api/src/notificationsapi.ts
@@ -8,6 +8,21 @@ import {
 } from '.'
 
 /**
+ * Error thrown by Notifications API methods that require the core
+ * NotificationManager when `notifications.manageNotifications` is `false`.
+ * Identify it with `instanceof` or via its `code` property.
+ *
+ * @category Notifications API
+ */
+export class NotificationManagerDisabledError extends Error {
+  readonly code = 'NOTIFICATION_MANAGER_DISABLED'
+  constructor() {
+    super('Core notification management is disabled on this server.')
+    this.name = 'NotificationManagerDisabledError'
+  }
+}
+
+/**
  * Plugin interface functions.
  * @see [Notifications REST API](../../../docs/develop/rest-api/notifications_api.md) for further details.
  * @category  Notifications API
@@ -19,6 +34,8 @@ export interface NotificationsApi {
    * @category Notifications API
    *
    * @param id - Notification identifier.
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -29,6 +46,12 @@ export interface NotificationsApi {
 
   /**
    * Retrieve the notification(s) with the supplied path.
+   *
+   * When core notification management is disabled, entries are read from the
+   * data model (`self` context only): values carry no core-side `status`, keys
+   * are the source-supplied `value.id` when present (otherwise the
+   * notification path), and matching is by subtree (path prefix) rather than
+   * exact path.
    *
    * @category Notifications API
    *
@@ -43,6 +66,11 @@ export interface NotificationsApi {
 
   /**
    * Retrieve a list notifications keyed by identifier.
+   *
+   * When core notification management is disabled, entries are read from the
+   * data model (`self` context only): values carry no core-side `status`, and
+   * keys are the source-supplied `value.id` when present, otherwise the
+   * notification path.
    *
    * @category Notifications API
    *
@@ -92,6 +120,12 @@ export interface NotificationsApi {
    * // path = `notifications.propulsion.port.temperature.{notificationId}`
    * ```
    *
+   * Note: when core notification management is disabled
+   * (`notifications.manageNotifications = false`), `path` is required — there
+   * is no `notifications.{notificationId}` fallback — and a plain `Error` is
+   * thrown if it is missing. The returned id is embedded in the emitted value
+   * but not tracked by the server. `context` is ignored: the notification is
+   * emitted for the self context, matching managed-mode emission.
    */
   raise(options: AlarmRaiseOptions): NotificationId
 
@@ -125,6 +159,8 @@ export interface NotificationsApi {
    *
    * @param id - Notification identifier.
    * @param options - Alarm options.
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -149,6 +185,8 @@ export interface NotificationsApi {
    * @category Notifications API
    *
    * @param id - Notification identifier.
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -161,6 +199,9 @@ export interface NotificationsApi {
    * Silences all notifications.
    *
    * @category Notifications API
+   *
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -178,6 +219,8 @@ export interface NotificationsApi {
    * @category Notifications API
    *
    * @param id - Notification identifier.
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -190,6 +233,9 @@ export interface NotificationsApi {
    * Acknowledges all notifications.
    *
    * @category Notifications API
+   *
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript
@@ -206,6 +252,8 @@ export interface NotificationsApi {
    * @category Notifications API
    *
    * @param id - Notification identifier.
+   * @throws {@link NotificationManagerDisabledError} when core notification
+   * management is disabled (`notifications.manageNotifications = false`).
    *
    * @example
    * ```typescript

--- a/packages/server-api/src/typebox/notifications-schemas.ts
+++ b/packages/server-api/src/typebox/notifications-schemas.ts
@@ -42,10 +42,13 @@ export const AlarmSchema = Type.Object(
     method: AlarmMethodArraySchema,
     message: Type.String({ description: 'Message to display or speak' }),
     status: Type.Optional(AlarmStatusSchema),
-    id: Type.String({
-      description: 'Notification Identifier',
-      example: '8dac314c-ef20-4e6f-9098-db64ce20e117'
-    }),
+    id: Type.Optional(
+      Type.String({
+        description:
+          'Notification Identifier. Always present when core notification management is enabled; otherwise present only when supplied by the notification source.',
+        example: '8dac314c-ef20-4e6f-9098-db64ce20e117'
+      })
+    ),
     position: Type.Optional(Type.Union([PositionSchema, Type.Null()])),
     createdAt: Type.Optional(IsoTimeSchema),
     data: Type.Optional(Type.Record(Type.String(), Type.Unknown()))

--- a/src/api/notifications/index.ts
+++ b/src/api/notifications/index.ts
@@ -12,9 +12,14 @@ import {
   Update,
   AlarmProperties,
   NotificationId,
+  NotificationManagerDisabledError,
   AlarmRaiseOptions,
   AlarmUpdateOptions,
-  Path
+  Path,
+  ALARM_STATE,
+  ALARM_METHOD,
+  Notification,
+  Timestamp
 } from '@signalk/server-api'
 import { IRouter, Request, Response } from 'express'
 import { ConfigApp } from '../../config/config'
@@ -37,28 +42,50 @@ export interface NotificationApplication
 const SIGNALK_API_PATH = `/signalk/v2/api`
 const NOTI_API_PATH = `${SIGNALK_API_PATH}/notifications`
 
+const DISABLED_MESSAGE = new NotificationManagerDisabledError().message
+
+/** Non-path metadata keys on fullsignalk model nodes */
+const MODEL_NODE_KEYS = new Set([
+  'value',
+  'values',
+  'meta',
+  '$source',
+  'timestamp'
+])
+
 export const deltaVersion: SKVersion = SKVersion.v1
 
 export class NotificationApi {
   private app: NotificationApplication
   private notiKeys: Map<NotificationKey, NotificationId> = new Map()
-  private notificationManager: NotificationManager
+  private notificationManager?: NotificationManager
 
   constructor(private server: NotificationApplication) {
     this.app = server
-    this.notificationManager = new NotificationManager(server)
   }
 
   async start() {
-    return new Promise<void>(async (resolve) => {
+    return new Promise<void>((resolve) => {
       this.initNotificationRoutes()
-      this.app.registerDeltaInputHandler(
-        (delta: Delta, next: (delta: Delta) => void) => {
-          next(this.filterNotifications(delta))
-        }
-      )
+      if (this.isManaging()) {
+        this.notificationManager = new NotificationManager(this.server)
+        this.app.registerDeltaInputHandler(
+          (delta: Delta, next: (delta: Delta) => void) => {
+            next(this.filterNotifications(delta))
+          }
+        )
+      } else {
+        debug(
+          'Core notification management disabled ' +
+            '(settings.notifications.manageNotifications=false)'
+        )
+      }
       resolve()
     })
+  }
+
+  private isManaging(): boolean {
+    return this.app.config.settings.notifications?.manageNotifications !== false
   }
 
   /** Filter out notifications.* paths and push onto notiUpdate */
@@ -115,7 +142,7 @@ export class NotificationApi {
         this.notiKeys.set(key, update.notificationId)
       }
       // register with manager
-      this.notificationManager.processNotificationUpdate(update, context)
+      this.notificationManager?.processNotificationUpdate(update, context)
     }
   }
 
@@ -132,6 +159,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/:id`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         if (uuid.validate(req.params.id)) {
           const n = this.getId(req.params.id as NotificationId)
           if (n) {
@@ -150,6 +178,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/silenceAll`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           this.silenceAll()
           res.status(200).json(Responses.ok)
@@ -168,6 +197,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/:id/silence`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           if (uuid.validate(req.params.id)) {
             this.silence(req.params.id as NotificationId)
@@ -190,6 +220,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/acknowledgeAll`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           this.acknowledgeAll()
           res.status(200).json(Responses.ok)
@@ -208,6 +239,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/:id/acknowledge`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           if (uuid.validate(req.params.id)) {
             this.acknowledge(req.params.id as NotificationId)
@@ -230,6 +262,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/:id`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           if (uuid.validate(req.params.id)) {
             this.clear(req.params.id as NotificationId)
@@ -267,6 +300,7 @@ export class NotificationApi {
       `${NOTI_API_PATH}/:id`,
       async (req: Request, res: Response) => {
         debug(`** ${req.method} ${req.path}`)
+        if (this.rejectIfDisabled(res)) return
         try {
           if (uuid.validate(req.params.id)) {
             this.update(req.params.id as NotificationId, req.body)
@@ -306,46 +340,187 @@ export class NotificationApi {
   //** Plugin Interface Methods */
 
   list(): Record<NotificationId, AlarmProperties> {
-    return this.notificationManager.list
+    return this.notificationManager
+      ? this.notificationManager.list
+      : this.listFromModel()
   }
 
   getId(id: NotificationId): AlarmProperties | undefined {
-    return this.notificationManager.get(id)
+    return this.requireManager().get(id)
   }
 
   getPath(path: Path): Record<NotificationId, AlarmProperties> {
-    return this.notificationManager.getPath(path)
+    return this.notificationManager
+      ? this.notificationManager.getPath(path)
+      : this.listFromModel(path)
   }
 
   silence(id: NotificationId): void {
-    this.notificationManager.silence(id)
+    this.requireManager().silence(id)
   }
 
   silenceAll(): void {
-    this.notificationManager.silenceAll()
+    this.requireManager().silenceAll()
   }
 
   acknowledge(id: NotificationId): void {
-    this.notificationManager.acknowledge(id)
+    this.requireManager().acknowledge(id)
   }
 
   acknowledgeAll(): void {
-    this.notificationManager.acknowledgeAll()
+    this.requireManager().acknowledgeAll()
   }
 
   clear(id: NotificationId): void {
-    this.notificationManager.clear(id)
+    this.requireManager().clear(id)
   }
 
   raise(options: AlarmRaiseOptions): NotificationId {
-    return this.notificationManager.raise(options)
+    return this.notificationManager
+      ? this.notificationManager.raise(options)
+      : this.raiseViaDelta(options)
   }
 
   update(id: NotificationId, options: AlarmUpdateOptions): void {
-    this.notificationManager.update(id, options)
+    this.requireManager().update(id, options)
   }
 
   mob(message?: string): NotificationId {
-    return this.notificationManager.mob(message)
+    return this.notificationManager
+      ? this.notificationManager.mob(message)
+      : this.raiseViaDelta({
+          state: ALARM_STATE.emergency,
+          message: message ?? 'Person Overboard!',
+          path: 'mob' as Path,
+          idInPath: true,
+          includePosition: true,
+          includeCreatedAt: true
+        })
+  }
+
+  // ----- Disabled-mode behaviour (no NotificationManager) -----
+
+  private requireManager(): NotificationManager {
+    if (!this.notificationManager) {
+      throw new NotificationManagerDisabledError()
+    }
+    return this.notificationManager
+  }
+
+  private rejectIfDisabled(res: Response): boolean {
+    if (this.notificationManager) {
+      return false
+    }
+    res.status(501).json({
+      state: 'FAILED',
+      statusCode: 501,
+      message: DISABLED_MESSAGE
+    })
+    return true
+  }
+
+  /**
+   * Read notifications from the data model. A handler's notifications still
+   * appear in the model when core management is off, so list/getPath serve
+   * them. A handler-supplied `id` in the value is used as the key; otherwise
+   * the path is used (no core-side status enrichment).
+   */
+  private listFromModel(
+    pathFilter?: Path
+  ): Record<NotificationId, AlarmProperties> {
+    const result: Record<string, AlarmProperties> = Object.create(null)
+    const root: unknown = this.app.signalk.self?.notifications
+    if (!root) {
+      return result
+    }
+    const filter = pathFilter
+      ? String(pathFilter).replace(/^notifications(\.|$)/, '')
+      : ''
+    // iterative walk: a notification leaf can itself parent further
+    // notification nodes, so leaves do not end the descent
+    const stack: Array<[unknown, string]> = [[root, '']]
+    while (stack.length) {
+      const [entry, dotted] = stack.pop()!
+      if (!entry || typeof entry !== 'object') {
+        continue
+      }
+      const node = entry as Record<string, unknown>
+      const nodeValue = node.value
+      if (
+        nodeValue &&
+        typeof nodeValue === 'object' &&
+        'state' in nodeValue &&
+        (!filter || dotted === filter || dotted.startsWith(`${filter}.`))
+      ) {
+        const value = nodeValue as Notification
+        const path = `notifications.${dotted}` as Path
+        // key by source-supplied id; on a duplicate id fall back to the
+        // (unique) path so no notification is silently dropped
+        const key =
+          typeof value.id === 'string' && !(value.id in result)
+            ? value.id
+            : path
+        result[key] = { context: 'vessels.self' as Context, path, value }
+      }
+      for (const segment of Object.keys(node)) {
+        if (!MODEL_NODE_KEYS.has(segment)) {
+          stack.push([node[segment], dotted ? `${dotted}.${segment}` : segment])
+        }
+      }
+    }
+    return result
+  }
+
+  /**
+   * Emit a notification as a delta without a NotificationManager. It lands in
+   * the data model and reaches any external handler. A generated id is
+   * embedded in the value (matching managed-mode) and returned.
+   */
+  private raiseViaDelta(options: AlarmRaiseOptions): NotificationId {
+    if (!options || !options.state || !options.message) {
+      throw new Error(
+        'Notification `state` or `message` properties are missing!'
+      )
+    }
+    if (!options.path) {
+      throw new Error(
+        'Notification `path` is required when core notification management is disabled.'
+      )
+    }
+    const id = uuid.v4() as NotificationId
+    const basePath = String(options.path).startsWith('notifications.')
+      ? String(options.path)
+      : `notifications.${options.path}`
+    const path = (options.idInPath ? `${basePath}.${id}` : basePath) as Path
+
+    const value: Notification = {
+      state: options.state,
+      message: options.message,
+      method: [ALARM_METHOD.visual, ALARM_METHOD.sound],
+      id
+    }
+    if (options.includePosition || options.state === ALARM_STATE.emergency) {
+      value.position =
+        this.app.signalk.self?.navigation?.position?.value ?? null
+    }
+    if (options.includeCreatedAt || options.state === ALARM_STATE.emergency) {
+      value.createdAt = new Date().toISOString() as Timestamp
+    }
+    if (options.data) {
+      value.data = structuredClone(options.data)
+    }
+
+    const delta: Delta = {
+      // managed-mode raise also emits for self regardless of options.context
+      // (Alarm attaches context to the delta only for external updates)
+      context: 'vessels.self' as Context,
+      updates: [
+        {
+          values: [{ path, value }]
+        } as Update
+      ]
+    }
+    this.app.handleMessage('notificationApi', delta, deltaVersion)
+    return id
   }
 }

--- a/src/api/notifications/openApi.ts
+++ b/src/api/notifications/openApi.ts
@@ -123,6 +123,24 @@ const notificationsApiDoc = {
           }
         }
       },
+      '501Disabled': {
+        description:
+          'Core notification management is disabled (`notifications.manageNotifications = false`). All identifier-addressed and bulk operations respond with `501`, including requests with a malformed identifier.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              description: 'Request error response',
+              properties: {
+                state: { type: 'string', enum: ['FAILED'] },
+                statusCode: { type: 'number', enum: [501] },
+                message: { type: 'string' }
+              },
+              required: ['state', 'statusCode', 'message']
+            }
+          }
+        }
+      },
       ErrorResponse: {
         description: 'Failed operation',
         content: {
@@ -156,7 +174,8 @@ const notificationsApiDoc = {
       get: {
         tags: ['Operations'],
         summary: 'List notifications.',
-        description: 'Returns a list of notifications.',
+        description:
+          'Returns a list of notifications. When core notification management is disabled (`notifications.manageNotifications = false`), entries are read from the data model for the `self` context only: values carry no server-assigned `id` or `status`, and keys are the source-supplied `value.id` when present, otherwise the notification path.',
         responses: {
           '200': { $ref: '#/components/responses/NotificationList' },
           default: { $ref: '#/components/responses/ErrorResponse' }
@@ -166,7 +185,7 @@ const notificationsApiDoc = {
         tags: ['Operations'],
         summary: 'Raise notification.',
         description:
-          'Raises a notification and sets `ALARM_METHOD` based on the supplied `state`.',
+          'Raises a notification and sets `ALARM_METHOD` based on the supplied `state`. When core notification management is disabled (`notifications.manageNotifications = false`), `path` is required, `context` is ignored (the notification is emitted for the self context), and the returned `id` is embedded in the emitted value but not tracked by the server.',
         requestBody: {
           description: 'Alarm Options',
           required: true,
@@ -194,6 +213,7 @@ const notificationsApiDoc = {
         responses: {
           '200': { $ref: '#/components/responses/Notification' },
           '404': { $ref: '#/components/responses/404NotFound' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       },
@@ -216,6 +236,7 @@ const notificationsApiDoc = {
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
           '404': { $ref: '#/components/responses/404NotFound' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       },
@@ -227,6 +248,7 @@ const notificationsApiDoc = {
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
           '404': { $ref: '#/components/responses/404NotFound' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       }
@@ -268,6 +290,7 @@ const notificationsApiDoc = {
           'Removes `sound` from the ALARM METHOD of all notifications and sets `status.silenced = true`.',
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       }
@@ -280,6 +303,7 @@ const notificationsApiDoc = {
           'Removes both `visual` and `sound` from the ALARM METHOD of all notifications and sets `status.acknowledged = true`.',
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       }
@@ -293,6 +317,7 @@ const notificationsApiDoc = {
           'Removes `sound` from the notification ALARM METHOD and sets `status.silenced = true`.',
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       }
@@ -306,6 +331,7 @@ const notificationsApiDoc = {
           'Acknowledge alarm by setting `status.acknowledged = true` and removing `sound` from ALARM METHOD.',
         responses: {
           '200': { $ref: '#/components/responses/200Ok' },
+          '501': { $ref: '#/components/responses/501Disabled' },
           default: { $ref: '#/components/responses/ErrorResponse' }
         }
       }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -127,6 +127,9 @@ export interface Config {
     courseApi?: {
       apiOnly?: boolean
     }
+    notifications?: {
+      manageNotifications?: boolean
+    }
   }
   defaults: object
 }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -831,6 +831,10 @@ module.exports = function (
       runFromSystemd: process.env.RUN_FROM_SYSTEMD === 'true',
       courseApi: {
         apiOnly: app.config.settings.courseApi?.apiOnly || false
+      },
+      notifications: {
+        manageNotifications:
+          app.config.settings.notifications?.manageNotifications ?? true
       }
     }
 
@@ -1157,6 +1161,12 @@ module.exports = function (
       const courseApi: { [index: string]: boolean | string | number } =
         updatedSettings.courseApi || (updatedSettings.courseApi = {})
       courseApi[name] = enabled
+    })
+
+    forIn(settings.notifications, (enabled, name) => {
+      const notifications: { [index: string]: boolean | string | number } =
+        updatedSettings.notifications || (updatedSettings.notifications = {})
+      notifications[name] = enabled
     })
 
     writeSettingsFile(app, updatedSettings, (err: Error) => {

--- a/test/notifications.ts
+++ b/test/notifications.ts
@@ -1,10 +1,15 @@
 import { expect } from 'chai'
 import chai from 'chai'
 import { NotificationApi } from '../dist/api/notifications/index.js'
-import { startServer } from './ts-servertestutilities'
+import { startServer, DATETIME_REGEX } from './ts-servertestutilities'
+import {
+  ALARM_STATE,
+  NotificationManagerDisabledError
+} from '@signalk/server-api'
 import type {
   Delta,
   Context,
+  Notification,
   Path,
   Timestamp,
   SourceRef,
@@ -31,7 +36,8 @@ describe('NotificationApi', () => {
         handleMessageCalls.push(delta)
       },
       config: {
-        configPath: '/tmp/test'
+        configPath: '/tmp/test',
+        settings: {}
       },
       setPluginStatus: () => {},
       setPluginError: () => {},
@@ -163,6 +169,618 @@ describe('NotificationApi', () => {
       )
     }
     expect(mobNotificationUpdate).to.have.property('notificationId')
+  })
+
+  describe('with management disabled', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const makeApp = (overrides: any = {}) => {
+      const handleMessageCalls: Delta[] = []
+      let registeredHandler:
+        | ((delta: Delta, next: (delta: Delta) => void) => void)
+        | null = null
+      const app = {
+        registerDeltaInputHandler: (
+          handler: (delta: Delta, next: (delta: Delta) => void) => void
+        ) => {
+          registeredHandler = handler
+        },
+        handleMessage: (_pluginId: string, delta: Delta) => {
+          handleMessageCalls.push(delta)
+        },
+        config: {
+          configPath: '/tmp/test',
+          settings: { notifications: { manageNotifications: false } }
+        },
+        signalk: { self: {} },
+        get: () => {},
+        post: () => {},
+        put: () => {},
+        delete: () => {},
+        ...overrides
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any
+      return {
+        app,
+        handleMessageCalls,
+        getHandler: () => registeredHandler
+      }
+    }
+
+    it('does not register a delta input handler', async function () {
+      const { app, getHandler } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      void expect(getHandler()).to.be.null
+    })
+
+    const modelWithNotifications = () => ({
+      signalk: {
+        self: {
+          notifications: {
+            engine: {
+              temp: {
+                value: {
+                  state: 'alarm',
+                  method: ['visual', 'sound'],
+                  message: 'Engine hot',
+                  id: 'handler-supplied-id'
+                },
+                $source: 'handler',
+                timestamp: '2026-06-07T00:00:00.000Z'
+              }
+            },
+            bilge: {
+              value: {
+                state: 'alert',
+                method: ['visual'],
+                message: 'Bilge level high',
+                id: 'nm-style-id',
+                status: {
+                  silenced: false,
+                  acknowledged: false,
+                  canSilence: true,
+                  canAcknowledge: true,
+                  canClear: false
+                }
+              },
+              $source: 'oldNM',
+              timestamp: '2026-06-07T00:00:00.000Z'
+            },
+            tanks: {
+              fuel: {
+                value: {
+                  state: 'warn',
+                  method: ['visual'],
+                  message: 'Fuel low'
+                },
+                $source: 'device',
+                timestamp: '2026-06-07T00:00:00.000Z'
+              }
+            }
+          }
+        }
+      }
+    })
+
+    it('list() reads notifications from the data model', async function () {
+      const { app } = makeApp(modelWithNotifications())
+      const api = new NotificationApi(app)
+      await api.start()
+      const list = api.list() as Record<string, AlarmProperties>
+      // keyed by value.id when present, by path otherwise
+      expect(Object.keys(list)).to.have.members([
+        'handler-supplied-id',
+        'nm-style-id',
+        'notifications.tanks.fuel'
+      ])
+      expect(list['handler-supplied-id'].context).to.equal('vessels.self')
+      expect(list['handler-supplied-id'].path).to.equal(
+        'notifications.engine.temp'
+      )
+      expect(list['handler-supplied-id'].value.state).to.equal('alarm')
+      // NM-style value with an embedded status block passes through verbatim
+      expect(list['nm-style-id'].value.status).to.deep.equal({
+        silenced: false,
+        acknowledged: false,
+        canSilence: true,
+        canAcknowledge: true,
+        canClear: false
+      })
+      expect(list['notifications.tanks.fuel'].value.id).to.equal(undefined)
+    })
+
+    it('getPath() returns only the requested subtree', async function () {
+      const { app } = makeApp(modelWithNotifications())
+      const api = new NotificationApi(app)
+      await api.start()
+      const subtree = api.getPath('notifications.engine' as Path) as Record<
+        string,
+        AlarmProperties
+      >
+      expect(Object.keys(subtree)).to.deep.equal(['handler-supplied-id'])
+      // unprefixed form is accepted too
+      const bare = api.getPath('engine' as Path) as Record<
+        string,
+        AlarmProperties
+      >
+      expect(Object.keys(bare)).to.deep.equal(['handler-supplied-id'])
+    })
+
+    it('list() includes notifications nested under a notification leaf', async function () {
+      const { app } = makeApp({
+        signalk: {
+          self: {
+            notifications: {
+              engine: {
+                value: {
+                  state: 'alarm',
+                  method: ['visual'],
+                  message: 'Engine alarm'
+                },
+                $source: 'handler',
+                timestamp: '2026-06-07T00:00:00.000Z',
+                temperature: {
+                  value: {
+                    state: 'warn',
+                    method: ['visual'],
+                    message: 'Engine hot'
+                  },
+                  $source: 'handler',
+                  timestamp: '2026-06-07T00:00:00.000Z'
+                }
+              }
+            }
+          }
+        }
+      })
+      const api = new NotificationApi(app)
+      await api.start()
+      const list = api.list() as Record<string, AlarmProperties>
+      expect(Object.keys(list)).to.have.members([
+        'notifications.engine',
+        'notifications.engine.temperature'
+      ])
+    })
+
+    it('list() skips multi-source values nodes', async function () {
+      const { app } = makeApp({
+        signalk: {
+          self: {
+            notifications: {
+              pump: {
+                value: null,
+                $source: 'handler',
+                timestamp: '2026-06-07T00:00:00.000Z',
+                values: {
+                  otherSource: {
+                    value: {
+                      state: 'alarm',
+                      method: ['visual'],
+                      message: 'stale per-source value'
+                    },
+                    timestamp: '2026-06-07T00:00:00.000Z'
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+      const api = new NotificationApi(app)
+      await api.start()
+      const list = api.list() as Record<string, AlarmProperties>
+      expect(Object.keys(list)).to.deep.equal([])
+    })
+
+    it('list() keeps both entries on a duplicate value.id', async function () {
+      const { app } = makeApp({
+        signalk: {
+          self: {
+            notifications: {
+              a: {
+                value: {
+                  state: 'alarm',
+                  method: ['visual'],
+                  message: 'first',
+                  id: 'dup-id'
+                },
+                $source: 'handler',
+                timestamp: '2026-06-07T00:00:00.000Z'
+              },
+              b: {
+                value: {
+                  state: 'warn',
+                  method: ['visual'],
+                  message: 'second',
+                  id: 'dup-id'
+                },
+                $source: 'handler',
+                timestamp: '2026-06-07T00:00:00.000Z'
+              }
+            }
+          }
+        }
+      })
+      const api = new NotificationApi(app)
+      await api.start()
+      const list = api.list() as Record<string, AlarmProperties>
+      expect(Object.keys(list)).to.have.lengthOf(2)
+      const paths = Object.values(list).map((entry) => entry.path)
+      expect(paths).to.have.members(['notifications.a', 'notifications.b'])
+    })
+
+    it('list() survives a deep notification path', async function () {
+      // deeper than the default call-stack limit (~10k frames)
+      const depth = 12000
+      const leaf: Record<string, unknown> = {
+        value: { state: 'alarm', method: ['visual'], message: 'deep' },
+        $source: 'handler',
+        timestamp: '2026-06-07T00:00:00.000Z'
+      }
+      let node: Record<string, unknown> = leaf
+      for (let i = 0; i < depth; i++) {
+        node = { s: node }
+      }
+      const { app } = makeApp({
+        signalk: { self: { notifications: node } }
+      })
+      const api = new NotificationApi(app)
+      await api.start()
+      const list = api.list() as Record<string, AlarmProperties>
+      expect(Object.keys(list)).to.have.lengthOf(1)
+    })
+
+    it('raise() emits a delta and returns an id', async function () {
+      const { app, handleMessageCalls } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      const id = api.raise({
+        state: ALARM_STATE.warn,
+        message: 'Low tank',
+        path: 'tanks.fuel.0' as Path
+      })
+      expect(id).to.be.a('string')
+      expect(handleMessageCalls).to.have.lengthOf(1)
+      const update = handleMessageCalls[0].updates![0]
+      if ('values' in update) {
+        expect(update.values[0].path).to.equal('notifications.tanks.fuel.0')
+        expect((update.values[0].value as Notification).id).to.equal(id)
+      } else {
+        throw new Error('Expected update to have values property')
+      }
+    })
+
+    it('raise() honors idInPath', async function () {
+      const { app, handleMessageCalls } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      const id = api.raise({
+        state: ALARM_STATE.warn,
+        message: 'Low tank',
+        path: 'tanks.fuel.0' as Path,
+        idInPath: true
+      })
+      const update = handleMessageCalls[0].updates![0]
+      if ('values' in update) {
+        expect(update.values[0].path).to.equal(
+          `notifications.tanks.fuel.0.${id}`
+        )
+      } else {
+        throw new Error('Expected update to have values property')
+      }
+    })
+
+    it('raise() ignores a context override and emits for self', async function () {
+      const { app, handleMessageCalls } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      api.raise({
+        state: ALARM_STATE.warn,
+        message: 'ctx',
+        path: 'environment.test' as Path,
+        context: 'vessels.urn:mrn:imo:mmsi:230099999' as Context
+      })
+      expect(handleMessageCalls[0].context).to.equal('vessels.self')
+    })
+
+    it('raise() without a path throws', async function () {
+      const { app } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      expect(() =>
+        api.raise({ state: 'warn', message: 'no path' } as never)
+      ).to.throw(/path/)
+    })
+
+    it('uuid-addressed and bulk operations throw the named error', async function () {
+      const { app } = makeApp()
+      const api = new NotificationApi(app)
+      await api.start()
+      const id = 'some-id' as never
+      expect(() => api.getId(id)).to.throw(NotificationManagerDisabledError)
+      expect(() => api.silence(id)).to.throw(NotificationManagerDisabledError)
+      expect(() => api.acknowledge(id)).to.throw(
+        NotificationManagerDisabledError
+      )
+      expect(() => api.clear(id)).to.throw(NotificationManagerDisabledError)
+      expect(() => api.update(id, {} as never)).to.throw(
+        NotificationManagerDisabledError
+      )
+      expect(() => api.silenceAll()).to.throw(NotificationManagerDisabledError)
+      expect(() => api.acknowledgeAll())
+        .to.throw(NotificationManagerDisabledError)
+        .with.property('code', 'NOTIFICATION_MANAGER_DISABLED')
+    })
+
+    it('REST: raise and list work end to end', async function () {
+      const { post, get, stop } = await startServer({
+        notifications: { manageNotifications: false }
+      })
+      try {
+        let response = await get(`/notifications`)
+        response.status.should.equal(200)
+        const empty = await response.json()
+        expect(empty).to.deep.equal({})
+
+        response = await post(`/notifications`, {
+          state: 'warn',
+          message: 'disabled-mode raise',
+          path: 'environment.test'
+        })
+        response.status.should.equal(200)
+        const postBody = (await response.json()) as {
+          state: string
+          statusCode: number
+          id: string
+        }
+        postBody.state.should.equal('COMPLETED')
+        postBody.statusCode.should.equal(200)
+        postBody.id.should.be.a('string')
+
+        response = await get(`/notifications`)
+        response.status.should.equal(200)
+        const list = (await response.json()) as Record<string, AlarmProperties>
+        expect(Object.keys(list)).to.include(postBody.id)
+        const entry = list[postBody.id]
+        entry.context.should.equal('vessels.self')
+        entry.path.should.equal('notifications.environment.test')
+        entry.value.state.should.equal('warn')
+        expect(entry.value.id).to.equal(postBody.id)
+        // no core-side status enrichment
+        expect(entry.value.status).to.equal(undefined)
+
+        // re-raise on the same path: the model entry is overwritten, so the
+        // new id replaces the old one in the list
+        response = await post(`/notifications`, {
+          state: 'alarm',
+          message: 'raised again',
+          path: 'environment.test'
+        })
+        const second = (await response.json()) as { id: string }
+        response = await get(`/notifications`)
+        const relisted = (await response.json()) as Record<
+          string,
+          AlarmProperties
+        >
+        expect(Object.keys(relisted)).to.include(second.id)
+        expect(Object.keys(relisted)).to.not.include(postBody.id)
+      } finally {
+        stop()
+      }
+    })
+
+    it('REST: raise without a path returns 400', async function () {
+      const { post, stop } = await startServer({
+        notifications: { manageNotifications: false }
+      })
+      try {
+        const response = await post(`/notifications`, {
+          state: 'warn',
+          message: 'no path'
+        })
+        response.status.should.equal(400)
+      } finally {
+        stop()
+      }
+    })
+
+    it('REST: mob raises at notifications.mob.<id> with position and createdAt', async function () {
+      const { createWsPromiser, post, stop } = await startServer({
+        notifications: { manageNotifications: false }
+      })
+      try {
+        const wsPromiser = createWsPromiser()
+        await wsPromiser.nthMessage(1)
+
+        const response = await post(`/notifications/mob`, {})
+        response.status.should.equal(200)
+        const { id } = (await response.json()) as { id: string }
+
+        const mobDelta = JSON.parse(await wsPromiser.nthMessage(2))
+        const { path, value } = mobDelta.updates[0].values[0]
+        path.should.equal(`notifications.mob.${id}`)
+        value.state.should.equal('emergency')
+        value.id.should.equal(id)
+        value.message.should.equal('Person Overboard!')
+        expect(value).to.have.property('position')
+        value.createdAt.should.match(DATETIME_REGEX)
+      } finally {
+        stop()
+      }
+    })
+
+    it('REST: injected notifications delta passes through un-stamped', async function () {
+      const { createWsPromiser, sendADelta, stop } = await startServer({
+        notifications: { manageNotifications: false }
+      })
+      try {
+        const wsPromiser = createWsPromiser()
+        await wsPromiser.nthMessage(1)
+
+        await sendADelta({
+          context: 'vessels.self',
+          updates: [
+            {
+              values: [
+                {
+                  path: 'notifications.test.alarm',
+                  value: {
+                    state: 'alarm',
+                    method: ['visual'],
+                    message: 'raw value'
+                  }
+                }
+              ]
+            }
+          ]
+        })
+        const delta = JSON.parse(await wsPromiser.nthMessage(2))
+        const update = delta.updates[0]
+        expect(update).to.not.have.property('notificationId')
+        const { path, value } = update.values[0]
+        path.should.equal('notifications.test.alarm')
+        value.should.deep.equal({
+          state: 'alarm',
+          method: ['visual'],
+          message: 'raw value'
+        })
+      } finally {
+        stop()
+      }
+    })
+
+    it('REST: uuid-addressed and bulk routes return 501 with the standard body', async function () {
+      const { get, post, put, host, stop } = await startServer({
+        notifications: { manageNotifications: false }
+      })
+      try {
+        const VALID_UUID = '9922c05a-2813-4995-ab72-33f8f2246ff7'
+        const responses = await Promise.all([
+          get(`/notifications/${VALID_UUID}`),
+          put(`/notifications/${VALID_UUID}`, { message: 'x' }),
+          fetch(`${host}/signalk/v2/api/notifications/${VALID_UUID}`, {
+            method: 'DELETE'
+          }),
+          post(`/notifications/${VALID_UUID}/silence`, {}),
+          post(`/notifications/${VALID_UUID}/acknowledge`, {}),
+          post(`/notifications/silenceAll`, {}),
+          post(`/notifications/acknowledgeAll`, {}),
+          // flag pre-check wins over uuid validation
+          get(`/notifications/not-a-uuid`),
+          post(`/notifications/not-a-uuid/silence`, {})
+        ])
+        responses.forEach((r) => r.status.should.equal(501))
+
+        const body = (await responses[0].json()) as {
+          state: string
+          statusCode: number
+          message: string
+        }
+        body.state.should.equal('FAILED')
+        body.statusCode.should.equal(501)
+        body.message.should.equal(
+          new NotificationManagerDisabledError().message
+        )
+      } finally {
+        stop()
+      }
+    })
+  })
+
+  describe('with management enabled', () => {
+    it('GET /notifications/:id with an unknown uuid returns 404', async function () {
+      const { get, stop } = await startServer()
+      try {
+        const response = await get(
+          `/notifications/9922c05a-2813-4995-ab72-33f8f2246ff7`
+        )
+        response.status.should.equal(404)
+      } finally {
+        stop()
+      }
+    })
+
+    it('REST: full lifecycle round trip works', async function () {
+      const { get, post, put, host, stop } = await startServer()
+      try {
+        let response = await post(`/notifications`, {
+          state: 'alarm',
+          message: 'lifecycle',
+          path: 'environment.lifecycle'
+        })
+        response.status.should.equal(200)
+        const { id } = (await response.json()) as { id: string }
+
+        response = await post(`/notifications/${id}/silence`, {})
+        response.status.should.equal(200)
+        response = await get(`/notifications/${id}`)
+        response.status.should.equal(200)
+        const silenced = (await response.json()) as {
+          value: { status: { silenced: boolean } }
+        }
+        silenced.value.status.silenced.should.equal(true)
+
+        response = await put(`/notifications/${id}`, { message: 'updated' })
+        response.status.should.equal(200)
+
+        response = await post(`/notifications/silenceAll`, {})
+        response.status.should.equal(200)
+        response = await post(`/notifications/acknowledgeAll`, {})
+        response.status.should.equal(200)
+
+        // a fresh alarm, acknowledged individually
+        response = await post(`/notifications`, {
+          state: 'alarm',
+          message: 'lifecycle 2',
+          path: 'environment.lifecycle2'
+        })
+        const second = (await response.json()) as { id: string }
+        response = await post(`/notifications/${second.id}/acknowledge`, {})
+        response.status.should.equal(200)
+
+        response = await fetch(`${host}/signalk/v2/api/notifications/${id}`, {
+          method: 'DELETE'
+        })
+        response.status.should.equal(200)
+      } finally {
+        stop()
+      }
+    })
+  })
+
+  describe('settings persistence', () => {
+    it('PUT /skServer/settings merges the notifications block and preserves siblings', async function () {
+      const { host, stop } = await startServer()
+      try {
+        const settingsUrl = `${host}/skServer/settings`
+        // the PUT handler dereferences settings.options unconditionally;
+        // constructor-supplied settings suppress file writes, so this
+        // exercises the PUT merge and GET exposure in memory
+        const putSettings = (body: object) =>
+          fetch(settingsUrl, {
+            method: 'PUT',
+            body: JSON.stringify({ options: {}, ...body }),
+            headers: { 'Content-Type': 'application/json' }
+          })
+
+        let response = await putSettings({ courseApi: { apiOnly: true } })
+        response.status.should.equal(200)
+        response = await putSettings({
+          notifications: { manageNotifications: false }
+        })
+        response.status.should.equal(200)
+
+        const settings = (await (await fetch(settingsUrl)).json()) as {
+          notifications: { manageNotifications: boolean }
+          courseApi: { apiOnly: boolean }
+        }
+        settings.notifications.manageNotifications.should.equal(false)
+        // sibling block untouched by the notifications-only PUT
+        settings.courseApi.apiOnly.should.equal(true)
+      } finally {
+        stop()
+      }
+    })
   })
 
   describe('MOB Notification', () => {

--- a/test/ts-servertestutilities.ts
+++ b/test/ts-servertestutilities.ts
@@ -20,7 +20,7 @@ const emptyConfigDirectory = () =>
       .map((dir) => rimraf(dir).then(() => console.error(dir)))
   )
 
-export const startServer = async () => {
+export const startServer = async (extraSettings: object = {}) => {
   const port = await freeport()
   const host = 'http://localhost:' + port
   const sendDeltaUrl = host + '/signalk/v1/api/_test/delta'
@@ -32,7 +32,8 @@ export const startServer = async () => {
     settings: {
       interfaces: {
         plugins: true
-      }
+      },
+      ...extraSettings
     }
   })
   return {


### PR DESCRIPTION
## Motivation

Since the v2 Notifications API, the core NotificationManager intercepts every `notifications.*` delta, assigns UUIDs, and manages the notification lifecycle. An external notification handler (e.g. signalk-alert-manager) that implements its own lifecycle ends up in dual management with core. 

## Approach

New setting `notifications.manageNotifications` (default `true`; absent key = behavior unchanged). When `false`, the NotificationManager and its delta-stream interception are not started, so `notifications.*` deltas flow to the data model unmodified and an external handler can own the lifecycle. Takes effect on restart; toggleable from admin UI Server Settings.

The v2 API stays mounted in disabled mode, split by addressing:

- **Kept** (content/path-addressed): `GET /notifications` and plugin `list`/`getPath` are served from the data model (self context); `POST /notifications` and `/notifications/mob` emit deltas directly — an id is minted, embedded in the value, and returned, but not tracked. `path` is required for raise in this mode.
- **Dropped** (uuid-addressed and bulk): `GET/PUT/DELETE /:id`, `/:id/silence`, `/:id/acknowledge`, `/silenceAll`, `/acknowledgeAll` return `501`; the matching `app.notifications.*` methods throw `NotificationManagerDisabledError` (new `@signalk/server-api` export, identifiable via `instanceof` or `error.code`).

The OpenAPI spec documents the 501 responses and mode-dependent fields, and the REST API doc page gains a section describing the switch.

## Breaking changes

None with the switch on (the default; behavior is byte-identical). `AlarmSchema.value.id` becomes optional in the published typebox schema — this aligns the spec with the existing `Notification.id?` TS type but loosens the derived `Alarm` static type. With the switch off, plugins calling the dropped ops receive the documented throw, and a pathless `raise()` (which today falls back to `notifications.{uuid}`) is rejected.

Covered by unit and REST integration tests for both modes (22 scenarios in `test/notifications.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a configurable settings switch to disable the core NotificationManager so external handlers can own notification lifecycle. The new setting notifications.manageNotifications (default true; absent = unchanged) is editable from the Admin UI and takes effect on restart. When disabled, the server does not instantiate the NotificationManager and notifications.* deltas flow into the data model unmodified; uuid-addressed and bulk management operations become unavailable (HTTP 501 / thrown error).

## Changes

### Configuration & Settings
- Extends Config.settings to include optional notifications?: { manageNotifications?: boolean }.
- Exposes notifications.manageNotifications via server settings GET and persists it via PUT (PUT merges notifications into stored settings).
- Adds "Manage Notifications (restart required)" toggle to Admin UI Server Settings; checkbox defaults to true when unset.

### Core API Implementation
- Notification API supports two modes:
  - Enabled (default): Instantiates NotificationManager, intercepts and enriches notifications.* deltas, and provides full lifecycle via uuid-addressed endpoints.
  - Disabled: Does not instantiate NotificationManager. Reads use a new listFromModel traversal of self-context notifications; writes use raiseViaDelta which requires path, mints a UUID, emits a delta via app.handleMessage and returns the id but does not track lifecycle.
- Adds rejectIfDisabled helper used by routes that require the manager to return HTTP 501 when disabled.
- Adds export class NotificationManagerDisabledError (code = 'NOTIFICATION_MANAGER_DISABLED') from `@signalk/server-api`; app.notifications.* plugin methods throw this when management is disabled.

### API Behavior When Disabled
- Read/listing (GET /notifications, plugin list/getPath) are served from the data model (self context) without server-assigned status enrichment; identifier selection prefers embedded value.id then path.
- POST /notifications and /notifications/mob emit deltas directly; the server mints and returns an id embedded in the value but does not track it. raise()/mob require path (pathless raise is rejected in disabled mode).
- Uuid-addressed and bulk operations (GET/PUT/DELETE /:id, /:id/silence, /:id/acknowledge, /silenceAll, /acknowledgeAll) return HTTP 501 over REST; corresponding plugin methods throw NotificationManagerDisabledError.

### Schema, Docs & OpenAPI
- Makes AlarmSchema.value.id optional in the published typebox schema to align with Notification.id? TypeScript typing.
- Adds a 501Disabled OpenAPI response component and documents 501 responses and mode-dependent fields on affected endpoints.
- Adds REST API docs section describing disabling core notification management.
- Updates NotificationsApi JSDoc to describe disabled-mode behaviors.

### Tests
- Adds unit and integration tests (~22 scenarios) covering:
  - Disabled-mode behavior (no delta input handler registration, model-driven list/getPath semantics, deep paths, duplicate value.id handling).
  - raise() and mob behavior when disabled (UUID generation, delta emission, required path, MOB payload shape).
  - 501 responses and NotificationManagerDisabledError for manager-dependent operations; invalid-UUID pre-checks still apply.
  - Management-enabled integration tests for full lifecycle (create/ack/silence/update/list/delete) and settings persistence.
- Updates test utilities (startServer) to accept optional extraSettings for test configuration.

## Breaking Changes

No change when notifications.manageNotifications remains true (default). If the switch is set to false, plugins that call uuid-addressed or bulk notification operations receive documented 501 errors or NotificationManagerDisabledError; pathless raise() is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
