### PR TITLE
style: apply prettier formatting across repo

### DIFF
--- a/examples/wasm-plugins/example-anchor-watch-rust/README.md
+++ b/examples/wasm-plugins/example-anchor-watch-rust/README.md
@@ -168,11 +168,12 @@ curl -X POST http://localhost:3000/plugins/_signalk_example-anchor-watch-rust/ap
 ```
 
 **Request Body:**
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `latitude` | number | Yes | Latitude in degrees (-90 to 90) |
-| `longitude` | number | Yes | Longitude in degrees (-180 to 180) |
-| `maxRadius` | number | No | Max swing radius in meters (default: 50) |
+
+| Field       | Type   | Required | Description                              |
+| ----------- | ------ | -------- | ---------------------------------------- |
+| `latitude`  | number | Yes      | Latitude in degrees (-90 to 90)          |
+| `longitude` | number | Yes      | Longitude in degrees (-180 to 180)       |
+| `maxRadius` | number | No       | Max swing radius in meters (default: 50) |
 
 **Response:**
 

--- a/packages/resources-provider-plugin/src/index.ts
+++ b/packages/resources-provider-plugin/src/index.ts
@@ -361,8 +361,7 @@ module.exports = (server: ResourceProviderApp): Plugin => {
 
   const getVesselPosition = () => {
     const p = server.getSelfPath('navigation.position') as
-      | { value?: { longitude: number; latitude: number } }
-      | undefined
+      { value?: { longitude: number; latitude: number } } | undefined
     return p?.value ? [p.value.longitude, p.value.latitude] : null
   }
 

--- a/packages/server-admin-ui/public_src/react-16.production.min.js
+++ b/packages/server-admin-ui/public_src/react-16.production.min.js
@@ -146,7 +146,7 @@
           (h = 'function' === typeof h ? h : null)),
       'function' === typeof h)
     )
-      for (a = h.call(a), f = 0; !(e = a.next()).done; )
+      for (a = h.call(a), f = 0; !(e = a.next()).done;)
         ((e = e.value), (h = b + P(e, f++)), (d += O(e, h, c, g)))
     else if ('object' === e)
       throw (
@@ -226,7 +226,7 @@
       var c = a.pop()
       if (c !== b) {
         a[0] = c
-        a: for (var g = 0, e = a.length; g < e; ) {
+        a: for (var g = 0, e = a.length; g < e;) {
           var d = 2 * (g + 1) - 1,
             f = a[d],
             h = d + 1,
@@ -249,7 +249,7 @@
     return 0 !== c ? c : a.id - b.id
   }
   function F(a) {
-    for (var b = n(u); null !== b; ) {
+    for (var b = n(u); null !== b;) {
       if (null === b.callback) E(u)
       else if (b.startTime <= a)
         (E(u), (b.sortIndex = b.expirationTime), S(p, b))
@@ -274,7 +274,7 @@
     var c = m
     try {
       F(b)
-      for (l = n(p); null !== l && (!(l.expirationTime > b) || (a && !W())); ) {
+      for (l = n(p); null !== l && (!(l.expirationTime > b) || (a && !W()));) {
         var g = l.callback
         if (null !== g) {
           l.callback = null

--- a/packages/server-admin-ui/public_src/react-dom-16.production.min.js
+++ b/packages/server-admin-ui/public_src/react-dom-16.production.min.js
@@ -418,12 +418,10 @@
   function Jf(a, b, c) {
     if (b.hasOwnProperty('value') || b.hasOwnProperty('defaultValue')) {
       var d = b.type
-      if (
-        !(
-          ('submit' !== d && 'reset' !== d) ||
-          (void 0 !== b.value && null !== b.value)
-        )
-      )
+      if (!(
+        ('submit' !== d && 'reset' !== d) ||
+        (void 0 !== b.value && null !== b.value)
+      ))
         return
       b = '' + a._wrapperState.initialValue
       c || b === a.value || (a.value = b)
@@ -557,7 +555,7 @@
   function Na(a) {
     var b = a,
       c = a
-    if (a.alternate) for (; b.return; ) b = b.return
+    if (a.alternate) for (; b.return;) b = b.return
     else {
       a = b
       do ((b = a), 0 !== (b.effectTag & 1026) && (c = b.return), (a = b.return))
@@ -583,7 +581,7 @@
       if (null === b) throw Error(k(188))
       return b !== a ? null : a
     }
-    for (var c = a, d = b; ; ) {
+    for (var c = a, d = b; ;) {
       var e = c.return
       if (null === e) break
       var f = e.alternate
@@ -596,7 +594,7 @@
         break
       }
       if (e.child === f.child) {
-        for (f = e.child; f; ) {
+        for (f = e.child; f;) {
           if (f === c) return (Rf(e), a)
           if (f === d) return (Rf(e), b)
           f = f.sibling
@@ -605,7 +603,7 @@
       }
       if (c.return !== d.return) ((c = e), (d = f))
       else {
-        for (var g = !1, h = e.child; h; ) {
+        for (var g = !1, h = e.child; h;) {
           if (h === c) {
             g = !0
             c = e
@@ -621,7 +619,7 @@
           h = h.sibling
         }
         if (!g) {
-          for (h = f.child; h; ) {
+          for (h = f.child; h;) {
             if (h === c) {
               g = !0
               c = f
@@ -647,12 +645,12 @@
   function Sf(a) {
     a = vi(a)
     if (!a) return null
-    for (var b = a; ; ) {
+    for (var b = a; ;) {
       if (5 === b.tag || 6 === b.tag) return b
       if (b.child) ((b.child.return = b), (b = b.child))
       else {
         if (b === a) break
-        for (; !b.sibling; ) {
+        for (; !b.sibling;) {
           if (!b.return || b.return === a) return null
           b = b.return
         }
@@ -735,7 +733,7 @@
       var d = c
       if (3 === d.tag) d = d.stateNode.containerInfo
       else {
-        for (; d.return; ) d = d.return
+        for (; d.return;) d = d.return
         d = 3 !== d.tag ? null : d.stateNode.containerInfo
       }
       if (!d) break
@@ -891,7 +889,7 @@
     rc(a) && c.delete(b)
   }
   function Ci() {
-    for (Rd = !1; 0 < fa.length; ) {
+    for (Rd = !1; 0 < fa.length;) {
       var a = fa[0]
       if (null !== a.blockedOn) {
         a = Hb(a.blockedOn)
@@ -928,7 +926,7 @@
     Fb.forEach(b)
     for (b = 0; b < Jb.length; b++)
       ((c = Jb[b]), c.blockedOn === a && (c.blockedOn = null))
-    for (; 0 < Jb.length && ((b = Jb[0]), null === b.blockedOn); )
+    for (; 0 < Jb.length && ((b = Jb[0]), null === b.blockedOn);)
       (Ai(b), null === b.blockedOn && Jb.shift())
   }
   function Sd(a, b) {
@@ -1046,12 +1044,10 @@
         throw Error(k(137, a, ''))
       if (null != b.dangerouslySetInnerHTML) {
         if (null != b.children) throw Error(k(60))
-        if (
-          !(
-            'object' === typeof b.dangerouslySetInnerHTML &&
-            '__html' in b.dangerouslySetInnerHTML
-          )
-        )
+        if (!(
+          'object' === typeof b.dangerouslySetInnerHTML &&
+          '__html' in b.dangerouslySetInnerHTML
+        ))
           throw Error(k(61))
       }
       if (null != b.style && 'object' !== typeof b.style) throw Error(k(62, ''))
@@ -1090,20 +1086,20 @@
     }
   }
   function hg(a) {
-    for (; a && a.firstChild; ) a = a.firstChild
+    for (; a && a.firstChild;) a = a.firstChild
     return a
   }
   function ig(a, b) {
     var c = hg(a)
     a = 0
-    for (var d; c; ) {
+    for (var d; c;) {
       if (3 === c.nodeType) {
         d = a + c.textContent.length
         if (a <= b && d >= b) return { node: c, offset: b - a }
         a = d
       }
       a: {
-        for (; c; ) {
+        for (; c;) {
           if (c.nextSibling) {
             c = c.nextSibling
             break a
@@ -1131,7 +1127,7 @@
       : !1
   }
   function kg() {
-    for (var a = window, b = Wd(); b instanceof a.HTMLIFrameElement; ) {
+    for (var a = window, b = Wd(); b instanceof a.HTMLIFrameElement;) {
       try {
         var c = 'string' === typeof b.contentWindow.location.href
       } catch (d) {
@@ -1188,7 +1184,7 @@
   }
   function mg(a) {
     a = a.previousSibling
-    for (var b = 0; a; ) {
+    for (var b = 0; a;) {
       if (8 === a.nodeType) {
         var c = a.data
         if (c === ng || c === Zd || c === $d) {
@@ -1203,11 +1199,11 @@
   function Bb(a) {
     var b = a[Aa]
     if (b) return b
-    for (var c = a.parentNode; c; ) {
+    for (var c = a.parentNode; c;) {
       if ((b = c[Lb] || c[Aa])) {
         c = b.alternate
         if (null !== b.child || (null !== c && null !== c.child))
-          for (a = mg(a); null !== a; ) {
+          for (a = mg(a); null !== a;) {
             if ((c = a[Aa])) return c
             a = mg(a)
           }
@@ -1278,8 +1274,8 @@
   }
   function Ji(a) {
     if (a && a.dispatchConfig.phasedRegistrationNames) {
-      for (var b = a._targetInst, c = []; b; ) (c.push(b), (b = pa(b)))
-      for (b = c.length; 0 < b--; ) qg(c[b], 'captured', a)
+      for (var b = a._targetInst, c = []; b;) (c.push(b), (b = pa(b)))
+      for (b = c.length; 0 < b--;) qg(c[b], 'captured', a)
       for (b = 0; b < c.length; b++) qg(c[b], 'bubbled', a)
     }
   }
@@ -1673,7 +1669,7 @@
     a.type._context._currentValue = b
   }
   function Sg(a, b) {
-    for (; null !== a; ) {
+    for (; null !== a;) {
       var c = a.alternate
       if (a.childExpirationTime < b)
         ((a.childExpirationTime = b),
@@ -1999,11 +1995,11 @@
     }
     function c(c, d) {
       if (!a) return null
-      for (; null !== d; ) (b(c, d), (d = d.sibling))
+      for (; null !== d;) (b(c, d), (d = d.sibling))
       return null
     }
     function d(a, b) {
-      for (a = new Map(); null !== b; )
+      for (a = new Map(); null !== b;)
         (null !== b.key ? a.set(b.key, b) : a.set(b.index, b), (b = b.sibling))
       return a
     }
@@ -2219,7 +2215,7 @@
           case Pc:
             a: {
               n = f.key
-              for (m = d; null !== m; ) {
+              for (m = d; null !== m;) {
                 if (m.key === n) {
                   switch (m.tag) {
                     case 7:
@@ -2258,7 +2254,7 @@
             return g(a)
           case gb:
             a: {
-              for (m = f.key; null !== d; ) {
+              for (m = f.key; null !== d;) {
                 if (d.key === m)
                   if (
                     4 === d.tag &&
@@ -2344,7 +2340,7 @@
     Ub.current === a && (q(ja), q(Ub))
   }
   function Rc(a) {
-    for (var b = a; null !== b; ) {
+    for (var b = a; null !== b;) {
       if (13 === b.tag) {
         var c = b.memoizedState
         if (
@@ -2360,7 +2356,7 @@
         continue
       }
       if (b === a) break
-      for (; null === b.sibling; ) {
+      for (; null === b.sibling;) {
         if (null === b.return || b.return === a) return null
         b = b.return
       }
@@ -2743,7 +2739,7 @@
       5 !== a.tag ||
       ('head' !== b && 'body' !== b && !Yd(b, a.memoizedProps))
     )
-      for (b = Ka; b; ) (kh(a, b), (b = kb(b.nextSibling)))
+      for (b = Ka; b;) (kh(a, b), (b = kb(b.nextSibling)))
     mh(a)
     if (13 === a.tag) {
       a = a.memoizedState
@@ -2751,7 +2747,7 @@
       if (!a) throw Error(k(317))
       a: {
         a = a.nextSibling
-        for (b = 0; a; ) {
+        for (b = 0; a;) {
           if (8 === a.nodeType) {
             var c = a.data
             if (c === og) {
@@ -3036,7 +3032,7 @@
           ((g = null !== b.memoizedState ? b.child.child : b.child),
           g !== a.child)
         )
-          for (c.child = g; null !== g; ) ((g.return = c), (g = g.sibling))
+          for (c.child = g; null !== g;) ((g.return = c), (g = g.sibling))
         d = Sa(d, e)
         d.return = b
         c.sibling = d
@@ -3111,7 +3107,7 @@
     if (0 !== (d & 2)) ((d = (d & 1) | 2), (b.effectTag |= 64))
     else {
       if (null !== a && 0 !== (a.effectTag & 64))
-        a: for (a = b.child; null !== a; ) {
+        a: for (a = b.child; null !== a;) {
           if (13 === a.tag) null !== a.memoizedState && uh(a, c)
           else if (19 === a.tag) uh(a, c)
           else if (null !== a.child) {
@@ -3120,7 +3116,7 @@
             continue
           }
           if (a === b) break a
-          for (; null === a.sibling; ) {
+          for (; null === a.sibling;) {
             if (null === a.return || a.return === b) break a
             a = a.return
           }
@@ -3135,7 +3131,7 @@
       switch (e) {
         case 'forwards':
           c = b.child
-          for (e = null; null !== c; )
+          for (e = null; null !== c;)
             ((a = c.alternate),
               null !== a && null === Rc(a) && (e = c),
               (c = c.sibling))
@@ -3148,7 +3144,7 @@
         case 'backwards':
           c = null
           e = b.child
-          for (b.child = null; null !== e; ) {
+          for (b.child = null; null !== e;) {
             a = e.alternate
             if (null !== a && null === Rc(a)) {
               b.child = e
@@ -3179,7 +3175,7 @@
       a = b.child
       c = Sa(a, a.pendingProps)
       b.child = c
-      for (c.return = b; null !== a.sibling; )
+      for (c.return = b; null !== a.sibling;)
         ((a = a.sibling),
           (c = c.sibling = Sa(a, a.pendingProps)),
           (c.return = b))
@@ -3191,13 +3187,13 @@
     switch (a.tailMode) {
       case 'hidden':
         b = a.tail
-        for (var c = null; null !== b; )
+        for (var c = null; null !== b;)
           (null !== b.alternate && (c = b), (b = b.sibling))
         null === c ? (a.tail = null) : (c.sibling = null)
         break
       case 'collapsed':
         c = a.tail
-        for (var d = null; null !== c; )
+        for (var d = null; null !== c;)
           (null !== c.alternate && (d = c), (c = c.sibling))
         null === d
           ? b || null === a.tail
@@ -3511,7 +3507,7 @@
           if (e) $c(d, !1)
           else {
             if (F !== Xa || (null !== a && 0 !== (a.effectTag & 64)))
-              for (f = b.child; null !== f; ) {
+              for (f = b.child; null !== f;) {
                 a = Rc(f)
                 if (null !== a) {
                   b.effectTag |= 64
@@ -3520,7 +3516,7 @@
                   null !== e && ((b.updateQueue = e), (b.effectTag |= 4))
                   null === d.lastEffect && (b.firstEffect = null)
                   b.lastEffect = d.lastEffect
-                  for (d = b.child; null !== d; )
+                  for (d = b.child; null !== d;)
                     ((e = d),
                       (f = c),
                       (e.effectTag &= 2),
@@ -3859,7 +3855,7 @@
   }
   function Gh(a) {
     a: {
-      for (var b = a.return; null !== b; ) {
+      for (var b = a.return; null !== b;) {
         if (Fh(b)) {
           var c = b
           break a
@@ -3885,8 +3881,8 @@
         throw Error(k(161))
     }
     c.effectTag & 16 && (Wb(b, ''), (c.effectTag &= -17))
-    a: b: for (c = a; ; ) {
-      for (; null === c.sibling; ) {
+    a: b: for (c = a; ;) {
+      for (; null === c.sibling;) {
         if (null === c.return || Fh(c.return)) {
           c = null
           break a
@@ -3894,7 +3890,7 @@
         c = c.return
       }
       c.sibling.return = c.return
-      for (c = c.sibling; 5 !== c.tag && 6 !== c.tag && 18 !== c.tag; ) {
+      for (c = c.sibling; 5 !== c.tag && 6 !== c.tag && 18 !== c.tag;) {
         if (c.effectTag & 2) continue b
         if (null === c.child || 4 === c.tag) continue b
         else ((c.child.return = c), (c = c.child))
@@ -3923,7 +3919,7 @@
               null !== b.onclick ||
               (b.onclick = uc)))
     else if (4 !== d && ((a = a.child), null !== a))
-      for (Oe(a, b, c), a = a.sibling; null !== a; )
+      for (Oe(a, b, c), a = a.sibling; null !== a;)
         (Oe(a, b, c), (a = a.sibling))
   }
   function Pe(a, b, c) {
@@ -3933,11 +3929,11 @@
       ((a = e ? a.stateNode : a.stateNode.instance),
         b ? c.insertBefore(a, b) : c.appendChild(a))
     else if (4 !== d && ((a = a.child), null !== a))
-      for (Pe(a, b, c), a = a.sibling; null !== a; )
+      for (Pe(a, b, c), a = a.sibling; null !== a;)
         (Pe(a, b, c), (a = a.sibling))
   }
   function Dh(a, b, c) {
-    for (var d = b, e = !1, f, g; ; ) {
+    for (var d = b, e = !1, f, g; ;) {
       if (!e) {
         e = d.return
         a: for (;;) {
@@ -3961,12 +3957,12 @@
         e = !0
       }
       if (5 === d.tag || 6 === d.tag) {
-        a: for (var h = a, m = d, n = c, l = m; ; )
+        a: for (var h = a, m = d, n = c, l = m; ;)
           if ((Ch(h, l, n), null !== l.child && 4 !== l.tag))
             ((l.child.return = l), (l = l.child))
           else {
             if (l === m) break a
-            for (; null === l.sibling; ) {
+            for (; null === l.sibling;) {
               if (null === l.return || l.return === m) break a
               l = l.return
             }
@@ -3992,7 +3988,7 @@
         continue
       }
       if (d === b) break
-      for (; null === d.sibling; ) {
+      for (; null === d.sibling;) {
         if (null === d.return || d.return === b) return
         d = d.return
         4 === d.tag && (e = !1)
@@ -4073,7 +4069,7 @@
           ? (d = !1)
           : ((d = !0), (c = b.child), (Re = Y()))
         if (null !== c)
-          a: for (a = c; ; ) {
+          a: for (a = c; ;) {
             if (5 === a.tag)
               ((f = a.stateNode),
                 d
@@ -4105,7 +4101,7 @@
               continue
             }
             if (a === c) break
-            for (; null === a.sibling; ) {
+            for (; null === a.sibling;) {
               if (null === a.return || a.return === c) break a
               a = a.return
             }
@@ -4210,7 +4206,7 @@
       e = null
     if (null === d && 3 === a.tag) e = a.stateNode
     else
-      for (; null !== d; ) {
+      for (; null !== d;) {
         c = d.alternate
         d.childExpirationTime < b && (d.childExpirationTime = b)
         null !== c && c.childExpirationTime < b && (c.childExpirationTime = b)
@@ -4472,7 +4468,7 @@
     var c = a.timeoutHandle
     ;-1 !== c && ((a.timeoutHandle = -1), vj(c))
     if (null !== t)
-      for (c = t.return; null !== c; ) {
+      for (c = t.return; null !== c;) {
         var d = c
         switch (d.tag) {
           case 1:
@@ -4517,7 +4513,7 @@
         le()
         Sc.current = Tc
         if (Uc)
-          for (var c = z.memoizedState; null !== c; ) {
+          for (var c = z.memoizedState; null !== c;) {
             var d = c.queue
             null !== d && (d.pending = null)
             c = c.next
@@ -4666,10 +4662,10 @@
     a > Xb && (Xb = a)
   }
   function tj() {
-    for (; null !== t; ) t = Th(t)
+    for (; null !== t;) t = Th(t)
   }
   function rj() {
-    for (; null !== t && !yj(); ) t = Th(t)
+    for (; null !== t && !yj();) t = Th(t)
   }
   function Th(a) {
     var b = zj(a.alternate, a, P)
@@ -4686,7 +4682,7 @@
       if (0 === (t.effectTag & 2048)) {
         b = hj(b, t, P)
         if (1 === P || 1 !== t.childExpirationTime) {
-          for (var c = 0, d = t.child; null !== d; ) {
+          for (var c = 0, d = t.child; null !== d;) {
             var e = d.expirationTime,
               f = d.childExpirationTime
             e > c && (c = e)
@@ -4792,7 +4788,7 @@
                 r = g,
                 z = null
               b: for (;;) {
-                for (var v; ; ) {
+                for (var v; ;) {
                   r !== h || (0 !== n && 3 !== r.nodeType) || (w = ba + n)
                   r !== q || (0 !== m && 3 !== r.nodeType) || (y = ba + m)
                   3 === r.nodeType && (ba += r.nodeValue.length)
@@ -4830,7 +4826,7 @@
       l = e
       do
         try {
-          for (g = a, h = b; null !== l; ) {
+          for (g = a, h = b; null !== l;) {
             var x = l.effectTag
             x & 16 && Wb(l.stateNode, '')
             if (x & 128) {
@@ -4914,7 +4910,7 @@
                     ? (u.addRange(A), u.extend(q.node, q.offset))
                     : (A.setEnd(q.node, q.offset), u.addRange(A))))))
         A = []
-        for (u = x; (u = u.parentNode); )
+        for (u = x; (u = u.parentNode);)
           1 === u.nodeType &&
             A.push({ element: u, left: u.scrollLeft, top: u.scrollTop })
         'function' === typeof x.focus && x.focus()
@@ -4929,7 +4925,7 @@
       l = e
       do
         try {
-          for (x = a; null !== l; ) {
+          for (x = a; null !== l;) {
             var F = l.effectTag
             F & 36 && oj(x, l.alternate, l)
             if (F & 128) {
@@ -4961,7 +4957,7 @@
     } else a.current = c
     if (ld) ((ld = !1), (Zb = a), ($b = b))
     else
-      for (l = e; null !== l; )
+      for (l = e; null !== l;)
         ((b = l.nextEffect), (l.nextEffect = null), (l = b))
     b = a.firstPendingTime
     0 === b && (La = null)
@@ -4974,7 +4970,7 @@
     return null
   }
   function Bj() {
-    for (; null !== l; ) {
+    for (; null !== l;) {
       var a = l.effectTag
       0 !== (a & 256) && nj(l.alternate, l)
       0 === (a & 512) ||
@@ -5001,7 +4997,7 @@
     if ((p & (ca | ma)) !== H) throw Error(k(331))
     var b = p
     p |= ma
-    for (a = a.current.firstEffect; null !== a; ) {
+    for (a = a.current.firstEffect; null !== a;) {
       try {
         var c = a
         if (0 !== (c.effectTag & 512))
@@ -5034,7 +5030,7 @@
   function Za(a, b) {
     if (3 === a.tag) Vh(a, a, b)
     else
-      for (var c = a.return; null !== c; ) {
+      for (var c = a.return; null !== c;) {
         if (3 === c.tag) {
           Vh(c, a, b)
           break
@@ -5390,7 +5386,7 @@
     b ||
       ((b = a ? (9 === a.nodeType ? a.documentElement : a.firstChild) : null),
       (b = !(!b || 1 !== b.nodeType || !b.hasAttribute('data-reactroot'))))
-    if (!b) for (var c; (c = a.lastChild); ) a.removeChild(c)
+    if (!b) for (var c; (c = a.lastChild);) a.removeChild(c)
     return new ef(a, 0, b ? { hydrate: !0 } : void 0)
   }
   function nd(a, b, c, d, e) {
@@ -5619,8 +5615,8 @@
       else {
         od = od || document.createElement('div')
         od.innerHTML = '<svg>' + b.valueOf().toString() + '</svg>'
-        for (b = od.firstChild; a.firstChild; ) a.removeChild(a.firstChild)
-        for (; b.firstChild; ) a.appendChild(b.firstChild)
+        for (b = od.firstChild; a.firstChild;) a.removeChild(a.firstChild)
+        for (; b.firstChild;) a.appendChild(b.firstChild)
       }
     }),
     Wb = function (a, b) {
@@ -6202,9 +6198,9 @@
             for (a = m; a; a = pa(a)) g++
             a = 0
             for (b = l; b; b = pa(b)) a++
-            for (; 0 < g - a; ) ((m = pa(m)), g--)
-            for (; 0 < a - g; ) ((l = pa(l)), a--)
-            for (; g--; ) {
+            for (; 0 < g - a;) ((m = pa(m)), g--)
+            for (; 0 < a - g;) ((l = pa(l)), a--)
+            for (; g--;) {
               if (m === l || m === l.alternate) break a
               m = pa(m)
               l = pa(l)
@@ -6213,20 +6209,20 @@
           }
         else m = null
         l = m
-        for (m = []; d && d !== l; ) {
+        for (m = []; d && d !== l;) {
           g = d.alternate
           if (null !== g && g === l) break
           m.push(d)
           d = pa(d)
         }
-        for (d = []; k && k !== l; ) {
+        for (d = []; k && k !== l;) {
           g = k.alternate
           if (null !== g && g === l) break
           d.push(k)
           k = pa(k)
         }
         for (k = 0; k < m.length; k++) be(m[k], 'bubbled', n)
-        for (k = d.length; 0 < k--; ) be(d[k], 'captured', c)
+        for (k = d.length; 0 < k--;) be(d[k], 'captured', c)
         return 0 === (e & 64) ? [n] : [n, c]
       }
     },
@@ -6788,7 +6784,7 @@
     ia = !1,
     Je = { dehydrated: null, retryTime: 0 }
   var jj = function (a, b, c, d) {
-    for (c = b.child; null !== c; ) {
+    for (c = b.child; null !== c;) {
       if (5 === c.tag || 6 === c.tag) a.appendChild(c.stateNode)
       else if (4 !== c.tag && null !== c.child) {
         c.child.return = c
@@ -6796,7 +6792,7 @@
         continue
       }
       if (c === b) break
-      for (; null === c.sibling; ) {
+      for (; null === c.sibling;) {
         if (null === c.return || c.return === b) return
         c = c.return
       }
@@ -7100,7 +7096,7 @@
               (ra = b),
               (e = Wa = !0))
           if (e)
-            for (c = Fe(b, null, d, c), b.child = c; c; )
+            for (c = Fe(b, null, d, c), b.child = c; c;)
               ((c.effectTag = (c.effectTag & -3) | 1024), (c = c.sibling))
           else (T(a, b, d, c), Ee())
           b = b.child
@@ -7169,11 +7165,11 @@
                 break a
               }
             } else
-              for (h = b.child, null !== h && (h.return = b); null !== h; ) {
+              for (h = b.child, null !== h && (h.return = b); null !== h;) {
                 var m = h.dependencies
                 if (null !== m) {
                   g = h.child
-                  for (var l = m.firstContext; null !== l; ) {
+                  for (var l = m.firstContext; null !== l;) {
                     if (l.context === d && 0 !== (l.observedBits & f)) {
                       1 === h.tag && ((l = Ea(c, null)), (l.tag = Jc), Fa(h, l))
                       h.expirationTime < c && (h.expirationTime = c)
@@ -7196,7 +7192,7 @@
                       : h.child
                 if (null !== g) g.return = h
                 else
-                  for (g = h; null !== g; ) {
+                  for (g = h; null !== g;) {
                     if (g === b) {
                       g = null
                       break
@@ -7294,7 +7290,7 @@
         Dd(a, c)
         b = c.name
         if ('radio' === c.type && null != b) {
-          for (c = a; c.parentNode; ) c = c.parentNode
+          for (c = a; c.parentNode;) c = c.parentNode
           c = c.querySelectorAll(
             'input[name=' + JSON.stringify('' + b) + '][type="radio"]'
           )

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -204,14 +204,11 @@ export default function Sidebar({ location }: SidebarProps) {
 
     const unconfiguredCount = plugins.filter((plugin: Plugin) => {
       const bundled = (plugin as Record<string, unknown>).bundled as
-        | boolean
-        | undefined
+        boolean | undefined
       const schema = (plugin as Record<string, unknown>).schema as
-        | { properties?: Record<string, unknown> }
-        | undefined
+        { properties?: Record<string, unknown> } | undefined
       const data = (plugin as Record<string, unknown>).data as
-        | { configuration?: unknown }
-        | undefined
+        { configuration?: unknown } | undefined
       return (
         !bundled &&
         schema?.properties &&

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -2,11 +2,7 @@ import { useStore, type SignalKStore } from '../store'
 import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
-  | 'initial'
-  | 'connecting'
-  | 'open'
-  | 'closed'
-  | 'error'
+  'initial' | 'connecting' | 'open' | 'closed' | 'error'
 
 export type DeltaMessageHandler = (message: unknown) => void
 export type StatusChangeHandler = (status: WebSocketStatus) => void
@@ -20,8 +16,7 @@ interface WebSocketServiceState {
 type Listener = () => void
 type ZustandStateSetter = (
   partial:
-    | Partial<SignalKStore>
-    | ((state: SignalKStore) => Partial<SignalKStore>)
+    Partial<SignalKStore> | ((state: SignalKStore) => Partial<SignalKStore>)
 ) => void
 
 export class WebSocketService {

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -395,8 +395,7 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const clear = (get() as any).clearRetiredSuppressions as
-      | ((s: Record<string, string[]>) => void)
-      | undefined
+      ((s: Record<string, string[]>) => void) | undefined
     clear?.(newcomersByGroup)
   },
 

--- a/packages/server-admin-ui/src/store/slices/wsSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/wsSlice.ts
@@ -1,11 +1,7 @@
 import type { StateCreator } from 'zustand'
 
 export type WebSocketStatus =
-  | 'initial'
-  | 'connecting'
-  | 'open'
-  | 'closed'
-  | 'error'
+  'initial' | 'connecting' | 'open' | 'closed' | 'error'
 
 export type DeltaMessageHandler = (message: unknown) => void
 

--- a/packages/server-admin-ui/src/utils/sourceLabels.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.ts
@@ -40,8 +40,7 @@ export interface SourceDevice {
 
 export interface SourcesData {
   [connectionOrKey: string]:
-    | SourceDevice
-    | { type?: string; [key: string]: unknown }
+    SourceDevice | { type?: string; [key: string]: unknown }
 }
 
 /**
@@ -153,8 +152,7 @@ export function canonicaliseSourceRef(
   const parsed = parseSourceRef(sourceRef)
   if (!parsed) return sourceRef
   const conn = sourcesData[parsed.connection] as
-    | Record<string, unknown>
-    | undefined
+    Record<string, unknown> | undefined
   if (!conn || typeof conn !== 'object') return sourceRef
   const dev = conn[parsed.src] as SourceDevice | undefined
   if (!dev || typeof dev !== 'object') return sourceRef

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
@@ -236,8 +236,7 @@ const DataBrowser: React.FC = () => {
       const connNode = tree[conn] as Record<string, unknown> | undefined
       if (!connNode) return true
       const dev = connNode[addr] as
-        | { n2k?: { manufacturerCode?: string; modelId?: string } }
-        | undefined
+        { n2k?: { manufacturerCode?: string; modelId?: string } } | undefined
       if (!dev) return true
       // For non-N2K sources (no n2k subtree), there's nothing to
       // populate later — don't bother refetching. For N2K, refetch
@@ -704,8 +703,7 @@ const DataBrowser: React.FC = () => {
           continue
         }
         const incomingData = currentData[ctxPrefix || context]?.[realKey] as
-          | PathData
-          | undefined
+          PathData | undefined
         // Server emits livePreferredSources in canonical (canName) form;
         // canonicalise the incoming raw $source before comparing so the
         // dedup decision matches the engine's identity rule.

--- a/packages/server-admin-ui/src/views/DataBrowser/useSignalKData.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/useSignalKData.ts
@@ -256,8 +256,7 @@ export function useSignalKData() {
 
     if (contextKeys.includes('self')) {
       const contextData = currentData['self']?.['name'] as
-        | { value?: string }
-        | undefined
+        { value?: string } | undefined
       const contextName = contextData?.value
       options.push({
         value: 'self',
@@ -270,8 +269,7 @@ export function useSignalKData() {
     contextKeys.forEach((key) => {
       if (key !== 'self') {
         const contextData = currentData[key]?.['name'] as
-          | { value?: string }
-          | undefined
+          { value?: string } | undefined
         const contextName = contextData?.value
         options.push({
           value: key,

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
@@ -86,8 +86,7 @@ function extractPathSourceMeta(tree: unknown): SourceMetaMap {
     }
 
     const values = n.values as
-      | Record<string, Record<string, unknown>>
-      | undefined
+      Record<string, Record<string, unknown>> | undefined
     if (values && typeof values === 'object') {
       for (const [ref, entry] of Object.entries(values)) {
         if (!entry || typeof entry !== 'object') continue

--- a/packages/server-admin-ui/src/views/Webapps/dynamicutilities.ts
+++ b/packages/server-admin-ui/src/views/Webapps/dynamicutilities.ts
@@ -534,8 +534,7 @@ export const toLazyDynamicComponent = (
   React.lazy(() =>
     (async () => {
       let container = window[toSafeModuleId(moduleName)] as
-        | Container
-        | undefined
+        Container | undefined
 
       if (container === undefined) {
         const remoteEntryScript = findRemoteEntryScript(moduleName)

--- a/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
@@ -12,12 +12,7 @@ export interface PluginCiJob {
   platform: string
   node: number
   conclusion:
-    | 'success'
-    | 'failure'
-    | 'skipped'
-    | 'cancelled'
-    | 'in_progress'
-    | null
+    'success' | 'failure' | 'skipped' | 'cancelled' | 'in_progress' | null
   server_version?: string
   job_url?: string
 }

--- a/packages/server-api/src/autopilotapi.ts
+++ b/packages/server-api/src/autopilotapi.ts
@@ -5,13 +5,7 @@ import { Value } from './deltas'
  * @category  Autopilot API
  */
 export type AutopilotUpdateAttrib =
-  | 'mode'
-  | 'state'
-  | 'target'
-  | 'engaged'
-  | 'options'
-  | 'actions'
-  | 'alarm'
+  'mode' | 'state' | 'target' | 'engaged' | 'options' | 'actions' | 'alarm'
 
 /**@hidden
  * @category  Autopilot API

--- a/packages/server-api/src/resourcesapi.ts
+++ b/packages/server-api/src/resourcesapi.ts
@@ -1,10 +1,6 @@
 /** @category  Resources API */
 export type SignalKResourceType =
-  | 'routes'
-  | 'waypoints'
-  | 'notes'
-  | 'regions'
-  | 'charts'
+  'routes' | 'waypoints' | 'notes' | 'regions' | 'charts'
 
 /**
  * @hidden

--- a/packages/server-api/src/subscriptionmanager.ts
+++ b/packages/server-api/src/subscriptionmanager.ts
@@ -121,8 +121,7 @@ type InstantPolicyOptions = {
  * @category Server API
  */
 export type SubscriptionOptions = (
-  | FixedPolicyOptions
-  | InstantPolicyOptions
+  FixedPolicyOptions | InstantPolicyOptions
 ) & {
   /**
    * The path to subscribe to.

--- a/packages/server-api/src/weatherapi.ts
+++ b/packages/server-api/src/weatherapi.ts
@@ -361,10 +361,7 @@ export interface WeatherData {
  * @category  Weather API
  */
 export type TendencyKind =
-  | 'steady'
-  | 'decreasing'
-  | 'increasing'
-  | 'not available'
+  'steady' | 'decreasing' | 'increasing' | 'not available'
 
 /**
  * @category  Weather API

--- a/packages/streams/src/n2k-signalk.ts
+++ b/packages/streams/src/n2k-signalk.ts
@@ -247,8 +247,7 @@ export default class N2kToSignalK extends Transform {
       }
 
       const delta = this.n2kMapper.toDelta(chunk) as unknown as
-        | Delta
-        | undefined
+        Delta | undefined
 
       const src = Number(chunk.src)
       if (!this.sourceMeta[src]) {

--- a/src/api/course/index.ts
+++ b/src/api/course/index.ts
@@ -1361,8 +1361,7 @@ export class CourseApi {
     if (h) {
       try {
         return (await this.resourcesApi.getResource(h.type, h.id)) as
-          | Route
-          | undefined
+          Route | undefined
       } catch (_err) {
         debug(`** Unable to fetch resource: ${h.type}, ${h.id}`)
         return undefined

--- a/src/appstore/detail.ts
+++ b/src/appstore/detail.ts
@@ -29,9 +29,7 @@ interface FetchOptions {
 // 'error' = network/timeout/abort or 5xx; we don't know whether the asset
 // exists, so the caller must not advertise it as missing.
 type FetchTextResult =
-  | { kind: 'ok'; text: string }
-  | { kind: 'missing' }
-  | { kind: 'error' }
+  { kind: 'ok'; text: string } | { kind: 'missing' } | { kind: 'error' }
 
 async function fetchText(
   url: string,

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -509,8 +509,7 @@ export default class DeltaCache {
     // age out and badge Offline despite the cache holding fresh data
     // for it (admin Priority Groups view, see SOURCESTATUS).
     const sourceMeta = (this.app.signalk as any)?.sourceMeta as
-      | Record<string, { lastSeen: number }>
-      | undefined
+      Record<string, { lastSeen: number }> | undefined
     const now = Date.now()
     for (const update of delta.updates) {
       if (!('values' in update) || !update.values) continue
@@ -608,8 +607,7 @@ export default class DeltaCache {
   private getSourcesCachePath(): string | null {
     if (this.sourcesCachePath === null) {
       const configPath = (this.app.config as any).configPath as
-        | string
-        | undefined
+        string | undefined
       if (configPath) {
         this.sourcesCachePath = join(configPath, SOURCES_CACHE_FILE)
       }
@@ -881,8 +879,7 @@ export default class DeltaCache {
     }
 
     const persisted = (this.app.config as any).settings?.priorityOverrides as
-      | Record<string, Array<{ sourceRef?: string }>>
-      | undefined
+      Record<string, Array<{ sourceRef?: string }>> | undefined
     if (persisted) {
       for (const [path, entries] of Object.entries(persisted)) {
         if (!Array.isArray(entries)) continue
@@ -1023,8 +1020,7 @@ export default class DeltaCache {
     }
 
     const savedGroups = (this.app.config as any).settings?.priorityGroups as
-      | Array<{ id: string; sources: string[]; inactive?: boolean }>
-      | undefined
+      Array<{ id: string; sources: string[]; inactive?: boolean }> | undefined
 
     // Membership: which saved group claims each source? Inactive groups
     // still claim their sources for display purposes.

--- a/src/interfaces/n2k-discovery.ts
+++ b/src/interfaces/n2k-discovery.ts
@@ -394,8 +394,7 @@ module.exports = (app: N2kDiscoveryApp) => {
     const statuses: SourceStatus[] = []
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sourceMeta = (app.signalk as any)?.sourceMeta as
-      | Record<string, { lastSeen?: number }>
-      | undefined
+      Record<string, { lastSeen?: number }> | undefined
     // sourceMeta is the canonical per-source freshness map. Its keys are
     // already in `sourceRef` form (e.g. "can0.44", "0183-1.II",
     // "derived-data") matching getSourceId(). Walk it directly so we
@@ -454,8 +453,7 @@ module.exports = (app: N2kDiscoveryApp) => {
     if (debug.enabled) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sourceMeta = (app.signalk as any)?.sourceMeta as
-        | Record<string, { lastSeen?: number }>
-        | undefined
+        Record<string, { lastSeen?: number }> | undefined
       debug(
         'tick: %d statuses, %d sourceMeta entries, %d source providers',
         statuses.length,
@@ -933,8 +931,7 @@ module.exports = (app: N2kDiscoveryApp) => {
         const sources = app.signalk?.sources
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const sourceMeta = (app.signalk as any).sourceMeta as
-          | Record<string, { lastSeen?: number }>
-          | undefined
+          Record<string, { lastSeen?: number }> | undefined
         const removedRefs: string[] = []
 
         if (sources && typeof sources === 'object') {

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1051,8 +1051,7 @@ function handleValuesMeta(
           // Clone and enhance metadata with displayUnits formulas
           const metaClone = structuredClone(meta) as Record<string, unknown>
           let storedDisplayUnits = metaClone.displayUnits as
-            | Record<string, unknown>
-            | undefined
+            Record<string, unknown> | undefined
           const username = this.spark.request.skPrincipal?.identifier
           if (!storedDisplayUnits?.category && path) {
             const defaultCategory = getDefaultCategory(
@@ -1315,8 +1314,7 @@ function handleRealtimeConnection(
           const pathMeta =
             (getMetadata(fullPath) as Record<string, unknown>) || {}
           const storedDU = pathMeta.displayUnits as
-            | DisplayUnitsMetadata
-            | undefined
+            DisplayUnitsMetadata | undefined
           const category =
             storedDU?.category ||
             getDefaultCategory(

--- a/src/put.ts
+++ b/src/put.ts
@@ -112,8 +112,7 @@ let putNotificationHandler: (
 // registry alone would leave the field stuck on the tree leaf.
 function removeLeafMetaField(app: PutApp, metaPath: string, name: string) {
   const leaf = _get(app.signalk.self, metaPath) as
-    | { meta?: Record<string, unknown> }
-    | undefined
+    { meta?: Record<string, unknown> } | undefined
   if (leaf?.meta) {
     delete leaf.meta[name]
   }
@@ -201,8 +200,7 @@ export function start(app: PutApp): void {
 
     // Validate displayUnits.category if present
     const displayUnits = metaValue.displayUnits as
-      | { category?: string }
-      | undefined
+      { category?: string } | undefined
     if (displayUnits?.category) {
       const schemaMeta = getMetadata('vessels.self.' + metaPath) as Record<
         string,

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -1569,12 +1569,10 @@ module.exports = function (
       const addr = dotIdx === -1 ? '' : sourceRef.slice(dotIdx + 1)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sources = (app.signalk as any)?.sources as
-        | Record<string, Record<string, unknown>>
-        | undefined
+        Record<string, Record<string, unknown>> | undefined
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sourceMeta = (app.signalk as any)?.sourceMeta as
-        | Record<string, unknown>
-        | undefined
+        Record<string, unknown> | undefined
       const inSourceDeltas = Object.prototype.hasOwnProperty.call(
         app.deltaCache.sourceDeltas,
         sourceRef

--- a/src/wasm/bindings/socket-manager.ts
+++ b/src/wasm/bindings/socket-manager.ts
@@ -35,9 +35,7 @@ interface PendingOption {
     | 'joinMulticast'
     | 'leaveMulticast'
   value:
-    | boolean
-    | number
-    | { multicastAddress: string; interfaceAddress?: string }
+    boolean | number | { multicastAddress: string; interfaceAddress?: string }
 }
 
 /**

--- a/src/wasm/loader/plugin-routes.ts
+++ b/src/wasm/loader/plugin-routes.ts
@@ -232,10 +232,7 @@ export function setupPluginSpecificRoutes(plugin: WasmPlugin): void {
     for (const endpoint of endpoints) {
       const { method, path: endpointPath, handler } = endpoint
       const routeMethod = method.toLowerCase() as
-        | 'get'
-        | 'post'
-        | 'put'
-        | 'delete'
+        'get' | 'post' | 'put' | 'delete'
 
       if (!['get', 'post', 'put', 'delete'].includes(routeMethod)) {
         debug(`Skipping unsupported method: ${method}`)

--- a/test/notifications.ts
+++ b/test/notifications.ts
@@ -17,8 +17,7 @@ describe('NotificationApi', () => {
     // Track handleMessage calls
     const handleMessageCalls: Delta[] = []
     let registeredHandler:
-      | ((delta: Delta, next: (delta: Delta) => void) => void)
-      | null = null
+      ((delta: Delta, next: (delta: Delta) => void) => void) | null = null
 
     // Mock app
     const mockApp = {

--- a/test/oidc/oidc-auth.test.ts
+++ b/test/oidc/oidc-auth.test.ts
@@ -132,8 +132,7 @@ describe('OIDC Auth Routes', () => {
     method: string,
     path: string
   ):
-    | ((req: Request, res: ExpressResponse) => Promise<void> | void)
-    | undefined {
+    ((req: Request, res: ExpressResponse) => Promise<void> | void) | undefined {
     const route = registeredRoutes.find(
       (r) => r.method === method && r.path === path
     )

--- a/test/oidc/user-service.test.ts
+++ b/test/oidc/user-service.test.ts
@@ -22,8 +22,7 @@ describe('ExternalUserService', () => {
           const { sub, issuer } = lookup.criteria
           const user = users.find((u) => {
             const oidc = u.providerData as
-              | { sub: string; issuer: string }
-              | undefined
+              { sub: string; issuer: string } | undefined
             return oidc?.sub === sub && oidc?.issuer === issuer
           })
           return user || null

--- a/test/removeSource.ts
+++ b/test/removeSource.ts
@@ -49,8 +49,7 @@ describe('DELETE /skServer/removeSource', function () {
       const tick = () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const sources = (server.app.signalk as any)?.sources as
-          | Record<string, Record<string, unknown>>
-          | undefined
+          Record<string, Record<string, unknown>> | undefined
         if (sources?.['0183-1']?.['II']) return resolve()
         if (Date.now() > deadline) {
           return reject(


### PR DESCRIPTION
Some updates must have happend and now previously passed files fails in format check.

Reformat 32 files to satisfy `prettier --check` in the ci-lint script. Changes are formatting-only, bringing files in line with the current prettier version.