### PR TITLE
Prevent prototype pollution from delta path segments in addValue

### DIFF
--- a/packages/server-api/src/fullsignalk.test.ts
+++ b/packages/server-api/src/fullsignalk.test.ts
@@ -2,6 +2,48 @@ import { expect } from 'chai'
 import { FullSignalK } from './fullsignalk'
 
 describe('FullSignalK', function () {
+  afterEach(function () {
+    // Guard against a regression leaking prototype pollution into sibling tests.
+    delete (Object.prototype as Record<string, unknown>).polluted
+  })
+
+  it('does not pollute Object.prototype via a __proto__ path segment', function () {
+    const delta = {
+      updates: [
+        {
+          source: { label: 'evil', type: 'NMEA0183' },
+          timestamp: '2014-08-15T19:03:21.532Z',
+          values: [{ path: 'navigation.__proto__.polluted', value: 'pwned' }]
+        }
+      ],
+      context: 'vessels.foo'
+    }
+    const fullSignalK = new FullSignalK()
+    fullSignalK.addDelta(delta)
+    expect(({} as Record<string, unknown>).polluted).to.equal(undefined)
+  })
+
+  it('does not pollute via a constructor path segment', function () {
+    const delta = {
+      updates: [
+        {
+          source: { label: 'evil', type: 'NMEA0183' },
+          timestamp: '2014-08-15T19:03:21.532Z',
+          values: [
+            {
+              path: 'navigation.constructor.prototype.polluted',
+              value: 'pwned'
+            }
+          ]
+        }
+      ],
+      context: 'vessels.foo'
+    }
+    const fullSignalK = new FullSignalK()
+    fullSignalK.addDelta(delta)
+    expect(({} as Record<string, unknown>).polluted).to.equal(undefined)
+  })
+
   it('Delta with object value should produce full tree leaf without the .value', function () {
     const delta = {
       updates: [

--- a/packages/server-api/src/fullsignalk.ts
+++ b/packages/server-api/src/fullsignalk.ts
@@ -22,6 +22,11 @@ import { metadataRegistry } from '@signalk/path-metadata'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = Record<string, any>
 
+// A delta path segment of __proto__ / constructor / prototype would let the
+// tree walk in addValue reach and mutate Object.prototype process-wide (#2768).
+// None of these are valid Signal K path segments, so such deltas are dropped.
+const FORBIDDEN_PATH_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
 export interface SourceMetaEntry {
   lastSeen: number
   pgnInstances?: Record<string, number[]>
@@ -197,6 +202,17 @@ function addValue(
     return
   } else {
     const splitPath: string[] = pathValue.path.split('.')
+    for (const pathPart of splitPath) {
+      if (FORBIDDEN_PATH_KEYS.has(pathPart)) {
+        console.error(
+          'Delta path contains forbidden segment "' +
+            pathPart +
+            '" in ' +
+            JSON.stringify(pathValue)
+        )
+        return
+      }
+    }
     valueLeaf = splitPath.reduce(
       (previous: AnyObject, pathPart: string, i: number) => {
         if (!previous[pathPart]) {


### PR DESCRIPTION
## Motivation

`FullSignalK.addValue` walks a delta path with `previous[part] = previous[part] || {}`. A path segment of `__proto__`, `constructor`, or `prototype` resolves to an existing prototype object, so the walk reaches and mutates `Object.prototype` for the whole process; deeply dotted paths also nest the model without bound. This is reachable from any write-authorized delta or notification raise, in both managed and disabled notification modes.

## Approach

Reject any delta whose path contains one of these reserved segments before the tree is built — they are never valid Signal K paths. Tests cover both a `__proto__` and a `constructor.prototype` path, asserting `Object.prototype` is untouched.

fixes #2768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR prevents prototype pollution attacks in `FullSignalK.addValue` by rejecting delta paths that contain reserved segments (`__proto__`, `constructor`, or `prototype`), which could otherwise allow manipulation of shared prototype objects.

## Changes

**packages/server-api/src/fullsignalk.ts**

The code adds validation during delta path traversal in the `addValue` method. A `FORBIDDEN_PATH_KEYS` set defines the reserved segments (`__proto__`, `constructor`, `prototype`). For each segment in the delta path, the code checks if it matches a forbidden key; if so, it logs an error with the offending segment and delta payload, then returns early without applying the delta.

**packages/server-api/src/fullsignalk.test.ts**

Regression tests verify the protection against prototype pollution. An `afterEach` hook cleans up `Object.prototype.polluted` between tests. Test cases confirm that:
- Deltas with `__proto__` in the path do not pollute `Object.prototype`
- Deltas with `constructor.prototype` in the path do not create unwanted properties on plain objects

## Issue Resolution

Fixes issue `#2768`, which identified that the previous path-traversal logic (`previous[part] = previous[part] || {}`) was vulnerable to prototype pollution from write-authorized deltas and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->