### PR TITLE
fix(config): serialize concurrent settings.json writes

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -30,10 +30,10 @@ import DeltaEditor from '../deltaeditor'
 import { getExternalPort } from '../ports'
 import { atomicWriteFile } from '../atomicWrite'
 import {
+  getPrioritiesFilePath,
   loadPrioritiesIntoSettings,
   migratePrioritiesIntoSeparateFile,
-  splitPrioritiesFromSettings,
-  writePrioritiesFile
+  splitPrioritiesFromSettings
 } from './priorities-file'
 import {
   loadAll as loadUnitPreferences,
@@ -42,6 +42,16 @@ import {
 const debug = createDebug('signalk-server:config')
 
 let disableWriteSettings = false
+
+// Serialises every settings.json (and priorities.json) write. Callers
+// commonly mutate app.config.settings in place and pass it here; without a
+// queue two overlapping writes can interleave their priorities.json and
+// settings.json phases, and a slow write can land on disk after a newer one.
+// Chaining on this promise runs the file I/O one write at a time in call
+// order. The payload is stringified synchronously at call time (below) so a
+// later in-place mutation of the settings object cannot change what an
+// already-queued write persists.
+let settingsWriteQueue: Promise<void> = Promise.resolve()
 
 // use dynamic path so that ts compiler does not detect this
 // json file, as ts compile needs to copy all (other) used
@@ -564,8 +574,28 @@ export function writeSettingsFile(app: ConfigApp, settings: any, cb: any) {
     cb()
     return
   }
-  const { settingsWithoutPriorities, priorities } =
-    splitPrioritiesFromSettings(settings)
+  // Capture the exact bytes now, before the write is queued: callers hand
+  // us app.config.settings and may mutate it (even nested) before this
+  // deferred write actually runs. Stringifying up front pins each queued
+  // write to the state at call time. Do it inside try/catch so a stringify
+  // failure (e.g. a circular reference in settings) reaches the caller via
+  // cb, matching the async error path, instead of throwing synchronously.
+  let settingsJson: string
+  let prioritiesJson: string
+  let prioritiesFile: string
+  let settingsFile: string
+  try {
+    const { settingsWithoutPriorities, priorities } =
+      splitPrioritiesFromSettings(settings)
+    settingsJson = JSON.stringify(settingsWithoutPriorities, null, 2)
+    prioritiesJson = JSON.stringify(priorities, null, 2)
+    prioritiesFile = getPrioritiesFilePath(app)
+    settingsFile = getSettingsFilename(app)
+  } catch (err) {
+    cb(err)
+    return
+  }
+
   // Always overwrite priorities.json — when the user resets all priority
   // state, the in-memory `priorities` is `{}` and the file must be cleared
   // too, otherwise stale entries from a previous save reload on next start.
@@ -576,15 +606,22 @@ export function writeSettingsFile(app: ConfigApp, settings: any, cb: any) {
   // settings write fails after priorities succeeded, only the
   // non-priority slice is stale, which is the safer half: the engine
   // keeps using the just-saved priorities.json on next load.
-  writePrioritiesFile(app, priorities)
-    .then(() =>
-      atomicWriteFile(
-        getSettingsFilename(app),
-        JSON.stringify(settingsWithoutPriorities, null, 2)
-      )
+  //
+  // The whole two-file write is queued behind any earlier write so
+  // concurrent callers cannot interleave their phases or land out of order.
+  const write = () =>
+    atomicWriteFile(prioritiesFile, prioritiesJson).then(() =>
+      atomicWriteFile(settingsFile, settingsJson)
     )
-    .then(() => cb())
-    .catch(cb)
+  const done = settingsWriteQueue.then(write, write)
+  // Keep the queue alive regardless of this write's outcome so a failed
+  // write doesn't wedge every later one; each caller still gets its own
+  // success/failure via cb.
+  settingsWriteQueue = done.then(
+    () => undefined,
+    () => undefined
+  )
+  done.then(() => cb()).catch(cb)
 }
 
 function getSettingsFilename(app: ConfigApp) {

--- a/test/settings-write-serialization.ts
+++ b/test/settings-write-serialization.ts
@@ -1,0 +1,149 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { writeSettingsFile } from '../src/config/config'
+import { ConfigApp } from '../src/config/config'
+
+// Minimal app shape writeSettingsFile needs: a config dir and argv.s.
+function makeApp(configPath: string): ConfigApp {
+  return { config: { configPath }, argv: {} } as unknown as ConfigApp
+}
+
+function writeP(app: ConfigApp, settings: object): Promise<void> {
+  return new Promise((resolve, reject) => {
+    writeSettingsFile(app, settings, (err: unknown) =>
+      err ? reject(err) : resolve()
+    )
+  })
+}
+
+describe('writeSettingsFile serialization', () => {
+  let dir: string
+  let savedSettingsEnv: string | undefined
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-settings-'))
+    // getSettingsFilename honours SIGNALK_NODE_SETTINGS over configPath;
+    // clear it so writes land in the temp dir (and never clobber a real
+    // settings file), restoring it afterwards.
+    savedSettingsEnv = process.env.SIGNALK_NODE_SETTINGS
+    delete process.env.SIGNALK_NODE_SETTINGS
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+    if (savedSettingsEnv === undefined) {
+      delete process.env.SIGNALK_NODE_SETTINGS
+    } else {
+      process.env.SIGNALK_NODE_SETTINGS = savedSettingsEnv
+    }
+  })
+
+  it('runs concurrent writes without corrupting settings.json', async () => {
+    const app = makeApp(dir)
+    // Fire many overlapping writes with distinct payloads.
+    const N = 25
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        writeP(app, { interfaces: {}, marker: i })
+      )
+    )
+    // The file must be complete, valid JSON (never a half-written mix), and
+    // because each payload is snapshotted at call time the queue applies
+    // them in enqueue order — so the last one deterministically wins.
+    const raw = fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+    const parsed = JSON.parse(raw) as { marker: number }
+    expect(parsed.marker).to.equal(N - 1)
+  })
+
+  it('preserves call order: the last enqueued write wins on disk', async () => {
+    const app = makeApp(dir)
+    const N = 15
+    // Await sequentially-enqueued (but internally queued) writes; the queue
+    // must apply them in order so the final on-disk value is the last one.
+    for (let i = 0; i < N; i++) {
+      await writeP(app, { interfaces: {}, marker: i })
+    }
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+    ) as { marker: number }
+    expect(parsed.marker).to.equal(N - 1)
+  })
+
+  it('pins each write to the state at call time, not at write time', async () => {
+    const app = makeApp(dir)
+    // Caller mutates the same object after enqueuing: the persisted value
+    // must reflect the snapshot taken when writeSettingsFile was called.
+    const settings = { interfaces: {}, marker: 'first' } as {
+      interfaces: object
+      marker: string
+    }
+    const p = writeP(app, settings)
+    settings.marker = 'mutated-after-call'
+    await p
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+    ) as { marker: string }
+    expect(parsed.marker).to.equal('first')
+  })
+
+  it('a failing write does not wedge later writes', async () => {
+    const app = makeApp(dir)
+    // Point the first write at a path that cannot be created (parent is a
+    // file, not a dir) to force a failure, then a good write must still land.
+    const badApp = makeApp(path.join(dir, 'nope', 'deeper'))
+    fs.writeFileSync(path.join(dir, 'nope'), 'x')
+    let failed = false
+    await writeP(badApp, { interfaces: {}, marker: 0 }).catch(() => {
+      failed = true
+    })
+    expect(failed).to.equal(true)
+    // Subsequent write on the healthy app still succeeds, writing both the
+    // priorities and settings files (the failure was at the priorities
+    // phase, which is written first, so this also proves the chain recovers).
+    await writeP(app, { interfaces: {}, marker: 99 })
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+    ) as { marker: number }
+    expect(parsed.marker).to.equal(99)
+    expect(fs.existsSync(path.join(dir, 'priorities.json'))).to.equal(true)
+  })
+
+  it('serializes the priorities-file phase in call order too', async () => {
+    const app = makeApp(dir)
+    const N = 12
+    // priorityGroups is split out into priorities.json; the last enqueued
+    // write must win there as well, proving the priorities phase is queued.
+    for (let i = 0; i < N; i++) {
+      await writeP(app, {
+        interfaces: {},
+        priorityGroups: [{ id: `group${i}`, priorities: [] }]
+      })
+    }
+    const priorities = JSON.parse(
+      fs.readFileSync(path.join(dir, 'priorities.json'), 'utf8')
+    ) as { priorityGroups: Array<{ id: string }> }
+    expect(priorities.priorityGroups.map((g) => g.id)).to.deep.equal([
+      `group${N - 1}`
+    ])
+  })
+
+  it('routes a synchronous stringify failure through the callback', async () => {
+    const app = makeApp(dir)
+    // A circular reference makes JSON.stringify throw during the synchronous
+    // snapshot; the error must reach the caller via cb, not escape.
+    const circular: Record<string, unknown> = { interfaces: {} }
+    circular.self = circular
+    let caught: unknown
+    await writeP(app, circular).catch((e) => {
+      caught = e
+    })
+    expect(caught).to.be.an('error')
+    // The queue is not wedged: a normal write still lands.
+    await writeP(app, { interfaces: {}, marker: 7 })
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+    ) as { marker: number }
+    expect(parsed.marker).to.equal(7)
+  })
+})


