### PR TITLE
Fix core Docker image optional dependency reinstalls

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN case "$EDITION" in \
   && npm install "$server_tarball" --install-strategy=nested $npm_flags \
   && if [ "$EDITION" = core ]; then \
        serialport_spec=$(node -p "require('signalk-server/package.json').optionalDependencies.serialport") \
-       && npm install "serialport@$serialport_spec"; \
+       && npm install $npm_flags "serialport@$serialport_spec"; \
      fi \
   && if [ -d node_modules/@signalk ]; then \
        mkdir -p node_modules/signalk-server/node_modules/@signalk/ \

--- a/docker/Dockerfile_rel
+++ b/docker/Dockerfile_rel
@@ -42,7 +42,7 @@ RUN case "$EDITION" in \
   && if [ "$EDITION" = core ]; then \
        adminui_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@signalk/server-admin-ui']") \
        && serialport_spec=$(node -p "require('signalk-server/package.json').optionalDependencies.serialport") \
-       && npm install "@signalk/server-admin-ui@$adminui_spec" "serialport@$serialport_spec"; \
+       && npm install $npm_flags "@signalk/server-admin-ui@$adminui_spec" "serialport@$serialport_spec"; \
      fi \
   && mkdir -p node_modules/signalk-server/node_modules/@signalk/ \
   && cp -rf node_modules/@signalk/* node_modules/signalk-server/node_modules/@signalk/ \


### PR DESCRIPTION
## Summary

Fix the Docker `core` image build so follow-up installs keep omitting optional dependencies.

The core build first installs `signalk-server` with `--omit=optional`, but the later install used to add back `@signalk/server-admin-ui` and `serialport` without the same npm flags. That second install can rehydrate `signalk-server` optional dependencies, causing bundled webapps/plugins such as KIP and Freeboard to be included in `latest-core`.

This change reuses `$npm_flags` for those follow-up installs in both Dockerfiles.

Fixes #2782.

## Validation

Built a local release-style core image:

```sh
docker build -t signalk-core-omit-test:2.28.0 \
  -f docker/Dockerfile_rel \
  --build-arg BASE_IMAGE=24.04-24.x \
  --build-arg TAG=2.28.0 \
  --build-arg EDITION=core .
```

Confirmed bundled optional webapps/plugins are absent from the image:

```text
absent  @mxtommy/kip
absent  @signalk/freeboard-sk
absent  @signalk/instrumentpanel
absent  @signalk/app-dock
absent  @signalk/set-system-time
absent  @signalk/signalk-to-nmea0183
absent  @signalk/udp-nmea-plugin
absent  signalk-n2kais-to-nmea0183
absent  signalk-to-nmea2000
```

Confirmed required core packages remain present:

```text
nested present @signalk/server-admin-ui
top present serialport
nested present @signalk/server-api
nested present @signalk/streams
nested present @signalk/signalk-schema
nested present @signalk/course-provider
nested present @signalk/resources-provider
nested present @signalk/nmea0183-signalk
nested present @signalk/n2k-signalk
```

Smoke-tested the image by starting Signal K and checking that `/` redirects to `/admin/`.

Also deployed this image in a local `signalk-sandbox` compose setup and confirmed it starts while intentionally installed `.signalk` plugins still work from the persistent config volume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the Docker `core` image build to prevent optional dependencies from being reinstalled during subsequent npm install commands. The `core` image build initially installs `signalk-server` with the `--omit=optional` flag to exclude bundled webapps and plugins. However, follow-up commands that install `@signalk/server-admin-ui` and `serialport` were executed without the same npm flags, causing `signalk-server` optional dependencies to be rehydrated and included in the `latest-core` image, contrary to the documented behavior.

## Changes

The fix applies the `$npm_flags` variable (containing `--omit=optional`) to both follow-up install commands in both `docker/Dockerfile` and `docker/Dockerfile_rel`:

- **docker/Dockerfile**: Updates the `serialport` installation to use the conditional `$npm_flags` variable, ensuring optional dependencies remain omitted during the core build path.
- **docker/Dockerfile_rel**: Updates the core-edition installation step with proper line continuation for the conditional npm install of `@signalk/server-admin-ui` and `serialport`, consistently applying the `$npm_flags` variable.

## Impact

The changes ensure that bundled optional webapps and plugins (`@mxtommy/kip`, `@signalk/freeboard-sk`, `@signalk/instrumentpanel`, `@signalk/app-dock`, `@signalk/set-system-time`, `@signalk/signalk-to-nmea0183`, `@signalk/udp-nmea-plugin`, signalk-n2kais-to-nmea0183, and signalk-to-nmea2000) are absent from the built image, while required core packages (`@signalk/server-admin-ui`, serialport, `@signalk/server-api`, `@signalk/streams`, `@signalk/signalk-schema`, `@signalk/course-provider`, `@signalk/resources-provider`, `@signalk/nmea0183-signalk`, and `@signalk/n2k-signalk`) remain present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->