### PR TITLE
fix(admin-ui): evict stale priority-group source on remove 404

### DIFF
--- a/packages/server-admin-ui/src/utils/sourceLabels.test.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.test.ts
@@ -7,6 +7,7 @@ import {
   canonicaliseSourceRef,
   detectInstanceConflicts,
   isProprietaryPGN,
+  isRemoveSourceFailure,
   type SourcesData,
   type N2kDeviceEntry
 } from './sourceLabels'
@@ -782,5 +783,34 @@ describe('isProprietaryPGN', () => {
 
   it('rejects non-numeric input', () => {
     expect(isProprietaryPGN('not-a-number')).toBe(false)
+  })
+})
+
+describe('isRemoveSourceFailure', () => {
+  it('treats a 2xx response as success', () => {
+    expect(isRemoveSourceFailure(200, true, false)).toBe(false)
+    expect(isRemoveSourceFailure(200, true, true)).toBe(false)
+  })
+
+  it('treats a 404 on a missing-from-status ref as success', () => {
+    // The stale-saved-ref case: a device that re-registered under a new
+    // transport leaves an old ref in the saved group. The server 404s
+    // because that ref is genuinely gone — which is exactly the outcome
+    // the user wanted, so the optimistic removal must stick.
+    expect(isRemoveSourceFailure(404, false, true)).toBe(false)
+  })
+
+  it('treats a 404 on a still-tracked ref as a failure', () => {
+    // Not missing from status: a 404 here is unexpected, so revert.
+    expect(isRemoveSourceFailure(404, false, false)).toBe(true)
+  })
+
+  it('treats auth and server errors as failures regardless of status flag', () => {
+    expect(isRemoveSourceFailure(401, false, true)).toBe(true)
+    expect(isRemoveSourceFailure(403, false, true)).toBe(true)
+    expect(isRemoveSourceFailure(500, false, true)).toBe(true)
+    expect(isRemoveSourceFailure(401, false, false)).toBe(true)
+    expect(isRemoveSourceFailure(403, false, false)).toBe(true)
+    expect(isRemoveSourceFailure(500, false, false)).toBe(true)
   })
 })

--- a/packages/server-admin-ui/src/utils/sourceLabels.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.ts
@@ -446,3 +446,25 @@ export function detectInstanceConflicts(
 export function conflictKey(sourceRefA: string, sourceRefB: string): string {
   return [sourceRefA, sourceRefB].sort().join('+')
 }
+
+/**
+ * Classify a removeSource/n2kRemoveSource DELETE response so the trash flow
+ * knows whether to keep the optimistic removal or revert it.
+ *
+ * A 404 on a source the live status snapshot no longer reports
+ * (`isMissingFromStatus`) is the success case, not a failure: the server is
+ * confirming the source is already gone, so the saved-group ref is a stale
+ * leftover — a device that re-registered under a new transport (a renumbered
+ * ttyUSB port, a fresh canName). Keeping the removal lets the ref drop out of
+ * the group on Save; reverting would pin the zombie ref in place forever,
+ * since the DELETE can never succeed for a source the server doesn't have.
+ */
+export function isRemoveSourceFailure(
+  status: number,
+  ok: boolean,
+  isMissingFromStatus: boolean
+): boolean {
+  if (ok) return false
+  if (status === 404 && isMissingFromStatus) return false
+  return true
+}

--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -39,6 +39,7 @@ import {
   canonicaliseSourceRef,
   isN2kSource,
   isPluginSource,
+  isRemoveSourceFailure,
   type SourcesData
 } from '../../utils/sourceLabels'
 import { useSourceAliases } from '../../hooks/useSourceAliases'
@@ -488,7 +489,11 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
     setSelectedSource(null)
   }
 
