### PR TITLE
docs: Add Plotter Extensions API specification (proposed)

### DIFF
--- a/docs/develop/plugins/README.md
+++ b/docs/develop/plugins/README.md
@@ -10,6 +10,7 @@ children:
   - course_calculations.md
   - resource_provider_plugins.md
   - weather_provider_plugins.md
+  - plotter_extension_provider_plugins.md
   - custom_renderers.md
   - publishing.md
   - ci.md

--- a/docs/develop/plugins/plotter_extension_provider_plugins.md
+++ b/docs/develop/plugins/plotter_extension_provider_plugins.md
@@ -4,22 +4,111 @@ title: Plotter Extension Provider plugins
 
 # Plotter Extension Provider plugins
 
-A _plotter extension provider_ is a Signal K server plugin that contributes
-optional UI and behaviour to chartplotter applications (widgets, panels,
-toolbar buttons, resource filters, background runtimes) without those
-applications needing to know about the plugin. The contract — the
-`plotterExtensions` resource type, the manifest shape, capability negotiation
-and the host/extension message bus — is defined in the
-[Plotter Extensions API](../rest-api/proposed/plotter-extensions-api.md). This
-guide covers the two server-side concerns a provider plugin must implement:
-exposing the manifest, and serving its browser assets.
+A _plotter extension provider_ is a Signal K server plugin that adds optional
+UI and behaviour to **chartplotter applications** — widgets overlaid on the
+chart, interactive panels, toolbar buttons, resource display filters and
+headless background runtimes — without the chartplotter needing to know the
+plugin exists. The user installs your plugin from the App Store; any host
+chartplotter that supports the mechanism then offers what your plugin
+contributes. Freeboard-SK is the reference host.
 
-## Registering the resource provider
+This guide is the how-to for **writing one**. The wire contract it builds on —
+the `plotterExtensions` resource type, the manifest shape, capability
+negotiation, the message bus and the host API — is defined in the
+[Plotter Extensions API](../rest-api/proposed/plotter-extensions-api.md); keep
+it open alongside this guide. General plugin mechanics (`package.json`
+keywords, `start`/`stop`, `schema`, `npm link`, debugging) are **not** repeated
+here — see [Server plugins](./README.md) for those.
 
-A provider exposes its manifest as a single, read-only resource of the custom
-type `plotterExtensions`. Register it during plugin startup with
-`registerResourceProvider`. The manifest is plugin code, not user data, so the
-write methods reject:
+## It is more than "iframes on a chart"
+
+The visible part of an extension is an iframe (a widget or panel). What makes
+it powerful is what that iframe is plugged into:
+
+- **A host API.** From inside the iframe you call host methods to manipulate the plotter UI — drive the map, add a button to open a panel, subscribe to
+  live Signal K values, filter resource queries, listen for and react to events.
+- **A publish/subscribe message bus.** Every context (widget, panel,
+  background runtime) and the host share an event bus. The host emits contract
+  events (`state.changed`, `sk.<path>`, `filters.changed`); a button can
+  publish a topic; contexts from the _same or different_ plugins can coordinate
+  over it.
+- **Headless background runtimes.** A hidden iframe that runs while your plugin
+  is enabled — a client-side service that holds session state and reacts to
+  events, so a panel can close without losing work.
+- **New resource types with UI around them.** Because a plugin can be a
+  resource provider _and_ contribute the panels/widgets/filters that present
+  those resources, a single plugin can introduce an entirely new kind of data
+  and everything needed to work with it on the chart.
+
+So a "Display value" widget and a route-optimising background service are the
+same mechanism at different points on a spectrum.
+
+### Good candidates
+
+- Glanceable instrument readouts overlaid on the chart (a single SK value).
+- A search/filter panel over a resource type ("show anchorages within 10 nm").
+- A workflow that creates or curates resources (a dive-site logger that
+  provides a custom resource type, drops symbols for it, and offers a panel to
+  search and route to sites).
+- A background service that reacts to host events (route created, waypoint
+  added) and computes something.
+
+### Poor candidates
+
+- A full-screen standalone application with its own navigation — that is a
+  [webapp](../webapps.md), not an extension. Extensions are guests inside the
+  host's chrome.
+- Anything that needs to take over the chart, the host's menus, or the whole
+  viewport. Extensions interact only through the host API, never the host DOM.
+- Heavy, always-running computation in a visible widget. Put work in a
+  background runtime and keep widgets glanceable.
+
+## Who does what
+
+The single most important thing to understand before building:
+
+| Concern              | The **host** provides                                                                            | Your **plugin** provides                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Integration surface  | The bus, the handshake, the capabilities it advertises, the host API methods, the iframe sandbox | A manifest declaring contributions, and the iframe assets that fill them |
+| Widget **placement** | The widget areas, the placement UI, and persistence of the chosen layout                         | Only the widget's **size** (`1x1`…`2x2`) and its content                 |
+| Panel **chrome**     | The drawer/dialog the panel is shown in, and the open/close controls                             | The panel's content and behaviour                                        |
+| Live data, resources | A multiplexed Signal K connection and authenticated resource access, relayed over the bus        | The calls that consume them                                              |
+| Enablement           | Nothing — there is no host-side per-extension switch                                             | Enablement _is_ the server plugin being enabled                          |
+
+Two consequences worth stating plainly because they surprise people:
+
+- **A widget never chooses where it appears.** It declares a size; the _user_
+  picks the area and cells through host UI, and the host persists that. Your
+  code receives a stable `instanceId` for each placement and nothing about
+  position. (The spec does not prescribe a layout to the host either — the
+  reference host happens to offer five anchor areas, each a 2×2 cell grid.)
+- **There is no "enable extension" step in the host.** Presence in the
+  `plotterExtensions` collection — i.e. the providing plugin is installed and
+  enabled — _is_ the consent signal.
+
+### What is the minimum?
+
+- **Minimum a plugin must deliver:** register the `plotterExtensions` resource
+  provider returning a manifest with `apiVersion`, `requires`, and **one**
+  contribution (e.g. a single widget), plus the iframe asset that contribution
+  points at. That is a working extension.
+- **Minimum a host must support to run it:** the bus handshake plus every
+  capability your manifest lists in `requires`. A host that cannot meet your
+  `requires` simply does not offer your extension; capabilities in `optional`
+  are used when present and skipped when not. The reference host implements all
+  version-1 capabilities.
+
+## Server side: two responsibilities
+
+The plugin's Node code is deliberately tiny — all UI lives in iframes. It does
+two things.
+
+### 1. Register the manifest as a read-only resource
+
+Expose your manifest as a single, read-only resource of the custom type
+`plotterExtensions`. No server upgrade is required — it works on current
+servers as a user-defined resource type. The manifest is code, not user data,
+so the write methods reject:
 
 ```js
 module.exports = (app) => {
@@ -27,7 +116,7 @@ module.exports = (app) => {
   let running = false
 
   const buildManifest = () => ({
-    /* apiVersion, name, requires, widgets/panels/buttons/background, … */
+    /* see "The manifest" below */
   })
 
   return {
@@ -62,17 +151,17 @@ module.exports = (app) => {
 }
 ```
 
-No server upgrade is required — `plotterExtensions` works on current servers
-as a user-defined resource type.
+`registerResourceProvider` is the same server method used by every
+[resource provider plugin](./resource_provider_plugins.md); here the resource
+type just happens to be your manifest.
 
-## Serving extension assets
+### 2. Serve the iframe assets
 
 Widget, panel and background pages must be reachable from the browser at the
-server-relative URLs declared in the manifest. The `app` object passed to your
+server-relative URLs your manifest declares. The `app` object passed to your
 plugin is the Signal K server API — a copy of the server's Express application
-extended with the server methods (`registerResourceProvider` and friends) — so
-it also exposes Express's `use()`. Mount the asset directory as a top-level
-static route during startup:
+extended with the server methods — so it also exposes Express's `use()`. Mount
+your asset directory as a top-level static route during startup:
 
 ```js
 const path = require('path')
@@ -81,7 +170,7 @@ const PUBLIC_DIR = path.join(__dirname, '..', 'public')
 
 // in start():
 app.use(ASSET_BASE, require('express').static(PUBLIC_DIR))
-// manifest widget/panel/background urls then point at `${ASSET_BASE}/...`
+// manifest urls then point at `${ASSET_BASE}/<page>.html`
 ```
 
 Express is provided by the server, so requiring it adds no runtime dependency
@@ -105,23 +194,325 @@ authenticated session, and extension _discovery_ is gated by the authenticated
 resources API — an unauthenticated user sees no extensions regardless of how
 the assets are served.
 
