### PR TITLE
ci(test): improve npm install against transient network errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,13 @@ jobs:
       - uses: SocketDev/action@v1
         with:
           mode: firewall-free
-      - run: sfw npm install
+      - name: Install dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: sfw npm install
       - run: npm run build:all
 
       - name: resources-provider-plugin

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 package-lock=false
 legacy-peer-deps=true
+fetch-retries=5
+fetch-retry-mintimeout=20000
+fetch-retry-maxtimeout=120000


### PR DESCRIPTION
The CI test job intermittently fails when a registry tarball download is interrupted (ECONNRESET / socket hang up). 
Add npm fetch-retry settings and wrap the install step in a retry action so transient network errors are retried instead of failing the run.