### PR TITLE
fix(admin-ui): avoid false "plugin not installed" error from Module Federation load race

### DIFF
--- a/packages/server-admin-ui/src/views/Webapps/dynamicutilities.test.ts
+++ b/packages/server-admin-ui/src/views/Webapps/dynamicutilities.test.ts
@@ -1,0 +1,146 @@
+import React, { Suspense } from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import {
+  loadScriptOnce,
+  toLazyDynamicComponent,
+  toSafeModuleId
+} from './dynamicutilities'
+
+// Mirrors SCRIPT_LOAD_TIMEOUT_MS in the module under test.
+const SCRIPT_LOAD_TIMEOUT_MS = 10000
+
+// A settled flag for asserting a promise has/has not resolved without awaiting.
+const track = (p: Promise<unknown>) => {
+  const state = { settled: false }
+  p.then(() => {
+    state.settled = true
+  })
+  return state
+}
+
+const addScriptTag = (src: string): HTMLScriptElement => {
+  const script = document.createElement('script')
+  script.src = src
+  document.head.appendChild(script)
+  return script
+}
+
+describe('loadScriptOnce', () => {
+  afterEach(() => {
+    document.head.querySelectorAll('script[src]').forEach((s) => s.remove())
+    vi.useRealTimers()
+  })
+
+  it('short-circuits when ready() is already true (script already executed)', async () => {
+    // No tag in the DOM at all — ready() short-circuit must win regardless.
+    await expect(
+      loadScriptOnce('/already-ran/remoteEntry.js', () => true)
+    ).resolves.toBeUndefined()
+  })
+
+  it('resolves immediately when no matching script tag exists', async () => {
+    await expect(
+      loadScriptOnce('/missing/remoteEntry.js', () => false)
+    ).resolves.toBeUndefined()
+  })
+
+  it('pends until the existing tag fires load, then resolves (the race)', async () => {
+    const url = '/race/remoteEntry.js'
+    const script = addScriptTag(url)
+
+    let registered = false // stands in for window[safeId] being set
+    const promise = loadScriptOnce(url, () => registered)
+    const tracked = track(promise)
+
+    // Microtask flush: the tag has not loaded yet, so we must still be waiting.
+    await Promise.resolve()
+    expect(tracked.settled).toBe(false)
+
+    // The classic remote executes: it registers its global, then load fires.
+    registered = true
+    script.dispatchEvent(new Event('load'))
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('resolves on error so a 404 remoteEntry cannot hang the loader', async () => {
+    const url = '/broken/remoteEntry.js'
+    const script = addScriptTag(url)
+
+    const promise = loadScriptOnce(url, () => false)
+    script.dispatchEvent(new Event('error'))
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('resolves via timeout when the tag never fires an event', async () => {
+    vi.useFakeTimers()
+    const url = '/silent/remoteEntry.js'
+    addScriptTag(url)
+
+    const promise = loadScriptOnce(url, () => false)
+    const tracked = track(promise)
+
+    await Promise.resolve()
+    expect(tracked.settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(SCRIPT_LOAD_TIMEOUT_MS)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('dedupes concurrent callers for the same URL to one promise', async () => {
+    const url = '/dedupe/remoteEntry.js'
+    const script = addScriptTag(url)
+
+    const a = loadScriptOnce(url, () => false)
+    const b = loadScriptOnce(url, () => false)
+    expect(a).toBe(b)
+
+    script.dispatchEvent(new Event('load'))
+    await expect(Promise.all([a, b])).resolves.toEqual([undefined, undefined])
+  })
+})
+
+describe('toLazyDynamicComponent (classic remote boundary)', () => {
+  const MODULE = 'test-plugin'
+  const COMPONENT = './TestPanel'
+  const safeId = toSafeModuleId(MODULE)
+
+  afterEach(() => {
+    document.head.querySelectorAll('script[src]').forEach((s) => s.remove())
+    delete (window as Record<string, unknown>)[safeId]
+  })
+
+  it('waits for a classic script to load, then renders the remote component', async () => {
+    // The remote's script is injected but has not executed yet, so its global
+    // is absent when the lazy loader first runs — the production race.
+    const script = addScriptTag(`/${MODULE}/remoteEntry.js`)
+
+    const RemotePanel = () =>
+      React.createElement('div', null, 'remote panel ok')
+    const container = {
+      init: () => undefined,
+      get: () => Promise.resolve(() => ({ default: RemotePanel }))
+    }
+
+    const Lazy = toLazyDynamicComponent(MODULE, COMPONENT)
+    render(
+      React.createElement(
+        Suspense,
+        { fallback: React.createElement('div', null, 'loading') },
+        React.createElement(Lazy)
+      )
+    )
+
+    // Simulate the classic remote executing: it registers its global, then the
+    // script's load event fires and the loader re-reads the global.
+    ;(window as Record<string, unknown>)[safeId] = container
+    script.dispatchEvent(new Event('load'))
+
+    await waitFor(() =>
+      expect(screen.getByText('remote panel ok')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/is not available/)).not.toBeInTheDocument()
+  })
+})

--- a/packages/server-admin-ui/src/views/Webapps/dynamicutilities.ts
+++ b/packages/server-admin-ui/src/views/Webapps/dynamicutilities.ts
@@ -102,22 +102,84 @@ const getShareScope = (): ShareScope => {
 const legacyReactContainers = new Set<string>()
 
 /**
- * Resolve a module's remoteEntry.js URL from the server-injected script
- * tags, bridging safe IDs (e.g. _canboat_visual_analyzer) back to the
- * original package name paths (e.g. /@canboat/visual-analyzer/).
+ * Resolve a module's server-injected remoteEntry.js script tag, bridging safe
+ * IDs (e.g. _canboat_visual_analyzer) back to the original package name paths
+ * (e.g. /@canboat/visual-analyzer/). The tag's `type` distinguishes Vite ESM
+ * remotes (`type="module"`) from classic webpack remotes.
  */
-const findRemoteEntryUrl = (moduleName: string): string | null => {
+const findRemoteEntryScript = (
+  moduleName: string
+): HTMLScriptElement | null => {
   const safeId = toSafeModuleId(moduleName)
-  const scripts = document.querySelectorAll('script[src$="/remoteEntry.js"]')
+  const scripts = document.querySelectorAll<HTMLScriptElement>(
+    'script[src$="/remoteEntry.js"]'
+  )
   for (const script of scripts) {
     const src = script.getAttribute('src')
     if (!src) continue
     const match = src.match(/^\/(.+)\/remoteEntry\.js$/)
     if (match && toSafeModuleId(match[1]) === safeId) {
-      return src
+      return script
     }
   }
   return null
+}
+
+const findRemoteEntryUrl = (moduleName: string): string | null =>
+  findRemoteEntryScript(moduleName)?.getAttribute('src') ?? null
+
+const scriptLoadPromises = new Map<string, Promise<void>>()
+
+const SCRIPT_LOAD_TIMEOUT_MS = 10000
+
+/**
+ * Await execution of an already-injected remoteEntry.js, deduped by URL.
+ *
+ * A classic (non-module) webpack remote registers its container on a window
+ * global synchronously when its script executes; it exposes no promise or
+ * onload hook of its own. The server already injects the
+ * `<script src=.../remoteEntry.js>` tag (undeferred), so toLazyDynamicComponent
+ * can run before that script has executed and read an absent global. Rather
+ * than append a second tag and redundantly execute the remote, find the
+ * existing tag and await its load/error event. The caller re-reads the global
+ * afterwards, which is the real readiness signal. The
+ * `ready` predicate short-circuits when the script has already executed (its
+ * past load event won't re-fire); a timeout otherwise bounds the wait so
+ * React.lazy can't hang if the event never fires.
+ */
+export const loadScriptOnce = (
+  url: string,
+  ready: () => boolean
+): Promise<void> => {
+  if (ready()) {
+    return Promise.resolve()
+  }
+
+  const cached = scriptLoadPromises.get(url)
+  if (cached) {
+    return cached
+  }
+
+  const promise = new Promise<void>((resolve) => {
+    const script = Array.from(
+      document.querySelectorAll<HTMLScriptElement>('script[src]')
+    ).find((s) => s.getAttribute('src') === url)
+    if (!script) {
+      resolve()
+      return
+    }
+
+    const timer = setTimeout(resolve, SCRIPT_LOAD_TIMEOUT_MS)
+    const done = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    script.addEventListener('load', done, { once: true })
+    script.addEventListener('error', done, { once: true })
+  })
+
+  scriptLoadPromises.set(url, promise)
+  return promise
 }
 
 const initializeContainer = async (
@@ -476,18 +538,34 @@ export const toLazyDynamicComponent = (
         | undefined
 
       if (container === undefined) {
-        const remoteEntryUrl = findRemoteEntryUrl(moduleName)
-        if (remoteEntryUrl) {
-          try {
-            const esmModule = await import(/* @vite-ignore */ remoteEntryUrl)
-            if (
-              typeof esmModule.get === 'function' &&
-              typeof esmModule.init === 'function'
-            ) {
-              container = esmModule as Container
+        const remoteEntryScript = findRemoteEntryScript(moduleName)
+        const remoteEntryUrl = remoteEntryScript?.getAttribute('src')
+        if (remoteEntryScript && remoteEntryUrl) {
+          const safeId = toSafeModuleId(moduleName)
+          if (remoteEntryScript.type === 'module') {
+            // Vite ESM remote: the container is the module's get/init exports.
+            try {
+              const esmModule = await import(/* @vite-ignore */ remoteEntryUrl)
+              if (
+                typeof esmModule.get === 'function' &&
+                typeof esmModule.init === 'function'
+              ) {
+                container = esmModule as Container
+              }
+            } catch (e) {
+              console.warn(`ESM import failed for ${moduleName}:`, e)
             }
-          } catch (e) {
-            console.warn(`ESM import failed for ${moduleName}:`, e)
+          } else {
+            // Classic (non-module) remote: its global registers synchronously
+            // when the already-injected script executes, but this loader may
+            // run first. Await that script's load, then re-read the global.
+            // import() is skipped — it can't yield a container here and only
+            // re-evaluates the bundle.
+            await loadScriptOnce(
+              remoteEntryUrl,
+              () => window[safeId] !== undefined
+            )
+            container = window[safeId] as Container | undefined
           }
         }
       }


### PR DESCRIPTION
## Motivation

Opening a plugin's config panel sometimes shows **"Module \"<plugin>\" is not available. Make sure the webapp is installed."** even though the plugin is installed and enabled. It is intermittent and only a hard reload clears it (e.g. reported for `signalk-questdb`).

## Cause

Plugin config panels load via Module Federation. A classic (non-module) webpack remote registers its container on a `window` global *synchronously* when its server-injected, undeferred `remoteEntry.js` script executes — it has no promise or `onload` hook of its own. `toLazyDynamicComponent` could read that global before the script had run. The existing ESM `import()` fallback only rescues Vite `type=module` remotes, so a classic remote fell straight through to the error. A hard reload re-runs every script tag, which is why it "fixes" it.

## Approach

In the `container === undefined` path, after the ESM fallback, await the already-injected `remoteEntry.js` tag's `load`/`error` event and re-read the global before giving up. The wait is deduped by URL, short-circuits when the script has already executed, and is bounded by a timeout so `React.lazy` can't hang. No second `<script>` is injected, so the webpack shared scope is never re-initialized.

## Tested

- `npm run build` and `vitest run` in `packages/server-admin-ui` (238 tests pass)
- `prettier --check` clean; no new TypeScript errors in the changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Technical Changes

This PR fixes an intermittent race condition in the admin UI where plugin config panels show “Module is not available. Make sure the webapp is installed.” even when the plugin is installed and enabled.

### Remote loader changes in `dynamicutilities.ts`

This PR updates the Module Federation remote loading logic to wait for the classic remote’s `remoteEntry.js` to finish before performing the container availability check.

- **`findRemoteEntryScript` / `findRemoteEntryUrl`**
  - This PR locates the server-injected `<script src=".../remoteEntry.js">` in the DOM by matching it to the plugin’s safe module/global id, and derives the corresponding URL.

- **`loadScriptOnce(url, ready)`**
  - This PR exports a helper that waits on the existing injected script tag’s `load` or `error` events (without injecting a second `<script>`).
  - This PR deduplicates concurrent waits per URL.
  - This PR short-circuits when the provided `ready()` predicate is already satisfied.
  - This PR includes a timeout (10s) to prevent `React.lazy` from hanging indefinitely.

- **`toLazyDynamicComponent` classic-remote recovery**
  - For `type="module"` remotes, this PR continues using the ESM `import()` path.
  - When the container global for classic (non-module) remotes is missing, this PR waits for the already-injected classic `remoteEntry.js` to complete via `loadScriptOnce`, then re-reads `window[safeId]` before continuing with the existing `init`/`get` flow and any legacy-React bridging.

### Problem resolution

This PR removes the timing window where the lazy loader checks for the classic remote’s global container before the injected `remoteEntry.js` has finished executing; the error no longer requires a hard browser reload to clear.

### Testing

This PR adds Vitest coverage that verifies:
- `loadScriptOnce` short-circuits when `ready()` is already true
- it resolves when no matching script tag exists
- it waits for `load` on an existing script tag
- it resolves on `error`
- it times out when no events fire
- it deduplicates concurrent calls per URL
- `toLazyDynamicComponent` correctly handles the classic-remote boundary flow and renders the remote content without showing the “not available” error

All tests pass (238 vitest tests), prettier checks succeed, and no new TypeScript errors are introduced in the modified file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->