### PR TITLE
fix(ci): tolerate missing label in stale workflow removal

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -63,12 +63,21 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'awaiting response'
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'awaiting response'
+              })
+            } catch (error) {
+              // The label may already be gone (removed by a concurrent run or a
+              // stale webhook payload). GitHub answers 403/404 in that case;
+              // treat it as a no-op rather than failing the job.
+              if (error.status !== 403 && error.status !== 404) {
+                throw error
+              }
+            }
 
   remove-awaiting-response-pr:
     # Any push to the PR clears the awaiting response label.
@@ -81,9 +90,18 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'awaiting response'
-            })
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'awaiting response'
+              })
+            } catch (error) {
+              // The label may already be gone (removed by a concurrent run or a
+              // stale webhook payload). GitHub answers 403/404 in that case;
+              // treat it as a no-op rather than failing the job.
+              if (error.status !== 403 && error.status !== 404) {
+                throw error
+              }
+            }


### PR DESCRIPTION
## What problem does this solve?

The `remove-awaiting-response` and `remove-awaiting-response-pr` jobs in `stale.yml` (added in #2824) call `removeLabel` unconditionally, gated only on the label list from the triggering webhook payload. That payload is a snapshot from when the event fired and can be stale by the time the job runs — the label may already have been cleared by a concurrent run (e.g. an author comment and a push arriving close together). GitHub then answers `403`/`404` and the job hard-fails, surfacing a spurious red X on the PR:

```
DELETE /repos/SignalK/signalk-server/issues/2399/labels/awaiting%20response
→ 403 Resource not accessible by integration
```

This wraps both `removeLabel` calls in a `try/catch` that swallows `403`/`404` and re-throws anything else, so an already-absent label is treated as a no-op instead of a failure.

## How was this tested?

Validated that `stale.yml` still parses as valid YAML after the change. The runtime path (a `403`/`404` from `removeLabel` being swallowed) cannot be exercised locally without a live `pull_request_target`/`issue_comment` event; the try/catch only changes error handling and leaves the successful-removal path unchanged.