### PR TITLE
fix(docker): resolve .local hostnames under network_mode: host

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,19 @@ The server automatically detects which container runtime is being used (Docker, 
 
 Supported runtimes: `docker`, `podman`, `kubernetes`, `containerd`, `crio`, `lxc`
 
+## Resolving `.local` hostnames (mDNS)
+
+Some plugins reach devices by their `.local` (mDNS/Bonjour) hostname, e.g. `shelly-xxxx.local`. Inside the container this goes through `getaddrinfo()`, which needs a working mDNS resolver — the server's own mDNS advertisement does not help here.
+
+The image ships `avahi-daemon` + `libnss-mdns`. In **bridge networking** the container starts its own avahi and `.local` resolution works out of the box. But with **`network_mode: host` on a host that already runs avahi** (e.g. Raspberry Pi OS), the container cannot run a second responder — avahi detects the conflict and refuses, leaving no resolver, so `.local` lookups fail with `EAI_AGAIN` even though the host resolves the same name fine. The container logs a `WARNING` when this happens.
+
+The fix is to let the container use the **host's** avahi by mounting the host
+D-Bus (or avahi) socket — see the `volumes:` entry in the provided
+`docker-compose.yml`. `startup.sh` then detects the host avahi and uses it
+instead of starting its own, so there is no mDNS conflict on the host. (On
+rootless podman the socket's peer credentials must match the host user, which
+needs `--userns=keep-id`.)
+
 ## Release images
 
 Release images `docker/Dockerfile_rel` are size optimized and there are only mandatory files in the images. During the release process updated npm packages in the server repo are built and published to npmjs. Release docker image is then built from the published npm packages like Signal K server is installed normally from npmjs.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,12 @@ services:
     #   ----------------------
     volumes:
       - /dev:/dev
+      # Use the host's avahi/D-Bus for mDNS, so the server and plugins can
+      # resolve other devices' .local hostnames (without it those lookups fail
+      # with EAI_AGAIN on a host that already runs avahi). This relies on
+      # network_mode: host above — comment it out if you switch to bridge mode
+      # or run on a host without avahi. See README for runtime details.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro
     #      - $PWD/signalk_conf:/home/node/.signalk    # uncomment and make signalk_conf -folder where .signalk is bind mounted
     #   ----------------------
     #      - type: bind    # (1/3) uncomment these 3 lines to control startup.sh outside container

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -83,27 +83,23 @@ else
     service dbus restart
     /usr/sbin/avahi-daemon -k 2>/dev/null
 
-    # Watch avahi's startup output live through a FIFO instead of polling a temp
-    # file. avahi runs in the foreground (no -D) writing stdout+stderr into the
-    # FIFO; a background reader forwards each line to the container log in real
-    # time and keeps draining for the daemon's whole life so avahi never blocks
-    # on a full pipe once startup is done.
+    # Stream avahi's log live through a FIFO (no temp file). avahi writes to the
+    # FIFO in the foreground; a background reader forwards each line to the
+    # container log and keeps draining for the daemon's whole life so avahi
+    # never blocks on a full pipe.
     avahi_fifo=$(mktemp -u)
     mkfifo "$avahi_fifo"
     /usr/sbin/avahi-daemon --no-drop-root >"$avahi_fifo" 2>&1 &
     avahi_pid=$!
 
-    # Under network_mode: host on a host that already runs avahi, our
-    # avahi-daemon detects the other responder (it logs "Detected another ...
-    # mDNS stack") and then either exits or runs degraded — either way it
-    # registers wrong addresses and makes mDNS unreliable, and .local lookups
-    # from inside the container fail. Detect that marker, stop our daemon so we
-    # don't degrade the host's mDNS, and point the user at the fix.
+    # Under network_mode: host on a host that already runs avahi, ours detects
+    # the other responder ("Detected another ... mDNS stack") and exits or runs
+    # degraded, breaking .local lookups. On that marker we stop our daemon (so
+    # it doesn't degrade the host's mDNS) and print how to fix it.
     (
-        # Open the read end (this rendezvous unblocks avahi's write open), then
+        # Open the read end (rendezvous unblocks avahi's write open), then
         # unlink the FIFO name — the open fd keeps it alive, leaving nothing in
-        # /tmp. On a clean start the loop drains avahi's log until it exits; on
-        # a conflict it stops our daemon and prints the fix.
+        # /tmp.
         exec 3<"$avahi_fifo"
         rm -f "$avahi_fifo"
         outcome="exited"
@@ -118,6 +114,7 @@ else
                 ;;
             *"Server startup complete"*)
                 outcome="started"
+                # keep running to drain the log until avahi exits
                 ;;
             esac
         done

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -45,16 +45,79 @@ export IS_IN_DOCKER=true
 # available" notice; the self-update button stays hidden via IS_IN_DOCKER.
 export SIGNALK_SERVER_IS_UPDATABLE=true
 
-# Check if host D-Bus socket is mounted (rootless container scenario)
-# If mounted, we use the host's D-Bus/Avahi instead of starting our own
-if [ -S /run/dbus/system_bus_socket ] && dbus-send --system --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames >/dev/null 2>&1; then
-    echo "Using host D-Bus (socket mounted from host)"
+# mDNS / D-Bus setup.
+#
+# Use the HOST's avahi (and don't run our own responder) when it is reachable.
+# This is the right setup on a host that already runs avahi (e.g. Raspberry Pi
+# OS) under network_mode: host — the container resolves .local names via
+# libnss-mdns talking to the host avahi. Two ways the host avahi is exposed:
+#   - the host D-Bus system socket is mounted and answering
+#     (-v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro); common
+#     on Docker.
+#   - the host avahi socket is mounted (-v /run/avahi-daemon/socket:...);
+#     libnss-mdns talks to it directly. Common on rootless podman, where the
+#     D-Bus EXTERNAL handshake needs --userns=keep-id to match peer creds.
+#
+# Otherwise start our own D-Bus + Avahi. This is correct for bridge mode (an
+# isolated network namespace). Under network_mode: host on a host that already
+# runs avahi WITHOUT either socket mounted, our avahi-daemon detects the other
+# mDNS stack and exits or runs degraded — so .local lookups fail (EAI_AGAIN).
+# We detect that ("Detected another ... mDNS stack"), stop our daemon so we
+# don't degrade the host's mDNS, and tell the user how to fix it.
+if [ -S /run/dbus/system_bus_socket ]; then
+    # A host D-Bus socket is mounted — do not start our own D-Bus (that would
+    # restart against the mounted host socket). Use the host's avahi if it is
+    # registered on that bus; otherwise warn rather than silently leaving no
+    # resolver.
+    if dbus-send --system --reply-timeout=3000 --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null | grep -q org.freedesktop.Avahi; then
+        echo "Using host D-Bus (socket mounted from host)"
+    else
+        echo "WARNING: host D-Bus is mounted but Avahi is not registered on it,"
+        echo "so .local names will not resolve. Start avahi on the host, or"
+        echo "remove the host D-Bus mount to run a container-local responder."
+    fi
+elif [ -S /run/avahi-daemon/socket ]; then
+    echo "Using host Avahi (socket mounted from host)"
 else
     echo "Starting container D-Bus and Avahi services"
     service dbus restart
     /usr/sbin/avahi-daemon -k 2>/dev/null
-    /usr/sbin/avahi-daemon --no-drop-root &
+    avahi_log=$(mktemp)
+    /usr/sbin/avahi-daemon --no-drop-root >"$avahi_log" 2>&1 &
+    avahi_pid=$!
     service bluetooth restart
+    # Under network_mode: host on a host that already runs avahi, our
+    # avahi-daemon detects the other responder (it logs "Detected another ...
+    # mDNS stack") and then either exits or runs degraded — either way it
+    # registers wrong addresses and makes mDNS unreliable, and .local lookups
+    # from inside the container fail. Detect that marker, stop our daemon so we
+    # don't degrade the host's mDNS, and point the user at the fix.
+    # Poll briefly rather than a single fixed wait: the conflict line can take
+    # a moment to appear, and a clean start logs "Server startup complete".
+    i=0
+    while [ "$i" -lt 10 ]; do
+        grep -q "Detected another" "$avahi_log" 2>/dev/null && break
+        grep -q "Server startup complete" "$avahi_log" 2>/dev/null && break
+        ! kill -0 "$avahi_pid" 2>/dev/null && break
+        sleep 0.5
+        i=$((i + 1))
+    done
+    if grep -q "Detected another" "$avahi_log" 2>/dev/null; then
+        kill "$avahi_pid" 2>/dev/null
+        /usr/sbin/avahi-daemon -k 2>/dev/null
+        echo "WARNING: this host already runs an mDNS responder (avahi) and the"
+        echo "container shares its network (network_mode: host), so it cannot run"
+        echo "its own. .local name resolution will not work from inside the"
+        echo "container until you let it use the host's avahi:"
+        echo "  - Docker:         mount the host D-Bus system socket"
+        echo "                      -v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro"
+        echo "  - rootless podman: run with --userns=keep-id and mount the avahi"
+        echo "                    socket -v /run/avahi-daemon/socket:/run/avahi-daemon/socket"
+    elif ! kill -0 "$avahi_pid" 2>/dev/null; then
+        echo "WARNING: avahi-daemon exited during startup; .local name resolution"
+        echo "may not work. Check the container logs for details."
+    fi
+    rm -f "$avahi_log"
 fi
 
 exec /home/node/signalk/node_modules/signalk-server/bin/signalk-server --securityenabled "$@"

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -82,42 +82,65 @@ else
     echo "Starting container D-Bus and Avahi services"
     service dbus restart
     /usr/sbin/avahi-daemon -k 2>/dev/null
-    avahi_log=$(mktemp)
-    /usr/sbin/avahi-daemon --no-drop-root >"$avahi_log" 2>&1 &
+
+    # Watch avahi's startup output live through a FIFO instead of polling a temp
+    # file. avahi runs in the foreground (no -D) writing stdout+stderr into the
+    # FIFO; a background reader forwards each line to the container log in real
+    # time and keeps draining for the daemon's whole life so avahi never blocks
+    # on a full pipe once startup is done.
+    avahi_fifo=$(mktemp -u)
+    mkfifo "$avahi_fifo"
+    /usr/sbin/avahi-daemon --no-drop-root >"$avahi_fifo" 2>&1 &
     avahi_pid=$!
-    service bluetooth restart
+
     # Under network_mode: host on a host that already runs avahi, our
     # avahi-daemon detects the other responder (it logs "Detected another ...
     # mDNS stack") and then either exits or runs degraded — either way it
     # registers wrong addresses and makes mDNS unreliable, and .local lookups
     # from inside the container fail. Detect that marker, stop our daemon so we
     # don't degrade the host's mDNS, and point the user at the fix.
-    # Poll briefly rather than a single fixed wait: the conflict line can take
-    # a moment to appear, and a clean start logs "Server startup complete".
-    i=0
-    while [ "$i" -lt 10 ]; do
-        grep -q "Detected another" "$avahi_log" 2>/dev/null && break
-        grep -q "Server startup complete" "$avahi_log" 2>/dev/null && break
-        ! kill -0 "$avahi_pid" 2>/dev/null && break
-        sleep 0.5
-        i=$((i + 1))
-    done
-    if grep -q "Detected another" "$avahi_log" 2>/dev/null; then
-        kill "$avahi_pid" 2>/dev/null
-        /usr/sbin/avahi-daemon -k 2>/dev/null
-        echo "WARNING: this host already runs an mDNS responder (avahi) and the"
-        echo "container shares its network (network_mode: host), so it cannot run"
-        echo "its own. .local name resolution will not work from inside the"
-        echo "container until you let it use the host's avahi:"
-        echo "  - Docker:         mount the host D-Bus system socket"
-        echo "                      -v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro"
-        echo "  - rootless podman: run with --userns=keep-id and mount the avahi"
-        echo "                    socket -v /run/avahi-daemon/socket:/run/avahi-daemon/socket"
-    elif ! kill -0 "$avahi_pid" 2>/dev/null; then
-        echo "WARNING: avahi-daemon exited during startup; .local name resolution"
-        echo "may not work. Check the container logs for details."
-    fi
-    rm -f "$avahi_log"
+    (
+        # Open the read end (this rendezvous unblocks avahi's write open), then
+        # unlink the FIFO name — the open fd keeps it alive, leaving nothing in
+        # /tmp. On a clean start the loop drains avahi's log until it exits; on
+        # a conflict it stops our daemon and prints the fix.
+        exec 3<"$avahi_fifo"
+        rm -f "$avahi_fifo"
+        outcome="exited"
+        while IFS= read -r line <&3; do
+            printf '%s\n' "$line"
+            case "$line" in
+            *"Detected another"*)
+                outcome="conflict"
+                kill "$avahi_pid" 2>/dev/null
+                /usr/sbin/avahi-daemon -k 2>/dev/null
+                break
+                ;;
+            *"Server startup complete"*)
+                outcome="started"
+                ;;
+            esac
+        done
+
+        case "$outcome" in
+        conflict)
+            echo "WARNING: this host already runs an mDNS responder (avahi) and the"
+            echo "container shares its network (network_mode: host), so it cannot run"
+            echo "its own. .local name resolution will not work from inside the"
+            echo "container until you let it use the host's avahi:"
+            echo "  - Docker:         mount the host D-Bus system socket"
+            echo "                      -v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro"
+            echo "  - rootless podman: run with --userns=keep-id and mount the avahi"
+            echo "                    socket -v /run/avahi-daemon/socket:/run/avahi-daemon/socket"
+            ;;
+        exited)
+            echo "WARNING: avahi-daemon exited during startup; .local name resolution"
+            echo "may not work. Check the container logs for details."
+            ;;
+        esac
+    ) &
+
+    service bluetooth restart
 fi
 
 exec /home/node/signalk/node_modules/signalk-server/bin/signalk-server --securityenabled "$@"