### PR DESCRIPTION
## Summary

`writeSettingsFile` is called from many places — server routes, the Course/Resources/Sensors APIs, provider config, N2K discovery, source-ref migration — and callers commonly mutate `app.config.settings` in place and then persist it. Because each call performed its two-file write (priorities.json then settings.json) independently, two overlapping calls could:

- interleave their write phases, and
- land on disk out of order, so a slower earlier write overwrites a newer one — leaving disk diverged from memory until the next restart.

## Solution

Serialize the writes at the single choke point instead of asking each caller to opt into a lock:

- Every `writeSettingsFile` call queues its two-file write behind any earlier one on a module-level promise, so the writes run one at a time in call order.
- The payload is `JSON.stringify`-d **synchronously at call time**, so a later in-place mutation of the settings object cannot change what an already-queued write persists.
- A failed write no longer wedges later writes; each caller still receives its own success/failure through its callback.

## Scope

This fixes the file-write race for all callers. It deliberately does **not** change any caller's in-memory read-modify-write or rollback logic — that per-caller atomicity is a separate concern and out of scope here.

## Testing

- New `test/settings-write-serialization.ts`: concurrent writes never corrupt settings.json; the last enqueued write wins on disk; each write is pinned to the state at call time (mutating the object after the call doesn't leak in); a failing write doesn't wedge later writes.
- Existing Course, Resources and priorities suites (which persist settings through the real APIs) pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a race in `writeSettingsFile` by serializing persistence of `priorities.json` followed by `settings.json` behind a module-level promise, ensuring writes run one at a time in call order so older slower writes cannot overwrite newer state.

It snapshots the payload at call time by resolving the target file paths and synchronously `JSON.stringify`ing the derived “settings-without-priorities” and `priorities` before enqueueing, so later in-place mutations of `app.config.settings` do not change what gets written. Failed writes do not block subsequent writes, and each invocation still receives its own success or failure through its callback.

A new `test/settings-write-serialization.ts` suite verifies concurrent last-write-wins behavior, call-time payload pinning, serialized priorities-file “phase” ordering, and recovery after failures (including ensuring `JSON.stringify` errors propagate to the correct caller without wedging the write queue).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->