### PR TITLE
feat(appstore): surface npm install log for failed installs

### DIFF
--- a/packages/server-admin-ui/src/utils/clipboard.ts
+++ b/packages/server-admin-ui/src/utils/clipboard.ts
@@ -1,0 +1,26 @@
+export function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text)
+  }
+
+  // Fallback for HTTP (Clipboard API requires secure context)
+  const textArea = document.createElement('textarea')
+  textArea.value = text
+  textArea.style.position = 'fixed'
+  textArea.style.left = '-9999px'
+  textArea.style.top = '-9999px'
+  document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+
+  try {
+    const success = document.execCommand('copy')
+    return success
+      ? Promise.resolve()
+      : Promise.reject(new Error('execCommand copy failed'))
+  } catch (err) {
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)))
+  } finally {
+    document.body.removeChild(textArea)
+  }
+}

--- a/packages/server-admin-ui/src/views/DataBrowser/CopyToClipboardWithFade.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/CopyToClipboardWithFade.tsx
@@ -1,30 +1,5 @@
 import { useState, useCallback, ReactNode } from 'react'
-
-function copyToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard && window.isSecureContext) {
-    return navigator.clipboard.writeText(text)
-  }
-
-  // Fallback for HTTP (Clipboard API requires secure context)
-  const textArea = document.createElement('textarea')
-  textArea.value = text
-  textArea.style.position = 'fixed'
-  textArea.style.left = '-9999px'
-  textArea.style.top = '-9999px'
-  document.body.appendChild(textArea)
-  textArea.focus()
-  textArea.select()
-
-  return new Promise((resolve, reject) => {
-    const success = document.execCommand('copy')
-    document.body.removeChild(textArea)
-    if (success) {
-      resolve()
-    } else {
-      reject(new Error('execCommand copy failed'))
-    }
-  })
-}
+import { copyToClipboard } from '../../utils/clipboard'
 
 interface CopyToClipboardWithFadeProps {
   text: string

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -14,6 +14,7 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons/faAr
 import { faLink } from '@fortawesome/free-solid-svg-icons/faLink'
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation'
 import { urlToWebapp } from '../../../Webapps/Webapp'
+import InstallLogModal from '../../components/InstallLogModal'
 import semver from 'semver'
 
 interface PluginDataSize {
@@ -66,6 +67,7 @@ export default function ActionCellRenderer({
   const [dataSize, setDataSize] = useState<PluginDataSize | null>(null)
   const [loadingDataSize, setLoadingDataSize] = useState(false)
   const [removeError, setRemoveError] = useState<string | null>(null)
+  const [showLogModal, setShowLogModal] = useState(false)
 
   const handleInstallClick = () => {
     fetch(
@@ -224,7 +226,18 @@ export default function ActionCellRenderer({
 
     content = (
       <div className="progress__wrapper">
-        <div className={statusClasses}>{status}</div>
+        {isTerminalFailure ? (
+          <button
+            type="button"
+            className={`${statusClasses} border-0 w-100`}
+            onClick={() => setShowLogModal(true)}
+            title="Show the npm log for this failure"
+          >
+            {status} — view log
+          </button>
+        ) : (
+          <div className={statusClasses}>{status}</div>
+        )}
         {progress}
       </div>
     )
@@ -332,6 +345,11 @@ export default function ActionCellRenderer({
   return (
     <div className="cell__renderer cell-action">
       <div>{content}</div>
+      <InstallLogModal
+        appName={app.name}
+        show={showLogModal}
+        onClose={() => setShowLogModal(false)}
+      />
       {/* Versions Modal */}
       <Modal
         show={showVersionsModal}

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -238,6 +238,7 @@
 .plugin-card .card-body,
 .plugin-card .card-footer {
   position: relative;
+
   // No z-index here: a z-index would create a stacking context that
   // traps the clickable children (author button, failed-install pill)
   // below the stretched link no matter their own z-index, so the link
@@ -302,7 +303,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid currentColor;
+    outline: 2px solid currentcolor;
     outline-offset: 2px;
   }
 }

--- a/packages/server-admin-ui/src/views/appstore/appStore.scss
+++ b/packages/server-admin-ui/src/views/appstore/appStore.scss
@@ -238,18 +238,19 @@
 .plugin-card .card-body,
 .plugin-card .card-footer {
   position: relative;
-  // Keep the visible content above the overlay so text selection and
-  // hover styles still work; the link still receives clicks because
-  // these elements don't intercept them on their own.
-  z-index: 0;
+  // No z-index here: a z-index would create a stacking context that
+  // traps the clickable children (author button, failed-install pill)
+  // below the stretched link no matter their own z-index, so the link
+  // would intercept their clicks.
   pointer-events: none;
 }
 
 // Re-enable pointer events on the controls that need to be clickable
-// in their own right (currently just the author filter button — the
-// chevron, state pill, and badges are decorative and the link below
-// them handles the click).
-.plugin-card .plugin-card__author-button {
+// in their own right (the author filter button and the failed-install
+// pill that opens the npm log — the chevron, other state pills, and
+// badges are decorative and the link below them handles the click).
+.plugin-card .plugin-card__author-button,
+.plugin-card .plugin-card__state-pill-button {
   position: relative;
   z-index: 2;
   pointer-events: auto;
@@ -288,6 +289,21 @@
   &--failed {
     background: #f8d7da;
     color: #721c24;
+  }
+}
+
+.plugin-card__state-pill-button {
+  border: none;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
   }
 }
 

--- a/packages/server-admin-ui/src/views/appstore/components/InstallLogModal.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/InstallLogModal.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import InstallLogModal, { logFilename } from './InstallLogModal'
+
+interface InstallLogPayload {
+  name: string
+  version?: string
+  isRemove?: boolean
+  code?: number
+  log: string
+}
+
+function mockFetch(payload: InstallLogPayload | undefined, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(payload)
+    } as Response)
+  )
+}
+
+function renderModal(appName = 'signalk-example') {
+  ;(window as unknown as { serverRoutesPrefix: string }).serverRoutesPrefix =
+    '/signalk/v1'
+  return render(
+    <InstallLogModal appName={appName} show={true} onClose={() => undefined} />
+  )
+}
+
+let originalServerRoutesPrefix: string | undefined
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  originalServerRoutesPrefix = (
+    window as unknown as { serverRoutesPrefix?: string }
+  ).serverRoutesPrefix
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  ;(window as unknown as { serverRoutesPrefix?: string }).serverRoutesPrefix =
+    originalServerRoutesPrefix
+})
+
+describe('InstallLogModal', () => {
+  it('fetches and renders the log', async () => {
+    mockFetch({
+      name: 'signalk-example',
+      code: 1,
+      log: 'npm ERR! gyp failed'
+    })
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText('npm ERR! gyp failed')).toBeDefined()
+    })
+    expect(screen.getByText('npm exited with code 1')).toBeDefined()
+    expect(fetch).toHaveBeenCalledWith(
+      '/signalk/v1/appstore/installLog/signalk-example',
+      expect.objectContaining({ credentials: 'include' })
+    )
+  })
+
+  it('titles the modal as a remove log for removals', async () => {
+    mockFetch({ name: 'signalk-example', isRemove: true, code: 1, log: 'x' })
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText(/Remove log/)).toBeDefined()
+    })
+  })
+
+  it('explains that logs do not survive a restart on 404', async () => {
+    mockFetch(undefined, 404)
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText(/lost when the server restarts/)).toBeDefined()
+    })
+  })
+
+  it('copies the log via the execCommand fallback on http', async () => {
+    mockFetch({ name: 'signalk-example', code: 1, log: 'some npm output' })
+    // jsdom has neither navigator.clipboard nor a secure context, so
+    // this exercises the textarea + execCommand path used on plain http.
+    document.execCommand = vi.fn().mockReturnValue(true)
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText('some npm output')).toBeDefined()
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Copy log' }))
+    await waitFor(() => {
+      expect(screen.getByText('Copied!')).toBeDefined()
+    })
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('shows a manual-copy hint when copying fails', async () => {
+    mockFetch({ name: 'signalk-example', code: 1, log: 'some npm output' })
+    document.execCommand = vi.fn().mockReturnValue(false)
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText('some npm output')).toBeDefined()
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Copy log' }))
+    await waitFor(() => {
+      expect(
+        screen.getByText(/select the text and copy manually/)
+      ).toBeDefined()
+    })
+  })
+
+  it('shows a generic error message for non-404 failures', async () => {
+    mockFetch(undefined, 500)
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load the log \(500\)/)).toBeDefined()
+    })
+  })
+
+  it('calls onClose when the close button is clicked', async () => {
+    mockFetch({ name: 'signalk-example', code: 1, log: 'output' })
+    ;(window as unknown as { serverRoutesPrefix: string }).serverRoutesPrefix =
+      '/signalk/v1'
+    const onClose = vi.fn()
+    render(
+      <InstallLogModal
+        appName="signalk-example"
+        show={true}
+        onClose={onClose}
+      />
+    )
+    await waitFor(() => {
+      expect(screen.getByText('output')).toBeDefined()
+    })
+    // getByText targets the footer button; the header X also has the
+    // accessible name "Close" but no text content.
+    await userEvent.click(screen.getByText('Close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('downloads the log as a file', async () => {
+    mockFetch({ name: 'signalk-example', code: 1, log: 'output' })
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock-url')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText('output')).toBeDefined()
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }))
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('disables copy and download while loading and on empty logs', async () => {
+    mockFetch({ name: 'signalk-example', code: 1, log: '' })
+    renderModal()
+    await waitFor(() => {
+      expect(screen.getByText('No output was captured.')).toBeDefined()
+    })
+    expect(
+      (screen.getByRole('button', { name: 'Copy log' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+    expect(
+      (screen.getByRole('button', { name: 'Download' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+  })
+})
+
+describe('logFilename', () => {
+  it('flattens scoped package names', () => {
+    expect(logFilename('@signalk/charts-plugin')).toBe(
+      'npm-_signalk_charts-plugin.log'
+    )
+    expect(logFilename('signalk-example')).toBe('npm-signalk-example.log')
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/components/InstallLogModal.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/InstallLogModal.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react'
+import Button from 'react-bootstrap/Button'
+import Modal from 'react-bootstrap/Modal'
+import { copyToClipboard } from '../../../utils/clipboard'
+
+interface InstallLog {
+  name: string
+  version?: string
+  isRemove?: boolean
+  code?: number
+  log: string
+}
+
+interface InstallLogModalProps {
+  appName: string
+  show: boolean
+  onClose: () => void
+}
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'loaded'; data: InstallLog }
+
+export function downloadAsFile(filename: string, text: string) {
+  const blob = new Blob([text], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+export function logFilename(appName: string): string {
+  return `npm-${appName.replace(/[@/]/g, '_')}.log`
+}
+
+export default function InstallLogModal({
+  appName,
+  show,
+  onClose
+}: InstallLogModalProps) {
+  const [state, setState] = useState<LoadState>({ status: 'loading' })
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!show) return
+    const controller = new AbortController()
+    setState({ status: 'loading' })
+    setCopyFeedback(null)
+    fetch(`${window.serverRoutesPrefix}/appstore/installLog/${appName}`, {
+      credentials: 'include',
+      signal: controller.signal
+    })
+      .then(async (res) => {
+        if (res.ok) {
+          setState({ status: 'loaded', data: (await res.json()) as InstallLog })
+        } else if (res.status === 404) {
+          setState({
+            status: 'error',
+            message:
+              'No log available. Logs are kept in memory and are lost when the server restarts.'
+          })
+        } else {
+          setState({
+            status: 'error',
+            message: `Failed to load the log (${res.status}).`
+          })
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setState({
+          status: 'error',
+          message: `Failed to load the log: ${err instanceof Error ? err.message : String(err)}`
+        })
+      })
+    return () => controller.abort()
+  }, [show, appName])
+
+  const log = state.status === 'loaded' ? state.data.log : ''
+
+  const handleCopy = () => {
+    copyToClipboard(log)
+      .then(() => setCopyFeedback('Copied!'))
+      .catch(() =>
+        setCopyFeedback('Copy failed — select the text and copy manually')
+      )
+  }
+
+  return (
+    <Modal show={show} onHide={onClose} size="lg">
+      <Modal.Header closeButton>
+        <Modal.Title>
+          {state.status === 'loaded' && state.data.isRemove
+            ? 'Remove log'
+            : 'Install log'}
+          : {appName}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {state.status === 'loading' && <p className="mb-0">Loading log...</p>}
+        {state.status === 'error' && (
+          <p className="mb-0 text-danger">{state.message}</p>
+        )}
+        {state.status === 'loaded' && (
+          <>
+            {typeof state.data.code === 'number' && state.data.code !== 0 && (
+              <p className="text-danger">
+                npm exited with code {state.data.code}
+              </p>
+            )}
+            <pre
+              className="bg-light border rounded p-2 small"
+              style={{
+                maxHeight: '50vh',
+                overflow: 'auto',
+                whiteSpace: 'pre-wrap',
+                userSelect: 'text'
+              }}
+            >
+              {log || 'No output was captured.'}
+            </pre>
+          </>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        {copyFeedback && (
+          <span className="me-auto small text-muted">{copyFeedback}</span>
+        )}
+        <Button
+          variant="primary"
+          disabled={state.status !== 'loaded' || log.length === 0}
+          onClick={handleCopy}
+        >
+          Copy log
+        </Button>
+        <Button
+          variant="outline-primary"
+          disabled={state.status !== 'loaded' || log.length === 0}
+          onClick={() => downloadAsFile(logFilename(appName), log)}
+        >
+          Download
+        </Button>
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/packages/server-admin-ui/src/views/appstore/components/PluginCard.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginCard.tsx
@@ -6,6 +6,7 @@ import ProgressBar from 'react-bootstrap/ProgressBar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight'
 import type { AppInfo } from '../../../store/types'
+import InstallLogModal from './InstallLogModal'
 import PluginIcon from './PluginIcon'
 import RecencyBadge from './RecencyBadge'
 import ScoreRing from './ScoreRing'
@@ -26,9 +27,10 @@ function isFiniteNumber(v: unknown): v is number {
 
 interface StatePillProps {
   app: AppInfo
+  onFailedClick: () => void
 }
 
-const StatePill: React.FC<StatePillProps> = ({ app }) => {
+const StatePill: React.FC<StatePillProps> = ({ app, onFailedClick }) => {
   if (app.installing) {
     if (app.isInstalling || app.isWaiting || app.isRemoving) {
       const label = app.isRemoving
@@ -44,9 +46,17 @@ const StatePill: React.FC<StatePillProps> = ({ app }) => {
     }
     if (app.installFailed) {
       return (
-        <span className="plugin-card__state-pill plugin-card__state-pill--failed">
+        <button
+          type="button"
+          className="plugin-card__state-pill plugin-card__state-pill--failed plugin-card__state-pill-button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onFailedClick()
+          }}
+          title="Show the npm log for this failure"
+        >
           Install failed
-        </span>
+        </button>
       )
     }
   }
@@ -79,6 +89,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
   detailLinkBase = '/apps/store/plugin'
 }) => {
   const navigate = useNavigate()
+  const [showLogModal, setShowLogModal] = React.useState(false)
   const handleAuthorClick = (e: React.MouseEvent) => {
     if (!app.author) return
     e.preventDefault()
@@ -206,12 +217,17 @@ const PluginCard: React.FC<PluginCardProps> = ({
             </Badge>
           ))}
         </div>
-        <StatePill app={app} />
+        <StatePill app={app} onFailedClick={() => setShowLogModal(true)} />
         <FontAwesomeIcon
           icon={faChevronRight}
           className="plugin-card__chevron text-muted"
         />
       </Card.Footer>
+      <InstallLogModal
+        appName={app.name}
+        show={showLogModal}
+        onClose={() => setShowLogModal(false)}
+      />
       {isBusy && (
         <ProgressBar
           className="plugin-card__bottom-progress"

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -223,6 +223,31 @@ module.exports = function (app) {
         }
       )
 
+      app.get(
+        [
+          `${SERVERROUTESPREFIX}/appstore/installLog/:name`,
+          `${SERVERROUTESPREFIX}/appstore/installLog/:org/:name`
+        ],
+        (req, res) => {
+          let name = req.params.name
+          if (req.params.org) {
+            name = req.params.org + '/' + name
+          }
+          const entry = modulesInstalledSinceStartup[name]
+          if (!entry) {
+            res.status(404).json({ error: `No install log for ${name}` })
+            return
+          }
+          res.json({
+            name,
+            version: entry.version,
+            isRemove: !!entry.isRemove,
+            code: entry.code,
+            log: entry.output.map(String).join('')
+          })
+        }
+      )
+
       app.get(`${SERVERROUTESPREFIX}/appstore/available/`, (req, res) => {
         const installedNames = getInstalledPackageNames()
         let storeAvailable = true

--- a/test/appstore-install-log.ts
+++ b/test/appstore-install-log.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai'
+import { startServer } from './ts-servertestutilities'
+
+describe('appstore install log', function () {
+  let stop: (() => Promise<unknown>) | undefined
+  let host: string
+
+  before(async function () {
+    const s = await startServer()
+    stop = s.stop
+    host = s.host
+  })
+
+  after(async function () {
+    if (stop) await stop()
+  })
+
+  it('returns 404 when no install has produced a log', async function () {
+    const res = await fetch(`${host}/skServer/appstore/installLog/some-plugin`)
+    expect(res.status).to.equal(404)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).to.match(/No install log/)
+  })
+
+  it('resolves scoped package names via the org route', async function () {
+    const res = await fetch(
+      `${host}/skServer/appstore/installLog/@signalk/some-plugin`
+    )
+    expect(res.status).to.equal(404)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).to.contain('@signalk/some-plugin')
+  })
+})


### PR DESCRIPTION
## Motivation

When a plugin install fails in the App Store, the user is left with a bare "Failed" badge and no indication of why. The server already captures the full npm stdout/stderr for every install/remove in memory — it just never reaches the browser, so users can't diagnose the failure or attach anything useful to a support request.

## Changes

- New `GET /skServer/appstore/installLog/:name` endpoint (plus the `:org/:name` variant for scoped packages) returning the captured npm output, exit code, and whether it was a remove. Admin-gated like the rest of `/appstore`. The log is in-memory since startup, matching the existing `modulesInstalledSinceStartup` lifetime; the UI explains this when no log is available.
- The "Failed" badge in the list view and on the detail page becomes "Failed — view log", and the "Install failed" pill on grid cards is now clickable. Both open a modal showing the log with the npm exit code.
- The modal offers "Copy log" and "Download". Copying uses `navigator.clipboard` only in secure contexts and falls back to the hidden-textarea `document.execCommand('copy')` path on plain http and older browsers; this fallback was extracted from DataBrowser's `CopyToClipboardWithFade` into a shared `utils/clipboard.ts`. Download is a Blob object-URL link that works regardless of clipboard support, and the log text itself is selectable for manual copying.
- Dropped `z-index: 0` from the plugin card body/footer: it created a stacking context that trapped clickable children below the card's stretched link, so the link intercepted their clicks. This also fixes the same latent interception on the existing author filter button.

## Tested

- Mocha test for the new endpoint (404 contract incl. scoped names); vitest coverage for the modal (load, 404 and non-404 errors, execCommand copy fallback, copy-failure hint, download, close, disabled states on empty logs).
- Manually end-to-end: triggered a real failed install (`signalk-to-nmea2000@99.99.99`, npm ETARGET) on a clean server and drove headless Chromium through the grid pill, list-view button, and modal. Verified copy in a secure context (clipboard contents checked), copy over plain http via LAN IP (`isSecureContext === false`, execCommand fallback), and the download filename.
- Full suite: `npm run format`, `npm run build:all`, server mocha suite and admin-ui vitest all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Server-Side Changes

This PR adds a new GET /skServer/appstore/installLog/:name endpoint (and /skServer/appstore/installLog/:org/:name for scoped packages) that returns captured npm install/remove logs. The endpoint is admin-gated, returns JSON with module name, version, isRemove flag, exit code, and a concatenated log string, and keeps logs in memory for the server runtime (matching modulesInstalledSinceStartup). Requests for modules with no stored log return HTTP 404 with an explanatory error.

## UI Changes

App Store failure states become interactive: the "Failed" badge (list and detail) changes to "Failed — view log" and the "Install failed" pill on grid cards becomes a clickable button. Both open an Install Log modal that fetches and displays the full npm stdout/stderr and exit code, renders selectable log text, and provides "Copy log" and "Download" actions. The modal distinguishes 404 (no log) from other HTTP errors and disables copy/download when the log is empty. Downloaded filenames flatten scoped package names (e.g., `@org/package` → org-package.log).

## Clipboard Utility Refactor

Clipboard copying is centralized in packages/server-admin-ui/src/utils/clipboard.ts as copyToClipboard(text): Promise<void>. It attempts navigator.clipboard.writeText in secure contexts and falls back to a hidden textarea + document.execCommand('copy') approach for insecure/older environments. The Install Log modal and other components use this shared helper and show a manual-copy hint when copy fails.

## CSS Fixes

appStore.scss removes z-index: 0 from .plugin-card .card-body and .plugin-card .card-footer to avoid an intrusive stacking context, applies pointer-events: none to those overlays, and re-enables pointer-events for .plugin-card__author-button and the new .plugin-card__state-pill-button (which receives reset button styling and hover/focus/focus-visible visuals). This fixes click interception for card children (pills and author filter).

## Testing

Server-side Mocha tests verify the installLog endpoint returns 404 for missing logs, including for scoped package routes. Client-side Vitest/RTL tests cover the Install Log modal and helpers: successful log fetches, removal-log titles, 404 vs other HTTP errors, copy-to-clipboard behavior including execCommand fallback (success and failure with manual-copy hint), download behavior via Blob/object URLs, close behavior, disabled states for empty logs, and logFilename flattening of scoped names. Manual end-to-end reproduction of a failed install and verification of clipboard/download behavior are performed; build and test suites pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->