### PR DESCRIPTION
## Why

On a host that already runs avahi (e.g. Raspberry Pi OS) with `network_mode: host`, the container started its own `avahi-daemon`, which detects the host's mDNS stack and exits or runs degraded. That left no working resolver inside the container, so plugins resolving a device's `.local` name (e.g. a Shelly at `shelly-xxxx.local`) failed with `getaddrinfo EAI_AGAIN` — even though the host resolved the same name fine. The container also degraded the host's mDNS by registering wrong addresses.

## How

`startup.sh` now uses the host's avahi instead of starting a conflicting one:

- It already handled a mounted host D-Bus socket (Docker); that check now also confirms avahi is actually on the bus, not just that D-Bus answers.
- It now also recognises a mounted host avahi socket (`/run/avahi-daemon/socket`), which `libnss-mdns` uses directly — the path for rootless podman, where the D-Bus EXTERNAL handshake needs `--userns=keep-id`.
- When neither is mounted and a host mDNS stack is detected, it stops its own daemon (so it doesn't degrade the host's mDNS) and logs how to enable resolution per runtime.

Bridge mode is unchanged — the container still runs its own avahi there.

The example `docker-compose.yml` mounts `/run/dbus` so this works out of the box, and the README documents the per-runtime setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes `.local` hostname resolution in Docker host mode by making `docker/startup.sh` prefer the host’s mDNS/Avahi setup when it is available.

It now:
- Detects a mounted host D-Bus system bus socket and verifies that `org.freedesktop.Avahi` is registered on that bus before using host integration; otherwise it warns that `.local` names will not resolve and provides host setup/remediation guidance.
- Recognizes a mounted host Avahi daemon socket at `/run/avahi-daemon/socket` (used by `libnss-mdns`), including guidance for rootless Podman to use `--userns=keep-id`.
- Avoids degrading an existing host mDNS stack when host networking is shared by streaming Avahi startup logs (via a FIFO) and stopping the container’s `avahi-daemon` when it detects the “Detected another … mDNS stack” conflict marker, along with host socket mount instructions.
- Warns when `avahi-daemon` exits during startup without the conflict marker, since `.local` may not work.
- Sets `dbus-send` with `--reply-timeout=3000` so a stale host bus fails fast.

Bridge mode behavior remains unchanged: the container still starts its own `avahi-daemon`.

The Docker Compose example and README document the host-networking runtime setup, including mounting the host D-Bus system bus socket read-only (`/run/dbus/system_bus_socket:/run/dbus/system_bus_socket:ro`) so `startup.sh` can use the host Avahi resolver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->