### PR TITLE
fix(backpressure): keep accumulating while backpressure is active

### DIFF
--- a/src/BackpressureManager.ts
+++ b/src/BackpressureManager.ts
@@ -79,7 +79,7 @@ export class BackpressureManager {
 
   send(delta: Delta): void {
     const bufferLength = this.transport.getBufferLength()
-    if (bufferLength > this.options.enterThreshold) {
+    if (this.active || bufferLength > this.options.enterThreshold) {
       if (!this.active) {
         this.active = true
         this.since = Date.now()

--- a/test/BackpressureManager.ts
+++ b/test/BackpressureManager.ts
@@ -104,6 +104,25 @@ describe('BackpressureManager', function () {
       expect(manager.accumulatorSize).to.equal(1)
     })
 
+    it('should keep accumulating while active even after buffer drops below enter threshold', function () {
+      const transport = createMockTransport(2000)
+      const manager = new BackpressureManager(transport, defaultOptions)
+
+      // Enter backpressure: first delta is accumulated, not written.
+      manager.send(createDelta('navigation.speedOverGround', 5.0))
+      expect(manager.isActive).to.be.true
+
+      // Buffer drains below enterThreshold but stays above exitThreshold, so
+      // we are still in backpressure and the accumulated delta is pending.
+      transport._bufferLength = 500
+      manager.send(createDelta('navigation.courseOverGroundTrue', 1.57))
+
+      // The newer delta must not be written ahead of the pending accumulated
+      // one - it has to keep accumulating until the next flush.
+      expect(transport._writes.length).to.equal(0)
+      expect(manager.accumulatorSize).to.equal(2)
+    })
+
     it('should keep only latest value per context:path:source', function () {
       const transport = createMockTransport(2000)
       const manager = new BackpressureManager(transport, defaultOptions)


### PR DESCRIPTION
`send()` chose accumulate-vs-write from the buffer length alone. Once backpressure was active, a delta arriving while the buffer sat between the exit and enter thresholds (drain hadn't flushed yet) took the direct-write path and got sent ahead of the older deltas still waiting in the accumulator — out-of-order delivery, exactly as flagged in #2531 after the refactor in #2472.

Fix gates accumulation on the `active` flag too, so deltas keep accumulating until `flush()` completes on drain. Added a regression test covering the buffer-drops-below-enter-while-active window.

closes #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request fixes a backpressure ordering bug in WebSocket/TCP delta delivery. When backpressure is active and the transport buffer drops below the enter threshold but remains above the exit threshold, newly arriving deltas now continue to accumulate rather than being sent directly, preventing out-of-order delivery.

## Changes

### BackpressureManager.ts
The `send()` method updates its accumulation condition from checking only buffer size to also gating on the backpressure active flag. Deltas now accumulate when either `this.active` is true OR the buffer length exceeds the enter threshold, ensuring accumulated deltas are flushed on drain before any newer deltas bypass the accumulator.

### Test Coverage
A new regression test validates the fix by verifying that once backpressure becomes active, the manager continues accumulating deltas even when the transport buffer drops below the enter threshold (but remains above the exit threshold), with no direct writes occurring during this continued accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->