### PR TITLE
fix: allow multiple deltaHandler next calls

### DIFF
--- a/src/deltachain.ts
+++ b/src/deltachain.ts
@@ -32,24 +32,27 @@ export default class DeltaChain {
       dispatch(msg, now, version)
       return
     }
-    // Isolate handlers: a plugin's delta input handler that throws must not
-    // abort the chain, or the delta (and any later handler's work, including
-    // metadata registration) is silently dropped for every input. Log and
-    // pass the unmodified delta to the next handler. `continued` guards
-    // against advancing twice when a handler calls next() and then throws.
-    let continued = false
+    // Isolate handlers: a plugin's delta input handler that throws must
+    // not abort the chain, or the delta is silently dropped. A handler may
+    // call next() multiple times (e.g. to fan one delta out into several).
+    // `nextCalled` guards the catch block from resubmitting the message
+    // when a handler calls next() and then throws.
+    let nextCalled = false
     const next = (nextMsg: Delta) => {
-      if (continued) {
-        return
-      }
-      continued = true
+      nextCalled = true
       this.doProcess(index + 1, nextMsg, dispatch, now, version)
     }
     try {
       this.chain[index](msg, next)
     } catch (err) {
-      console.error('Delta input handler threw, skipping it:', err)
-      next(msg)
+      console.error(
+        'Delta input handler threw:',
+        err,
+        nextCalled ? '(next already called)' : ''
+      )
+      if (!nextCalled) {
+        next(msg)
+      }
     }
   }
 

--- a/test/deltachain.ts
+++ b/test/deltachain.ts
@@ -9,6 +9,14 @@ const delta = (id: string): Delta => ({
 
 const now = new Date(0)
 
+const firstValue = (msg: Delta) => {
+  const update = msg.updates[0]
+  if (!('values' in update)) {
+    throw new Error('expected a values update')
+  }
+  return update.values[0]
+}
+
 const collector = () => {
   const dispatched: Delta[] = []
   const dispatch = (msg: Delta) => dispatched.push(msg)
@@ -85,5 +93,31 @@ describe('DeltaChain', function () {
     chain.process(msg, dispatch, now, SKVersion.v1)
     expect(seen).to.deep.equal(['after'])
     expect(dispatched).to.deep.equal([msg])
+  })
+
+  it('handles every delta when a handler calls next multiple times', function () {
+    const { dispatched, dispatch } = collector()
+    const chain = new DeltaChain()
+    const seen: Value[] = []
+    chain.register((msg, next) => {
+      next({
+        ...msg,
+        updates: [{ values: [{ path: 'foo' as Path, value: 1 as Value }] }]
+      })
+      next({
+        ...msg,
+        updates: [{ values: [{ path: 'bar' as Path, value: 2 as Value }] }]
+      })
+    })
+    chain.register((msg, next) => {
+      seen.push(firstValue(msg).value)
+      next(msg)
+    })
+    chain.process(delta('a'), dispatch, now, SKVersion.v1)
+    expect(seen).to.deep.equal([1, 2])
+    expect(dispatched.map((d) => firstValue(d).path)).to.deep.equal([
+      'foo',
+      'bar'
+    ])
   })
 })


### PR DESCRIPTION
Fixes #2813.

Change the guard against handlers calling next and then throwing to pass the original message only
when the handler has not called next at all.

This allows deltaHandlers to call next multiple times.

Includes a test for calling next multiple times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes `DeltaChain` error handling for handlers that call `next()` and then throw, so the original message is only forwarded when `next()` has not been called at all. It also allows `deltaHandler` implementations to call `next()` multiple times without being blocked by the previous single-advance guard.

The test suite adds coverage for multiple `next()` calls, verifying that both emitted deltas are processed and dispatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->