### PR TITLE
fix(nmea-tcp): remove event listeners on stop

### DIFF
--- a/src/interfaces/nmea-tcp.ts
+++ b/src/interfaces/nmea-tcp.ts
@@ -38,6 +38,7 @@ interface NmeaTcpApp extends SignalKServer {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   emit(event: string, ...args: any[]): boolean
   on(event: string, listener: (...args: string[]) => void): this
+  removeListener(event: string, listener: (...args: string[]) => void): this
 }
 
 module.exports = (app: NmeaTcpApp) => {
@@ -46,6 +47,7 @@ module.exports = (app: NmeaTcpApp) => {
   const bufferExceededSince: Record<number, number | undefined> = {}
   let idSequence = 0
   let server: Server | null = null
+  let sendListener: ((data: string) => void) | null = null
   const port = Number(process.env.NMEA0183PORT) || 10110
   const api = new Interface()
 
@@ -108,6 +110,7 @@ module.exports = (app: NmeaTcpApp) => {
         }
       })
     }
+    sendListener = send
     app.signalk.on('nmea0183', send)
     app.on('nmea0183out', send)
     server.on('listening', () =>
@@ -120,6 +123,11 @@ module.exports = (app: NmeaTcpApp) => {
   }
 
   api.stop = () => {
+    if (sendListener) {
+      app.signalk.removeListener('nmea0183', sendListener)
+      app.removeListener('nmea0183out', sendListener)
+      sendListener = null
+    }
     if (server) {
       server.close()
       server = null

--- a/src/interfaces/nmea-tcp.ts
+++ b/src/interfaces/nmea-tcp.ts
@@ -73,7 +73,7 @@ module.exports = (app: NmeaTcpApp) => {
         delete bufferExceededSince[socket.id!]
       })
     })
-    const send = (data: string) => {
+    sendListener = (data: string) => {
       Object.values(openSockets).forEach((socket) => {
         try {
           if (socket.writableLength > BUFFER_LIMIT) {
@@ -110,9 +110,8 @@ module.exports = (app: NmeaTcpApp) => {
         }
       })
     }
-    sendListener = send
-    app.signalk.on('nmea0183', send)
-    app.on('nmea0183out', send)
+    app.signalk.on('nmea0183', sendListener)
+    app.on('nmea0183out', sendListener)
     server.on('listening', () =>
       debug('NMEA0183 tcp server listening on ' + port)
     )

--- a/test/nmea-tcp-listeners.ts
+++ b/test/nmea-tcp-listeners.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'events'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const nmeaTcpInterface = require('../dist/interfaces/nmea-tcp.js')
+
+describe('NMEA0183 TCP interface listener lifecycle', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function createInterface(port: number): { app: any; api: any } {
+    process.env.NMEA0183PORT = String(port)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app: any = new EventEmitter()
+    app.signalk = new EventEmitter()
+    return { app, api: nmeaTcpInterface(app) }
+  }
+
+  it('removes its event listeners on stop', () => {
+    const { app, api } = createInterface(18753)
+    api.start()
+    expect(app.signalk.listenerCount('nmea0183')).to.equal(1)
+    expect(app.listenerCount('nmea0183out')).to.equal(1)
+
+    api.stop()
+    expect(app.signalk.listenerCount('nmea0183')).to.equal(0)
+    expect(app.listenerCount('nmea0183out')).to.equal(0)
+  })
+
+  it('does not accumulate duplicate listeners across restarts', () => {
+    const { app, api } = createInterface(18754)
+    api.start()
+    api.stop()
+    api.start()
+
+    // A restart must leave exactly one listener per event; otherwise each
+    // NMEA sentence would be broadcast to every connected client twice.
+    expect(app.signalk.listenerCount('nmea0183')).to.equal(1)
+    expect(app.listenerCount('nmea0183out')).to.equal(1)
+
+    api.stop()
+  })
+})


### PR DESCRIPTION
Follow-up to the #2532 review. The `send` listener registered on `app.signalk` (`nmea0183`) and `app` (`nmea0183out`) in `start()` was never removed in `stop()`, so restarting the interface left stale listeners attached and each NMEA sentence got broadcast to clients once per restart.

Hoists the listener reference into the interface closure and detaches it in `stop()`.

## Test plan
- [x] Added `test/nmea-tcp-listeners.ts` (listener removal on stop, no accumulation across restart)
- [x] `npm run build` passes
- [x] `npm test` server suite passes
- [x] `npm run format` — no changes

closes #2533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes stale event listener accumulation in the NMEA-TCP interface that causes duplicate NMEA sentence broadcasts after server restarts. It ensures the listeners registered in `start()` are removed when the interface stops.

## Changes

### `src/interfaces/nmea-tcp.ts`

- Extends the `NmeaTcpApp` type with a `removeListener(event, listener)` method so the interface can detach handlers.
- Tracks the registered outbound handler in a shared `sendListener` reference.
- Registers `sendListener` for:
  - `app.signalk` event `nmea0183`
  - `app` event `nmea0183out`
- Detaches the same `sendListener` from both emitters during `api.stop()`, then clears the reference to prevent reuse across restarts.

### `test/nmea-tcp-listeners.ts`

- Adds tests that verify listener cleanup and prevent accumulation:
  - **removes its event listeners on stop**: confirms listener counts for `nmea0183` and `nmea0183out` drop to zero after `api.stop()`.
  - **does not accumulate duplicate listeners across restarts**: confirms restarting the interface keeps listener counts at exactly one per event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->