+## The manifest
+
+The manifest is the contract between your plugin and any host. It names your
+required and optional capabilities and lists your contributions. A real one
+(from `signalk-poi-search`, which contributes all three visible kinds):
+
+```js
+{
+  name: 'POI Search',
+  description: 'Search points of interest (notes) by name, category and distance.',
+  version: pkg.version,
+  apiVersion: '1',                                  // extension API major version
+  requires: ['panels.iframe', 'resources', 'resources.filter'],
+  optional: ['buttons', 'widgets', 'map', 'units'],
+  buttons: [
+    {
+      id: 'open-poi-search',
+      title: 'POI Search',
+      slot: 'mapToolbar',                           // host-defined placement
+      icon: 'travel_explore',                       // Material icon name
+      action: { type: 'togglePanel', panel: 'poi-search-panel' }
+    }
+  ],
+  panels: [
+    {
+      id: 'poi-search-panel',
+      title: 'POI Search',
+      type: 'iframe',
+      url: `${ASSET_BASE}/panel.html`,
+      lifecycle: 'keepAlive'                        // stay alive when hidden
+    }
+  ],
+  widgets: [
+    {
+      id: 'poi-results',
+      title: 'POI Search Results',
+      type: 'iframe',
+      url: `${ASSET_BASE}/widget.html`,
+      size: '2x1',                                  // 2 cols × 1 row
+      lifecycle: 'whileEnabled'
+    }
+  ]
+}
+```
+
+**Top-level fields**
+
+- `apiVersion` (**required**) — the extension API major version your manifest
+  targets; this document and spec define `"1"`. A host ignores manifests
+  targeting a newer version.
+- `requires` — capability ids the host **must** support or it will not offer
+  your extension at all. List only what you genuinely cannot work without.
+- `optional` — capabilities you _use when present_. Absence must not stop your
+  extension running; check at runtime with `client.hasCapability(id)` and
+  degrade gracefully.
+- Contribution arrays — `widgets`, `panels`, `buttons`, `background`. Include
+  only the ones you provide.
+
+**Capabilities you will reach for** (full list in the spec):
+
+| Capability          | What it lets you do                                           |
+| ------------------- | ------------------------------------------------------------- |
+| `widgets`           | Contribute chart-overlay widgets (and config panels)          |
+| `panels.iframe`     | Contribute iframe panels                                      |
+| `buttons`           | Add toolbar buttons                                           |
+| `signalk.stream`    | Subscribe to live SK path values (`client.signalk.subscribe`) |
+| `signalk.put`       | Send SK PUT requests (`client.signalk.put`)                   |
+| `resources`         | Run resource queries (`resources.list`)                       |
+| `resources.filter`  | Push display filters (`resources.setFilter`)                  |
+| `map`               | Read/drive the map view (`map.*`)                             |
+| `units`             | Read the user's display-unit preferences (`units.get`)        |
+| `background.iframe` | Run a headless background runtime                             |
+
+**Contribution fields**
+
+- **Widget:** `id`, `title`, `type: 'iframe'`, `url`, `size`
+  (`1x1`|`2x1`|`1x2`|`2x2`), optional `configPanel` (id of a panel in the same
+  manifest), optional `lifecycle`.
+- **Panel:** `id`, `title`, `type: 'iframe'`, `url`, optional `lifecycle`.
+- **Button:** `id`, `title`, `slot` (`mapToolbar` is the well-known slot),
+  `icon` (Material icon name), `action` — one of
+  `{ type: 'togglePanel'|'openPanel', panel }` or
+  `{ type: 'sendMessage', topic, params? }`.
+- **Background:** `id`, `title?`, `type: 'iframe'`, `url`.
+
+**Lifecycle** controls when the host loads a context's iframe:
+
+- `onOpen` — load when shown, unload when closed (good for config panels).
+- `keepAlive` — load on first open, keep running hidden; state survives
+  close/reopen.
+- `whileEnabled` — load while the extension is available regardless of
+  visibility (the norm for placed widgets).
+
+## Inside an extension iframe
+
+All the reference contributions are plain JavaScript built on the reference
+client library [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+(the `/extension` entry point). No framework, no TypeScript required. You
+connect once, then talk to the host through the returned `client`:
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension() // resolves after the host handshake
+
+client.context // { kind, id, instanceId, targetInstance, targetWidget }
+client.hasCapability('map') // is an optional capability available?
+
+await client.call('method', params) // call any host API method (table in spec)
+await client.subscribe(['event.name'], (name, params) => {}) // bus events
+```
+
+`client` also wraps the most common calls so you do not hand-assemble them:
+
+- `client.state.get(keys?, scope?)` / `client.state.set(values, scope?)` —
+  host-persisted key/value storage. Scope defaults to the widget `instance`;
+  pass `'extension'` for state shared across all your contexts.
+- `client.signalk.subscribe(paths, ev => …)` — live SK values; the callback
+  gets `{ path, value, … }`. Returns an unsubscribe function.
+- `client.signalk.put(path, value)` — a SK PUT through the user's session.
+
+The full host method list and the contract events (`state.changed`,
+`sk.<path>`, `filters.changed`) are in the
+[Host API section of the spec](../rest-api/proposed/plotter-extensions-api.md#host-api-version-1).
+The two examples below show the surface in practice.
+
+## Example: a widget (the simplest contribution)
+
+The "Display value" widget shows one Signal K value as text. The HTML is
+trivial — a single mount point — so this section is all host API:
+
+```
+<!-- display.html (skeleton) -->
+<div id="root"></div>
+<script type="module" src="display.js"></script>
+```
+
+The whole widget lifecycle is four host interactions: **load config**,
+**follow the configured path**, **reload when the config panel saves**, and
+**open the config panel on long-press**.
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const root = document.getElementById('root')
+const client = await connectExtension()
+
+let unsubscribe = null
+
+async function applyConfig() {
+  // Per-instance config — two placements of this widget are independent.
+  const config = await client.state.get() // default scope: this instance
+
+  if (unsubscribe) await unsubscribe()
+  root.textContent = config.path ? '--' : 'Not configured'
+
+  if (config.path) {
+    // Live values arrive over the host's multiplexed SK connection.
+    unsubscribe = await client.signalk.subscribe([config.path], (ev) => {
+      root.textContent = ev.value ?? '--'
+    })
+  }
+}
+
+// The config panel writes instance state, which fires state.changed; reload.
+await client.subscribe(['state.changed'], () => applyConfig())
+await applyConfig()
+
+// Pointer events inside a sandboxed iframe are invisible to the host, so the
+// widget detects its own long-press and asks the host to open its config panel.
+let timer
+addEventListener('pointerdown', () => {
+  timer = setTimeout(
+    () => client.call('ui.openConfigPanel').catch(() => {}),
+    1500
+  )
+})
+addEventListener('pointerup', () => clearTimeout(timer))
+```
+
+Points that generalise to every widget:
+
+- **It never positions itself.** It declares `size: '1x1'`; the user placed it
+  and the host gave this placement an `instanceId`. `client.state.get()` is
+  scoped to that instance automatically.
+- **Live data is relayed, not fetched.** `client.signalk.subscribe` rides the
+  host's single upstream Signal K connection — you do not open your own.
+- **The config loop is the bus.** The config panel saves to this instance's
+  state → the host emits `state.changed` → the widget re-reads and re-renders.
+
+(The reference plugin factors this shared wiring into a `common.js` so each
+widget file is just a `render()` — but the calls above are exactly what it
+does.)
+
+### The config panel side
+
+A widget names a panel with `configPanel: 'instrument-config'`. When the host
+opens it, `client.context.targetInstance` is the widget instance being
+configured, and `state.set` writes **that** instance's scope:
+
+```js
+const client = await connectExtension()
+const target = client.context.targetInstance
+// read current settings, render a form, then on save:
+await client.state.set({ path: chosenPath /* … */ }) // fires state.changed
+```
+
+A widget with no `configPanel` still gets a host-provided dialog on long-press
+so the user can remove it; the host always provides a Remove affordance.
+
+## Example: a panel that drives the host
+
+`signalk-poi-search` is a `keepAlive` panel opened by a toolbar button. It runs
+a resource query, shows only the matches on the chart with a display filter,
+and fits the map to them — exercising `resources.list`, `resources.setFilter`,
+`map.*` and extension-scope state. The form HTML is ordinary (`<input>`s and a
+`<button>`); the host API is the interesting part:
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension()
+// Extension-scope state: shared with the companion results widget and a
+// reopened panel (a keepAlive panel survives hide/show, but this also lets a
+// sibling widget read the summary).
+const saved = await client.state.get(undefined, 'extension').catch(() => ({}))
+
+// …render the form from `saved`…
+
+async function runSearch(keyword, category, distanceNm) {
+  // Relayed through the host's authenticated session — same auth as the user.
+  const collection = await client.call('resources.list', {
+    type: 'notes',
+    query: { position: [lon, lat], distance: distanceNm * 1852 }
+  })
+
+  const matches = Object.entries(
+    collection ?? {}
+  ).filter(/* keyword/category */)
+  const label = `POI: ${matches.length} matches`
+
+  if (matches.length) {
+    // Display-only: the host shows just these ids and renders a clearable
+    // chip with `label`. It never modifies the stored resources.
+    await client.call('resources.setFilter', {
+      type: 'notes',
+      filter: { mode: 'include', ids: matches.map(([id]) => id), label }
+    })
+
+    // `map` is optional — guard before using it.
+    if (client.hasCapability('map')) {
+      await client.call('map.fitBounds', { bounds }).catch(() => {})
+    }
+  } else {
+    await client.call('resources.clearFilter', { type: 'notes' })
+  }
+
+  // Publish a summary for the results widget; also survives reopen.
+  await client.state.set({ label, count: matches.length }, 'extension')
+}
+
+// The host renders the active filter as a chip the user can dismiss without
+// reopening this panel. Reflect that so our UI/state stay in sync.
+await client.subscribe(['filters.changed'], (_name, params) => {
+  if (params.type === 'notes' && params.active === false) {
+    // clear our own state / status
+  }
+})
+```
+
+Points that generalise:
+
+- **Prefer the relayed calls over direct REST.** `resources.list` keeps you
+  inside the host's auth/session and its resource semantics. (You _may_ call
+  the server REST API directly same-origin when the host API does not suffice —
+  the reference panel does that for the vessel position.)
+- **Filters are display-only and user-owned.** You push an id set or a property
+  `match`; the host must surface it as something the user can clear. Watch
+  `filters.changed` so an externally-cleared filter updates your UI.
+- **Guard optional capabilities** with `hasCapability` and carry on without
+  them.
+
+## Background runtimes
+
+A `background` contribution is a hidden iframe with no UI that the host loads
+**while your plugin is enabled** (capability `background.iframe`), independent
+of any panel or widget being open. It speaks the same bus protocol; its
+`client.context.kind` is `'background'`.
+
+The canonical pattern: a panel does its real work in a runtime that holds the
+session state, so the panel can **close itself** (`ui.closePanel`) without
+losing it and reattach on reopen. To poke a runtime, give a button a
+`sendMessage` action publishing a topic the runtime subscribed to with
+`client.subscribe`; results flow back through the normal events
+(`state.changed`, `filters.changed`). A runtime drives the host, not the other
+way around, in this version.
+
+## Reference implementations
+
+Copy these — they are written to be read and adapted (an AI coding agent does
+well pointed at the spec plus one of these as a template):
+
+- [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
+  — gauge, meter, switch and display-value widgets with a shared, unit-aware
+  configuration panel. The smallest end-to-end example.
+- [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
+  toolbar button, a `keepAlive` search panel and a results widget exercising
+  resource queries, display filters and map control.
+- [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+  — the client/host library and the authoritative wire-format documentation.
+
 ## Declaring companion plugins
 
-When an extension is more useful alongside another plugin (for example one that
-filters resources another provider supplies), declare the relationship through
-the App Store recommendation mechanism rather than a hard dependency:
+When your extension is more useful alongside another plugin (e.g. it searches
+resources another plugin provides), declare the relationship through the App
+Store recommendation mechanism rather than a hard dependency:
 
 ```json
 {
   "signalk": { "recommends": ["<plugin-name>"] }
 }
 ```
-
-## Reference implementations
-
-- [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
-  — gauge, meter, switch and display-value widgets with a shared, unit-aware
-  configuration panel.
-- [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
-  toolbar button, a keepAlive search panel and a results widget exercising
-  resource queries, display filters and map control.

--- a/docs/develop/plugins/plotter_extension_provider_plugins.md
+++ b/docs/develop/plugins/plotter_extension_provider_plugins.md
@@ -1,0 +1,127 @@
+---
+title: Plotter Extension Provider plugins
+---
+
+# Plotter Extension Provider plugins
+
+A _plotter extension provider_ is a Signal K server plugin that contributes
+optional UI and behaviour to chartplotter applications (widgets, panels,
+toolbar buttons, resource filters, background runtimes) without those
+applications needing to know about the plugin. The contract — the
+`plotterExtensions` resource type, the manifest shape, capability negotiation
+and the host/extension message bus — is defined in the
+[Plotter Extensions API](../rest-api/proposed/plotter-extensions-api.md). This
+guide covers the two server-side concerns a provider plugin must implement:
+exposing the manifest, and serving its browser assets.
+
+## Registering the resource provider
+
+A provider exposes its manifest as a single, read-only resource of the custom
+type `plotterExtensions`. Register it during plugin startup with
+`registerResourceProvider`. The manifest is plugin code, not user data, so the
+write methods reject:
+
+```js
+module.exports = (app) => {
+  const PLUGIN_ID = 'my-plotter-extension'
+  let running = false
+
+  const buildManifest = () => ({
+    /* apiVersion, name, requires, widgets/panels/buttons/background, … */
+  })
+
+  return {
+    id: PLUGIN_ID,
+    name: 'My Plotter Extension',
+    start() {
+      running = true
+      app.registerResourceProvider({
+        type: 'plotterExtensions',
+        methods: {
+          listResources: async () =>
+            running ? { [PLUGIN_ID]: buildManifest() } : {},
+          getResource: async (id) => {
+            if (!running || id !== PLUGIN_ID) {
+              throw new Error(`No such plotterExtensions resource: ${id}`)
+            }
+            return buildManifest()
+          },
+          setResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`)
+          },
+          deleteResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`)
+          }
+        }
+      })
+    },
+    stop() {
+      running = false
+    }
+  }
+}
+```
+
+No server upgrade is required — `plotterExtensions` works on current servers
+as a user-defined resource type.
+
+## Serving extension assets
+
+Widget, panel and background pages must be reachable from the browser at the
+server-relative URLs declared in the manifest. The `app` object passed to your
+plugin is the Signal K server API — a copy of the server's Express application
+extended with the server methods (`registerResourceProvider` and friends) — so
+it also exposes Express's `use()`. Mount the asset directory as a top-level
+static route during startup:
+
+```js
+const path = require('path')
+const ASSET_BASE = `/plotterext/${PLUGIN_ID}`
+const PUBLIC_DIR = path.join(__dirname, '..', 'public')
+
+// in start():
+app.use(ASSET_BASE, require('express').static(PUBLIC_DIR))
+// manifest widget/panel/background urls then point at `${ASSET_BASE}/...`
+```
+
+Express is provided by the server, so requiring it adds no runtime dependency
+of your own. A namespaced prefix such as `/plotterext/<package-name>/` keeps
+the top-level path collision-free.
+
+Two routes to **avoid**:
+
+- **`/plugins/*`** (e.g. via `registerWithRouter`) — the server gates the
+  entire `/plugins` path behind _admin_ authentication, so read-only users
+  could not load the assets.
+- **The `signalk-webapp` keyword** — it auto-mounts `public/` at
+  `/<package-name>/`, but it also lists the package in the server's Webapps
+  launcher. Extension assets are only ever loaded inside the host's iframe,
+  never launched standalone, so they should not appear there. Omit the keyword
+  and self-mount instead.
+
+Serving the asset _bytes_ publicly is not a data-exposure concern: the files
+are inert UI code, all data flows through the bus over the user's own
+authenticated session, and extension _discovery_ is gated by the authenticated
+resources API — an unauthenticated user sees no extensions regardless of how
+the assets are served.
+
+## Declaring companion plugins
+
+When an extension is more useful alongside another plugin (for example one that
+filters resources another provider supplies), declare the relationship through
+the App Store recommendation mechanism rather than a hard dependency:
+
+```json
+{
+  "signalk": { "recommends": ["<plugin-name>"] }
+}
+```
+
+## Reference implementations
+
+- [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
+  — gauge, meter, switch and display-value widgets with a shared, unit-aware
+  configuration panel.
+- [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
+  toolbar button, a keepAlive search panel and a results widget exercising
+  resource queries, display filters and map control.

--- a/docs/develop/plugins/plotter_extension_provider_plugins.md
+++ b/docs/develop/plugins/plotter_extension_provider_plugins.md
@@ -50,8 +50,11 @@ same mechanism at different points on a spectrum.
 - A workflow that creates or curates resources (a dive-site logger that
   provides a custom resource type, drops symbols for it, and offers a panel to
   search and route to sites).
-- A background service that reacts to host events (route created, waypoint
-  added) and computes something.
+- A route tool that reshapes the route the user is editing (the `routes`
+  capability) — an auto-router that detours around land, a leg optimiser, a
+  "reverse this route" button.
+- A background service that reacts to host events (a route shown or edited,
+  config changed) and computes something.
 
 ### Poor candidates
 
@@ -264,6 +267,7 @@ required and optional capabilities and lists your contributions. A real one
 | `resources`         | Run resource queries (`resources.list`)                       |
 | `resources.filter`  | Push display filters (`resources.setFilter`)                  |
 | `map`               | Read/drive the map view (`map.*`)                             |
+| `routes`            | Read & edit the routes on the chart (`route.*`)               |
 | `units`             | Read the user's display-unit preferences (`units.get`)        |
 | `background.iframe` | Run a headless background runtime                             |
 
@@ -475,6 +479,77 @@ Points that generalise:
   `filters.changed` so an externally-cleared filter updates your UI.
 - **Guard optional capabilities** with `hasCapability` and carry on without
   them.
+
+## Example: editing a route
+
+The `routes` capability lets an extension read and rewrite the routes the user
+is actively working with — the one or two on the chart, never the whole stored
+catalogue. An auto-router is the motivating case: the user draws a route, the
+extension reshapes it (below, just *reversing* it as a stand-in for a real
+routing engine), and the user saves when happy. The host owns the chart, the
+edit buffer and the Save dialog; the extension only supplies geometry.
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension()
+
+// `routes` is optional — degrade gracefully if the host doesn't offer it.
+if (!client.hasCapability('routes')) {
+  document.body.textContent = 'This host does not support route editing.'
+}
+
+// Lock onto a route. The visible set is small; take the most recent (or, with
+// several, let the user pick). A routeId is an opaque handle — never parse it.
+async function pickRoute() {
+  const { routes } = await client.call('route.list')
+  return routes[routes.length - 1]?.routeId ?? null
+}
+
+let routeId = await pickRoute()
+
+// Re-read whenever a route changes — by us, by the user's own editing, or by
+// another extension. `route.dirty` is the catch-all "it changed, re-fetch"
+// signal; `route.visible` means a route entered the set.
+await client.subscribe(['route.**'], async (name) => {
+  if (name === 'route.visible') routeId = await pickRoute()
+  if (name === 'route.dirty' && routeId) {
+    render(await client.call('route.get', { routeId }))
+  }
+})
+if (routeId) render(await client.call('route.get', { routeId }))
+
+// The panel's one button: reshape the route. Hand the host a whole new point
+// list with `route.replace`; it re-renders the chart and marks the route
+// `dirty` (unsaved). Nothing is written to the server.
+async function reshape() {
+  if (!routeId) return
+  const { points } = await client.call('route.get', { routeId })
+  const reworked = points.slice().reverse() // ← a real routing engine goes here
+  await client.call('route.replace', { routeId, points: reworked })
+}
+
+// Save on demand: the host persists it through the user's session and (with
+// `dialog: true`) prompts for a name. The route stays on the chart, now saved.
+async function save() {
+  if (routeId) await client.call('route.save', { routeId, dialog: true })
+}
+```
+
+Points that generalise:
+
+- **You edit the visible set, not the catalogue.** `route.list` is the one or
+  two routes on the chart. Pull a stored route in with `route.show({ ref })`
+  first; to browse the whole catalogue, read `/resources/routes` directly.
+- **Geometry is staged, never written through.** `route.replace` changes the
+  in-memory route and marks it `dirty` — the chart updates, the server does not.
+  Only `route.save` persists, and a server-rejected save reports
+  `routes.saveFailed` (distinct from the user cancelling the dialog,
+  `routes.saveCancelled`).
+- **Re-read on `route.dirty`.** It fires for every change whoever made it, so a
+  single "on dirty, `route.get`" keeps you in sync without tracking who edited.
+- **`routeId` is an opaque handle**, distinct from the saved resource's `href`
+  (which `route.save` returns) — the two are not interchangeable.
 
 ## Background runtimes
 

--- a/docs/develop/rest-api/proposed/README.md
+++ b/docs/develop/rest-api/proposed/README.md
@@ -2,14 +2,16 @@
 title: Proposed APIs
 children:
   - anchor_api.md
+  - plotter-extensions-api.md
 ---
 
 # PROPOSED APIs
 
 The following APIs have been identified for future development:
 
-| Proposed API                | Description                                                             | Endpoint                         |
-| --------------------------- | ----------------------------------------------------------------------- | -------------------------------- |
-| _[`Anchor`](anchor_api.md)_ | Provide endpoints to perform operations and facilitate an anchor alarm. | `vessels/self/navigation/anchor` |
+| Proposed API                                        | Description                                                                                                                    | Endpoint                         |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| _[`Anchor`](anchor_api.md)_                         | Provide endpoints to perform operations and facilitate an anchor alarm.                                                        | `vessels/self/navigation/anchor` |
+| _[`Plotter Extensions`](plotter-extensions-api.md)_ | Let server plugins contribute widgets, panels, buttons, background runtimes and resource filters to chartplotter applications. | `resources/plotterExtensions`    |
 
 ---

--- a/docs/develop/rest-api/proposed/plotter-extensions-api.md
+++ b/docs/develop/rest-api/proposed/plotter-extensions-api.md
@@ -1,0 +1,615 @@
+---
+title: Plotter Extensions API
+---
+
+# Working with the Plotter Extensions API
+
+Web-based Signal K chartplotters (e.g. Freeboard-SK) are general-purpose
+applications. Many valuable features — instrument widgets, custom panels,
+domain-specific tooling — are too specific to bundle into a chartplotter's
+core, yet forking the application to add them fragments the community.
+
+The **Plotter Extensions API** defines a Signal K resource type —
+`plotterExtensions` — through which any server plugin can offer optional
+features to chartplotter applications without forking them. A host
+chartplotter discovers extension manifests at runtime and lets the user
+place and configure the contributions. Extensions are distributed through
+the existing Signal K plugin/app-store flow.
+
+`plotterExtensions` is a user-defined resource type hosted under the
+`resources` path, so the collection is accessible at:
+
+```text
+/signalk/v2/api/resources/plotterExtensions
+```
+
+> **Status: draft.** This document describes extension API version `1` as
+> implemented by the reference host (Freeboard-SK) and the reference
+> extensions (`signalk-instrument-widgets`, `signalk-poi-search`): widgets,
+> panels, toolbar buttons, state storage, Signal K data relay, unit
+> preferences, resource display filters, map control and headless
+> background runtimes. Manifest-declared filter chains and host-into-runtime
+> calls are out of scope for this version (see Non-Goals).
+
+---
+
+## Design Principles
+
+1. **Host-agnostic.** Nothing in the manifest or wire protocol names a
+   specific chartplotter. Hosts identify themselves and their capabilities
+   at runtime; extensions declare what they need.
+2. **Framework-neutral.** The baseline integration unit is a sandboxed
+   iframe plus a plain-JSON message protocol. Extensions need no particular
+   UI framework and no TypeScript.
+3. **Capability negotiation, not version lockstep.** An extension declares
+   required and optional capabilities; a host only offers extensions whose
+   requirements it can meet.
+4. **The host stays the orchestrator.** Extensions interact through a
+   deliberate host API — never host internals or the host DOM.
+5. **Enablement lives on the server.** The user installed and enabled the
+   providing plugin; that is the consent signal. The server's plugin
+   enable/disable switch turns the whole extension off. Hosts must not add
+   a second per-extension enable gate — presence in the
+   `plotterExtensions` collection means enabled.
+
+---
+
+## Discovery
+
+A host fetches the collection and receives extension manifests keyed by
+extension id (the providing plugin's id is the recommended key):
+
+```json
+{
+  "signalk-instrument-widgets": {
+    "name": "Instrument Widgets",
+    "description": "Single-value instrument widgets: gauge, percent meter and switch.",
+    "version": "0.2.0",
+    "apiVersion": "1",
+    "requires": ["widgets", "panels.iframe", "signalk.stream"],
+    "optional": ["signalk.put", "units"],
+    "widgets": [
+      {
+        "id": "gauge",
+        "title": "Gauge",
+        "type": "iframe",
+        "url": "/plotterext/signalk-instrument-widgets/gauge.html",
+        "size": "1x1",
+        "configPanel": "instrument-config",
+        "lifecycle": "whileEnabled"
+      }
+    ],
+    "panels": [
+      {
+        "id": "instrument-config",
+        "title": "Instrument Setup",
+        "type": "iframe",
+        "url": "/plotterext/signalk-instrument-widgets/config.html",
+        "lifecycle": "onOpen"
+      }
+    ]
+  }
+}
+```
+
+**Manifest fields**
+
+- `name`, `description`, `version` — display metadata.
+- `apiVersion` (required) — extension API major version; this document
+  defines `"1"`. Hosts must not offer manifests targeting a newer version.
+- `requires` — capability ids the host must support for the extension to be
+  offered at all.
+- `optional` — capability ids the extension uses when present; absence must
+  not prevent it from running.
+- Contribution sections: `widgets`, `panels`, `buttons`, `background` (this
+  version). Hosts must ignore unknown sections and fields.
+- Any individual contribution entry may declare its own `apiVersion` when
+  it needs a newer host API than the manifest baseline; hosts silently omit
+  contributions they cannot satisfy while keeping the rest.
+
+**Capability identifiers (version 1)**
+
+| Capability          | Meaning                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `widgets`           | Host supports the widget grid described below (including the configuration-panel methods `ui.openConfigPanel` / `ui.closePanel`). |
+| `panels.iframe`     | Host supports iframe panels.                                                                                                      |
+| `background.iframe` | Host supports headless background-runtime iframes (no UI, loaded while the extension is present).                                 |
+| `buttons`           | Host renders extension toolbar buttons in at least one slot.                                                                      |
+| `signalk.stream`    | Host streams Signal K path values to extension contexts over the message bus.                                                     |
+| `signalk.put`       | Host relays Signal K PUT requests from extension contexts.                                                                        |
+| `units`             | Host exposes the user's preferred display units (`units.get`).                                                                    |
+| `map`               | Host implements the `map.*` methods (view query and control).                                                                     |
+| `resources`         | Host implements `resources.list` (relayed resource queries).                                                                      |
+| `resources.filter`  | Host implements imperative resource display filters.                                                                              |
+| `ui`                | Host implements `ui.openPanel` / `ui.closePanel`.                                                                                 |
+
+The vocabulary is open-ended: future versions add ids (buttons, resource
+filters, map control), and hosts may expose vendor-specific experiments
+under a prefix such as `x-<host>.<capability>`. Unknown ids in `optional`
+are ignored; unknown ids in `requires` make the extension incompatible.
+
+---
+
+## Widgets
+
+A widget is a small, always-visible tile overlaid on the chart — for
+glanceable state, not complex interaction (interaction belongs in panels).
+
+**Layout model.** The host defines _widget areas_ at fixed anchor positions
+of the chartplotter window — typically corners and/or edge centers; the set
+is the host's choice (the reference host uses top-right, top-center,
+bottom-center, bottom-left and bottom-right, reserving top-left for its own
+controls). Each area is a grid of **2 columns × 2 rows**. A widget declares
+only its size in grid cells as `<columns>x<rows>`: `1x1`, `2x1`, `1x2`, or
+`2x2`.
+
+**Placement is entirely the user's choice.** The user decides which area
+and cells a widget occupies; the host provides the placement UI and
+persists the layout. A widget never requests a position. (Reference host
+UI: press-and-hold an empty anchor cell lists the widgets that fit there;
+widgets pack from the screen edge inward.)
+
+**Instances.** Placement is cell-based, not area-exclusive: widgets from
+different extensions may share an area, and the same widget definition may
+be placed multiple times. The host assigns each placement a unique, stable
+instance id (a GUID), persists it with the layout, and passes it in the
+handshake `context.instanceId`. Per-instance state is keyed by that id, so
+two instances of the same widget are configured independently.
+
+**Configuration.** A widget entry may name a panel from the same manifest
+via `configPanel`. Pointer events inside a sandboxed iframe are invisible
+to the host, so the press-and-hold gesture is detected by the widget
+content itself (the reference client library implements it), which calls
+the host method `ui.openConfigPanel` or `ui.toggleConfigPanel`. The host
+opens the named panel with `context.targetInstance` set to the widget's
+instance id and `context.targetWidget` set to the widget's manifest-local
+id, and must also provide a gesture-independent path to the same panel plus
+an affordance to **remove** the widget instance (the reference host places a
+Remove button in the configuration dialog). A widget that also handles a
+short tap should distinguish it from a long press so the press-and-hold does
+not trigger the tap action. A widget with **no** `configPanel` still gets a
+configuration dialog on long-press so it can be removed (the reference host
+shows a remove-only dialog).
+
+**Widget fields:** `id`, `title`, `type` (`iframe`), `url`, `size`,
+`configPanel?`, `lifecycle?`, `apiVersion?`.
+
+---
+
+## Panels
+
+A panel is interactive content the host displays inside its existing UI
+(dialog, drawer — the host chooses the chrome). The baseline type every
+host supporting `panels.iframe` must implement is a sandboxed iframe served
+by the providing plugin.
+
+**Panel fields:** `id`, `title`, `type` (`iframe`), `url`, `lifecycle?`,
+`apiVersion?`.
+
+**Lifecycle values**
+
+- `onOpen` — load when opened, unload when closed.
+- `keepAlive` — load on first open, keep running (hidden) while available;
+  panel state survives close/reopen.
+- `whileEnabled` — load while the extension is available, independent of
+  visibility (the expected default for placed widgets).
+
+Panels are opened by toolbar buttons, by the host methods `ui.openPanel` /
+`ui.togglePanel` (e.g. a widget tap), or — for configuration panels — by
+`ui.openConfigPanel` / `ui.toggleConfigPanel`. The `toggle*` variants close
+the panel if it is already the active one, otherwise open it. The reference
+host shows general panels in a right-side drawer that pushes the chart
+aside, and configuration panels in a dialog.
+
+---
+
+## Background Runtimes
+
+A background runtime is a **headless** extension context — a hidden iframe
+with no UI — declared in a `background` manifest section and gated by the
+`background.iframe` capability:
+
+```json
+{
+  "background": [
+    {
+      "id": "search-service",
+      "title": "POI Search Service",
+      "type": "iframe",
+      "url": "/plotterext/signalk-poi-search/runtime.html"
+    }
+  ]
+}
+```
+
+The host loads one iframe per declared runtime **while the extension is
+present in the collection** (i.e. its providing plugin is enabled) and tears
+it down when the extension leaves — independent of any panel or widget being
+open. This is the distinction from a `keepAlive` panel: a kept-alive panel is
+a _visible_ context that had to be opened at least once, whereas a runtime
+runs from the moment the extension is available with no user interaction. A
+host that supports `background.iframe` **must not** keep a visible panel
+alive merely to give an extension background behavior — that is what runtimes
+are for.
+
+A runtime speaks the same bus protocol as widgets and panels; its handshake
+`context.kind` is `background`. It may call the host API — `state.*`
+(extension scope by default, as it has no widget instance), `signalk.*`,
+`resources.*` including `resources.setFilter`, `units.get`, `map.*`, and
+`ui.openPanel`/`ui.togglePanel`. It has no `ui.closePanel` or
+`ui.*ConfigPanel` (those are panel/widget affordances). The typical use is a
+client-side service that holds session state and keeps work alive so a panel
+can **close itself** (`ui.closePanel`) without losing that state, then
+reattach to the runtime's state when reopened.
+
+`whileEnabled` is the only meaningful lifecycle for a runtime and is implied;
+the host does not unload a runtime on its own while the extension is present.
+
+To **trigger** a runtime, the runtime subscribes to a topic with
+`events.subscribe` and a `sendMessage` button (see Buttons) publishes that
+topic — fire-and-forget, the direction this version supports.
+
+**Background fields:** `id`, `title?`, `type` (`iframe`), `url`,
+`lifecycle?`, `apiVersion?`.
+
+> Runtimes a host can _call into_ from a button or a declarative filter (the
+> `callRuntime` action) are a further step not part of this version; a
+> version-1 runtime drives the host, not the other way around.
+
+---
+
+## Buttons
+
+An extension may contribute buttons to host-defined UI slots:
+
+```json
+{
+  "id": "open-poi-search",
+  "title": "POI Search",
+  "slot": "mapToolbar",
+  "icon": "travel_explore",
+  "action": { "type": "openPanel", "panel": "poi-search-panel" }
+}
+```
+
+- `slot` — host-defined placement; `mapToolbar` is the one well-known slot
+  every host supporting `buttons` must map to a reasonable toolbar
+  location. Hosts fall back to a default slot for unknown values.
+- `icon` — a Material icon name the host may render; hosts without that
+  icon set may substitute a generic extension icon. (A generic `symbol`
+  reference field is reserved for the symbols resource integration.)
+- `action` — what the button does:
+
+  - `togglePanel` — open the named `panel` from the same manifest, or close
+    it if it is already the active panel (recommended; matches the host's
+    built-in panel-button behavior).
+  - `openPanel` — always open (or switch to) the named `panel`.
+  - `sendMessage` — publish a message onto the host bus. The button carries a
+    `topic` (the event name) and optional `params`; the host publishes it as
+    a bus event delivered to every live extension context that subscribed to
+    that topic via `events.subscribe`. This is fire-and-forget — no reply.
+
+    ```json
+    {
+      "id": "refresh-pois",
+      "title": "Refresh nearby POIs",
+      "slot": "mapToolbar",
+      "icon": "refresh",
+      "action": { "type": "sendMessage", "topic": "poi-search:refresh" }
+    }
+    ```
+
+    The **primary use case is to reach the extension's own background
+    runtime** — a button poke that a kept-alive headless context handles
+    (re-run a search, recompute a filter, etc.), with any visible result
+    flowing back through the normal event loop (`state.changed`,
+    `filters.changed`, …). But it is a general message: the host delivers a
+    topic to _any_ subscribed context, so it can also drive a panel or, across
+    extensions, let a federation of plugins coordinate and even build ad-hoc
+    service discovery over nothing but this messaging infrastructure.
+
+    Delivery is subscription-gated — a context receives a topic only if it
+    subscribed — so an unheard message simply does nothing. Topics **should**
+    be namespaced (e.g. `<extension-id>:<name>` or an `ext.*` prefix) to avoid
+    colliding with host events (`state.changed`, `sk.*`, `filters.changed`) or
+    with another extension's topics. This is a **convention, not an enforced
+    requirement**; the host does not validate topic names.
+
+---
+
+## Communication
+
+Extension iframes talk to the host over a message bus: **JSON-RPC 2.0
+inside a routing envelope over `postMessage`**:
+
+```json
+{ "bus": "plotterExt/1", "msg": { "jsonrpc": "2.0", "...": "..." } }
+```
+
+- **Calls** are JSON-RPC requests with a fresh per-call `id` nonce; exactly
+  one response with `result` XOR `error`. Protocol errors use the JSON-RPC
+  reserved codes; host API errors use implementation-defined codes with a
+  stable string in `error.data.reason`.
+- **Events** are JSON-RPC notifications whose `method` is a hierarchical
+  dot-separated event name. Hosts only forward events a context subscribed
+  to via `events.subscribe`; subscription patterns support
+  eventemitter2-style wildcards (`*` one segment, `**` any remainder).
+- **Connection**: the extension repeats the `bus.ready` notification until
+  the host answers with `bus.handshake`:
+
+```json
+{
+  "host": "freeboard-sk",
+  "hostVersion": "2.24.0",
+  "apiVersion": "1",
+  "capabilities": [
+    "widgets",
+    "panels.iframe",
+    "buttons",
+    "signalk.stream",
+    "signalk.put",
+    "units",
+    "map",
+    "resources",
+    "resources.filter",
+    "background.iframe",
+    "ui"
+  ],
+  "context": {
+    "kind": "widget",
+    "id": "gauge",
+    "instanceId": "b9c1a7e2-4f3d-4c2a-9d1e-7a5b3c8e0f42",
+    "targetInstance": null,
+    "targetWidget": null
+  }
+}
+```
+
+`context.kind` is `widget`, `panel` or `background` (this version). For a
+configuration panel, `targetInstance`/`targetWidget` identify the widget
+being configured; a `background` runtime carries neither.
+
+The reference implementation of both sides of this protocol is the
+[`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+npm package (`/host` and `/extension` entry points). Its README documents
+the full wire format; **the documented wire format, not the package, is the
+contract** — any conforming implementation interoperates.
+
+---
+
+## Host API (version 1)
+
+| Method                  | Params                                         | Result                     |
+| ----------------------- | ---------------------------------------------- | -------------------------- |
+| `events.subscribe`      | `{ patterns: string[] }`                       | `{ subscriptionId }`       |
+| `events.unsubscribe`    | `{ subscriptionId }`                           | `{}`                       |
+| `state.get`             | `{ scope?, keys? }`                            | `{ values }`               |
+| `state.set`             | `{ scope?, values }`                           | `{}`                       |
+| `signalk.subscribe`     | `{ paths: string[] }` (literal paths)          | `{ subscriptionId }`       |
+| `signalk.unsubscribe`   | `{ subscriptionId }`                           | `{}`                       |
+| `signalk.put`           | `{ path, value }`                              | server PUT response        |
+| `units.get`             | —                                              | `{ units }`                |
+| `resources.list`        | `{ type, query? }`                             | resource collection        |
+| `resources.setFilter`   | `{ type, filter }`                             | `{}`                       |
+| `resources.clearFilter` | `{ type }`                                     | `{}`                       |
+| `map.getView`           | —                                              | `{ center, zoom, bounds }` |
+| `map.center`            | `{ position: [lon, lat], zoom? }`              | `{}`                       |
+| `map.fitBounds`         | `{ bounds: [minLon, minLat, maxLon, maxLat] }` | `{}`                       |
+| `ui.openPanel`          | `{ panel }`                                    | `{}`                       |
+| `ui.togglePanel`        | `{ panel }`                                    | `{}`                       |
+| `ui.openConfigPanel`    | — (widget contexts)                            | `{}`                       |
+| `ui.toggleConfigPanel`  | — (widget contexts)                            | `{}`                       |
+| `ui.closePanel`         | — (panel contexts)                             | `{}`                       |
+
+**Host events**
+
+These events are part of the API contract — any conforming host emits them,
+they are not host-specific. Each is delivered only to contexts that have
+subscribed to its name via `events.subscribe` (so a context that never
+subscribes pays nothing). A host emits an event when the corresponding
+capability is supported: `state.changed` always; `sk.<path>` with
+`signalk.stream`; `filters.changed` with `resources.filter`. The
+connection-level notifications `bus.ready` and `bus.handshake` (see
+Communication) are the only other host/extension events and are
+handled by the protocol layer, not subscribed to.
+
+- `state.changed` — `{ scope, instanceId, keys }`: the extension's stored
+  state changed (e.g. its configuration panel saved). Published to the
+  extension's subscribed contexts.
+- `sk.<path>` — `{ path, value, timestamp, $source }`: a subscribed
+  Signal K path value, relayed over the host's multiplexed server
+  connection (one upstream connection per host, not per widget).
+- `filters.changed` — `{ type, active }`: the extension's display filter for
+  a resource type was set (`active: true`) or cleared (`active: false`, e.g.
+  the user dismissed the host's filter chip). Extensions should reflect a
+  clear in their own UI/state.
+
+### Resource queries and display filters
+
+`resources.list` relays a resource collection request through the host's
+authenticated client: `{ type: "notes", query: { position: [lon, lat],
+distance: 18520 } }` serializes to the resources API query string. This
+keeps extensions inside the host's auth/session semantics; extensions may
+still call the server REST API directly (same-origin) when needed.
+
+`resources.setFilter` controls what the host _displays_ for a resource
+type — it never modifies stored resources:
+
+```json
+{
+  "type": "notes",
+  "filter": {
+    "mode": "include",
+    "ids": ["urn:mrn:signalk:uuid:..."],
+    "match": [
+      { "path": "properties.skIcon", "op": "eq", "value": "anchorage" }
+    ],
+    "label": "Anchorage < 10 nm: 2 matches"
+  }
+}
+```
+
+- `mode` — `include` (show only matching) or `exclude` (hide matching).
+- `ids` — resource ids;
+- `match` — AND-combined property conditions with
+  `op` one of `eq | ne | lt | lte | gt | gte | in | contains | regex |
+exists`. `contains` is case-insensitive substring for strings, membership
+  for arrays; `regex` tests a JavaScript regular-expression pattern string
+  (in `value`) against the field's string value — a non-string field or an
+  invalid pattern fails. Conditions on missing fields are false except
+  `exists`. At least one of `ids`/`match` is required; when both are present
+  a resource must satisfy both.
+
+  **Symbol-reference tolerance.** `eq`, `ne` and `in` compare symbol
+  references (per the [Symbols API](https://github.com/joelkoz/signalk-symbol-manager))
+  namespace-tolerantly: a bare local id matches a qualified `namespace:id`
+  with the same id, and vice versa. So `{ "path": "properties.skIcon",
+"op": "eq", "value": "anchorage" }` matches a resource whose stored value
+  the host has qualified to `default:anchorage` (or `custom:anchorage`).
+  Differing namespaces (`custom:x` vs `fsk:x`) do not match, and only
+  single-colon `namespace:id` values participate — multi-colon strings such
+  as URNs keep strict equality. An extension that needs exact matching of a
+  qualified reference should set `"exact": true` on the condition (or write
+  the fully-qualified `value`, or use `regex`). With `exact`, `eq`/`ne`/`in`
+  compare strictly and `anchorage` will not match `default:anchorage`.
+
+- `label` — short human-readable description. **Hosts must surface active
+  filters to the user** (the reference host renders clearable chips) and
+  let the user clear any filter without opening the owning extension.
+
+The host tracks at most one filter per (extension, resource type); a new
+`setFilter` replaces it. Filters from multiple extensions compose by
+intersection. Filters are not persisted across host reloads.
+
+### State storage
+
+`state.get`/`state.set` give an extension small host-persisted key/value
+storage. Two scopes:
+
+- `instance` — keyed by the context's widget instance (default for widget
+  contexts; configuration panels opened with `targetInstance` read and
+  write the _target's_ instance scope).
+- `extension` — shared across the extension's contexts.
+
+Every successful `state.set` triggers a `state.changed` event — the loop
+that lets a widget re-render live while its configuration panel edits it.
+Quota and persistence backend are host-defined.
+
+### Unit preferences
+
+Signal K values are SI on the wire, and a path's `meta.units` names the
+unit. What the _user_ wants displayed is host configuration. `units.get`
+exposes it:
+
+```json
+{
+  "units": {
+    "speed": "kn",
+    "distance": "naut-mile",
+    "depth": "m",
+    "length": "m",
+    "temperature": "C"
+  }
+}
+```
+
+Vocabulary: `speed` `kn|m/s|km/h|mph`; `distance` `kilometer|naut-mile`;
+`depth`/`length` `m|foot`; `temperature` `C|F`. Hosts may add keys;
+extensions must tolerate missing ones. Extensions rendering path values
+should combine a path's `meta.units` with these preferences to decide which
+conversions to offer and which to preselect.
+
+---
+
+## Providing an Extension
+
+A Signal K plugin:
+
+1. Registers a resource provider for the custom type `plotterExtensions`
+   (works on current servers — no server upgrade required):
+
+   ```js
+   app.registerResourceProvider({
+     type: 'plotterExtensions',
+     methods: {
+       listResources: async () => ({ [PLUGIN_ID]: manifest }),
+       getResource: async (id) => {
+         /* ... */
+       },
+       setResource: async () => {
+         throw new Error('read-only')
+       },
+       deleteResource: async () => {
+         throw new Error('read-only')
+       }
+     }
+   })
+   ```
+
+2. Serves its widget, panel and background assets from a **publicly
+   readable**, non-admin-gated route. Manifest URLs are server-relative;
+   hosts resolve them against the Signal K server origin. The asset files are
+   inert UI code — all data flows through the bus over the user's own
+   authenticated session, and extension _discovery_ is gated by the
+   authenticated resources API, so an unauthenticated user sees no extensions
+   regardless of how the assets are served. For how to mount such a route from
+   a plugin, see
+   [Plotter Extension Provider plugins](../../plugins/plotter_extension_provider_plugins.md).
+
+3. Declares inter-plugin relationships through the App Store mechanism
+   (`"signalk": { "recommends": ["<plugin-name>"] }` in `package.json`)
+   rather than hard dependencies — e.g. an extension that searches another
+   provider's resources.
+
+---
+
+## Security and Trust
+
+By the time a manifest is visible, the user has already installed a server
+plugin — code that runs unrestricted on the server. Install time is the
+trust decision; browser-side isolation is **fault containment, not an
+adversarial boundary**:
+
+- Baseline iframe sandbox: `allow-scripts allow-same-origin allow-forms`.
+  Same-origin assets plus scripts mean the sandbox attribute is not a
+  security boundary; its value is lifecycle isolation, CSS/DOM separation
+  and crash containment. `allow-top-navigation`, `allow-popups` and
+  `allow-modals` are withheld to prevent accidents.
+- The host API validates arguments and applies call timeouts; one broken
+  extension must not prevent the host from loading.
+- Extension contexts are same-origin with the Signal K server and may call
+  its REST/WebSocket APIs directly with the user's session where the host
+  API does not suffice.
+
+---
+
+## Reference Implementations
+
+- **Protocol**: [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+  — wire format documentation plus host/extension endpoints with a
+  conformance test suite.
+- **Extensions**: [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
+  — gauge, meter, switch and display-value widgets with a
+  shared unit-aware configuration panel — and
+  [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
+  toolbar button + keepAlive search panel + results widget exercising
+  resource queries, display filters and map control.
+- **Host**: Freeboard-SK (feature branch, in development) — anchor-area
+  widget overlay, placement UI, state storage, multiplexed Signal K relay,
+  toolbar buttons, panel drawer, filter chips, map control.
+
+---
+
+## Non-Goals
+
+This version deliberately does not specify:
+
+- **Manifest-declared filter chains.** Display filtering here is imperative:
+  running extension code pushes an id set or `match` predicate via
+  `resources.setFilter`. Filters declared _statically in the manifest_ and
+  evaluated by the host on every resource fetch are out of scope for this
+  version.
+- **Host-into-runtime calls (`callRuntime`).** Background runtimes drive the
+  host — they call host methods and react to host events; the host does not
+  call into a runtime. The reverse call direction is out of scope for this
+  version.

--- a/docs/develop/rest-api/proposed/plotter-extensions-api.md
+++ b/docs/develop/rest-api/proposed/plotter-extensions-api.md
@@ -27,9 +27,9 @@ the existing Signal K plugin/app-store flow.
 > implemented by the reference host (Freeboard-SK) and the reference
 > extensions (`signalk-instrument-widgets`, `signalk-poi-search`): widgets,
 > panels, toolbar buttons, state storage, Signal K data relay, unit
-> preferences, resource display filters, map control and headless
-> background runtimes. Manifest-declared filter chains and host-into-runtime
-> calls are out of scope for this version (see Non-Goals).
+> preferences, resource display filters, map control, live route editing
+> and headless background runtimes. Manifest-declared filter chains and
+> host-into-runtime calls are out of scope for this version (see Non-Goals).
 
 ---
 
@@ -121,6 +121,7 @@ extension id (the providing plugin's id is the recommended key):
 | `map`               | Host implements the `map.*` methods (view query and control).                                                                     |
 | `resources`         | Host implements `resources.list` (relayed resource queries).                                                                      |
 | `resources.filter`  | Host implements imperative resource display filters.                                                                              |
+| `routes`            | Host implements live route edit-buffer commands (`route.*`) and emits route lifecycle/mutation events.                            |
 | `ui`                | Host implements `ui.openPanel` / `ui.closePanel`.                                                                                 |
 
 The vocabulary is open-ended: future versions add ids (buttons, resource
@@ -235,8 +236,8 @@ are for.
 A runtime speaks the same bus protocol as widgets and panels; its handshake
 `context.kind` is `background`. It may call the host API — `state.*`
 (extension scope by default, as it has no widget instance), `signalk.*`,
-`resources.*` including `resources.setFilter`, `units.get`, `map.*`, and
-`ui.openPanel`/`ui.togglePanel`. It has no `ui.closePanel` or
+`resources.*` including `resources.setFilter`, `route.*`, `units.get`,
+`map.*`, and `ui.openPanel`/`ui.togglePanel`. It has no `ui.closePanel` or
 `ui.*ConfigPanel` (those are panel/widget affordances). The typical use is a
 client-side service that holds session state and keeps work alive so a panel
 can **close itself** (`ui.closePanel`) without losing that state, then
@@ -352,6 +353,7 @@ inside a routing envelope over `postMessage`**:
     "map",
     "resources",
     "resources.filter",
+    "routes",
     "background.iframe",
     "ui"
   ],
@@ -392,6 +394,14 @@ contract** — any conforming implementation interoperates.
 | `resources.list`        | `{ type, query? }`                             | resource collection        |
 | `resources.setFilter`   | `{ type, filter }`                             | `{}`                       |
 | `resources.clearFilter` | `{ type }`                                     | `{}`                       |
+| `route.list`            | —                                              | `{ routes }` (the visible set) |
+| `route.create`          | `{ points (≥2), name?, description? }`         | `{ routeId, rev }`         |
+| `route.show`            | `{ ref }` (stored route reference)             | `{ routeId, rev }`         |
+| `route.hide`            | `{ routeId }`                                  | `{}`                       |
+| `route.delete`          | `{ routeId }`                                  | `{}`                       |
+| `route.get`             | `{ routeId }`                                  | `{ routeId, name, description, rev, saved, dirty, points }` |
+| `route.replace`         | `{ routeId, points (≥2) }`                     | `{ rev }`                  |
+| `route.save`            | `{ routeId, name?, description?, dialog? }`    | `{ href, rev }`            |
 | `map.getView`           | —                                              | `{ center, zoom, bounds }` |
 | `map.center`            | `{ position: [lon, lat], zoom? }`              | `{}`                       |
 | `map.fitBounds`         | `{ bounds: [minLon, minLat, maxLon, maxLat] }` | `{}`                       |
@@ -408,7 +418,8 @@ they are not host-specific. Each is delivered only to contexts that have
 subscribed to its name via `events.subscribe` (so a context that never
 subscribes pays nothing). A host emits an event when the corresponding
 capability is supported: `state.changed` always; `sk.<path>` with
-`signalk.stream`; `filters.changed` with `resources.filter`. The
+`signalk.stream`; `filters.changed` with `resources.filter`; route events
+(`route.*`) with `routes`. The
 connection-level notifications `bus.ready` and `bus.handshake` (see
 Communication) are the only other host/extension events and are
 handled by the protocol layer, not subscribed to.
@@ -423,6 +434,25 @@ handled by the protocol layer, not subscribed to.
   a resource type was set (`active: true`) or cleared (`active: false`, e.g.
   the user dismissed the host's filter chip). Extensions should reflect a
   clear in their own UI/state.
+- `route.visible` — `{ routeId, rev, name, pointCount, saved, dirty }`: a route
+  entered the visible set (became rendered on the chart). A freshly drawn or
+  `route.create`d draft arrives `saved:false, dirty:true`; a stored route brought
+  into view (`route.show`, or the user displaying it) arrives `saved:true,
+  dirty:false`.
+- `route.dirty` — `{ routeId, rev, reason? }`: content changed — a reorder,
+  multi-point edit, metadata change, or whole-geometry replace. Sets
+  `dirty:true`; leaves `saved` unchanged. A subscriber should re-seed with
+  `route.get`. This is the conformance floor — see *Live routes*.
+- `route.saved` — `{ routeId, rev, href, name, saved, dirty }`: the route's
+  current state was persisted to the `routes` resource collection; arrives
+  `saved:true, dirty:false`. `href` is the stored resource id, and `name` is the
+  persisted name (which the host's save dialog may have just set — e.g. an
+  unnamed draft saved as "rt1"), so a follower can relabel without re-fetching.
+  The route stays visible and addressable under the same `routeId`.
+- `route.hidden` — `{ routeId, rev, saved }`: a route left the visible set.
+  `saved:true` — a stored route was made invisible (the resource is untouched and
+  can be shown again); `saved:false` — an unsaved draft was deleted (gone for
+  good). The umbrella name never overstates what happened.
 
 ### Resource queries and display filters
 
@@ -480,6 +510,130 @@ exists`. `contains` is case-insensitive substring for strings, membership
 The host tracks at most one filter per (extension, resource type); a new
 `setFilter` replaces it. Filters from multiple extensions compose by
 intersection. Filters are not persisted across host reloads.
