### PR TITLE
ci(plugin-ci): fix Node 22 App Store install check (read npm pack name from --json)

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1291,7 +1291,11 @@ jobs:
           # This means native addons (better-sqlite3, serialport, etc.) are NOT compiled.
           # This test catches plugins that will break when installed via the App Store.
           echo "Simulating SignalK App Store install (npm install --ignore-scripts)..."
-          PLUGIN_TGZ=$(npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP")
+          # Read the tarball name from --json: a plugin "prepare" script (e.g. tsc)
+          # prints a lifecycle banner to stdout that would pollute a bare
+          # $(npm pack) capture (npm < 11 runs prepare here despite --ignore-scripts).
+          PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" \
+            | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -1675,9 +1679,11 @@ jobs:
 
       - name: Install plugin into SignalK
         run: |
-          # Pack the plugin and install it into the test server. Use basename
-          # defensively: some npm versions emit a path-prefixed tarball name.
-          PLUGIN_TGZ=$(npm pack --ignore-scripts --pack-destination /tmp)
+          # Pack the plugin and install it into the test server. Read the tarball
+          # name from --json so a plugin "prepare" lifecycle banner on stdout can't
+          # corrupt it (npm < 11 runs prepare here despite --ignore-scripts).
+          PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination /tmp \
+            | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
           cd /tmp/sk-test
           npm install "/tmp/$(basename "$PLUGIN_TGZ")"
 


### PR DESCRIPTION
The `Simulate App Store install` and `Install plugin into SignalK` steps fail on the Node 22 matrix legs for any TypeScript plugin with a `prepare: tsc` build step.

**Why:** they capture the tarball via `PLUGIN_TGZ=$(npm pack …)`, assuming stdout is just the filename. A `prepare` script prints a lifecycle banner (`> pkg prepare` / `> tsc`) to stdout, polluting the capture, so the following `npm install` resolves a bad path and exits 254. On npm ≥ 11 (Node 24) `--ignore-scripts` suppresses the pack-time `prepare`, so only the Node 22 legs fail (there `prepare` runs despite `--ignore-scripts`).

**How:** read the filename from `npm pack --json` and tolerate a leading banner — the same robust approach the `Verify npm pack includes all required files` step already uses (no behavior change on Node 24).

fixes #2777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a CI failure in the SignalK Plugin CI workflow on Node 22 when testing TypeScript plugins that define a `prepare` build script. The workflow updates how it captures the npm-packed tarball filename so lifecycle banners printed to stdout no longer corrupt the value used by subsequent `npm install` commands.

## Changes made

In `.github/workflows/plugin-ci.yml`, the PR updates two steps to extract the tarball filename via structured `npm pack` JSON output:

1. **“Simulate App Store install (--ignore-scripts)”** (around line 1290)
   - Replaces `PLUGIN_TGZ=$(npm pack ...)` with `PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" | node -e '...')`.
   - Parses the `npm pack --json` output with `JSON.parse(...)` and a line-start anchor (`s.search(/^\s*\[/m)`) to find the JSON array reliably even if npm lifecycle banner text appears before it.
   - Installs the resulting tarball using `npm install --ignore-scripts "$RUNNER_TEMP/$(basename "$PLUGIN_TGZ")"`.

2. **“Install plugin into SignalK”** (around line 1680)
   - Applies the same `npm pack --ignore-scripts --json --pack-destination /tmp` + Node JSON parsing approach to set `PLUGIN_TGZ` safely.
   - Installs using `npm install "/tmp/$(basename "$PLUGIN_TGZ")"`.

## Why this fixes the issue

When npm < 11 (including npm 10 on Node 22) executes `prepare`, npm prints lifecycle banner output to stdout even with `--ignore-scripts`, which breaks the previous brittle `PLUGIN_TGZ=$(npm pack ...)` capture logic. By reading the filename from `npm pack --json` and using the anchored JSON extraction, the workflow becomes npm-version-agnostic and avoids path/ENOENT failures triggered by polluted stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->