### PR TITLE
feat: add sourcePolicy to History API values requests

### DIFF
--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -32,6 +32,15 @@ export type ValueList = {
 }[]
 
 /**
+ * Controls how history providers should handle multiple sources for the
+ * requested paths.
+ *
+ * - `preferred`: provider default / priority-resolved source handling
+ * - `all`: return values split by source, with `sourceRef` set in `values`
+ */
+export type HistorySourcePolicy = 'preferred' | 'all'
+
+/**
  * A row of historical data: first element is timestamp, followed by aggregated values.
  * Values can be primitives, objects (like navigation.position), or null depending on the path.
  */
@@ -104,6 +113,7 @@ export type TimeRangeQueryParams =
 export type ValuesRequestQueryParams = TimeRangeQueryParams & {
   context?: string
   resolution?: number
+  sourcePolicy?: HistorySourcePolicy
 }
 
 export type PathsRequestQueryParams = TimeRangeQueryParams
@@ -258,6 +268,7 @@ export interface PathSpec {
 export type ValuesRequest = TimeRangeParams & {
   context?: Context
   resolution?: number
+  sourcePolicy?: HistorySourcePolicy
   pathSpecs: PathSpec[]
 }
 

--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -37,6 +37,9 @@ export type ValueList = {
  *
  * - `preferred`: provider default / priority-resolved source handling
  * - `all`: return values split by source, with `sourceRef` set in `values`
+ *
+ * A `sourceRef` specified on an individual path remains an explicit filter;
+ * `all` only expands paths that do not already specify a source.
  */
 export type HistorySourcePolicy = 'preferred' | 'all'
 

--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -28,7 +28,7 @@ export type AggregateMethod =
 export type ValueList = {
   path: Path
   method: AggregateMethod
-  sourceRef?: SourceRef
+  $source?: SourceRef
 }[]
 
 /**
@@ -36,7 +36,7 @@ export type ValueList = {
  * requested paths.
  *
  * - `preferred`: provider default / priority-resolved source handling
- * - `all`: return values split by source, with `sourceRef` set in `values`
+ * - `all`: return values split by source, with `$source` set in `values`
  *
  * A `sourceRef` specified on an individual path remains an explicit filter;
  * `all` only expands paths that do not already specify a source.

--- a/packages/server-api/src/history.ts
+++ b/packages/server-api/src/history.ts
@@ -35,13 +35,12 @@ export type ValueList = {
  * Controls how history providers should handle multiple sources for the
  * requested paths.
  *
- * - `preferred`: provider default / priority-resolved source handling
  * - `all`: return values split by source, with `$source` set in `values`
  *
  * A `sourceRef` specified on an individual path remains an explicit filter;
  * `all` only expands paths that do not already specify a source.
  */
-export type HistorySourcePolicy = 'preferred' | 'all'
+export type HistorySourcePolicy = 'all'
 
 /**
  * A row of historical data: first element is timestamp, followed by aggregated values.

--- a/packages/server-api/src/typebox/history-schemas.ts
+++ b/packages/server-api/src/typebox/history-schemas.ts
@@ -45,7 +45,13 @@ export const ValuesResponseSchema = Type.Object(
     values: Type.Array(
       Type.Object({
         path: Type.String({ description: 'Signal K path' }),
-        method: Type.String({ description: 'Aggregation method' })
+        method: Type.String({ description: 'Aggregation method' }),
+        sourceRef: Type.Optional(
+          Type.String({
+            description:
+              'Source reference for this value column, present when the values are source-specific'
+          })
+        )
       })
     ),
     data: Type.Array(
@@ -80,7 +86,13 @@ export const PathSpecSchema = Type.Object(
     parameter: Type.Array(Type.String(), {
       description:
         'Additional parameters for the aggregation method (e.g., sample count for sma, alpha for ema)'
-    })
+    }),
+    sourceRef: Type.Optional(
+      Type.String({
+        description:
+          'Optional source reference to filter this path to a single source'
+      })
+    )
   },
   {
     $id: 'PathSpec',

--- a/packages/server-api/src/typebox/history-schemas.ts
+++ b/packages/server-api/src/typebox/history-schemas.ts
@@ -46,7 +46,7 @@ export const ValuesResponseSchema = Type.Object(
       Type.Object({
         path: Type.String({ description: 'Signal K path' }),
         method: Type.String({ description: 'Aggregation method' }),
-        sourceRef: Type.Optional(
+        $source: Type.Optional(
           Type.String({
             description:
               'Source reference for this value column, present when the values are source-specific'

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -521,8 +521,8 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
 
 const parseSourcePolicy = (value: unknown): HistorySourcePolicy | undefined => {
   if (value === undefined || value === null || value === '') return undefined
-  if (value === 'preferred' || value === 'all') return value
-  throw new Error("sourcePolicy parameter must be 'preferred' or 'all'")
+  if (value === 'all') return value
+  throw new Error("sourcePolicy parameter must be 'all'")
 }
 
 // Maps the single-letter unit suffix in a resolution time expression to seconds.

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -9,6 +9,7 @@ import {
   PathSpec,
   PathsRequest,
   PathsResponse,
+  HistorySourcePolicy,
   TimeRangeParams,
   ValuesRequest,
   ValuesResponse,
@@ -491,6 +492,13 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
     errors.push('paths parameter is required and must be a string')
   }
 
+  let sourcePolicy: HistorySourcePolicy | undefined
+  try {
+    sourcePolicy = parseSourcePolicy(query.sourcePolicy)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Invalid sourcePolicy')
+  }
+
   if (errors.length > 0) {
     throw new Error(`Validation errors: ${errors.join(', ')}`)
   }
@@ -504,10 +512,17 @@ const parseValuesQuery = (query: Record<string, unknown>): ValuesRequest => {
     ...timeRangeParams,
     context,
     resolution,
+    sourcePolicy,
     pathSpecs
   }
   debug.enabled && debug(JSON.stringify(parsed, null, 2))
   return parsed
+}
+
+const parseSourcePolicy = (value: unknown): HistorySourcePolicy | undefined => {
+  if (value === undefined || value === null || value === '') return undefined
+  if (value === 'preferred' || value === 'all') return value
+  throw new Error("sourcePolicy parameter must be 'preferred' or 'all'")
 }
 
 // Maps the single-letter unit suffix in a resolution time expression to seconds.

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -154,7 +154,7 @@ historyApiDoc.paths = {
           name: 'sourcePolicy',
           in: 'query',
           description:
-            "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include sourceRef in the values metadata.",
+            "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include sourceRef in the values metadata. A sourceRef specified on an individual path remains an explicit filter; 'all' only expands paths that do not already specify a source.",
           schema: { type: 'string', enum: ['preferred', 'all'] }
         },
         { $ref: '#/components/parameters/ProviderIdQuery' }

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -150,6 +150,13 @@ historyApiDoc.paths = {
             "Length of data sample time window in seconds or as a time expression ('1s', '1m', '1h', '1d'). If resolution is not specified the server should provide data in a reasonable time resolution, depending on the time range in the request.",
           schema: { type: 'number', format: 'integer' }
         },
+        {
+          name: 'sourcePolicy',
+          in: 'query',
+          description:
+            "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include sourceRef in the values metadata.",
+          schema: { type: 'string', enum: ['preferred', 'all'] }
+        },
         { $ref: '#/components/parameters/ProviderIdQuery' }
       ],
       responses: {

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -154,7 +154,7 @@ historyApiDoc.paths = {
           name: 'sourcePolicy',
           in: 'query',
           description:
-            "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include sourceRef in the values metadata. A sourceRef specified on an individual path remains an explicit filter; 'all' only expands paths that do not already specify a source.",
+            "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include $source in the values metadata. A sourceRef specified on an individual path remains an explicit filter; 'all' only expands paths that do not already specify a source.",
           schema: { type: 'string', enum: ['preferred', 'all'] }
         },
         { $ref: '#/components/parameters/ProviderIdQuery' }
@@ -205,7 +205,7 @@ historyApiDoc.paths = {
                           type: 'string',
                           description: 'Aggregation method'
                         },
-                        sourceRef: {
+                        $source: {
                           type: 'string',
                           description:
                             'Source reference, present when the query specified a source filter for this path'

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -155,7 +155,7 @@ historyApiDoc.paths = {
           in: 'query',
           description:
             "Controls how multiple historical sources are handled. With 'all', providers should return values split by source and include $source in the values metadata. A sourceRef specified on an individual path remains an explicit filter; 'all' only expands paths that do not already specify a source.",
-          schema: { type: 'string', enum: ['preferred', 'all'] }
+          schema: { type: 'string', enum: ['all'] }
         },
         { $ref: '#/components/parameters/ProviderIdQuery' }
       ],

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -208,7 +208,7 @@ historyApiDoc.paths = {
                         $source: {
                           type: 'string',
                           description:
-                            'Source reference, present when the query specified a source filter for this path'
+                            'Source reference for this value series, present when source-aware history is requested, including sourcePolicy=all'
                         }
                       }
                     }

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -187,12 +187,12 @@ describe('History API v2', () => {
         {
           path: 'navigation.speedOverGround',
           method: 'average',
-          sourceRef: 'source.a'
+          $source: 'source.a'
         },
         {
           path: 'navigation.speedOverGround',
           method: 'average',
-          sourceRef: 'source.b'
+          $source: 'source.b'
         }
       ])
       body.data.should.deep.equal([['2025-01-01T12:00:00Z', 1.2, 2.4]])

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -176,6 +176,37 @@ describe('History API v2', () => {
       body.data.length.should.be.greaterThan(0)
     })
 
+    it('passes sourcePolicy=all to the provider', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.speedOverGround&from=${FROM}&to=${TO}&resolution=60&sourcePolicy=all`
+      )
+      res.status.should.equal(200)
+      const body = await res.json()
+      assertSchema(ValuesResponseSchema, body, 'ValuesResponse')
+      body.values.should.deep.equal([
+        {
+          path: 'navigation.speedOverGround',
+          method: 'average',
+          sourceRef: 'source.a'
+        },
+        {
+          path: 'navigation.speedOverGround',
+          method: 'average',
+          sourceRef: 'source.b'
+        }
+      ])
+      body.data.should.deep.equal([['2025-01-01T12:00:00Z', 1.2, 2.4]])
+    })
+
+    it('returns 400 for invalid sourcePolicy', async function () {
+      const res = await fetch(
+        `${api}/history/values?paths=navigation.position&from=${FROM}&to=${TO}&sourcePolicy=unknown`
+      )
+      res.status.should.equal(400)
+      const body = await res.json()
+      body.error.should.contain('sourcePolicy')
+    })
+
     it('returns paths from the provider', async function () {
       const res = await fetch(`${api}/history/paths?from=${FROM}&to=${TO}`)
       res.status.should.equal(200)

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -42,8 +42,8 @@ module.exports = function(app) {
               context: 'vessels.self',
               range: { from: '2025-01-01T00:00:00Z', to: '2025-01-02T00:00:00Z' },
               values: [
-                { path: 'navigation.speedOverGround', method: 'average', sourceRef: 'source.a' },
-                { path: 'navigation.speedOverGround', method: 'average', sourceRef: 'source.b' }
+                { path: 'navigation.speedOverGround', method: 'average', $source: 'source.a' },
+                { path: 'navigation.speedOverGround', method: 'average', $source: 'source.b' }
               ],
               data: [['2025-01-01T12:00:00Z', 1.2, 2.4]]
             })

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -36,12 +36,25 @@ module.exports = function(app) {
       })
 
       app.registerHistoryApiProvider({
-        getValues: (query) => Promise.resolve({
-          context: 'vessels.self',
-          range: { from: '2025-01-01T00:00:00Z', to: '2025-01-02T00:00:00Z' },
-          values: [{ path: 'navigation.position', method: 'first' }],
-          data: [['2025-01-01T12:00:00Z', [18.46, 57.71]]]
-        }),
+        getValues: (query) => {
+          if (query.sourcePolicy === 'all') {
+            return Promise.resolve({
+              context: 'vessels.self',
+              range: { from: '2025-01-01T00:00:00Z', to: '2025-01-02T00:00:00Z' },
+              values: [
+                { path: 'navigation.speedOverGround', method: 'average', sourceRef: 'source.a' },
+                { path: 'navigation.speedOverGround', method: 'average', sourceRef: 'source.b' }
+              ],
+              data: [['2025-01-01T12:00:00Z', 1.2, 2.4]]
+            })
+          }
+          return Promise.resolve({
+            context: 'vessels.self',
+            range: { from: '2025-01-01T00:00:00Z', to: '2025-01-02T00:00:00Z' },
+            values: [{ path: 'navigation.position', method: 'first' }],
+            data: [['2025-01-01T12:00:00Z', [18.46, 57.71]]]
+          })
+        },
         getContexts: () => Promise.resolve(['vessels.self']),
         getPaths: () => Promise.resolve(['navigation.position', 'navigation.speedOverGround'])
       })


### PR DESCRIPTION
Add a `sourcePolicy` query parameter to `/history/values` and pass it through to History API providers.

This allows clients to request source-aware historical values with `sourcePolicy=all`. Providers can then return separate value columns per source and include `sourceRef` in the `values` metadata.

Also update the History API response schema to document optional `values[].sourceRef`.

Closes #2780.

Validation:
- npm run build
- targeted eslint
- tested against signalk-to-influxdb2 in a local Signal K sandbox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a `sourcePolicy` query option to `/history/values` and threads it through the History API request types and handler logic. It validates `sourcePolicy` as `all` and rejects unknown values with a 400 response. OpenAPI documents the parameter and source-aware response behavior.

When `sourcePolicy=all`, History API providers can return values separated by source and include `$source` metadata for each value column. Path specifications with an explicit `sourceRef` remain source filters and take precedence.

The PR updates the TypeBox schemas and response contract for source metadata. It keeps `sourceRef` on `PathSpec` for request-side filtering. Tests verify per-source values and rejection of invalid `sourcePolicy` input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->