### PR TITLE
chore: label PRs by conventional commit title

### DIFF
--- a/.github/workflows/label-pr-by-title.yml
+++ b/.github/workflows/label-pr-by-title.yml
@@ -1,0 +1,75 @@
+name: Label PR by title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // Map conventional-commit types to the repo's PR labels
+            // (see .github/workflows/require_pr_label.yml).
+            const typeToLabel = {
+              feat: 'feature',
+              fix: 'fix',
+              docs: 'doc',
+              chore: 'chore',
+              test: 'test',
+              refactor: 'refactor',
+              perf: 'other',
+              style: 'other',
+              build: 'chore',
+              ci: 'chore'
+            }
+
+            const title = context.payload.pull_request.title || ''
+            // <type>(<optional scope>)<optional !>: e.g. "feat:", "fix(docker):"
+            const match = title.match(/^\s*([a-z]+)(\([^)]*\))?!?:/i)
+            if (!match) {
+              core.info(`No conventional prefix found in title: "${title}"`)
+              return
+            }
+
+            const type = match[1].toLowerCase()
+            const label = typeToLabel[type]
+            if (!label) {
+              core.info(`Unrecognized type "${type}", no label applied`)
+              return
+            }
+
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+
+            const managed = new Set(Object.values(typeToLabel))
+            const current = context.payload.pull_request.labels.map((l) => l.name)
+
+            // Remove any other managed label so exactly one type label remains.
+            for (const name of current) {
+              if (managed.has(name) && name !== label) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name
+                })
+              }
+            }
+
+            if (!current.includes(label)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: [label]
+              })
+              core.info(`Applied label "${label}" for type "${type}"`)
+            } else {
+              core.info(`Label "${label}" already present`)
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 1. In GitHub, create a pull request.
    - Use the same guidelines as commit messages to write the PR title and description.
+   - Start the PR title with a conventional-commit prefix (e.g. `feat:`, `fix:`, `docs:`, with an optional scope like `fix(docker):`). A GitHub Action reads this prefix and automatically applies the matching label, so a correctly prefixed title satisfies the required-label check.
    - The server's release notes are automatically generated from PR titles, so think about how you can make them **descriptive, informative and easy to understand**. Ask yourself: "If I only knew the title would I understand what the PR does?".
    - The description should tell how the change affects the server's behavior and motivation for doing the change.
    - If you change the Admin UI include screenshots in the description to help others get a quick idea what changes and how it will look. Before & after pictures are great for this.
@@ -114,7 +115,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 1. Wait for labeling and review
    - PRs are automatically reviewed by [CodeRabbit](https://coderabbit.ai/). Address any comments it raises. Once you are done addressing CodeRabbit's feedback, add a comment **"Ready for human review"** to signal that the PR is ready for maintainer review.
-   - The maintainers will apply a label to the PR. The label is used to group PRs, mainly to distinguish fixes and new features.
+   - A label is applied automatically from the PR title prefix (see above); maintainers may adjust it if needed. The label is used to group PRs, mainly to distinguish fixes, new features and chores.
    - If we require changes to your PR we expect you to:
    - Implement the agreed changes.
    - Rebase your branch and force push to your GitHub repository (this will update your Pull Request):


### PR DESCRIPTION
Automatically label PRs based on a conventional commit prefix in the PR title so that contributors need not receive messages for missing labels but can preclassify their PRs.

