### PR TITLE
ci(plugin): pin macOS runner to macos-15 in plugin-ci.yml

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -71,7 +71,7 @@ jobs:
     name: >-
       ${{ matrix.os == 'ubuntu-latest' && 'Linux' ||
           matrix.os == 'ubuntu-24.04-arm' && 'Linux arm64' ||
-          matrix.os == 'macos-latest' && 'macOS' ||
+          matrix.os == 'macos-15' && 'macOS' ||
           matrix.os == 'windows-latest' && 'Windows' ||
           matrix.os }} / Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, windows-latest]
         node: ${{ fromJson(inputs.node-versions) }}
     steps:
       - name: Checkout plugin
@@ -1460,7 +1460,7 @@ jobs:
           OS_NAME: >-
             ${{ matrix.os == 'ubuntu-latest' && 'Linux' ||
                 matrix.os == 'ubuntu-24.04-arm' && 'Linux arm64' ||
-                matrix.os == 'macos-latest' && 'macOS' ||
+                matrix.os == 'macos-15' && 'macOS' ||
                 matrix.os == 'windows-latest' && 'Windows' ||
                 matrix.os }}
           NODE_VER: ${{ matrix.node }}


### PR DESCRIPTION
## Why

The shared `plugin-ci.yml` runs its desktop matrix on `macos-latest`, which GitHub is auto-migrating to macOS 26 starting June 15, 2026. Since every plugin consumes this reusable workflow, that migration would silently move all plugin CI onto a newer Xcode/toolchain image and could shift native-module build behaviour (`better-sqlite3`, `sharp`, etc.) without warning.

## How

Pin the runner to `macos-15` (current stable) so the move to macOS 26 happens deliberately after validation. Also updates the two `matrix.os == 'macos-latest'` display-name conditionals so the job label still renders as "macOS".

closes #2798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR pins the macOS runner in the shared `plugin-ci.yml` reusable workflow from `macos-latest` to `macos-15` (current stable). The changes update the desktop platforms matrix to test macOS on `macos-15` and modify two conditionals in display-name fields to ensure the job labels continue to render correctly as "macOS" after the pin.

## Rationale

GitHub Actions is automatically migrating the `macos-latest` label to macOS 26 starting June 15, 2026. Since `plugin-ci.yml` is a shared workflow consumed by every plugin in the SignalK ecosystem, this auto-migration would silently shift all plugin CI to macOS 26 with a newer Xcode/toolchain version without warning to plugin authors. This could affect native module builds (e.g., `better-sqlite3`, `sharp`), which is exactly what the CI workflow validates. Pinning to `macos-15` allows the ecosystem to deliberately migrate to macOS 26 after validation, rather than experiencing an unintended shift in toolchain versions across all plugins.

## Changes

- Updates the `desktop` job matrix from `macos-latest` to `macos-15`
- Updates the job display-name conditional from `matrix.os == 'macos-latest' && 'macOS'` to `matrix.os == 'macos-15' && 'macOS'`
- Updates the `OS_NAME` environment variable conditional with the same runner reference change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->