### PR TITLE
fix(admin-ui/source-priorities): show server error on save failure

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
@@ -659,6 +659,7 @@ const SourcePriorities: React.FC = () => {
 
   const [resetBusy, setResetBusy] = useState(false)
   const [resetError, setResetError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   const handleReset = useCallback(async () => {
     const confirmed = window.confirm(
@@ -694,6 +695,7 @@ const SourcePriorities: React.FC = () => {
   const handleSave = useCallback(async () => {
     setGroupsSaving()
     setSaving()
+    setSaveError(null)
     const payload = buildSavePayload()
     try {
       const res = await fetch(`${window.serverRoutesPrefix}/priorities`, {
@@ -702,7 +704,13 @@ const SourcePriorities: React.FC = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
-      if (!res.ok) throw new Error('save failed')
+      if (!res.ok) {
+        // The server rejects invalid payloads with a plain-text reason
+        // (e.g. a source assigned to two active groups). Surface it so
+        // the user can act on it instead of a generic failure.
+        const reason = (await res.text().catch(() => '')).trim()
+        throw new Error(reason || `save failed (HTTP ${res.status})`)
+      }
       // Reflect the save we just made in the local store before the
       // WS echo arrives. Otherwise savedGroups lags by one async tick
       // and dirty-detection flips on then off, which confuses the UI.
@@ -719,9 +727,13 @@ const SourcePriorities: React.FC = () => {
       setSourcePriorities(payload.overrides)
     } catch (err) {
       console.error('Failed to save priorities:', err)
+      setSaveError(err instanceof Error ? err.message : String(err))
       setGroupsSaveFailed()
       setSaveFailed()
-      setTimeout(() => clearSaveFailed(), 5000)
+      setTimeout(() => {
+        clearSaveFailed()
+        setSaveError(null)
+      }, 5000)
     }
   }, [
     buildSavePayload,
@@ -967,8 +979,12 @@ const SourcePriorities: React.FC = () => {
           >
             <FontAwesomeIcon icon={faFloppyDisk} /> Save all changes
           </Button>
-          {(saveState.saveFailed || groupsSaveState.saveFailed) &&
-            ' Saving priorities settings failed!'}
+          {(saveState.saveFailed || groupsSaveState.saveFailed) && (
+            <span style={{ paddingLeft: '10px' }}>
+              <Badge bg="danger">Error</Badge>{' '}
+              {saveError || 'Saving priorities settings failed.'}
+            </span>
+          )}
           {!saveState.timeoutsOk && (
             <span style={{ paddingLeft: '10px' }}>
               <Badge bg="danger">Error</Badge>


### PR DESCRIPTION
## What problem does this solve?

Saving source priorities only ever showed a generic "Saving priorities
settings failed!" with no detail. The server returns a specific plain-text
reason when it rejects a save (for example, a source assigned to two active
groups), but the admin UI discarded it, so there was no way to see why the
save failed or how to fix it.

## How was this tested?

Ran the admin-ui build and test suite. Manually confirmed a rejected save now
shows the server's reason in the footer, and a valid save shows nothing.

Before: `Saving priorities settings failed!`
After: `Error  Source <ref> appears in groups <a> and <b>; a source may belong to at most one active group.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request improves error messaging in the admin UI's source priorities feature. When saving source priorities fails, the UI now reads and displays the server's plain-text error response in the footer instead of showing only a generic error message.

## Changes

The implementation modifies `SourcePriorities.tsx` to:

- Introduce a dedicated `saveError` state for tracking save failure reasons
- Clear `saveError` before attempting to save priorities via `PUT /priorities`
- Read the plain-text response body when the server rejects a save request and throw it as the error reason, falling back to an HTTP status message if the response body is empty
- Set `saveError` with the detailed error message on failure and trigger the existing store-level save-failed flags (`setGroupsSaveFailed`, `setSaveFailed`)
- Automatically clear both the generic save-failed state and the local `saveError` after 5 seconds
- Update the footer UI to render an "Error" danger badge followed by the `saveError` message (or a default message if none is available) when save operations fail

This enables users to see specific error reasons directly—such as "Source <ref> appears in groups <a> and <b>; a source may belong to at most one active group"—instead of a generic failure message, helping them understand and resolve save operation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->