### PR TITLE
fix(appstore): ignore bare git tags when sourcing changelog from GitHub

### DIFF
--- a/src/appstore/github-releases.ts
+++ b/src/appstore/github-releases.ts
@@ -171,6 +171,16 @@ export async function parseReleasesFeed(
   return entries.filter((e): e is GithubReleaseEntry => e !== undefined)
 }
 
+// github.com/<owner>/<repo>/releases.atom emits a synthetic entry for every
+// git tag, not just published Releases. A tag with no Release gets an
+// auto-generated body of exactly "Release <tag>" (or none). Those carry no
+// notes, so treat them as "not a real release" and let the caller fall back
+// to a published CHANGELOG.md.
+function isPublishedRelease(entry: GithubReleaseEntry): boolean {
+  const body = entry.bodyMarkdown.trim()
+  return body !== '' && body !== `Release ${entry.tag}`
+}
+
 export function renderReleasesAsChangelog(
   entries: GithubReleaseEntry[]
 ): string {
@@ -212,9 +222,16 @@ export function parseGithubSlug(url: string | undefined): RepoSlug | undefined {
 
 /**
  * Fetch and render a changelog from GitHub Releases for the given repo.
- * Returns Markdown when at least one release was found and parsed,
- * otherwise undefined. No GitHub token required — uses the public
- * releases.atom feed.
+ * Returns Markdown when at least one real release was found and parsed,
+ * otherwise undefined.
+ *
+ * Reads the public releases.atom feed rather than the /releases REST API on
+ * purpose: the feed is served off github.com and does not draw down the 60/hr
+ * unauthenticated REST budget. That budget is shared per source IP, so new
+ * users and boats on Starlink (which recycles IPs aggressively) could exhaust
+ * it before the App Store renders once. The cost is that the feed can't
+ * distinguish a published Release from a bare tag, so isPublishedRelease
+ * filters the placeholders out below.
  */
 export async function fetchReleasesMarkdown(
   owner: string,
@@ -222,7 +239,7 @@ export async function fetchReleasesMarkdown(
 ): Promise<string | undefined> {
   const xml = await fetchReleasesFeed(owner, repo)
   if (!xml) return undefined
-  const entries = await parseReleasesFeed(xml)
+  const entries = (await parseReleasesFeed(xml)).filter(isPublishedRelease)
   if (entries.length === 0) return undefined
   return renderReleasesAsChangelog(entries)
 }

--- a/test/appstore/detail.test.ts
+++ b/test/appstore/detail.test.ts
@@ -1,6 +1,28 @@
 import { expect } from 'chai'
 import { buildPluginDetail } from '../../dist/appstore/detail.js'
 
+// GitHub's releases.atom emits a synthetic entry per git tag even when no
+// Release was published; the body is an auto-generated "Release <tag>".
+const TAG_ONLY_ATOM = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>1.4.0</title>
+    <updated>2026-01-01T00:00:00Z</updated>
+    <link rel="alternate" href="https://github.com/owner/repo/releases/tag/1.4.0"/>
+    <content type="html">&lt;p&gt;Release 1.4.0&lt;/p&gt;</content>
+  </entry>
+</feed>`
+
+const REAL_RELEASE_ATOM = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>v2.0.0</title>
+    <updated>2026-01-01T00:00:00Z</updated>
+    <link rel="alternate" href="https://github.com/owner/repo/releases/tag/v2.0.0"/>
+    <content type="html">&lt;p&gt;Notes from GitHub Releases&lt;/p&gt;</content>
+  </entry>
+</feed>`
+
 describe('appstore/detail', () => {
   const summaryBase = {
     name: 'signalk-example',
@@ -12,6 +34,72 @@ describe('appstore/detail', () => {
     keywords: [],
     npmReadme: '# hi'
   }
+
+  describe('changelog source', () => {
+    const realFetch = globalThis.fetch
+    // Each test sets which assets "exist"; the stub 404s everything else.
+    let changelogBody: string | undefined
+    let releasesAtom: string | undefined
+
+    beforeEach(() => {
+      changelogBody = undefined
+      releasesAtom = undefined
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/CHANGELOG.md')) {
+          return changelogBody === undefined
+            ? new Response('Not found', { status: 404 })
+            : new Response(changelogBody, { status: 200 })
+        }
+        if (url.includes('releases.atom')) {
+          return releasesAtom === undefined
+            ? new Response('Not found', { status: 404 })
+            : new Response(releasesAtom, { status: 200 })
+        }
+        return new Response('Not found', { status: 404 })
+      }) as typeof fetch
+    })
+
+    afterEach(() => {
+      globalThis.fetch = realFetch
+    })
+
+    const withGithub = {
+      ...summaryBase,
+      githubUrl: 'https://github.com/owner/repo'
+    }
+
+    it('ignores tag-only release entries and falls back to CHANGELOG.md', async () => {
+      changelogBody = '# Changelog\n## 1.4.0\n- curated entry'
+      releasesAtom = TAG_ONLY_ATOM
+      const detail = await buildPluginDetail(withGithub)
+      expect(detail.changelog).to.contain('curated entry')
+      expect(detail.changelog).to.not.contain('Release 1.4.0')
+      expect(detail.changelogFormat).to.equal('markdown')
+    })
+
+    it('renders nothing when the feed is only tags and no CHANGELOG.md exists', async () => {
+      releasesAtom = TAG_ONLY_ATOM
+      const detail = await buildPluginDetail(withGithub)
+      expect(detail.changelog).to.equal('')
+      expect(detail.changelogFormat).to.equal('synthesized')
+    })
+
+    it('uses GitHub Releases when the feed has real release notes', async () => {
+      releasesAtom = REAL_RELEASE_ATOM
+      const detail = await buildPluginDetail(withGithub)
+      expect(detail.changelog).to.contain('Notes from GitHub Releases')
+      expect(detail.changelogFormat).to.equal('markdown')
+    })
+
+    it('keeps GitHub Releases ahead of CHANGELOG.md when both are real', async () => {
+      changelogBody = '# Changelog\n## 2.0.0\n- curated entry'
+      releasesAtom = REAL_RELEASE_ATOM
+      const detail = await buildPluginDetail(withGithub)
+      expect(detail.changelog).to.contain('Notes from GitHub Releases')
+      expect(detail.changelog).to.not.contain('curated entry')
+    })
+  })
 
   it('hydrates required deps against resolver', async () => {
     const detail = await buildPluginDetail(


### PR DESCRIPTION
GitHub's `releases.atom` emits a synthetic entry for every git tag, not just published Releases — a tag with no Release gets an auto-generated `Release <tag>` body. The changelog source treated those as real notes, so a plugin with tags but no Releases (e.g. signalk-meshtastic) showed empty version headings instead of its published CHANGELOG.md.

Filter out the placeholder entries before rendering. If nothing real remains, the existing CHANGELOG.md fallback applies. Staying on the atom feed keeps us off the 60/hr unauthenticated REST budget, which matters for new users and boats on Starlink's recycled IPs.

closes #2792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes an issue where the App Store changelog displays empty release entries for plugins that have git tags but no published GitHub Releases. GitHub's `releases.atom` feed generates synthetic placeholder entries for every git tag with auto-generated "Release <tag>" body text. The fix filters out these placeholder entries, allowing the application to fall back to the plugin's `CHANGELOG.md` file when only bare tags exist.

## Changes

**src/appstore/github-releases.ts**
- Introduces an internal `isPublishedRelease` predicate that identifies and filters out placeholder GitHub atom feed entries
- Treats entries with empty or exactly `Release <tag>` formatted body text as non-real releases
- Updates `fetchReleasesMarkdown` to filter parsed feed entries through this predicate before returning Markdown and rendering the changelog

**test/appstore/detail.test.ts**
- Adds Atom feed fixtures for testing (`TAG_ONLY_ATOM` and `REAL_RELEASE_ATOM`)
- Implements comprehensive test coverage for changelog source behavior including:
  - Tag-only release entries are ignored with fallback to `CHANGELOG.md`
  - When the feed contains only tags and no `CHANGELOG.md` exists, the changelog is empty with `changelogFormat` set to `synthesized`
  - Real GitHub release notes are used when present
  - Real GitHub release notes take precedence over `CHANGELOG.md` when both exist

## Benefits

Using the atom feed approach preserves API rate limit budget by avoiding the REST API, which is important for new users and instances on limited bandwidth connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->