### PR TITLE
fix(logfiles): repair /ziplogs 500 by migrating dead res.zip to sendZip

### DIFF
--- a/src/interfaces/logfiles.js
+++ b/src/interfaces/logfiles.js
@@ -18,6 +18,7 @@ const moment = require('moment')
 const path = require('path')
 const { getFullLogDir, listLogFiles } = require('@signalk/streams/logging')
 import { SERVERROUTESPREFIX } from '../constants'
+import { sendZip } from '../zip'
 
 module.exports = function (app) {
   return {
@@ -81,7 +82,7 @@ function mountApi(app) {
     const sanitizedBoatName = boatName.replace(/\W/g, '_')
     const zipFileName = `sk-logs-${sanitizedBoatName}-${moment().format('YYYY-MM-DD-HH-mm')}`
 
-    res.zip({
+    sendZip(res, {
       files: [{ path: getFullLogDir(app), name: zipFileName }],
       filename: zipFileName + '.zip'
     })


### PR DESCRIPTION
## Motivation

"Get all logs in one ZIP file" (`GET /skServer/ziplogs`) returns HTTP 500:

```
TypeError: res.zip is not a function
    at .../dist/interfaces/logfiles.js:79:13
GET /skServer/ziplogs 500
```

`res.zip()` is the API of `express-easy-zip`, which was removed when the project migrated to an `archiver`-based `sendZip()` helper. The backup-download path in `serverroutes.ts` was migrated, but the `/ziplogs` handler in `logfiles.js` was missed and still calls the now-undefined `res.zip`. It was the sole remaining `res.zip` caller in the tree, so this route has been broken on every release since the migration.

## Solution

Migrate the `/ziplogs` call site to `sendZip()`, mirroring the existing backup-download path. `sendZip` uses `filename` verbatim (no automatic `.zip` suffix), so the existing `zipFileName + '.zip'` is preserved.

The per-hour `/logfiles/:filename` downloads use `res.sendFile` and were never affected.

## Tested

- `npm run build` — compiled `dist/interfaces/logfiles.js` now calls `sendZip` instead of `res.zip`.
- `npm test` — all suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes an HTTP 500 error on the `GET /skServer/ziplogs` endpoint by updating `src/interfaces/logfiles.js` to use the `sendZip()` helper function instead of the now-undefined `res.zip()` method.

## Changes

**src/interfaces/logfiles.js**
- Imports `sendZip` from `../zip`
- Migrates the `/ziplogs` route handler to call `sendZip(res, {...})` with the existing file structure and filename pattern, matching the approach used in the backup-download path in `serverroutes.ts`
- Preserves the `zipFileName + '.zip'` filename pattern and maintains the same directory and archive naming logic

The fix completes the migration away from the deprecated `express-easy-zip` middleware, addressing the sole remaining `res.zip()` caller in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->