### PR TITLE
feat: add acknowledgedAt timestamp to notification status.

### DIFF
--- a/docs/develop/rest-api/notifications_api.md
+++ b/docs/develop/rest-api/notifications_api.md
@@ -442,7 +442,7 @@ The result of a successful acknowledge request is that the:
 
 - Both `sound` & `visual` values are removed from the `method` attribute
 - `status.acknowledged` is set to `true`
-- `status.acknowledgedAt` holds the timestamp of when the alarm was acknowledged. 
+- `status.acknowledgedAt` holds the timestamp of when the alarm was acknowledged.
 
 If the acknowledge action is requested when the `status.canAcknowledge` property is `false`, the alarm will not be acknowledged and an ERROR response is returned to the requestor.
 

--- a/docs/develop/rest-api/notifications_api.md
+++ b/docs/develop/rest-api/notifications_api.md
@@ -103,6 +103,7 @@ The remaining properties indicate the actions that **HAVE been taken**:
 
 - `silenced` - `true` when the silence action has been taken
 - `acknowledged` - `true` when the acknowledge action has been taken
+- `acknowledgedAt` - timestamp indicating when the acknowledge action was taken
 
 ## Taking Action
 
@@ -328,6 +329,7 @@ The result of a successful clear request is that the:
 - `state` value is set to `normal`
 - `status.silenced` is set to `false`
 - `status.acknowledged` is set to `false`
+- `status.acknowledgedAt` is not present
 
 If the clear action is requested when the `status.canClear` property is `false`, the alarm will not be cleared and an ERROR response is returned to the requestor.
 
@@ -480,6 +482,7 @@ _Notification: after successful `acknowledge` request_
    "status": {
       "silenced": true,
       "acknowledged": true,
+      "acknowledgedAt": "2026-04-06T03:34:48.203Z",
       "canSilence": true,
       "canAcknow;edge": true,
       "canClear": true

--- a/docs/develop/rest-api/notifications_api.md
+++ b/docs/develop/rest-api/notifications_api.md
@@ -442,6 +442,7 @@ The result of a successful acknowledge request is that the:
 
 - Both `sound` & `visual` values are removed from the `method` attribute
 - `status.acknowledged` is set to `true`
+- `status.acknowledgedAt` holds the timestamp of when the alarm was acknowledged. 
 
 If the acknowledge action is requested when the `status.canAcknowledge` property is `false`, the alarm will not be acknowledged and an ERROR response is returned to the requestor.
 

--- a/packages/server-api/src/deltas.ts
+++ b/packages/server-api/src/deltas.ts
@@ -210,6 +210,7 @@ export enum ALARM_METHOD {
 export interface AlarmStatus {
   silenced: boolean
   acknowledged: boolean
+  acknowledgedAt?: Timestamp
   canSilence: boolean
   canAcknowledge: boolean
   canClear: boolean

--- a/packages/server-api/src/typebox/protocol-schemas.ts
+++ b/packages/server-api/src/typebox/protocol-schemas.ts
@@ -119,7 +119,8 @@ export const AlarmStatusSchema = Type.Object(
     }),
     acknowledgedAt: Type.Optional(
       Type.String({
-        description: 'Time at which the alarm was acknowledged'
+        pattern: IsoTimePattern,
+        description: 'ISO 8601 timestamp when the alarm was acknowledged'
       })
     ),
     canSilence: Type.Boolean({

--- a/packages/server-api/src/typebox/protocol-schemas.ts
+++ b/packages/server-api/src/typebox/protocol-schemas.ts
@@ -117,6 +117,11 @@ export const AlarmStatusSchema = Type.Object(
     acknowledged: Type.Boolean({
       description: 'Whether the alarm has been acknowledged'
     }),
+    acknowledgedAt: Type.Optional(
+      Type.String({
+        description: 'Time at which the alarm was acknowledged'
+      })
+    ),
     canSilence: Type.Boolean({
       description: 'Whether the alarm can be silenced'
     }),

--- a/src/api/notifications/alarm.ts
+++ b/src/api/notifications/alarm.ts
@@ -105,6 +105,7 @@ export class Alarm {
       this.value.state !== ALARM_STATE.normal
     ) {
       this.status.acknowledged = false
+      delete this.status.acknowledgedAt
       this.status.silenced = false
     }
 
@@ -113,8 +114,12 @@ export class Alarm {
       this.value &&
       'acknowledgeStatus' in this.value
     ) {
-      this.status.acknowledged =
-        this.value.acknowledgeStatus === 'Yes' ? true : false
+      if (this.value.acknowledgeStatus === 'Yes') {
+        this.status.acknowledgedAt = new Date().toISOString() as Timestamp
+        this.status.acknowledged = true
+      } else {
+        this.status.acknowledged = false
+      }
     }
     if (
       !this.status.silenced &&
@@ -228,6 +233,7 @@ export class Alarm {
       throw new Error('Alarm already acknowledged!')
     }
     this.status.acknowledged = true
+    this.status.acknowledgedAt = new Date().toISOString() as Timestamp
     this.alignAlarmMethod()
     this.timeStamp()
   }
@@ -239,6 +245,7 @@ export class Alarm {
     this.value.state = ALARM_STATE.normal
     this.status.silenced = false
     this.status.acknowledged = false
+    delete this.status.acknowledgedAt
     this.timeStamp()
   }
 }

--- a/src/api/notifications/alarm.ts
+++ b/src/api/notifications/alarm.ts
@@ -119,6 +119,7 @@ export class Alarm {
         this.status.acknowledged = true
       } else {
         this.status.acknowledged = false
+        delete this.status.acknowledgedAt
       }
     }
     if (


### PR DESCRIPTION
Add a new property `acknowledgedAt`  to the notification `status` object to hold the timestamp of when the alarm was acknowledged.

Tested using the Notifications API via postman to confirm operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds an optional `acknowledgedAt` timestamp to notification alarm status. The server API schema and `AlarmStatus` type include `acknowledgedAt` as an ISO 8601 time. The alarm records the current timestamp when it is acknowledged and removes `acknowledgedAt` when the alarm is cleared/reset or when the alarm is updated to a non-`normal` state, so the timestamp is not present in the payload afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->