### PR TITLE
ci(plugin): surface true armv7 job status via job-level continue-on-error

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1514,8 +1514,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ inputs.enable-armv7 }}
-    # Expose the test-step outcome so ci-status can distinguish a step
-    # failure (advisory) from the job itself completing.
+    # Advisory: armv7 is non-blocking. continue-on-error at the job level lets
+    # the job show its true red/green status in the GitHub UI while keeping the
+    # overall workflow check green so it never blocks a PR merge.
+    continue-on-error: true
     outputs:
       advisory-outcome: ${{ steps.armv7-test.outcome }}
     steps:
@@ -1524,8 +1526,8 @@ jobs:
 
       - name: Set up QEMU for ARM emulation
         # Advisory: a QEMU setup failure must not block the workflow — the
-        # armv7 test step handles its own failure via continue-on-error, and
-        # if QEMU truly didn't initialize, docker run will fail there instead.
+        # job-level continue-on-error handles this; if QEMU truly didn't
+        # initialize, docker run will fail there instead.
         continue-on-error: true
         uses: docker/setup-qemu-action@v4
         with:
@@ -1541,10 +1543,10 @@ jobs:
 
       - name: Test on armv7 via QEMU
         id: armv7-test
-        # Advisory: do not fail the workflow when armv7 tests fail. The
-        # outcome is captured via the job output above and surfaced in the
-        # ci-status summary.
-        continue-on-error: true
+        # The job-level continue-on-error keeps the workflow green; this step
+        # intentionally has no continue-on-error so that a failure shows the
+        # job as truly red rather than emitting a confusing red annotation
+        # under a green check.
         env:
           BUILD_CMD: ${{ inputs.build-command }}
           TEST_CMD: ${{ inputs.test-command }}
@@ -1611,8 +1613,8 @@ jobs:
         run: |
           PLUGIN_NAME=$(node -e "console.log(require('./package.json').name)" 2>/dev/null || echo "unknown")
           PLUGIN_VER=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "?")
-          # Use the test-step outcome, not job.status — the job itself
-          # succeeds (continue-on-error) even when the step fails.
+          # Use the test-step outcome — the job-level continue-on-error means
+          # job.status is always success; the step outcome carries the true result.
           RESULT="${{ steps.armv7-test.outcome }}"
 
           {


### PR DESCRIPTION
## Motivation

The armv7 advisory job used `continue-on-error: true` at the **step** level. This masked failures in a confusing way: the job check showed green while GitHub simultaneously emitted a red error annotation — making a genuine test failure visually indistinguishable from a pass at the check-status level (issue #2800).

## Change

Move `continue-on-error: true` from the `armv7-test` step to the **job** level. With job-level `continue-on-error`:

- The job shows its **true red/green status** in the GitHub UI and Checks tab
- The overall workflow check stays green — armv7 failures never block a PR merge
- The `ci-status` job's existing `::warning::` annotation and summary table continue to work unchanged (they read `steps.armv7-test.outcome` via the job output, which is the true step result regardless of the job-level flag)

Also updates two stale comments that still referenced the old step-level approach.

closes #2800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the armv7 (Cerbo GX) CI job configuration to surface test failures correctly in GitHub's UI while maintaining advisory, non-blocking status.

### Changes

**Job-level configuration**: The `armv7` job now applies `continue-on-error: true` at the job level rather than the step level. This allows the job to display its true success or failure status in the GitHub checks tab, while the overall workflow remains green—ensuring armv7 failures do not block PR merges.

**Step-level configuration**: The `armv7-test` step intentionally omits `continue-on-error`, allowing the step to report red when it fails. This prevents the confusing scenario where a genuine test failure would previously display as green in the checks tab while simultaneously emitting a red annotation.

**Job outputs**: The job exports `advisory-outcome` set to `steps.armv7-test.outcome`, allowing downstream jobs (like `ci-status`) to read the true step result rather than the artificially-adjusted job status.

**Comment updates**: Two comments are updated to reflect the job-level approach:
- The QEMU setup step comment now explains that job-level `continue-on-error` handles setup failures, with actual initialization errors caught during the docker-based test run
- The armv7-test step comment explains that the step intentionally lacks `continue-on-error` to display failures accurately
- The job summary step clarifies that it reads `steps.armv7-test.outcome` because job status is always success due to job-level `continue-on-error`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->