### PR TITLE
feat: staleness detection off by default

### DIFF
--- a/docs/setup/staleness.md
+++ b/docs/setup/staleness.md
@@ -6,7 +6,7 @@ title: Stale Data Detection
 
 When a sensor or bus stops sending data, the last received value would otherwise be displayed forever — and zone-based alerting plugins stay silent because no new delta ever arrives. Signal K Server therefore enforces `meta.timeout` on the self vessel: when a path stops updating beyond its effective timeout, the server marks the value as timed out so displays and plugins can react.
 
-Enforcement is enabled by default and applies to `vessels.self` paths only.
+Enforcement is disabled by default (see Configuration below) and applies to `vessels.self` paths only.
 
 ## How It Works
 
@@ -66,11 +66,11 @@ Timeout enforcement and notifications complement each other: when a sensor path 
 
 ## Configuration
 
-Enforcement is on by default. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it off there if a source's data is being marked stale unexpectedly while troubleshooting. The following settings keys control it:
+Enforcement is off by default for now, but the plan is to activate it in a future version. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it on there to have sources' data marked stale when they fall silent. The following settings keys control it:
 
 | Setting                    | Default | Purpose                                                              |
 | -------------------------- | ------- | -------------------------------------------------------------------- |
-| `enforceDataTimeouts`      | `true`  | Master switch for the enforcer                                       |
+| `enforceDataTimeouts`      | `false` | Master switch for the enforcer                                       |
 | `useDefaultTimeouts`       | `true`  | Apply the global default to periodic paths without their own timeout |
 | `defaultTimeout`           | `60`    | Global fallback timeout in seconds                                   |
 | `staleCheckIntervalMs`     | `1000`  | How often the enforcer checks, in milliseconds                       |

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -576,9 +576,7 @@ const ServerSettings: React.FC = () => {
                       id="enforceDataTimeouts"
                       className="switch-input"
                       onChange={handleStalenessChange}
-                      checked={
-                        settings.staleness?.enforceDataTimeouts !== false
-                      }
+                      checked={settings.staleness?.enforceDataTimeouts === true}
                     />
                     <span
                       className="switch-label"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -100,10 +100,7 @@ export interface Config {
     logCountToKeep?: number
     enablePluginLogging?: boolean
     loggingDirectory?: string
-    /** Master switch for the staleness enforcer. Default true.
-     * Emits a synthetic `value: null` delta with `state.timedOut: true`
-     * when a vessels.self.* path+source falls silent beyond its
-     * effective timeout. See src/staleness.ts. */
+    /** Master switch for the staleness enforcer */
     enforceDataTimeouts?: boolean
     /** When true, paths without an explicit numeric `meta.timeout`
      * fall back to `defaultTimeout` instead of being skipped. Default

--- a/src/index.ts
+++ b/src/index.ts
@@ -660,7 +660,7 @@ class Server {
     // immediately. The timer is started only after server.listen succeeds —
     // a startup failure between this point and `app.started = true` would
     // otherwise leave an orphan interval ticking against a half-built app.
-    if (app.config.settings.enforceDataTimeouts !== false) {
+    if (app.config.settings.enforceDataTimeouts === true) {
       app.stalenessEnforcer = new StalenessEnforcer(app)
     } else {
       // Clear any instance from a previous start: reload() stops it but

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -882,7 +882,7 @@ module.exports = function (
           app.config.settings.notifications?.manageNotifications ?? true
       },
       staleness: {
-        enforceDataTimeouts: app.config.settings.enforceDataTimeouts !== false
+        enforceDataTimeouts: app.config.settings.enforceDataTimeouts === true
       }
     }
 


### PR DESCRIPTION
Disable staleness detection by default. The plan is to ship it off by default and once we gained experience with it in the wild flip the default to true in a future version.

