### PR TITLE
docs: link community AI-assisted plugin-authoring skills

### DIFF
--- a/docs/develop/plugins/README.md
+++ b/docs/develop/plugins/README.md
@@ -352,3 +352,14 @@ Following are links to some published SignalK plugins that serve as an example o
 
 - [set-system-time](https://github.com/SignalK/set-system-time/blob/master/index.js)
 - [Ais Reporter](https://github.com/SignalK/aisreporter/issues)
+
+---
+
+## AI-assisted plugin development
+
+If you develop with an AI coding assistant, these community-maintained [Claude Code](https://claude.com/claude-code) skill collections encode the conventions in this guide as on-demand prompts:
+
+- [sailingnaturali/claude-skills](https://github.com/sailingnaturali/claude-skills) — authoring a plugin (the `@signalk/server-api` patterns, resource-provider vs. Express router, deltas, the plugin scaffold), checking a plugin's [registry](https://signalk.org/signalk-plugin-registry/) score, and publishing to npm via OIDC trusted publishing.
+- [VesselSense/vesselsense-claude-plugins](https://github.com/VesselSense/vesselsense-claude-plugins) — configuring SignalK integrations: the KIP and WilhelmSK instrument dashboards, and SensESP sensor firmware.
+
+These are third-party resources maintained by the community, not part of Signal K itself.


### PR DESCRIPTION
Adds a short "AI-assisted plugin development" section to the plugin developer guide linking two community-maintained Claude Code skill collections that encode the conventions already documented here:

- **sailingnaturali/claude-skills** — authoring & publishing plugins (the `@signalk/server-api` patterns, resource-provider vs. router, registry scoring, OIDC publishing).
- **VesselSense/vesselsense-claude-plugins** — configuring integrations (KIP and WilhelmSK dashboards, SensESP sensor firmware).

Together they cover both ends of the workflow: building a plugin and wiring up the boat's instruments and sensors. Framed as third-party community resources, alongside the existing Examples links.

**A note on direction:** Tony (VesselSense) and I think the better long-term home is a single marketplace hosted under the SignalK org (e.g. `SignalK/claude-plugins`), maintained by the two of us, so there's one canonical install rather than separate third-party repos. This PR shows the lighter-weight link-out option for comparison — happy to go either way, and glad to adjust wording, placement, or drop the disclaimer line. Keen for your steer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds an "AI-assisted plugin development" section to the plugin developer guide in `docs/develop/plugins/README.md`. The new section links to two community-maintained Claude Code skill collections that encode the plugin development conventions as on-demand prompts:

1. **sailingnaturali/claude-skills** — covers authoring plugins including `@signalk/server-api` patterns, resource-provider vs. Express router differentiation, deltas, plugin scaffolding, registry scoring, and publishing to npm via OIDC trusted publishing.

2. **VesselSense/vesselsense-claude-plugins** — covers configuring SignalK integrations with KIP and WilhelmSK instrument dashboards, and SensESP sensor firmware.

The section explicitly notes that these are third-party resources maintained by the community, not part of Signal K itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->