+
+### Live routes
+
+The `routes` capability gives an extension read/write access to the routes the
+host currently has **visible on the chart**, plus a stream of lifecycle and
+mutation events. The visible set is small and practical — the one or two routes a
+user is actually working with — never the hundreds that may be stored on the
+server.
+
+**The visible set.** A host renders some routes on the chart: routes the user is
+drawing or modifying, routes an extension created, and stored routes the user has
+chosen to display. Every route in that set is addressable. Routes that exist only
+on the server (the stored catalog) are **not** — an extension that wants one
+browses the server's resources API directly (`GET /resources/routes` returns the
+whole catalog with full geometry) and asks the host to display it (`route.show`).
+
+**Addressing — opaque handles.** Each visible route has a host-assigned `routeId`
+that is **opaque**: the extension treats it as a token and never parses it. The
+host mints and decodes it (it may encode a stored resource id, an ephemeral draft
+id, or anything else — that is implementation, kept behind the handle). A
+`routeId` is stable for as long as the route stays visible. Every command and
+event names its `routeId`. `route.list` enumerates the visible set; a host that
+only ever shows one route at a time simply exposes one entry.
+
+**Two flags: `saved` and `dirty`.** Orthogonal, and both appear on `route.get`,
+`route.list`, and the lifecycle events:
+
+- `saved` — is the route backed by a persisted `routes` resource? A never-saved
+  draft is `false`; a stored route is `true`.
+- `dirty` — does the in-memory geometry differ from what is persisted (pending
+  unsaved changes)? A clean route is `false`; an edited one is `true`.
+
+  | `saved` | `dirty` | state |
+  | ------- | ------- | ----- |
+  | `false` | `true`  | a draft with content — needs saving to persist |
+  | `true`  | `false` | a clean stored route — matches the server |
+  | `true`  | `true`  | a stored route with unsaved edits |
+
+**Editing stages; it does not write through.** Manipulating a visible route —
+`route.replace`, or the user's own native editing — changes the in-memory route
+and emits `route.dirty` (setting `dirty:true`); it does **not** touch the server,
+and it leaves `saved` unchanged. The change is committed only by `route.save`, or
+discarded by the host's editing UI / `route.hide` (for a draft). This mirrors how
+a native editor already works — manipulate, then save or discard — and applies
+uniformly to drafts and stored routes.
+
+**Bringing routes in and out of view.** The function calls are deliberately the
+traditional **create / show / hide / delete**; the visibility/`saved`/`dirty`
+model lives in the *events* and route properties, not in the verbs.
+
+- `route.create({ points, name?, description? })` adds a new unsaved route to the
+  visible set (`saved:false`). `points` is **required and must hold at least two
+  waypoints** (a route needs a segment); fewer is rejected with
+  `routes.badRequest`. `description` is the route-level description (distinct from
+  a waypoint's per-point `description`) and round-trips through `route.get` and
+  `route.save`.
+- `route.show({ ref })` brings an existing **stored** route into the visible set
+  and returns its `routeId`, so the extension can read and edit it in place.
+- `route.hide({ routeId })` removes a route from the map. For a **stored** route
+  this just unchecks its visibility — the resource is untouched
+  (`route.hidden saved:true`). For an **unsaved** route it deletes it, since the
+  only store it has is the visibility buffer (`route.hidden saved:false`).
+- `route.delete({ routeId })` **permanently deletes a stored route** from the
+  resource collection. Deleting an *unsaved* route has the same effect as hiding
+  it (the draft is discarded). Either way the route leaves the visible set as
+  `route.hidden saved:false` (gone — no longer retrievable).
+
+So `hide` and `delete` both emit `route.hidden`; the event's `saved` flag tells a
+follower the outcome (`true` = still on the server, `false` = gone), while the
+*verb the extension called* carries the intent.
+
+**Points and geometry.** A route's points are an ordered list (0-based). A point
+is `{ position: [lon, lat, alt?], name?, description? }` — `name`/`description`
+map to a host's per-point metadata and round-trip through `route.get`,
+`route.replace`, and `route.save`. `route.create` and `route.replace` require at
+least two points and reject a malformed point (a non-numeric `position`, or
+non-string `name`/`description`) with `routes.badRequest`.
+
+**Revisions and mirroring.** Each route carries a monotonic `rev` that
+increments on every mutation. `route.get` and `route.list` report the current
+`rev`, and every mutation event and every mutating command result carries the
+post-change `rev`. In v1 the mutation signal is **`route.dirty`**: an extension
+mirrors a route by calling `route.get` whenever it sees `route.dirty` (or a `rev`
+gap). The protocol still offers a full snapshot (`route.get`) so the author never
+has to reconstruct state from a partial stream.
+
+**`route.dirty` is the conformance floor.** Every change to a visible route's
+content — a multi-point edit, a whole-geometry `route.replace` (e.g. an
+auto-router's), a metadata change, or the reference host's `Modify` flow (which
+hands back a whole coordinate array with no "which vertex moved") — emits
+`route.dirty`. A host emits `route.visible`, `route.hidden`, `route.saved`, and
+`route.dirty` — geometry is always edited as a whole (`route.replace` or the
+host's own native editing), so a single "on `route.dirty`, `route.get`" keeps a
+follower in sync without tracking who changed what.
+
+**Origin transparency.** Events are emitted for _every_ change regardless of
+origin — an extension command, the user's native editing, or another
+extension — so a follower stays consistent no matter who is driving. As with
+all host events, a context receives them only after `events.subscribe` (e.g.
+`{ patterns: ["route.**"] }`).
+
+**Saving.** `route.save` persists the route's current state to the `routes`
+resource collection through the user's authenticated session, returning the
+stored resource `href` and emitting `route.saved` (`saved:true, dirty:false`).
+The route **stays visible and addressable under the same `routeId`** — saving
+does not remove or invalidate it. For a never-saved draft this creates a new
+resource; for an already-stored route with pending edits it updates that
+resource. It is **headless by default** — saved with the supplied
+`name`/`description`, falling back to the route's current name. Pass
+`dialog: true` to have the host prompt for the name/description instead, its
+dialog prefilled from those params; the reference host (Freeboard-SK) opens its
+Route Details dialog, and a cancelled dialog rejects with `routes.saveCancelled`.
+
+Note the `routeId` is the host's **opaque handle**, distinct from the `href` of
+the saved resource (an `/resources/routes/<id>` reference returned by the save) —
+they are not interchangeable, and a saved route keeps the same `routeId` it had
+before the save.
+
+**Errors** use the standard `error.data.reason` convention: `routes.unknownId`
+(no such `routeId`), `routes.badRequest` (invalid params — e.g. `route.create`
+with fewer than two points, a non-numeric `position`, or non-string metadata),
+`routes.badRef` (`route.show` reference not found), `routes.saveFailed` (server
+rejected the persist — distinct from a user cancel), `routes.saveCancelled` (the
+user dismissed the save dialog), `routes.notSupported` (host lacks `routes`).
 
 ### State storage
 
@@ -593,7 +747,10 @@ adversarial boundary**:
   shared unit-aware configuration panel — and
   [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
   toolbar button + keepAlive search panel + results widget exercising
-  resource queries, display filters and map control.
+  resource queries, display filters and map control — and
+  `signalk-auto-route` *(planned)* — a toolbar button + parameter panel +
+  server-side routing engine exercising the `routes` capability (land-avoidance
+  auto-routing over the host's live route buffer; see its own SPEC).
 - **Host**: Freeboard-SK (feature branch, in development) — anchor-area
   widget overlay, placement UI, state storage, multiplexed Signal K relay,
   toolbar buttons, panel drawer, filter chips, map control.


### PR DESCRIPTION
## What & why

Chartplotter web apps (Freeboard-SK and others) cannot be extended with plugin-specific UI without forking the application, which fragments the ecosystem. This proposes a host-agnostic **Plotter Extensions API**: a `plotterExtensions` resource type through which any server plugin can offer optional widgets, panels, toolbar buttons, resource filters and background runtimes to chartplotter applications. Contributions are discovered at runtime from the resource provider and run sandboxed in iframes over a small JSON-RPC-over-postMessage bus, so no chartplotter needs to know about any specific plugin.

## This PR

Docs only — adds the draft specification under `docs/develop/rest-api/proposed/` and registers it in the proposed-API index. No code or version changes.

## Reference implementations

- Bus protocol: [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
- Reference host: Freeboard-SK (host PR forthcoming)
- Reference extensions: [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets), [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search)

Opening as a draft for early feedback on the approach before the host PR lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds documentation-only, host-agnostic specifications for a proposed Plotter Extensions API. The specification enables chartplotter server plugins to expose optional UI components—widgets, panels, toolbar buttons, resource filters, and background runtimes—to chartplotter web apps without requiring host-specific UI integration.

## Changes

- **`docs/develop/rest-api/proposed/README.md`**
  - Adds a “Plotter Extensions” navigation entry and extends the Proposed APIs table with a “Plotter Extensions” row that maps server plugin contributions (widgets, panels, buttons, and resource filters) to the `resources/plotterExtensions` endpoint.

- **`docs/develop/rest-api/proposed/plotter-extensions-api.md` (new)**
  - Introduces the **Plotter Extensions API** (`apiVersion` 1) and defines a new `plotterExtensions` resource type, including runtime host discovery via `/signalk/v2/api/resources/plotterExtensions`.
  - Defines the extension manifest schema, capability negotiation (`requires`/`optional`), and contribution sections for widgets, panels, background runtimes, and toolbar buttons.
  - Specifies widget placement/layout rules (host-defined 2x2 grid areas plus user-controlled cell placement), per-placement instance IDs passed via handshake context, and configuration panel behavior (including `ui.openConfigPanel`/`ui.toggleConfigPanel`) and removal affordances.
  - Specifies background runtime behavior as headless iframe contexts gated by `background.iframe`, including allowed host API access and topic-driven triggering using `events.subscribe`, plus button publishing semantics.
  - Defines toolbar button JSON shapes (`togglePanel`, `openPanel`, `sendMessage`) and semantics including subscription-gated forwarding and topic-namespacing conventions.
  - Documents interop as **JSON-RPC 2.0 over `postMessage`** using a `plotterExt/1` routing envelope (`calls` with request IDs and `events` as notifications), including readiness/handshake (`bus.ready` → `bus.handshake`) and call vs event semantics with subscription-gated forwarding of host-delivered events.
  - Specifies the **Host API (v1)** method set and host event contracts, including `events.subscribe`/`unsubscribe`, `state.get`/`set`, `signalk.subscribe`/`unsubscribe`/`put`, `units.get`, `resources.list` plus `resources.setFilter`/`clearFilter`, and related map/panel controls, along with host-emitted events such as `state.changed`, `sk.<path>`, `filters.changed`, and `bus.*`.
  - Documents filter operator semantics, storage-scope behavior for `state.*` (instance vs extension), and unit preference vocabulary/behavior.
  - Describes how plugins register extensions via read-only `plotterExtensions` resource registration and how they serve publicly readable (non-admin-gated) asset routes.
  - Covers App Store recommendation metadata for inter-plugin relationships.
  - States security/trust assumptions (iframe sandbox fault containment) and explicit non-goals (for example, manifest-declared filter chains and host→runtime `callRuntime`).
  - References separate implementation repositories: `signalk-plotterext-bus`, `signalk-instrument-widgets`, and `signalk-poi-search` (with a Freeboard-SK host reference noted as forthcoming).

- **`docs/develop/plugins/README.md`**
  - Adds `plotter_extension_provider_plugins.md` to the sidebar under the Plugins documentation section.

- **`docs/develop/plugins/plotter_extension_provider_plugins.md` (new)**
  - Documents **Plotter Extension Provider plugins** and clarifies host vs plugin responsibilities, including iframe-based guest integration, publish/subscribe bus usage, optional headless background runtimes, and the `plotterExtensions` resource.
  - Specifies minimal provider/manifest requirements and the host-side responsibilities to:
    - register the plugin manifest as a single **read-only** `plotterExtensions` resource (with defined `listResources`/`getResource` behavior and rejection of `setResource`/`deleteResource`), and
    - serve plugin iframe UI assets from an Express static route mounted under a namespaced public base URL referenced by manifest URLs (avoiding `/plugins/*` and omitting `signalk-webapp` auto-mount behavior).
  - Documents the client-side iframe integration model using `signalk-plotterext-bus/extension`, including example widget variants, config-panel behavior, a panel that performs resource queries and drives filters/map, and background runtime concepts.
  - Lists reference implementations and shows how to declare companion-plugin relationships via App Store `signalk.recommends`.

## Scope

This PR remains documentation-only: it introduces no runtime code, no version updates, and no changes to the main server behavior, and it targets early feedback before host implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->