-  const handleRemoveSource = (sourceRef: string, label: string) => {
+  const handleRemoveSource = (
+    sourceRef: string,
+    label: string,
+    isMissingFromStatus = false
+  ) => {
     const ok = window.confirm(
       `Remove ${label} from this priority group?\n\n` +
         'Any path-level overrides in this group that mention the source ' +
@@ -547,8 +552,13 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
         // user sees the row briefly disappear (optimistic local edit)
         // and then reappear on the next reconcile with no clue why.
         // Most common cause is a non-admin session: addAdminMiddleware
-        // rejects the DELETE with 401.
-        if (res.ok) return
+        // rejects the DELETE with 401. A 404 on a missing-from-status ref
+        // is the exception — the server confirming an already-gone source,
+        // which isRemoveSourceFailure treats as success so the stale ref
+        // can finally be evicted from the saved group.
+        if (!isRemoveSourceFailure(res.status, res.ok, isMissingFromStatus)) {
+          return
+        }
         const detail =
           res.status === 401 || res.status === 403
             ? 'admin permission required'
@@ -882,7 +892,11 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                                 onRemove={
                                   canRemove
                                     ? () =>
-                                        handleRemoveSource(src, displayLabel)
+                                        handleRemoveSource(
+                                          src,
+                                          displayLabel,
+                                          isMissingFromStatus
+                                        )
                                     : undefined
                                 }
                                 deviceDot={deviceDot}


### PR DESCRIPTION
## Motivation

On the Source Priorities page, removing a source could fail with `Could not remove <sourceRef>: server returned 404`, and the source would stay stuck in the group.

This happens when a device re-registers under a new transport — a renumbered `ttyUSB` port, a fresh canName. The device's old `sourceRef` lingers in the saved priority group, so the reconciled group still lists it and the UI offers a trash icon (the source is `isMissingFromStatus`). But the `removeSource` DELETE 404s because the source is genuinely gone, and the handler then reverted the optimistic removal — pinning the stale ref in the group permanently, since the DELETE can never succeed for a source the server no longer has.

## Solution

Treat a 404 on a missing-from-status ref as success rather than failure: the server is confirming the source is already gone, which is exactly the desired outcome. The optimistic removal sticks and the ref drops out of the group on Save. Auth (401/403) and other errors still revert and alert as before.

The decision is factored into a pure, unit-tested `isRemoveSourceFailure` helper.

## Tested

- `isRemoveSourceFailure` unit tests (success, missing-from-status 404, tracked-ref 404, auth/server errors)
- `vitest run` admin-ui suite passes (242 tests)
- `vite build` of the admin UI succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a 404 error that occurs when removing a source from a priority group after the device re-registers under a new transport (such as a renumbered `ttyUSB` port). The issue arises when a stale source reference remains in the saved priority group but no longer exists on the server.

## Problem
When a user attempts to delete a source marked as `isMissingFromStatus`, the DELETE request returns a 404 error (since the source no longer exists). The existing handler treats this as a failure and reverts the optimistic removal, permanently pinning the stale reference in the group. This creates an impossible scenario where the DELETE can never succeed for a source that is genuinely gone.

## Solution
The PR introduces a new `isRemoveSourceFailure` helper function that distinguishes between different 404 scenarios:

- **404 on a missing-from-status reference**: Treated as success (the server confirming an already-gone source)
- **404 on a still-tracked reference**: Treated as failure (unexpected 404)
- **2xx responses**: Always treated as success
- **Auth/server errors (401, 403, 500)**: Always treated as failure

## Changes

### `sourceLabels.ts`
Adds a pure, unit-tested `isRemoveSourceFailure(status: number, ok: boolean, isMissingFromStatus: boolean): boolean` utility function that encapsulates the failure-detection logic for source removal operations.

### `sourceLabels.test.ts`
Includes comprehensive test coverage for `isRemoveSourceFailure`, verifying success cases, missing-from-status 404s, tracked-ref 404s, and authentication/server error handling.

### `PriorityGroupCard.tsx`
Updates the `handleRemoveSource` function to accept an `isMissingFromStatus` flag and uses `isRemoveSourceFailure` to determine whether to revert the optimistic removal and display an error alert. Authentication errors and other unexpected failures continue to trigger alerts as before.

## Testing
The admin-ui test suite (242 tests) passes, and the build succeeds. The new logic allows stale references to be successfully dropped from priority groups when their 404 response indicates the source is genuinely gone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->