### PR TITLE
fix(appstore): relax Happy Eyeballs connect timeout so the app store works on slow links

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "swagger-ui-express": "^4.5.0",
     "unified": "^11.0.5",
     "unzipper": "^0.12.3",
+    "undici": "^7.24.7",
     "uuid": "^8.1.0",
     "ws": "^8.17.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
 */
 
+import './networkConfig'
 import './baconjs-compat'
 import {
   Context,

--- a/src/networkConfig.ts
+++ b/src/networkConfig.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Signal K contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Agent, setGlobalDispatcher } from 'undici'
+
+// Node >= 20 enables Happy Eyeballs (autoSelectFamily) for outgoing
+// connections and caps each per-address connect attempt at 250 ms. On
+// high-latency links (cellular/satellite at sea) the SYN round-trip to
+// app-store hosts (signalk.org, registry.npmjs.org, api.github.com, the
+// jsDelivr/unpkg CDNs) routinely exceeds 250 ms, so every attempt aborts
+// and the request fails instantly regardless of any AbortController
+// timeout above it. The symptom is an app store that is intermittently
+// "offline". Raising the per-attempt timeout keeps the IPv6->IPv4
+// fallback while giving slow links room to complete the handshake.
+const CONNECT_ATTEMPT_TIMEOUT_MS = 5000
+
+setGlobalDispatcher(
+  new Agent({
+    connect: {
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: CONNECT_ATTEMPT_TIMEOUT_MS
+    }
+  })
+)

--- a/src/networkConfig.ts
+++ b/src/networkConfig.ts
@@ -25,7 +25,13 @@ import { Agent, setGlobalDispatcher } from 'undici'
 // timeout above it. The symptom is an app store that is intermittently
 // "offline". Raising the per-attempt timeout keeps the IPv6->IPv4
 // fallback while giving slow links room to complete the handshake.
-const CONNECT_ATTEMPT_TIMEOUT_MS = 5000
+//
+// This budget is only spent when an address stalls and Node falls back to
+// the next one; a reachable address completes its handshake well inside it
+// and the timer never fires. 1000 ms covers a bad satellite SYN round-trip
+// while keeping the worst-case failure (every address of a down host) an
+// order of magnitude shorter than a larger value would.
+const CONNECT_ATTEMPT_TIMEOUT_MS = 1000
 
 setGlobalDispatcher(
   new Agent({

--- a/test/networkConfig.ts
+++ b/test/networkConfig.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai'
+import { getGlobalDispatcher, setGlobalDispatcher, Agent } from 'undici'
+
+// networkConfig sets a global undici dispatcher at import time so that
+// every fetch() in the server uses a relaxed Happy Eyeballs per-attempt
+// connect timeout. Loading the compiled module is the behaviour under
+// test: it must replace the global dispatcher with its own Agent.
+const modulePath = require.resolve('../dist/networkConfig.js')
+
+describe('networkConfig global dispatcher', () => {
+  it('installs a new global dispatcher on load', () => {
+    const sentinel = new Agent()
+    setGlobalDispatcher(sentinel)
+    delete require.cache[modulePath]
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../dist/networkConfig.js')
+
+    const installed = getGlobalDispatcher()
+    expect(installed).to.be.instanceOf(Agent)
+    expect(installed).to.not.equal(sentinel)
+  })
+})


### PR DESCRIPTION
## Why

On Node >= 20, Happy Eyeballs (`autoSelectFamily`) is on by default and caps each per-address connect attempt at 250 ms. The app store hosts all resolve to multiple addresses — `signalk.org` (GitHub Pages, 4 A records), `registry.npmjs.org`, `api.github.com`, and the jsDelivr/unpkg CDNs. On high-latency cellular/satellite links at sea the SYN round-trip exceeds 250 ms, so every connect attempt aborts and the request fails instantly, regardless of any `AbortController` timeout sitting above it. The user-visible symptom is an app store that is intermittently "offline".

This is the same root cause [nfl-signalk fixed in their plugin](https://github.com/noforeignland/nfl-signalk/pull/47). The server hits it too because it uses the built-in global `fetch` (undici) for both app store code paths.

## How

Install a global undici dispatcher at startup with `autoSelectFamilyAttemptTimeout` raised to 5000 ms. This preserves the IPv6→IPv4 fallback while giving slow links room to complete the handshake. Because Node's global `fetch` ignores a `node-fetch`-style `agent:` option, the dispatcher is the correct lever, and one dispatcher covers every `fetch()` in the server.

Users can already work around this with `NODE_OPTIONS=--network-family-autoselection-attempt-timeout=2000`; this makes the sensible default ship in the box.

## Tested

- `npm run build`, `npm run format`, `npm run ci-lint` pass
- New unit test asserts the global dispatcher is installed on load
- Runtime probe confirms the live global dispatcher carries `autoSelectFamilyAttemptTimeout: 5000`
- App store test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR addresses intermittent app store connectivity failures on high-latency networks (cellular, satellite) by installing a global **undici** HTTP dispatcher configured to tolerate slower TCP handshakes. On Node.js >= 20, Happy Eyeballs (`autoSelectFamily`) caps per-address connection attempts at ~250 ms, which can cause connections to abort before they complete on links where SYN round-trip time exceeds that threshold—leading the app store to appear intermittently offline.

## Changes

**Dependencies**
- Adds `undici` (^7.24.7) to enable global dispatcher configuration.

**Network configuration**
- Introduces `src/networkConfig.ts`, which sets a global undici dispatcher via `setGlobalDispatcher()` using an `Agent` with:
  - `autoSelectFamily: true`
  - `autoSelectFamilyAttemptTimeout` set to `CONNECT_ATTEMPT_TIMEOUT_MS` (**1000 ms**)
- Updates `src/index.ts` to import `./networkConfig` as a side-effect module so the dispatcher is installed during server startup.

**Testing**
- Adds `test/networkConfig.ts` to verify that loading the compiled `dist/networkConfig.js` installs a new global undici dispatcher (replacing a pre-seeded sentinel dispatcher) and that the installed dispatcher is an `Agent` instance.
- Ensures the server-side build/format/lint checks and the app store test suite pass, with runtime verification that the live global dispatcher uses the configured timeout.

## Impact

The global dispatcher configuration applies to all `fetch()` calls on the server without requiring changes at individual call sites, improving reliability of app store access on slow links while still enabling IPv6-to-IPv4 fallback through Happy Eyeballs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->