### PR TITLE
fix(admin-ui/priorities): wrap long source labels in override picker

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/PrefsEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PrefsEditor.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowUp } from '@fortawesome/free-solid-svg-icons/faArrowUp'
 import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown'
 import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash'
-import Select from 'react-select'
+import Select, { type StylesConfig } from 'react-select'
 import { useStore, useSourceStatus, useSourceStatusLoaded } from '../../store'
 import { type SourcesData } from '../../utils/sourceLabels'
 import { DEFAULT_FALLBACK_MS } from '../../utils/sourceGroups'
@@ -49,6 +49,37 @@ const FANOUT_SOURCEREF = '*'
 
 function isFanOut(priorities: Priority[]): boolean {
   return priorities.length === 1 && priorities[0].sourceRef === FANOUT_SOURCEREF
+}
+
+// react-select's default single-line control height.
+const SELECT_MIN_HEIGHT = 38
+// Above Bootstrap's modal/dropdown layers so the portalled menu stays on top.
+const MENU_PORTAL_Z_INDEX = 9999
+
+// Long device labels (e.g. "Raymarine E70310 (ttyUSB0.c078915de76…)")
+// otherwise get clipped to a single line. Let the selected value and the
+// menu options wrap so the full name + sourceRef stays readable in the
+// narrow priorities column, and grow the control vertically to fit.
+const wrappingSelectStyles: StylesConfig<SelectOption, false> = {
+  control: (base) => ({
+    ...base,
+    minHeight: SELECT_MIN_HEIGHT,
+    height: 'auto'
+  }),
+  valueContainer: (base) => ({ ...base, flexWrap: 'wrap' }),
+  singleValue: (base) => ({
+    ...base,
+    whiteSpace: 'normal',
+    overflow: 'visible',
+    textOverflow: 'clip',
+    wordBreak: 'break-word'
+  }),
+  option: (base) => ({
+    ...base,
+    whiteSpace: 'normal',
+    wordBreak: 'break-word'
+  }),
+  menuPortal: (base) => ({ ...base, zIndex: MENU_PORTAL_Z_INDEX })
 }
 
 export const PrefsEditor: React.FC<PrefsEditorProps> = ({
@@ -222,6 +253,7 @@ export const PrefsEditor: React.FC<PrefsEditorProps> = ({
                     <div style={{ flex: 1 }}>
                       <Select
                         menuPortalTarget={document.body}
+                        styles={wrappingSelectStyles}
                         options={availableOptions}
                         value={
                           sourceRef


### PR DESCRIPTION
In the Source Priorities path-override editor, long device labels (a manufacturer name plus the full sourceRef) were clipped to a single line in the Source picker, forcing the column too wide and hiding the rest of the name.

The selected value and the menu options now wrap across lines and the control grows vertically, so the full label stays readable in the narrow priorities column.

## Tested

- Verified end-to-end in a browser with two long-named sources sharing a path: the picker control grows from one truncated line to a multi-line label showing the complete device name and sourceRef.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes text clipping in the Signal K Server's admin UI Source Priorities path-override editor. Long device labels that include manufacturer names and full sourceRef identifiers now display properly without truncation.

## Changes
The PR updates `PrefsEditor.tsx` to enable text wrapping in the source selection dropdown by:
- Importing the `StylesConfig` type from react-select
- Defining a `wrappingSelectStyles` configuration object that configures the Select component to allow multi-line display with proper text wrapping behavior
- Applying the `wrappingSelectStyles` configuration to the source Select component via a new `styles` prop

The styling configuration allows the control to expand vertically to accommodate wrapped text while ensuring selected values and menu options display complete device names and sourceRef identifiers without truncation.

## Result
The picker control now expands vertically to display multi-line labels instead of expanding horizontally, maintaining the narrow priorities column layout and preventing adjacent content from being hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->