### PR TITLE
feat(streams): include providerId on N2KAnalyzerOut PGN payload

### DIFF
--- a/packages/streams/src/canboatjs.test.ts
+++ b/packages/streams/src/canboatjs.test.ts
@@ -11,6 +11,7 @@ describe('CanboatJs', () => {
     const app = createMockApp()
     const stream = new CanboatJs({
       app,
+      providerId: 'test-provider',
       createDebug: createDebugStub()
     })
 
@@ -23,9 +24,14 @@ describe('CanboatJs', () => {
 
     const results = await outputPromise
     expect(results).to.have.length(1)
-    const pgn = results[0] as { pgn: number; fields: { heading: number } }
+    const pgn = results[0] as {
+      pgn: number
+      fields: { heading: number }
+      providerId?: string
+    }
     expect(pgn.pgn).to.equal(127250)
     expect(pgn.fields.heading).to.be.a('number')
+    expect(pgn.providerId).to.equal('test-provider')
   })
 
   it('emits analyzerOutEvent on app for each parsed PGN', async () => {
@@ -53,6 +59,7 @@ describe('CanboatJs', () => {
     const app = createMockApp()
     const stream = new CanboatJs({
       app,
+      providerId: 'test-provider',
       createDebug: createDebugStub()
     })
 
@@ -67,8 +74,9 @@ describe('CanboatJs', () => {
 
     const results = await outputPromise
     expect(results).to.have.length(1)
-    const pgn = results[0] as { timestamp: string }
+    const pgn = results[0] as { timestamp: string; providerId?: string }
     expect(pgn.timestamp).to.equal('2025-06-15T12:00:00.000Z')
+    expect(pgn.providerId).to.equal('test-provider')
   })
 
   it('emits canboatjs:unparsed:data for unparseable input', async () => {

--- a/packages/streams/src/canboatjs.ts
+++ b/packages/streams/src/canboatjs.ts
@@ -9,6 +9,7 @@ interface CanboatJsOptions {
   analyzerOutEvent?: string
   useCamelCompat?: boolean
   createDebug?: CreateDebug
+  providerId?: string
   [key: string]: unknown
 }
 
@@ -18,10 +19,15 @@ interface FileChunk {
   timestamp: string
 }
 
+type ParsedPgnData = ReturnType<InstanceType<typeof FromPgn>['parse']> & {
+  providerId?: string
+}
+
 export default class CanboatJs extends Transform {
   private readonly fromPgn: InstanceType<typeof FromPgn>
   private readonly app: CanboatJsOptions['app']
   private readonly analyzerOutEvent: string
+  private readonly providerId: string | undefined
 
   constructor(options: CanboatJsOptions) {
     super({ objectMode: true })
@@ -46,6 +52,7 @@ export default class CanboatJs extends Transform {
 
     this.app = options.app
     this.analyzerOutEvent = options.analyzerOutEvent ?? 'N2KAnalyzerOut'
+    this.providerId = options.providerId
   }
 
   _transform(
@@ -59,17 +66,19 @@ export default class CanboatJs extends Transform {
       'fromFile' in chunk &&
       chunk.fromFile
     ) {
-      const pgnData = this.fromPgn.parse(chunk.data)
+      const pgnData = this.fromPgn.parse(chunk.data) as ParsedPgnData
       if (pgnData) {
         pgnData.timestamp = new Date(Number(chunk.timestamp)).toISOString()
+        pgnData.providerId = this.providerId
         this.push(pgnData)
         this.app.emit(this.analyzerOutEvent, pgnData)
       } else {
         this.app.emit('canboatjs:unparsed:object', chunk)
       }
     } else {
-      const pgnData = this.fromPgn.parse(chunk)
+      const pgnData = this.fromPgn.parse(chunk) as ParsedPgnData
       if (pgnData) {
+        pgnData.providerId = this.providerId
         this.push(pgnData)
         this.app.emit(this.analyzerOutEvent, pgnData)
       } else {


### PR DESCRIPTION
### What problem does this solve?

The N2K analyzer stream output did not include provider identity, which makes it hard for downstream consumers to attribute PGN data to the correct source when multiple providers are active.

This change adds providerId to N2KAnalyzerOut PGN payloads so integrations can reliably map emitted data back to the originating provider.

### Related:

[https://github.com/sbender9/signalk-n2kais-to-nmea0183/pull/21](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### How was this tested?

Verified by running the stream/analyzer path and confirming emitted N2KAnalyzerOut PGN payloads now include providerId while preserving existing fields and behavior.

No performance-sensitive path changes beyond adding the providerId field to the emitted payload shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds optional `providerId` support to `CanboatJs` and includes it on successfully parsed `N2KAnalyzerOut` PGN payloads. The stream reads `providerId` from `CanboatJsOptions`, stores it on the transform, and attaches `providerId` to the parsed PGN data (`pgnData.providerId`) before emitting analyzer output for both file-based and raw-PGN parse branches. The existing parsing flow, the `timestamp` conversion for file-based chunks, and the unparsed event emissions remain unchanged aside from the parsed PGN typing and assertions now including the optional `providerId`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->