### PR TITLE
ci(plugin-ci): run es-check in module mode for ESM plugins

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1275,8 +1275,17 @@ jobs:
             exit 0
           fi
 
+          # ESM packages need es-check in module mode; otherwise top-level
+          # import/export parse as a script and falsely report ES2024+ syntax.
+          # es-check does not infer this from package.json "type", so pass it.
+          MODULE_FLAG=""
+          if [ "$(node -p "require('./package.json').type === 'module' ? 'y' : 'n'" 2>/dev/null)" = "y" ]; then
+            MODULE_FLAG="--module"
+            echo "Detected ESM package (type: module) — running es-check in module mode."
+          fi
+
           echo "Checking ES2023 compatibility: $FILES"
-          if ! npx --yes es-check@8 es2023 $FILES 2>&1; then
+          if ! npx --yes es-check@8 es2023 $MODULE_FLAG $FILES 2>&1; then
             echo ""
             echo "::warning::Plugin uses ES2024+ syntax not supported by Node 20 (Cerbo GX / Venus OS). Consider targeting ES2023 in your TypeScript/build config or tsconfig.json to maintain Cerbo GX compatibility."
           fi


### PR DESCRIPTION
The ES2023 (Cerbo GX / Node 20) compatibility step runs `es-check@8 es2023`, which defaults to a **script** sourceType. So an ESM plugin (`package.json` `"type": "module"`) has its top-level `import`/`export` parsed as a script and falsely reported as ES2024+ — firing the "not supported by Node 20" warning even when the plugin is otherwise ES2023-clean and only uses ES2015 module syntax. es-check does not infer module mode from `package.json` `"type"`.

Fix: pass `--module` to es-check when the package is `"type": "module"`. CJS plugins are unaffected.

Verified on an ESM plugin:
- `es-check es2023 index.js` → parse error (script mode)
- `es-check es2023 --module index.js` → `no ES version matching errors! 🎉`

Repro of the false positive: https://github.com/sailingnaturali/signalk-depth-offsets/actions/runs/27514148370 (armv7 job)

Workflow-only change — one step in `.github/workflows/plugin-ci.yml`.

cc @dirkwa — per the plugin-CI discussion; thanks for offering to take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a false positive ES2023 compatibility check in the plugin CI workflow for ESM (ECMAScript module) plugins. The issue occurs because `es-check@8` defaults to script mode and does not infer module mode from `package.json` `"type": "module"`, so top-level `import`/`export` is parsed as script syntax and incorrectly triggers ES2024+ feature reports (including the “not supported by Node 20” warning) even when the plugin stays ES2023-compliant.

## Changes

The workflow updates `.github/workflows/plugin-ci.yml` to detect whether the plugin package declares `"type": "module"`. When it does, the workflow passes `--module` to the `npx es-check` invocation for the ES2023 check; CommonJS plugins remain unaffected. This makes ESM plugins parse correctly during the compatibility check without changing plugin behavior or any other CI steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->