### PR TITLE
fix(admin-ui): indicate Signal K over TCP requires readonly access (#2786)

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -10,7 +11,7 @@ import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk'
 
 import VesselConfiguration from './VesselConfiguration'
 import Logging from './Logging'
-import { useStore } from '../../store'
+import { useStore, useLoginStatus } from '../../store'
 
 interface ServerSettingsData {
   hasData?: boolean
@@ -37,9 +38,14 @@ const SettableInterfaces: Record<string, string> = {
 }
 
 const ServerSettings: React.FC = () => {
+  const loginStatus = useLoginStatus()
   const [settings, setSettings] = useState<ServerSettingsData>({
     hasData: false
   })
+  // The Signal K over TCP interface only starts when anonymous readonly
+  // access is allowed (see src/interfaces/tcp.ts). Track that so the toggle
+  // can reflect when the port would not actually be available.
+  const [allowReadonly, setAllowReadonly] = useState(false)
 
   const fetchSettings = useCallback(() => {
     fetch(`${window.serverRoutesPrefix}/settings`, {
@@ -54,6 +60,22 @@ const ServerSettings: React.FC = () => {
   useEffect(() => {
     fetchSettings()
   }, [fetchSettings])
+
+  useEffect(() => {
+    if (loginStatus.authenticationRequired) {
+      fetch(`${window.serverRoutesPrefix}/security/config`, {
+        credentials: 'include'
+      })
+        .then((response) => response.json())
+        .then((data) => setAllowReadonly(Boolean(data.allow_readonly)))
+        .catch(() => undefined)
+    }
+  }, [loginStatus.authenticationRequired])
+
+  // When security is enabled but anonymous readonly access is off, the Signal K
+  // over TCP port is not opened by the server even if its toggle is on.
+  const tcpUnavailable =
+    loginStatus.authenticationRequired === true && !allowReadonly
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -252,28 +274,48 @@ const ServerSettings: React.FC = () => {
               </Col>
               <Col xs="12" md={fieldColWidthMd}>
                 {Object.keys(SettableInterfaces).map((name) => {
+                  const disabled = name === 'tcp' && tcpUnavailable
                   return (
-                    <div key={name} className="d-flex align-items-center mb-2">
-                      <Form.Label
-                        style={{ marginRight: '15px', marginBottom: 0 }}
-                        className="switch switch-text switch-primary"
+                    <div key={name} className="mb-2">
+                      <div
+                        className="d-flex align-items-center"
+                        style={{ opacity: disabled ? 0.5 : 1 }}
                       >
-                        <input
-                          type="checkbox"
-                          id={`interface-${name}`}
-                          name={name}
-                          className="switch-input"
-                          onChange={handleInterfaceChange}
-                          checked={settings.interfaces?.[name] || false}
-                        />
-                        <span
-                          className="switch-label"
-                          data-on="On"
-                          data-off="Off"
-                        />
-                        <span className="switch-handle" />
-                      </Form.Label>
-                      <span>{SettableInterfaces[name]}</span>
+                        <Form.Label
+                          style={{ marginRight: '15px', marginBottom: 0 }}
+                          className="switch switch-text switch-primary"
+                        >
+                          <input
+                            type="checkbox"
+                            id={`interface-${name}`}
+                            name={name}
+                            className="switch-input"
+                            onChange={handleInterfaceChange}
+                            checked={
+                              disabled
+                                ? false
+                                : settings.interfaces?.[name] || false
+                            }
+                            disabled={disabled}
+                          />
+                          <span
+                            className="switch-label"
+                            data-on="On"
+                            data-off="Off"
+                          />
+                          <span className="switch-handle" />
+                        </Form.Label>
+                        <span>{SettableInterfaces[name]}</span>
+                      </div>
+                      {disabled && (
+                        <Form.Text className="text-warning">
+                          Enable{' '}
+                          <Link to="/security/settings">
+                            Allow Readonly Access
+                          </Link>{' '}
+                          under Security → Settings to make this port available.
+                        </Form.Text>
+                      )}
                     </div>
                   )
                 })}

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
+import Alert from 'react-bootstrap/Alert'
 import Button from 'react-bootstrap/Button'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -30,8 +31,12 @@ interface ServerSettingsData {
 }
 
 interface SecurityConfig {
-  allow_readonly?: boolean
+  allow_readonly: boolean
 }
+
+// Opacity applied to the interface row when its toggle is disabled.
+const DISABLED_ROW_OPACITY = 0.5
+const ENABLED_ROW_OPACITY = 1
 
 const SettableInterfaces: Record<string, string> = {
   applicationData: 'Application Data Storage',
@@ -48,8 +53,9 @@ const ServerSettings: React.FC = () => {
   })
   // The Signal K over TCP interface only starts when anonymous readonly
   // access is allowed (see src/interfaces/tcp.ts). Track that so the toggle
-  // can reflect when the port would not actually be available.
-  const [allowReadonly, setAllowReadonly] = useState(false)
+  // can reflect when the port would not actually be available. null = unknown
+  // (not yet fetched, fetch failed, or security disabled).
+  const [allowReadonly, setAllowReadonly] = useState<boolean | null>(null)
 
   const fetchSettings = useCallback(() => {
     fetch(`${window.serverRoutesPrefix}/settings`, {
@@ -70,18 +76,25 @@ const ServerSettings: React.FC = () => {
       fetch(`${window.serverRoutesPrefix}/security/config`, {
         credentials: 'include'
       })
-        .then((response) => response.json())
-        .then((data: SecurityConfig) =>
-          setAllowReadonly(Boolean(data.allow_readonly))
-        )
-        .catch(() => undefined)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Unable to load security config')
+          }
+          return response.json() as Promise<SecurityConfig>
+        })
+        .then((data) => setAllowReadonly(data.allow_readonly))
+        .catch(() => setAllowReadonly(null))
+    } else {
+      setAllowReadonly(null)
     }
   }, [loginStatus.authenticationRequired])
 
   // When security is enabled but anonymous readonly access is off, the Signal K
-  // over TCP port is not opened by the server even if its toggle is on.
+  // over TCP port is not opened by the server even if its toggle is on. Only
+  // warn when we know readonly is off (allowReadonly === false), not when the
+  // security config is still unknown.
   const tcpUnavailable =
-    loginStatus.authenticationRequired === true && !allowReadonly
+    loginStatus.authenticationRequired === true && allowReadonly === false
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -285,7 +298,11 @@ const ServerSettings: React.FC = () => {
                     <div key={name} className="mb-2">
                       <div
                         className="d-flex align-items-center"
-                        style={{ opacity: disabled ? 0.5 : 1 }}
+                        style={{
+                          opacity: disabled
+                            ? DISABLED_ROW_OPACITY
+                            : ENABLED_ROW_OPACITY
+                        }}
                       >
                         <Form.Label
                           style={{ marginRight: '15px', marginBottom: 0 }}
@@ -314,13 +331,19 @@ const ServerSettings: React.FC = () => {
                         <span>{SettableInterfaces[name]}</span>
                       </div>
                       {disabled && (
-                        <Form.Text className="text-warning">
-                          Enable{' '}
-                          <Link to="/security/settings">
-                            Allow Readonly Access
-                          </Link>{' '}
-                          under Security → Settings to make this port available.
-                        </Form.Text>
+                        <Alert
+                          variant="warning"
+                          className="mt-1 mb-0 py-1 px-2"
+                        >
+                          <small>
+                            Enable{' '}
+                            <Link to="/security/settings">
+                              Allow Readonly Access
+                            </Link>{' '}
+                            under Security → Settings to make this port
+                            available.
+                          </small>
+                        </Alert>
                       )}
                     </div>
                   )

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -29,6 +29,10 @@ interface ServerSettingsData {
   }
 }
 
+interface SecurityConfig {
+  allow_readonly?: boolean
+}
+
 const SettableInterfaces: Record<string, string> = {
   applicationData: 'Application Data Storage',
   logfiles: 'Data log files access',
@@ -67,7 +71,9 @@ const ServerSettings: React.FC = () => {
         credentials: 'include'
       })
         .then((response) => response.json())
-        .then((data) => setAllowReadonly(Boolean(data.allow_readonly)))
+        .then((data: SecurityConfig) =>
+          setAllowReadonly(Boolean(data.allow_readonly))
+        )
         .catch(() => undefined)
     }
   }, [loginStatus.authenticationRequired])


### PR DESCRIPTION
Fixes #2786.

The Signal K over TCP interface (8375) only starts when anonymous readonly access is allowed (`src/interfaces/tcp.ts`). The Interfaces toggle could read "On" while the port was never opened, with no hint why nothing was listening.

Per the discussion in #2786 (no security-logic change): when security is enabled and Allow Readonly Access is off, the "Signal K over TCP (8375)" toggle is greyed out and disabled, with a warning linking directly to Security → Settings. Only `tcp` is affected — it's the sole interface gated on readonly access (`nmea-tcp`/10110 is not).

> [!NOTE]
> Not yet tested against a live server — the change is UI-only and fairly trivial, so reviewing from the diff should be straightforward. `npm run build` on `server-admin-ui` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR addresses issue `#2786` by fixing a misleading admin UI state where the “Signal K over TCP (8375)” interface toggle can appear enabled while the TCP port is not actually listening.

## Problem
The Signal K TCP interface backend only starts when anonymous readonly access is allowed, but the admin UI does not surface this dependency. As a result, users can enable the interface even though security settings prevent it from starting.

## Solution
This PR applies a UI-only change in `packages/server-admin-ui/src/views/ServerConfig/Settings.tsx` that conditions the “Signal K over TCP (8375)” toggle on security configuration:

- It uses `useLoginStatus` to determine when authentication is required.
- When authentication is required, it fetches `/security/config` and tracks `allow_readonly` using a nullable `allowReadonly: boolean | null`.
- It computes a `tcpUnavailable` flag from `authenticationRequired` and whether `allowReadonly` is explicitly false, while treating failures/unknown states as unavailable-unknown (so the toggle is not incorrectly greyed out).
- When `tcpUnavailable` is true, it forces the checkbox off, disables it, dims the control, and shows an `Alert` (warning variant) with a link to `/security/settings` explaining that “Allow Readonly Access” must be enabled under Security → Settings.

## Changes
- `packages/server-admin-ui/src/views/ServerConfig/Settings.tsx`: Adds security-config fetching and readonly-state handling, computes `tcpUnavailable`, and disables/overrides the TCP (8375) toggle with a warning `Alert` linking to the Security settings page. (Lines: +92/-21)

## Notes
- Only the TCP interface (port 8375) is affected; the NMEA-TCP interface (port 10110) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->