### PR TITLE
fix(admin-ui/databrowser): show vessel names in context dropdown

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
@@ -25,7 +25,7 @@ import {
   type SourcesData
 } from '../../utils/sourceLabels'
 import granularSubscriptionManager from './GranularSubscriptionManager'
-import { getPath$SourceKey, getPathFromKey } from './pathUtils'
+import { getPath$SourceKey, getPathFromKey, findContextName } from './pathUtils'
 import {
   useWebSocket,
   useDeltaMessages,
@@ -450,10 +450,7 @@ const DataBrowser: React.FC = () => {
     ]
 
     if (contextKeys.includes('self')) {
-      const contextData = currentData['self']?.['name'] as
-        | { value?: string }
-        | undefined
-      const contextName = contextData?.value
+      const contextName = findContextName(currentData['self'])
       options.push({
         value: 'self',
         label: `${contextName || ''} self`,
@@ -464,10 +461,7 @@ const DataBrowser: React.FC = () => {
     let isFirst = true
     contextKeys.forEach((key) => {
       if (key !== 'self') {
-        const contextData = currentData[key]?.['name'] as
-          | { value?: string }
-          | undefined
-        const contextName = contextData?.value
+        const contextName = findContextName(currentData[key])
         options.push({
           value: key,
           label: `${contextName || ''} ${key}`,
@@ -479,7 +473,9 @@ const DataBrowser: React.FC = () => {
     })
 
     return options
-  }, [contextKeys])
+    // dataVersion is included so the labels pick up a vessel's `name`
+    // leaf, which arrives in a delta after the context key first appears.
+  }, [contextKeys, dataVersion])
 
   useEffect(() => {
     subscribeToDataIfNeeded()

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
@@ -37,4 +37,12 @@ describe('findContextName', () => {
   it('ignores a non-string name value', () => {
     expect(findContextName({ 'name$AIS.1': { value: 42 } })).toBeUndefined()
   })
+
+  it('skips a non-string name entry for a later valid one', () => {
+    const contextData = {
+      'name$AIS.1': { value: 42 },
+      'name$AIS.2': { value: 'Black Pearl' }
+    }
+    expect(findContextName(contextData)).toBe('Black Pearl')
+  })
 })

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { findContextName } from './pathUtils'
+
+describe('findContextName', () => {
+  it('resolves the name from a source-suffixed key', () => {
+    const contextData = {
+      'name$AIS.123': { value: 'Black Pearl' },
+      'navigation.position$AIS.123': { value: { latitude: 1, longitude: 2 } }
+    }
+    expect(findContextName(contextData)).toBe('Black Pearl')
+  })
+
+  it('resolves the name from a bare key', () => {
+    expect(findContextName({ name: { value: 'Flying Dutchman' } })).toBe(
+      'Flying Dutchman'
+    )
+  })
+
+  it('does not match paths that merely start with name', () => {
+    const contextData = {
+      'nameplate$AIS.1': { value: 'ABC123' }
+    }
+    expect(findContextName(contextData)).toBeUndefined()
+  })
+
+  it('returns undefined when no name leaf is present', () => {
+    const contextData = {
+      'mmsi$AIS.123': { value: '123456789' }
+    }
+    expect(findContextName(contextData)).toBeUndefined()
+  })
+
+  it('returns undefined for missing context data', () => {
+    expect(findContextName(undefined)).toBeUndefined()
+  })
+
+  it('ignores a non-string name value', () => {
+    expect(findContextName({ 'name$AIS.1': { value: 42 } })).toBeUndefined()
+  })
+})

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
@@ -9,3 +9,20 @@ export function getPathFromKey(path$SourceKey: string): string {
   const idx = path$SourceKey.indexOf('$')
   return idx >= 0 ? path$SourceKey.substring(0, idx) : path$SourceKey
 }
+
+// Resolve a vessel's display name from its stored context data. The
+// `name` leaf arrives flattened under the empty-path object and is
+// keyed per source as `name$<source>`, so a bare `['name']` lookup
+// never matches — scan for the first key whose path is `name`.
+export function findContextName(
+  contextData: Record<string, { value?: unknown }> | undefined
+): string | undefined {
+  if (!contextData) return undefined
+  for (const key of Object.keys(contextData)) {
+    if (getPathFromKey(key) === 'name') {
+      const value = contextData[key]?.value
+      return typeof value === 'string' ? value : undefined
+    }
+  }
+  return undefined
+}

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
@@ -13,7 +13,9 @@ export function getPathFromKey(path$SourceKey: string): string {
 // Resolve a vessel's display name from its stored context data. The
 // `name` leaf arrives flattened under the empty-path object and is
 // keyed per source as `name$<source>`, so a bare `['name']` lookup
-// never matches — scan for the first key whose path is `name`.
+// never matches — scan for a key whose path is `name`. Keep scanning
+// past a non-string value so a malformed entry from one source doesn't
+// hide a valid name reported by another.
 export function findContextName(
   contextData: Record<string, { value?: unknown }> | undefined
 ): string | undefined {
@@ -21,7 +23,7 @@ export function findContextName(
   for (const key of Object.keys(contextData)) {
     if (getPathFromKey(key) === 'name') {
       const value = contextData[key]?.value
-      return typeof value === 'string' ? value : undefined
+      if (typeof value === 'string') return value
     }
   }
   return undefined


### PR DESCRIPTION
The Data Browser context dropdown showed only the raw URN (e.g. `vessels.urn:mrn:imo:mmsi:123456789`) instead of the vessel name — a regression since the 2.28 Data Browser rebuild.

Vessel/AIS static data such as `name` arrives flattened under the empty-path object and is stored per source as `name$<source>`, so the dropdown's bare `['name']` lookup never matched. The fix resolves the name by scanning the context's data for the `name` path regardless of its source suffix.

## Tested

- Unit tests for the new `findContextName` helper.
- Verified end-to-end in a browser: an AIS vessel now shows "Black Pearl …" in the dropdown where master shows only the URN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a regression in the Data Browser context dropdown where vessel names stop displaying after the 2.28 rebuild. The underlying mismatch comes from how vessel data is stored versus how it is read: vessel `name` values arrive flattened and stored under source-suffixed keys (for example, `name$<source>`), but the dropdown previously attempts to read a bare `name` key that never matches.

## Changes

- `pathUtils.ts` introduces a new exported helper function, `findContextName`, which derives a display `name` from optional `contextData`.
  - It scans all stored context keys, resolves each key’s path with `getPathFromKey`, and identifies entries whose resolved path equals `name`.
  - It returns the first matching `value` only when it is a string.
  - It skips non-string `name` values so malformed entries from one source do not hide valid names from other sources.
  - It returns `undefined` when `contextData` is missing, when no matching `name` leaf exists, or when no string `name` value is found.

- `DataBrowser.tsx` imports and uses `findContextName` to compute the label used in context dropdown options for both the `'self'` context and other vessel contexts.
  - The `contextOptions` memo includes `dataVersion` so dropdown labels refresh when vessel `name` arrives later via a delta.
  - The dropdown label no longer reads directly from `currentData[ctx]?.['name']?.value`.

- `pathUtils.test.ts` adds a Vitest suite for `findContextName` that covers:
  - name resolution from both source-suffixed and bare keys
  - non-matching behavior when keys merely start with `name`
  - returning `undefined` when no `name` leaf exists, when input `contextData` is `undefined`, when the resolved `name` value is not a string
  - the mixed-entries case where an invalid `name` entry is followed by a valid one

## Impact

Vessel names display correctly in the Data Browser context dropdown again (instead of only showing raw context URNs). For example, an AIS vessel now shows a name like “Black Pearl” rather than just a URN such as `vessels.urn:mrn:imo:mmsi:123456789`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->