### PR TITLE
ci(plugin): accept public/ location in appIcon path validation

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -252,14 +252,22 @@ jobs:
           function normaliseRelPath(p) {
             return p.replace(/^\.?\//, '');
           }
+          // existsSync returns true for directories too. The CDN serves
+          // files; pointing signalk.appIcon at a directory is just as
+          // broken as pointing it at a missing path.
+          function isFile(p) {
+            let stat;
+            try { stat = fs.statSync(p); } catch { stat = undefined; }
+            return !!stat && stat.isFile();
+          }
           function checkDeclaredPath(field, declared) {
             const rel = normaliseRelPath(declared);
-            // existsSync returns true for directories too. The CDN serves
-            // files; pointing signalk.appIcon at a directory is just as
-            // broken as pointing it at a missing path.
-            let stat;
-            try { stat = fs.statSync(rel); } catch { stat = undefined; }
-            if (!stat || !stat.isFile()) {
+            // The runtime webapp launcher mounts the package's public/ dir at
+            // its URL root, and the App Store icon probe tries public/ first,
+            // so an asset that only lives under public/ (commonly the build
+            // output) resolves fine at runtime. Accept either location here so
+            // this pre-build check does not warn about a path that works.
+            if (!isFile(rel) && !isFile('public/' + rel)) {
               warnings.push(
                 field + ' "' + declared + '" does not resolve to a file in the repo. ' +
                 'The App Store fetches assets from unpkg.com/{pkg}@{version}/{path} — ' +


### PR DESCRIPTION
The pre-build `plugin-ci.yml` validation warns when `signalk.appIcon` (or a screenshot) points at a path that only exists under `public/` — typically the build output. That asset resolves fine at runtime: the webapp launcher mounts the package `public/` dir at its URL root (`Webapp.tsx`) and the App Store icon probe tries `public/` first (`icon-probe.ts`). So the warning fires for a configuration that actually works, which is what #2803 is really about.

This accepts either the declared path or `public/<path>` in the check, removing the spurious warning while still warning when the file is genuinely absent.

Note: this is a warning, never a build failure — `process.exit(1)` only fires for errors, so no plugin author was ever blocked. The broader "three consumers can't agree on one path" framing in #2803 does not hold (e.g. `@signalk/freeboard-sk` uses a single `appIcon` value that satisfies CI, the launcher, and the App Store probe), but the misleading CI warning is the real kernel.

Refs #2803

## Tested
- Extracted the embedded validate script and confirmed `node --check` passes.
- Exercised `checkDeclaredPath` against a `public/`-only asset (no longer warns) and a missing path (still warns).
- `prettier --check` passes on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates the plugin CI pre-build validation for `signalk.appIcon` and `signalk.screenshots[]` so it accepts assets that exist either at the declared path or under `public/<path>`. This removes the false warning for `public/`-only files while still warning when an asset is genuinely missing. The change stays warning-only and does not fail the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->