### PR TITLE
feat: persist default History API provider, selectable in Admin UI

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../store'
 import classNames from 'classnames'
 import { isOverrideDormantUnderGroups } from '../../utils/sourceGroups'
+import { useHistoryProviderUnavailable } from '../../hooks/useHistoryProviderStatus'
 import './Sidebar.css'
 import SidebarFooter from './../SidebarFooter/SidebarFooter'
 import SidebarForm from './../SidebarForm/SidebarForm'
@@ -158,6 +159,7 @@ export default function Sidebar({ location }: SidebarProps) {
   ).length
 
   const unconfiguredGnssCount = useUnconfiguredGnssSources().length
+  const historyProviderUnavailable = useHistoryProviderUnavailable()
 
   const items = useMemo((): NavItemData[] => {
     const appUpdates = appStore.updates.length
@@ -306,13 +308,17 @@ export default function Sidebar({ location }: SidebarProps) {
       })()
     ]
 
+    const historyProviderBadge: BadgeData | null = historyProviderUnavailable
+      ? { variant: 'warning', text: '!' }
+      : null
+
     if (isAdmin) {
       result.push(
         {
           name: 'Apps & Plugins',
           url: '/apps',
           icon: 'icon-basket',
-          badges: [updatesBadge, unconfiguredBadge],
+          badges: [updatesBadge, unconfiguredBadge, historyProviderBadge],
           children: [
             {
               name: 'Store',
@@ -322,7 +328,7 @@ export default function Sidebar({ location }: SidebarProps) {
             {
               name: 'Configuration',
               url: '/apps/configuration/-',
-              badge: unconfiguredBadge
+              badges: [unconfiguredBadge, historyProviderBadge]
             }
           ]
         },
@@ -432,7 +438,8 @@ export default function Sidebar({ location }: SidebarProps) {
     conflictCount,
     unconfiguredPriorityCount,
     overridesWithMissingSourcesCount,
-    unconfiguredGnssCount
+    unconfiguredGnssCount,
+    historyProviderUnavailable
   ])
 
   const [openDropdowns, setOpenDropdowns] = useState<Set<string>>(

--- a/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
+++ b/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react'
+import { usePlugins } from '../store'
+
+const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
+
+/**
+ * True when a default History API provider is configured but not
+ * currently registered (e.g. its plugin is disabled), so requests are
+ * served by a fallback. Re-checks whenever the plugin list changes,
+ * since providers register and unregister with plugin enable/disable.
+ */
+export function useHistoryProviderUnavailable(): boolean {
+  const plugins = usePlugins()
+  const [unavailable, setUnavailable] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const check = async () => {
+      try {
+        const [providersRes, defaultRes] = await Promise.all([
+          fetch(PROVIDERS_PATH, { credentials: 'include' }),
+          fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
+        ])
+        if (!providersRes.ok || !defaultRes.ok) {
+          return
+        }
+        const ids = Object.keys(
+          (await providersRes.json()) as Record<string, unknown>
+        )
+        const defaultBody = (await defaultRes.json()) as {
+          configured?: string
+        }
+        if (!cancelled) {
+          setUnavailable(
+            defaultBody.configured !== undefined &&
+              !ids.includes(defaultBody.configured)
+          )
+        }
+      } catch {
+        // status stays as-is; the badge is best-effort
+      }
+    }
+    check()
+    return () => {
+      cancelled = true
+    }
+  }, [plugins])
+
+  return unavailable
+}

--- a/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
+++ b/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { usePlugins } from '../store'
 
-const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
+export const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
 
 /** Response of GET /signalk/v2/api/history/_providers */
 type HistoryProvidersResponse = Record<string, { isDefault: boolean }>

--- a/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
+++ b/packages/server-admin-ui/src/hooks/useHistoryProviderStatus.ts
@@ -1,7 +1,77 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { usePlugins } from '../store'
 
 const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
+
+/** Response of GET /signalk/v2/api/history/_providers */
+type HistoryProvidersResponse = Record<string, { isDefault: boolean }>
+
+export interface HistoryProvidersState {
+  ids: string[]
+  /** Provider currently serving unqualified History API requests */
+  defaultId: string | null
+  /** Provider persisted in server settings; may not be registered */
+  configuredId: string | null
+}
+
+/**
+ * Registered History API providers and the effective/configured
+ * default. Fetches once on mount; call refresh() to re-check.
+ */
+export function useHistoryProviders(): {
+  providers: HistoryProvidersState | null
+  loadError: string | null
+  refresh: () => Promise<void>
+} {
+  const [providers, setProviders] = useState<HistoryProvidersState | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [providersRes, defaultRes] = await Promise.all([
+        fetch(PROVIDERS_PATH, { credentials: 'include' }),
+        fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
+      ])
+      if (!providersRes.ok || !defaultRes.ok) {
+        setLoadError(
+          `Failed to load history providers (HTTP ${
+            providersRes.ok ? defaultRes.status : providersRes.status
+          })`
+        )
+        return
+      }
+      const providersBody =
+        (await providersRes.json()) as HistoryProvidersResponse
+      const defaultBody = (await defaultRes.json()) as {
+        id?: string
+        configured?: string
+      }
+      setProviders({
+        ids: Object.keys(providersBody),
+        defaultId: defaultBody.id ?? null,
+        configuredId: defaultBody.configured ?? null
+      })
+      setLoadError(null)
+    } catch (e) {
+      setLoadError(
+        e instanceof Error ? e.message : 'Failed to load history providers'
+      )
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return { providers, loadError, refresh }
+}
+
+export const isConfiguredProviderUnavailable = (
+  providers: HistoryProvidersState | null
+): boolean =>
+  providers !== null &&
+  providers.configuredId !== null &&
+  !providers.ids.includes(providers.configuredId)
 
 /**
  * True when a default History API provider is configured but not
@@ -11,40 +81,11 @@ const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
  */
 export function useHistoryProviderUnavailable(): boolean {
   const plugins = usePlugins()
-  const [unavailable, setUnavailable] = useState(false)
+  const { providers, refresh } = useHistoryProviders()
 
   useEffect(() => {
-    let cancelled = false
-    const check = async () => {
-      try {
-        const [providersRes, defaultRes] = await Promise.all([
-          fetch(PROVIDERS_PATH, { credentials: 'include' }),
-          fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
-        ])
-        if (!providersRes.ok || !defaultRes.ok) {
-          return
-        }
-        const ids = Object.keys(
-          (await providersRes.json()) as Record<string, unknown>
-        )
-        const defaultBody = (await defaultRes.json()) as {
-          configured?: string
-        }
-        if (!cancelled) {
-          setUnavailable(
-            defaultBody.configured !== undefined &&
-              !ids.includes(defaultBody.configured)
-          )
-        }
-      } catch {
-        // status stays as-is; the badge is best-effort
-      }
-    }
-    check()
-    return () => {
-      cancelled = true
-    }
-  }, [plugins])
+    refresh()
+  }, [plugins, refresh])
 
-  return unavailable
+  return isConfiguredProviderUnavailable(providers)
 }

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
@@ -25,6 +25,7 @@ import { faGear } from '@fortawesome/free-solid-svg-icons/faGear'
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation'
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons/faCircleInfo'
 import EmbeddedPluginConfigurationForm from './EmbeddedPluginConfigurationForm'
+import HistoryProviderSettings from '../ServerConfig/HistoryProviderSettings'
 import { useStore } from '../../store'
 
 interface PluginSchema {
@@ -350,163 +351,172 @@ export default function PluginConfigurationList() {
   const selectedPluginId = selectedPlugin ? selectedPlugin.id : null
 
   return (
-    <Row className="plugin-config-row g-0">
-      <Col xl={6}>
-        <Card>
-          <Card.Header>
-            <FontAwesomeIcon icon={faAlignJustify} />{' '}
-            <strong>Plugin Configuration</strong>
-          </Card.Header>
-          <Card.Body>
-            <Form
-              action=""
-              method="post"
-              encType="multipart/form-data"
-              className="form-horizontal"
-              onSubmit={(e: FormEvent) => {
-                e.preventDefault()
-              }}
-            >
-              <Form.Group className="mb-2">
-                <Form.Control
-                  type="text"
-                  name="search"
-                  id="search"
-                  onChange={handleSearch}
-                  value={search}
-                  placeholder="Filter installed plugins..."
-                />
-              </Form.Group>
-              <Form.Group className="mb-2">
-                <Form.Select
-                  name="statusFilter"
-                  id="statusFilter"
-                  onChange={handleStatusFilter}
-                  value={statusFilter}
-                  size="sm"
-                >
-                  <option value="all">All Plugins</option>
-                  <option value="enabled">Enabled</option>
-                  <option value="disabled">Disabled</option>
-                  <option value="unconfigured">Unconfigured</option>
-                </Form.Select>
-              </Form.Group>
-            </Form>
+    <>
+      <HistoryProviderSettings />
+      <Row className="plugin-config-row g-0">
+        <Col xl={6}>
+          <Card>
+            <Card.Header>
+              <FontAwesomeIcon icon={faAlignJustify} />{' '}
+              <strong>Plugin Configuration</strong>
+            </Card.Header>
+            <Card.Body>
+              <Form
+                action=""
+                method="post"
+                encType="multipart/form-data"
+                className="form-horizontal"
+                onSubmit={(e: FormEvent) => {
+                  e.preventDefault()
+                }}
+              >
+                <Form.Group className="mb-2">
+                  <Form.Control
+                    type="text"
+                    name="search"
+                    id="search"
+                    onChange={handleSearch}
+                    value={search}
+                    placeholder="Filter installed plugins..."
+                  />
+                </Form.Group>
+                <Form.Group className="mb-2">
+                  <Form.Select
+                    name="statusFilter"
+                    id="statusFilter"
+                    onChange={handleStatusFilter}
+                    value={statusFilter}
+                    size="sm"
+                  >
+                    <option value="all">All Plugins</option>
+                    <option value="enabled">Enabled</option>
+                    <option value="disabled">Disabled</option>
+                    <option value="unconfigured">Unconfigured</option>
+                  </Form.Select>
+                </Form.Group>
+              </Form>
 
-            <div
-              ref={tableContainerRef}
-              className="plugin-list-container"
-              style={{
-                border: '1px solid #dee2e6',
-                opacity: isFiltering ? 0.7 : 1,
-                transition: 'opacity 0.2s'
-              }}
-            >
-              <Table responsive bordered size="sm" hover className="mb-0">
-                <thead
-                  style={{
-                    position: 'sticky',
-                    top: 0,
-                    backgroundColor: '#f8f9fa',
-                    zIndex: 1
-                  }}
-                >
-                  <tr>
-                    <th>Plugin Name</th>
-                    <th style={{ width: '1%', whiteSpace: 'nowrap' }}>
-                      Status
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pluginList.map((plugin) => {
-                    const isSelected = selectedPluginId === plugin.id
-                    const configurationRequired =
-                      plugin.schema &&
-                      plugin.schema.properties &&
-                      Object.keys(plugin.schema?.properties).length !== 0 &&
-                      (plugin.data.configuration === null ||
-                        plugin.data.configuration === undefined)
+              <div
+                ref={tableContainerRef}
+                className="plugin-list-container"
+                style={{
+                  border: '1px solid #dee2e6',
+                  opacity: isFiltering ? 0.7 : 1,
+                  transition: 'opacity 0.2s'
+                }}
+              >
+                <Table responsive bordered size="sm" hover className="mb-0">
+                  <thead
+                    style={{
+                      position: 'sticky',
+                      top: 0,
+                      backgroundColor: '#f8f9fa',
+                      zIndex: 1
+                    }}
+                  >
+                    <tr>
+                      <th>Plugin Name</th>
+                      <th style={{ width: '1%', whiteSpace: 'nowrap' }}>
+                        Status
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pluginList.map((plugin) => {
+                      const isSelected = selectedPluginId === plugin.id
+                      const configurationRequired =
+                        plugin.schema &&
+                        plugin.schema.properties &&
+                        Object.keys(plugin.schema?.properties).length !== 0 &&
+                        (plugin.data.configuration === null ||
+                          plugin.data.configuration === undefined)
 
-                    const isWasmPlugin = plugin.type === 'wasm'
-                    const wasmDisabledForPlugin = isWasmPlugin && !wasmEnabled
+                      const isWasmPlugin = plugin.type === 'wasm'
+                      const wasmDisabledForPlugin = isWasmPlugin && !wasmEnabled
 
-                    let badgeClass = 'text-bg-secondary'
-                    let badgeText = 'Disabled'
+                      let badgeClass = 'text-bg-secondary'
+                      let badgeText = 'Disabled'
 
-                    if (wasmDisabledForPlugin) {
-                      badgeClass = 'text-bg-danger'
-                      badgeText = 'WASM disabled'
-                    } else if (!plugin.bundled && configurationRequired) {
-                      badgeClass = 'text-bg-warning'
-                      badgeText = 'Unconfigured'
-                    } else if (plugin.data.enabled && !configurationRequired) {
-                      badgeClass = 'text-bg-success'
-                      badgeText = 'Enabled'
-                    }
+                      if (wasmDisabledForPlugin) {
+                        badgeClass = 'text-bg-danger'
+                        badgeText = 'WASM disabled'
+                      } else if (!plugin.bundled && configurationRequired) {
+                        badgeClass = 'text-bg-warning'
+                        badgeText = 'Unconfigured'
+                      } else if (
+                        plugin.data.enabled &&
+                        !configurationRequired
+                      ) {
+                        badgeClass = 'text-bg-success'
+                        badgeText = 'Enabled'
+                      }
 
-                    return (
-                      <tr
-                        key={plugin.id}
-                        data-plugin-id={plugin.id}
-                        onClick={handlePluginClick}
-                        style={{ cursor: 'pointer' }}
-                        className={isSelected ? 'table-active' : ''}
-                      >
-                        <td>
-                          {isSelected ? (
-                            <strong>
-                              <FontAwesomeIcon icon={faGear} className="me-1" />
-                              {plugin.name}
-                            </strong>
-                          ) : (
-                            plugin.name
-                          )}
-                        </td>
-                        <td>
-                          <div className={`badge ${badgeClass}`}>
-                            {badgeText}
-                          </div>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </Table>
-            </div>
-          </Card.Body>
-        </Card>
-      </Col>
-
-      <Col xl={6} ref={configCardRef}>
-        {selectedPlugin && (
-          <PluginConfigCard
-            plugin={selectedPlugin}
-            isConfigurator={isConfigurator(selectedPlugin)}
-            saveData={(data: PluginData) => {
-              if (
-                selectedPlugin.data.enabled === undefined &&
-                data.enabled === undefined
-              ) {
-                data.enabled = true
-              }
-              return saveData(selectedPlugin.id, data)
-            }}
-          />
-        )}
-        {!selectedPlugin && (
-          <Card className="mt-3 mt-xl-0">
-            <Card.Body className="text-center text-muted py-5">
-              <FontAwesomeIcon
-                icon={faGear}
-                style={{ fontSize: '48px', opacity: 0.3 }}
-              />
-              <p className="mt-3">Select a plugin in the list to configure</p>
+                      return (
+                        <tr
+                          key={plugin.id}
+                          data-plugin-id={plugin.id}
+                          onClick={handlePluginClick}
+                          style={{ cursor: 'pointer' }}
+                          className={isSelected ? 'table-active' : ''}
+                        >
+                          <td>
+                            {isSelected ? (
+                              <strong>
+                                <FontAwesomeIcon
+                                  icon={faGear}
+                                  className="me-1"
+                                />
+                                {plugin.name}
+                              </strong>
+                            ) : (
+                              plugin.name
+                            )}
+                          </td>
+                          <td>
+                            <div className={`badge ${badgeClass}`}>
+                              {badgeText}
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </Table>
+              </div>
             </Card.Body>
           </Card>
-        )}
-      </Col>
-    </Row>
+        </Col>
+
+        <Col xl={6} ref={configCardRef}>
+          {selectedPlugin && (
+            <PluginConfigCard
+              plugin={selectedPlugin}
+              isConfigurator={isConfigurator(selectedPlugin)}
+              saveData={(data: PluginData) => {
+                if (
+                  selectedPlugin.data.enabled === undefined &&
+                  data.enabled === undefined
+                ) {
+                  data.enabled = true
+                }
+                return saveData(selectedPlugin.id, data)
+              }}
+            />
+          )}
+          {!selectedPlugin && (
+            <Card className="mt-3 mt-xl-0">
+              <Card.Body className="text-center text-muted py-5">
+                <FontAwesomeIcon
+                  icon={faGear}
+                  style={{ fontSize: '48px', opacity: 0.3 }}
+                />
+                <p className="mt-3">Select a plugin in the list to configure</p>
+              </Card.Body>
+            </Card>
+          )}
+        </Col>
+      </Row>
+    </>
   )
 }
 

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -8,10 +8,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft'
 import {
   useHistoryProviders,
-  isConfiguredProviderUnavailable
+  isConfiguredProviderUnavailable,
+  PROVIDERS_PATH
 } from '../../hooks/useHistoryProviderStatus'
 
-const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
 const SAVED_MESSAGE_CLEAR_MS = 3000
 
 const HistoryProviderSettings: React.FC = () => {

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -35,7 +35,7 @@ const HistoryProviderSettings: React.FC = () => {
           setSaved(true)
           setTimeout(() => setSaved(false), SAVED_MESSAGE_CLEAR_MS)
         } else {
-          const body = await res.json()
+          const body = (await res.json()) as { message?: string }
           setSaveError(body.message || `Save failed (HTTP ${res.status})`)
         }
       } catch (e) {

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -20,6 +20,7 @@ interface ProvidersState {
 
 const HistoryProviderSettings: React.FC = () => {
   const [providers, setProviders] = useState<ProvidersState | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
 
@@ -30,6 +31,11 @@ const HistoryProviderSettings: React.FC = () => {
         fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
       ])
       if (!providersRes.ok || !defaultRes.ok) {
+        setLoadError(
+          `Failed to load history providers (HTTP ${
+            providersRes.ok ? defaultRes.status : providersRes.status
+          })`
+        )
         return
       }
       const providersBody = (await providersRes.json()) as Record<
@@ -45,8 +51,11 @@ const HistoryProviderSettings: React.FC = () => {
         defaultId: defaultBody.id ?? null,
         configuredId: defaultBody.configured ?? null
       })
+      setLoadError(null)
     } catch (e) {
-      console.error('Failed to fetch history providers:', e)
+      setLoadError(
+        e instanceof Error ? e.message : 'Failed to load history providers'
+      )
     }
   }, [])
 
@@ -81,11 +90,12 @@ const HistoryProviderSettings: React.FC = () => {
     [fetchProviders]
   )
 
-  if (providers === null) {
+  if (providers === null && loadError === null) {
     return null
   }
 
   const configuredButUnavailable =
+    providers !== null &&
     providers.configuredId !== null &&
     !providers.ids.includes(providers.configuredId)
 
@@ -96,73 +106,80 @@ const HistoryProviderSettings: React.FC = () => {
         <strong>History Provider</strong>
       </Card.Header>
       <Card.Body>
-        <Form.Group
-          as={Row}
-          className="mb-0"
-          controlId="historyDefaultProvider"
-        >
-          <Col md={2}>
-            <Form.Label>Default Provider</Form.Label>
-          </Col>
-          <Col xs="12" md={10}>
-            {providers.ids.length === 0 ? (
-              <Form.Text className="text-muted">
-                No history providers are registered. Enable a plugin that
-                provides the History API to select a default.
-              </Form.Text>
-            ) : (
-              <>
-                <Form.Select
-                  value={providers.defaultId ?? ''}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                    handleChange(e.target.value)
-                  }
-                  style={{ maxWidth: '300px' }}
-                >
-                  {providers.ids.map((id) => (
-                    <option key={id} value={id}>
-                      {id}
-                    </option>
-                  ))}
-                </Form.Select>
+        {loadError && (
+          <Alert variant="danger" style={{ marginBottom: 0 }}>
+            {loadError}
+          </Alert>
+        )}
+        {providers !== null && (
+          <Form.Group
+            as={Row}
+            className="mb-0"
+            controlId="historyDefaultProvider"
+          >
+            <Col md={2}>
+              <Form.Label>Default Provider</Form.Label>
+            </Col>
+            <Col xs="12" md={10}>
+              {providers.ids.length === 0 ? (
                 <Form.Text className="text-muted">
-                  Serves History API requests that do not specify a provider.
-                  The setting persists across restarts and does not depend on
-                  plugin load order.
+                  No history providers are registered. Enable a plugin that
+                  provides the History API to select a default.
                 </Form.Text>
-              </>
-            )}
-            {configuredButUnavailable && (
-              <Alert
-                variant="warning"
-                style={{ marginTop: '10px', marginBottom: 0 }}
-              >
-                The configured default provider &quot;{providers.configuredId}
-                &quot; is not currently available
-                {providers.defaultId
-                  ? ` — using "${providers.defaultId}" as fallback`
-                  : ''}
-                . It will become the default again when its plugin is enabled.
-              </Alert>
-            )}
-            {saved && (
-              <Alert
-                variant="success"
-                style={{ marginTop: '10px', marginBottom: 0 }}
-              >
-                Default history provider saved.
-              </Alert>
-            )}
-            {saveError && (
-              <Alert
-                variant="danger"
-                style={{ marginTop: '10px', marginBottom: 0 }}
-              >
-                {saveError}
-              </Alert>
-            )}
-          </Col>
-        </Form.Group>
+              ) : (
+                <>
+                  <Form.Select
+                    value={providers.defaultId ?? ''}
+                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                      handleChange(e.target.value)
+                    }
+                    style={{ maxWidth: '300px' }}
+                  >
+                    {providers.ids.map((id) => (
+                      <option key={id} value={id}>
+                        {id}
+                      </option>
+                    ))}
+                  </Form.Select>
+                  <Form.Text className="text-muted">
+                    Serves History API requests that do not specify a provider.
+                    The setting persists across restarts and does not depend on
+                    plugin load order.
+                  </Form.Text>
+                </>
+              )}
+              {configuredButUnavailable && (
+                <Alert
+                  variant="warning"
+                  style={{ marginTop: '10px', marginBottom: 0 }}
+                >
+                  The configured default provider &quot;{providers.configuredId}
+                  &quot; is not currently available
+                  {providers.defaultId
+                    ? ` — using "${providers.defaultId}" as fallback`
+                    : ''}
+                  . It will become the default again when its plugin is enabled.
+                </Alert>
+              )}
+              {saved && (
+                <Alert
+                  variant="success"
+                  style={{ marginTop: '10px', marginBottom: 0 }}
+                >
+                  Default history provider saved.
+                </Alert>
+              )}
+              {saveError && (
+                <Alert
+                  variant="danger"
+                  style={{ marginTop: '10px', marginBottom: 0 }}
+                >
+                  {saveError}
+                </Alert>
+              )}
+            </Col>
+          </Form.Group>
+        )}
       </Card.Body>
     </Card>
   )

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -90,24 +90,33 @@ const HistoryProviderSettings: React.FC = () => {
     [fetchProviders]
   )
 
-  if (providers === null && loadError === null) {
-    return null
-  }
-
   const configuredButUnavailable =
     providers !== null &&
     providers.configuredId !== null &&
     !providers.ids.includes(providers.configuredId)
 
+  // The choice only matters when there is something to choose between:
+  // stay hidden for zero or one registered provider, unless the
+  // persisted choice points at an unavailable provider (worth a
+  // warning) or loading failed.
+  const visible =
+    loadError !== null ||
+    (providers !== null &&
+      (providers.ids.length > 1 || configuredButUnavailable))
+
+  if (!visible) {
+    return null
+  }
+
   return (
-    <Card>
+    <Card className="mb-3">
       <Card.Header>
         <FontAwesomeIcon icon={faClockRotateLeft} />{' '}
-        <strong>History Provider</strong>
+        <strong>Default History Provider</strong>
       </Card.Header>
       <Card.Body>
         {loadError && (
-          <Alert variant="danger" style={{ marginBottom: 0 }}>
+          <Alert variant="danger" className="mb-0">
             {loadError}
           </Alert>
         )}
@@ -135,6 +144,11 @@ const HistoryProviderSettings: React.FC = () => {
                     }
                     style={{ maxWidth: '300px' }}
                   >
+                    {!providers.defaultId && (
+                      <option value="" disabled>
+                        Select a provider...
+                      </option>
+                    )}
                     {providers.ids.map((id) => (
                       <option key={id} value={id}>
                         {id}
@@ -149,12 +163,9 @@ const HistoryProviderSettings: React.FC = () => {
                 </>
               )}
               {configuredButUnavailable && (
-                <Alert
-                  variant="warning"
-                  style={{ marginTop: '10px', marginBottom: 0 }}
-                >
-                  The configured default provider &quot;{providers.configuredId}
-                  &quot; is not currently available
+                <Alert variant="warning" className="mt-2 mb-0">
+                  The configured default provider &quot;
+                  {providers.configuredId}&quot; is not currently available
                   {providers.defaultId
                     ? ` — using "${providers.defaultId}" as fallback`
                     : ''}
@@ -162,18 +173,12 @@ const HistoryProviderSettings: React.FC = () => {
                 </Alert>
               )}
               {saved && (
-                <Alert
-                  variant="success"
-                  style={{ marginTop: '10px', marginBottom: 0 }}
-                >
+                <Alert variant="success" className="mt-2 mb-0">
                   Default history provider saved.
                 </Alert>
               )}
               {saveError && (
-                <Alert
-                  variant="danger"
-                  style={{ marginTop: '10px', marginBottom: 0 }}
-                >
+                <Alert variant="danger" className="mt-2 mb-0">
                   {saveError}
                 </Alert>
               )}

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft'
 
 const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
+const SAVED_MESSAGE_CLEAR_MS = 3000
 
 interface ProvidersState {
   ids: string[]
@@ -58,13 +59,16 @@ const HistoryProviderSettings: React.FC = () => {
       setSaveError(null)
       setSaved(false)
       try {
-        const res = await fetch(`${PROVIDERS_PATH}/_default/${id}`, {
-          method: 'POST',
-          credentials: 'include'
-        })
+        const res = await fetch(
+          `${PROVIDERS_PATH}/_default/${encodeURIComponent(id)}`,
+          {
+            method: 'POST',
+            credentials: 'include'
+          }
+        )
         if (res.ok) {
           setSaved(true)
-          setTimeout(() => setSaved(false), 3000)
+          setTimeout(() => setSaved(false), SAVED_MESSAGE_CLEAR_MS)
         } else {
           const body = await res.json()
           setSaveError(body.message || `Save failed (HTTP ${res.status})`)
@@ -92,7 +96,11 @@ const HistoryProviderSettings: React.FC = () => {
         <strong>History Provider</strong>
       </Card.Header>
       <Card.Body>
-        <Form.Group as={Row} className="mb-0">
+        <Form.Group
+          as={Row}
+          className="mb-0"
+          controlId="historyDefaultProvider"
+        >
           <Col md={2}>
             <Form.Label>Default Provider</Form.Label>
           </Col>

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 import Alert from 'react-bootstrap/Alert'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -6,62 +6,18 @@ import Form from 'react-bootstrap/Form'
 import Row from 'react-bootstrap/Row'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft'
+import {
+  useHistoryProviders,
+  isConfiguredProviderUnavailable
+} from '../../hooks/useHistoryProviderStatus'
 
 const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
 const SAVED_MESSAGE_CLEAR_MS = 3000
 
-interface ProvidersState {
-  ids: string[]
-  /** Provider currently serving unqualified History API requests */
-  defaultId: string | null
-  /** Provider persisted in server settings; may not be registered */
-  configuredId: string | null
-}
-
 const HistoryProviderSettings: React.FC = () => {
-  const [providers, setProviders] = useState<ProvidersState | null>(null)
-  const [loadError, setLoadError] = useState<string | null>(null)
+  const { providers, loadError, refresh } = useHistoryProviders()
   const [saveError, setSaveError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
-
-  const fetchProviders = useCallback(async () => {
-    try {
-      const [providersRes, defaultRes] = await Promise.all([
-        fetch(PROVIDERS_PATH, { credentials: 'include' }),
-        fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
-      ])
-      if (!providersRes.ok || !defaultRes.ok) {
-        setLoadError(
-          `Failed to load history providers (HTTP ${
-            providersRes.ok ? defaultRes.status : providersRes.status
-          })`
-        )
-        return
-      }
-      const providersBody = (await providersRes.json()) as Record<
-        string,
-        { isDefault: boolean }
-      >
-      const defaultBody = (await defaultRes.json()) as {
-        id?: string
-        configured?: string
-      }
-      setProviders({
-        ids: Object.keys(providersBody),
-        defaultId: defaultBody.id ?? null,
-        configuredId: defaultBody.configured ?? null
-      })
-      setLoadError(null)
-    } catch (e) {
-      setLoadError(
-        e instanceof Error ? e.message : 'Failed to load history providers'
-      )
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchProviders()
-  }, [fetchProviders])
 
   const handleChange = useCallback(
     async (id: string) => {
@@ -85,15 +41,12 @@ const HistoryProviderSettings: React.FC = () => {
       } catch (e) {
         setSaveError(e instanceof Error ? e.message : 'Save failed')
       }
-      await fetchProviders()
+      await refresh()
     },
-    [fetchProviders]
+    [refresh]
   )
 
-  const configuredButUnavailable =
-    providers !== null &&
-    providers.configuredId !== null &&
-    !providers.ids.includes(providers.configuredId)
+  const configuredButUnavailable = isConfiguredProviderUnavailable(providers)
 
   // The choice only matters when there is something to choose between:
   // stay hidden for zero or one registered provider, unless the

--- a/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/HistoryProviderSettings.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import Alert from 'react-bootstrap/Alert'
+import Card from 'react-bootstrap/Card'
+import Col from 'react-bootstrap/Col'
+import Form from 'react-bootstrap/Form'
+import Row from 'react-bootstrap/Row'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft'
+
+const PROVIDERS_PATH = '/signalk/v2/api/history/_providers'
+
+interface ProvidersState {
+  ids: string[]
+  /** Provider currently serving unqualified History API requests */
+  defaultId: string | null
+  /** Provider persisted in server settings; may not be registered */
+  configuredId: string | null
+}
+
+const HistoryProviderSettings: React.FC = () => {
+  const [providers, setProviders] = useState<ProvidersState | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const fetchProviders = useCallback(async () => {
+    try {
+      const [providersRes, defaultRes] = await Promise.all([
+        fetch(PROVIDERS_PATH, { credentials: 'include' }),
+        fetch(`${PROVIDERS_PATH}/_default`, { credentials: 'include' })
+      ])
+      if (!providersRes.ok || !defaultRes.ok) {
+        return
+      }
+      const providersBody = (await providersRes.json()) as Record<
+        string,
+        { isDefault: boolean }
+      >
+      const defaultBody = (await defaultRes.json()) as {
+        id?: string
+        configured?: string
+      }
+      setProviders({
+        ids: Object.keys(providersBody),
+        defaultId: defaultBody.id ?? null,
+        configuredId: defaultBody.configured ?? null
+      })
+    } catch (e) {
+      console.error('Failed to fetch history providers:', e)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchProviders()
+  }, [fetchProviders])
+
+  const handleChange = useCallback(
+    async (id: string) => {
+      setSaveError(null)
+      setSaved(false)
+      try {
+        const res = await fetch(`${PROVIDERS_PATH}/_default/${id}`, {
+          method: 'POST',
+          credentials: 'include'
+        })
+        if (res.ok) {
+          setSaved(true)
+          setTimeout(() => setSaved(false), 3000)
+        } else {
+          const body = await res.json()
+          setSaveError(body.message || `Save failed (HTTP ${res.status})`)
+        }
+      } catch (e) {
+        setSaveError(e instanceof Error ? e.message : 'Save failed')
+      }
+      await fetchProviders()
+    },
+    [fetchProviders]
+  )
+
+  if (providers === null) {
+    return null
+  }
+
+  const configuredButUnavailable =
+    providers.configuredId !== null &&
+    !providers.ids.includes(providers.configuredId)
+
+  return (
+    <Card>
+      <Card.Header>
+        <FontAwesomeIcon icon={faClockRotateLeft} />{' '}
+        <strong>History Provider</strong>
+      </Card.Header>
+      <Card.Body>
+        <Form.Group as={Row} className="mb-0">
+          <Col md={2}>
+            <Form.Label>Default Provider</Form.Label>
+          </Col>
+          <Col xs="12" md={10}>
+            {providers.ids.length === 0 ? (
+              <Form.Text className="text-muted">
+                No history providers are registered. Enable a plugin that
+                provides the History API to select a default.
+              </Form.Text>
+            ) : (
+              <>
+                <Form.Select
+                  value={providers.defaultId ?? ''}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                    handleChange(e.target.value)
+                  }
+                  style={{ maxWidth: '300px' }}
+                >
+                  {providers.ids.map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                </Form.Select>
+                <Form.Text className="text-muted">
+                  Serves History API requests that do not specify a provider.
+                  The setting persists across restarts and does not depend on
+                  plugin load order.
+                </Form.Text>
+              </>
+            )}
+            {configuredButUnavailable && (
+              <Alert
+                variant="warning"
+                style={{ marginTop: '10px', marginBottom: 0 }}
+              >
+                The configured default provider &quot;{providers.configuredId}
+                &quot; is not currently available
+                {providers.defaultId
+                  ? ` — using "${providers.defaultId}" as fallback`
+                  : ''}
+                . It will become the default again when its plugin is enabled.
+              </Alert>
+            )}
+            {saved && (
+              <Alert
+                variant="success"
+                style={{ marginTop: '10px', marginBottom: 0 }}
+              >
+                Default history provider saved.
+              </Alert>
+            )}
+            {saveError && (
+              <Alert
+                variant="danger"
+                style={{ marginTop: '10px', marginBottom: 0 }}
+              >
+                {saveError}
+              </Alert>
+            )}
+          </Col>
+        </Form.Group>
+      </Card.Body>
+    </Card>
+  )
+}
+
+export default HistoryProviderSettings

--- a/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import GnssPositionSettings from './GnssPositionSettings'
 import UnitPreferencesSettings from './UnitPreferencesSettings'
+import HistoryProviderSettings from './HistoryProviderSettings'
 
 const PreferencesPage: React.FC = () => {
   return (
     <div className="animated fadeIn">
       <GnssPositionSettings />
       <UnitPreferencesSettings />
+      <HistoryProviderSettings />
     </div>
   )
 }

--- a/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PreferencesPage.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 import GnssPositionSettings from './GnssPositionSettings'
 import UnitPreferencesSettings from './UnitPreferencesSettings'
-import HistoryProviderSettings from './HistoryProviderSettings'
 
 const PreferencesPage: React.FC = () => {
   return (
     <div className="animated fadeIn">
       <GnssPositionSettings />
       <UnitPreferencesSettings />
-      <HistoryProviderSettings />
     </div>
   )
 }

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -20,6 +20,7 @@ import { Context, Path, SourceRef } from '@signalk/server-api'
 import { createDebug } from '../../debug'
 import { Request, Response } from 'express'
 import { WithSecurityStrategy } from '../../security'
+import { ConfigApp, writeSettingsFile } from '../../config/config'
 
 import { Responses } from '../'
 
@@ -27,14 +28,31 @@ const debug = createDebug('signalk-server:api:history')
 
 const HISTORY_API_PATH = `/signalk/v2/api/history`
 
-interface HistoryApplication extends WithSecurityStrategy, IRouter {}
+export interface HistoryApplication
+  extends WithSecurityStrategy, IRouter, ConfigApp, WithHistoryApi {}
 
 export class HistoryApiHttpRegistry {
   private historyProviders: Map<string, HistoryProvider> = new Map()
-  private defaultProviderId?: string
+  /** Persisted user choice; may reference a provider that is not
+   * currently registered (e.g. plugin disabled). */
+  private configuredProviderId?: string
   proxy: HistoryApi
 
-  constructor(private app: HistoryApplication & WithHistoryApi) {
+  /** The configured provider when it is registered, otherwise the first
+   * registered provider as fallback. Keeps the default independent of
+   * plugin load order. */
+  private get defaultProviderId(): string | undefined {
+    if (
+      this.configuredProviderId &&
+      this.historyProviders.has(this.configuredProviderId)
+    ) {
+      return this.configuredProviderId
+    }
+    return this.historyProviders.keys().next().value
+  }
+
+  constructor(private app: HistoryApplication) {
+    this.configuredProviderId = app.config.settings.historyApi?.defaultProvider
     this.proxy = {
       getValues: (query: ValuesRequest): Promise<ValuesResponse> => {
         return this.defaultProvider().getValues(query)
@@ -72,9 +90,6 @@ export class HistoryApiHttpRegistry {
     if (!this.historyProviders.has(pluginId)) {
       this.historyProviders.set(pluginId, provider)
     }
-    if (this.historyProviders.size === 1) {
-      this.defaultProviderId = pluginId
-    }
     debug(
       `Registered history api provider ${pluginId},`,
       `total=${this.historyProviders.size},`,
@@ -87,9 +102,6 @@ export class HistoryApiHttpRegistry {
       return
     }
     this.historyProviders.delete(pluginId)
-    if (pluginId === this.defaultProviderId) {
-      this.defaultProviderId = this.historyProviders.keys().next().value
-    }
     debug(
       `Unregistered history api provider ${pluginId},`,
       `total=${this.historyProviders.size},`,
@@ -128,7 +140,8 @@ export class HistoryApiHttpRegistry {
         debug(`**route = ${req.method} ${req.path}`)
         try {
           res.status(200).json({
-            id: this.defaultProviderId
+            id: this.defaultProviderId,
+            configured: this.configuredProviderId
           })
         } catch (err: unknown) {
           res.status(400).json({
@@ -161,11 +174,21 @@ export class HistoryApiHttpRegistry {
             throw new Error('Provider id not supplied!')
           }
           if (this.historyProviders.has(req.params.id)) {
-            this.defaultProviderId = req.params.id
-            res.status(200).json({
-              statusCode: 200,
-              state: 'COMPLETED',
-              message: `Default provider set to ${req.params.id}.`
+            this.configuredProviderId = req.params.id
+            this.saveConfiguredProvider((err) => {
+              if (err) {
+                res.status(500).json({
+                  statusCode: 500,
+                  state: 'FAILED',
+                  message: `Failed to save settings: ${err.message}`
+                })
+              } else {
+                res.status(200).json({
+                  statusCode: 200,
+                  state: 'COMPLETED',
+                  message: `Default provider set to ${req.params.id}.`
+                })
+              }
             })
           } else {
             throw new Error(`Provider ${req.params.id} not found!`)
@@ -219,6 +242,15 @@ export class HistoryApiHttpRegistry {
         res
       )
     )
+  }
+
+  private saveConfiguredProvider(cb: (err?: Error) => void) {
+    const settings = this.app.config.settings
+    settings.historyApi = {
+      ...settings.historyApi,
+      defaultProvider: this.configuredProviderId
+    }
+    writeSettingsFile(this.app, settings, cb)
   }
 
   private defaultProvider(): HistoryProvider {

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -268,6 +268,9 @@ export class HistoryApiHttpRegistry {
       if (!err) {
         settings.historyApi = snapshot.historyApi
         this.configuredProviderId = id
+        // The newly configured id is guaranteed registered by the
+        // caller, so any active "unavailable" warning no longer applies.
+        this.notifyConfiguredAvailable()
       }
       cb(err)
     })
@@ -303,7 +306,7 @@ export class HistoryApiHttpRegistry {
     this.warnedUnavailable = false
     this.notify(
       'normal',
-      `Configured default history provider '${this.configuredProviderId}' is available again`
+      `Configured default history provider '${this.configuredProviderId}' is available`
     )
   }
 

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -174,8 +174,7 @@ export class HistoryApiHttpRegistry {
             throw new Error('Provider id not supplied!')
           }
           if (this.historyProviders.has(req.params.id)) {
-            this.configuredProviderId = req.params.id
-            this.saveConfiguredProvider((err) => {
+            this.saveConfiguredProvider(req.params.id, (err) => {
               if (err) {
                 res.status(500).json({
                   statusCode: 500,
@@ -244,13 +243,24 @@ export class HistoryApiHttpRegistry {
     )
   }
 
-  private saveConfiguredProvider(cb: (err?: Error) => void) {
+  // Commit the new default only when the write succeeds, so a failed
+  // save does not leave the active provider out of sync with the
+  // settings file.
+  private saveConfiguredProvider(id: string, cb: (err?: Error) => void) {
     const settings = this.app.config.settings
+    const previous = settings.historyApi
     settings.historyApi = {
-      ...settings.historyApi,
-      defaultProvider: this.configuredProviderId
+      ...previous,
+      defaultProvider: id
     }
-    writeSettingsFile(this.app, settings, cb)
+    writeSettingsFile(this.app, settings, (err?: Error) => {
+      if (err) {
+        settings.historyApi = previous
+      } else {
+        this.configuredProviderId = id
+      }
+      cb(err)
+    })
   }
 
   private defaultProvider(): HistoryProvider {

--- a/src/api/history/index.ts
+++ b/src/api/history/index.ts
@@ -27,6 +27,8 @@ import { Responses } from '../'
 const debug = createDebug('signalk-server:api:history')
 
 const HISTORY_API_PATH = `/signalk/v2/api/history`
+const PROVIDER_NOTIFICATION_PATH =
+  'notifications.server.history.defaultProvider' as Path
 
 export interface HistoryApplication
   extends WithSecurityStrategy, IRouter, ConfigApp, WithHistoryApi {}
@@ -36,6 +38,9 @@ export class HistoryApiHttpRegistry {
   /** Persisted user choice; may reference a provider that is not
    * currently registered (e.g. plugin disabled). */
   private configuredProviderId?: string
+  /** True while a warn notification about the configured provider
+   * being unavailable is active. */
+  private warnedUnavailable = false
   proxy: HistoryApi
 
   /** The configured provider when it is registered, otherwise the first
@@ -89,6 +94,9 @@ export class HistoryApiHttpRegistry {
     }
     if (!this.historyProviders.has(pluginId)) {
       this.historyProviders.set(pluginId, provider)
+    }
+    if (pluginId === this.configuredProviderId) {
+      this.notifyConfiguredAvailable()
     }
     debug(
       `Registered history api provider ${pluginId},`,
@@ -244,26 +252,82 @@ export class HistoryApiHttpRegistry {
   }
 
   // Commit the new default only when the write succeeds, so a failed
-  // save does not leave the active provider out of sync with the
-  // settings file.
+  // save does not leave the active provider or the in-memory settings
+  // out of sync with the settings file. The write gets an immutable
+  // snapshot; app.config.settings is untouched until the write lands.
   private saveConfiguredProvider(id: string, cb: (err?: Error) => void) {
     const settings = this.app.config.settings
-    const previous = settings.historyApi
-    settings.historyApi = {
-      ...previous,
-      defaultProvider: id
+    const snapshot = {
+      ...settings,
+      historyApi: {
+        ...settings.historyApi,
+        defaultProvider: id
+      }
     }
-    writeSettingsFile(this.app, settings, (err?: Error) => {
-      if (err) {
-        settings.historyApi = previous
-      } else {
+    writeSettingsFile(this.app, snapshot, (err?: Error) => {
+      if (!err) {
+        settings.historyApi = snapshot.historyApi
         this.configuredProviderId = id
       }
       cb(err)
     })
   }
 
+  // Raise a warn notification the first time a request needs the
+  // default provider while the configured one is unavailable; cleared
+  // via notifyConfiguredAvailable() when its plugin registers again.
+  private warnIfConfiguredUnavailable() {
+    const configured = this.configuredProviderId
+    if (
+      !configured ||
+      this.historyProviders.has(configured) ||
+      this.warnedUnavailable
+    ) {
+      return
+    }
+    this.warnedUnavailable = true
+    const fallback = this.defaultProviderId
+    this.notify(
+      'warn',
+      `Configured default history provider '${configured}' is not available` +
+        (fallback
+          ? `, using '${fallback}' instead`
+          : ' and no other provider is registered')
+    )
+  }
+
+  private notifyConfiguredAvailable() {
+    if (!this.warnedUnavailable) {
+      return
+    }
+    this.warnedUnavailable = false
+    this.notify(
+      'normal',
+      `Configured default history provider '${this.configuredProviderId}' is available again`
+    )
+  }
+
+  private notify(state: 'normal' | 'warn', message: string) {
+    this.app.handleMessage('historyApi', {
+      updates: [
+        {
+          values: [
+            {
+              path: PROVIDER_NOTIFICATION_PATH,
+              value: {
+                state,
+                method: [],
+                message
+              }
+            }
+          ]
+        }
+      ]
+    })
+  }
+
   private defaultProvider(): HistoryProvider {
+    this.warnIfConfiguredUnavailable()
     if (
       this.defaultProviderId &&
       this.historyProviders.has(this.defaultProviderId)
@@ -281,6 +345,7 @@ export class HistoryApiHttpRegistry {
       }
       return provider
     }
+    this.warnIfConfiguredUnavailable()
     return this.defaultProviderId
       ? this.historyProviders.get(this.defaultProviderId)
       : undefined

--- a/src/api/history/openApi.ts
+++ b/src/api/history/openApi.ts
@@ -345,6 +345,11 @@ historyApiDoc.paths = {
                   id: {
                     type: 'string',
                     description: 'Provider identifier.'
+                  },
+                  configured: {
+                    type: 'string',
+                    description:
+                      'Provider identifier persisted in server settings. May differ from `id` when the configured provider is not currently registered.'
                   }
                 },
                 example: { id: 'signalk-to-influxdb2' }
@@ -360,7 +365,8 @@ historyApiDoc.paths = {
     post: {
       tags: ['Provider'],
       summary: 'Sets the default history provider.',
-      description: 'Sets the provider with the supplied `id` as the default.',
+      description:
+        'Sets the provider with the supplied `id` as the default and persists the choice in server settings.',
       responses: {
         default: { $ref: '#/components/responses/ErrorResponse' },
         '200': { $ref: '#/components/responses/200OKResponse' }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,7 +7,7 @@ import { ResourcesApi } from './resources'
 import { WeatherApi } from './weather'
 import { AutopilotApi } from './autopilot'
 import { RadarApi } from './radar'
-import { HistoryApiHttpRegistry } from './history'
+import { HistoryApiHttpRegistry, HistoryApplication } from './history'
 import { SignalKApiId, WithFeatures } from '@signalk/server-api'
 import { NotificationApi, NotificationApplication } from './notifications'
 import {
@@ -96,7 +96,9 @@ export const startApis = (
 
   const featuresApi = new FeaturesApi(app)
 
-  const historyApiHttpRegistry = new HistoryApiHttpRegistry(app)
+  const historyApiHttpRegistry = new HistoryApiHttpRegistry(
+    app as HistoryApplication
+  )
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(app as any).historyApiHttpRegistry = historyApiHttpRegistry
   apiList.push('history')

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -166,6 +166,14 @@ export interface Config {
     courseApi?: {
       apiOnly?: boolean
     }
+    historyApi?: {
+      /** Plugin id of the History API provider to use as the default.
+       * Applied whenever the provider is registered, so the default does
+       * not depend on plugin load order. When the configured provider is
+       * not registered (e.g. plugin disabled), the first registered
+       * provider serves as fallback. */
+      defaultProvider?: string
+    }
     notifications?: {
       manageNotifications?: boolean
     }

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -259,19 +259,39 @@ describe('History API v2', () => {
       getPaths: async () => []
     })
 
-    interface TestApp extends WithHistoryApi {
-      config: { settings: { historyApi?: { defaultProvider?: string } } }
+    interface NotificationValue {
+      state: string
+      message: string
     }
 
-    const makeApp = (configuredDefault?: string): TestApp => ({
-      config: {
-        settings: {
-          historyApi: configuredDefault
-            ? { defaultProvider: configuredDefault }
-            : undefined
+    interface TestApp extends WithHistoryApi {
+      config: { settings: { historyApi?: { defaultProvider?: string } } }
+      handleMessage: (id: string, delta: unknown) => void
+      /** Notification values captured from handleMessage */
+      notifications: NotificationValue[]
+    }
+
+    const makeApp = (configuredDefault?: string): TestApp => {
+      const notifications: NotificationValue[] = []
+      return {
+        config: {
+          settings: {
+            historyApi: configuredDefault
+              ? { defaultProvider: configuredDefault }
+              : undefined
+          }
+        },
+        notifications,
+        handleMessage: (_id: string, delta: unknown) => {
+          const update = (
+            delta as {
+              updates: { values: { value: NotificationValue }[] }[]
+            }
+          ).updates[0]
+          notifications.push(update.values[0].value)
         }
       }
-    })
+    }
 
     const makeRegistry = (app: TestApp) =>
       new HistoryApiHttpRegistry(app as unknown as HistoryApplication)
@@ -337,6 +357,36 @@ describe('History API v2', () => {
         .catch((err: Error) =>
           err.message.should.contain('No history api provider')
         )
+    })
+
+    it('emits a single warn notification when the configured provider is needed but unavailable', async function () {
+      const app = makeApp('questdb')
+      const registry = makeRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      await defaultOf(app)
+      await defaultOf(app)
+      app.notifications.length.should.equal(1)
+      app.notifications[0].state.should.equal('warn')
+      app.notifications[0].message.should.contain('questdb')
+      app.notifications[0].message.should.contain('kip')
+    })
+
+    it('clears the warning when the configured provider registers', async function () {
+      const app = makeApp('questdb')
+      const registry = makeRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      await defaultOf(app)
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      app.notifications.length.should.equal(2)
+      app.notifications[1].state.should.equal('normal')
+    })
+
+    it('does not notify when the configured provider serves requests', async function () {
+      const app = makeApp('questdb')
+      const registry = makeRegistry(app)
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      await defaultOf(app)
+      app.notifications.length.should.equal(0)
     })
 
     it('does not change the active provider when persisting fails', async function () {

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -12,11 +12,18 @@ import { startServerP } from './servertestutilities'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Server = require('../dist/')
-import { HistoryApiHttpRegistry } from '../dist/api/history/index.js'
+import {
+  HistoryApiHttpRegistry,
+  type HistoryApplication
+} from '../dist/api/history/index.js'
 import type {
   HistoryProvider,
-  ValuesResponse
+  ValuesRequest,
+  ValuesResponse,
+  WithHistoryApi
 } from '@signalk/server-api/history'
+import type { Context, Path, Timestamp } from '@signalk/server-api'
+import { Temporal } from '@js-temporal/polyfill'
 
 chai.should()
 
@@ -236,14 +243,27 @@ describe('History API v2', () => {
   })
 
   describe('default provider selection', () => {
+    const providerContext = (name: string) => `vessels.${name}` as Context
+
     const provider = (name: string): HistoryProvider => ({
-      getValues: async () => name as unknown as ValuesResponse,
+      getValues: async (): Promise<ValuesResponse> => ({
+        context: providerContext(name),
+        range: {
+          from: FROM as Timestamp,
+          to: TO as Timestamp
+        },
+        values: [{ path: 'navigation.position' as Path, method: 'first' }],
+        data: [[FROM as Timestamp, null]]
+      }),
       getContexts: async () => [],
       getPaths: async () => []
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const makeApp = (configuredDefault?: string): any => ({
+    interface TestApp extends WithHistoryApi {
+      config: { settings: { historyApi?: { defaultProvider?: string } } }
+    }
+
+    const makeApp = (configuredDefault?: string): TestApp => ({
       config: {
         settings: {
           historyApi: configuredDefault
@@ -253,61 +273,125 @@ describe('History API v2', () => {
       }
     })
 
-    const defaultOf = async (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      app: any
-    ) => (await (await app.getHistoryApi()).getValues({})) as unknown as string
+    const makeRegistry = (app: TestApp) =>
+      new HistoryApiHttpRegistry(app as unknown as HistoryApplication)
+
+    const VALUES_QUERY: ValuesRequest = {
+      duration: Temporal.Duration.from({ minutes: 15 }),
+      pathSpecs: []
+    }
+
+    // Identifies the provider serving unqualified requests by the
+    // context its getValues stub reports.
+    const defaultOf = async (app: TestApp): Promise<Context> => {
+      const api = await app.getHistoryApi!()
+      return (await api.getValues(VALUES_QUERY)).context
+    }
 
     it('uses the configured provider even when it registers last', async function () {
       const app = makeApp('questdb')
-      const registry = new HistoryApiHttpRegistry(app)
+      const registry = makeRegistry(app)
       registry.registerHistoryApiProvider('kip', provider('kip'))
       registry.registerHistoryApiProvider('questdb', provider('questdb'))
-      ;(await defaultOf(app)).should.equal('questdb')
+      ;(await defaultOf(app)).should.equal(providerContext('questdb'))
     })
 
     it('falls back to the first registered provider when the configured one is not registered', async function () {
       const app = makeApp('questdb')
-      const registry = new HistoryApiHttpRegistry(app)
+      const registry = makeRegistry(app)
       registry.registerHistoryApiProvider('kip', provider('kip'))
-      ;(await defaultOf(app)).should.equal('kip')
+      ;(await defaultOf(app)).should.equal(providerContext('kip'))
     })
 
     it('reverts to the configured provider when the fallback unregisters', async function () {
       const app = makeApp('questdb')
-      const registry = new HistoryApiHttpRegistry(app)
+      const registry = makeRegistry(app)
       registry.registerHistoryApiProvider('kip', provider('kip'))
       registry.registerHistoryApiProvider('questdb', provider('questdb'))
       registry.unregisterHistoryApiProvider('kip')
-      ;(await defaultOf(app)).should.equal('questdb')
+      ;(await defaultOf(app)).should.equal(providerContext('questdb'))
     })
 
     it('falls back when the configured provider unregisters', async function () {
       const app = makeApp('questdb')
-      const registry = new HistoryApiHttpRegistry(app)
+      const registry = makeRegistry(app)
       registry.registerHistoryApiProvider('questdb', provider('questdb'))
       registry.registerHistoryApiProvider('kip', provider('kip'))
       registry.unregisterHistoryApiProvider('questdb')
-      ;(await defaultOf(app)).should.equal('kip')
+      ;(await defaultOf(app)).should.equal(providerContext('kip'))
     })
 
     it('defaults to the first registered provider without configuration', async function () {
       const app = makeApp()
-      const registry = new HistoryApiHttpRegistry(app)
+      const registry = makeRegistry(app)
       registry.registerHistoryApiProvider('kip', provider('kip'))
       registry.registerHistoryApiProvider('questdb', provider('questdb'))
-      ;(await defaultOf(app)).should.equal('kip')
+      ;(await defaultOf(app)).should.equal(providerContext('kip'))
     })
 
     it('rejects when no provider is registered', async function () {
       const app = makeApp('questdb')
-      new HistoryApiHttpRegistry(app)
-      await app
-        .getHistoryApi()
+      makeRegistry(app)
+      await app.getHistoryApi!()
         .then(() => chai.assert.fail('should have rejected'))
         .catch((err: Error) =>
           err.message.should.contain('No history api provider')
         )
+    })
+
+    it('does not change the active provider when persisting fails', async function () {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const config = require('../dist/config/config')
+      const origWriteSettingsFile = config.writeSettingsFile
+      config.writeSettingsFile = (
+        _app: unknown,
+        _settings: unknown,
+        cb: (err?: Error) => void
+      ) => cb(new Error('disk full'))
+      try {
+        const app = makeApp() as TestApp & {
+          securityStrategy: { shouldAllowPut: () => boolean }
+          get: (path: string, handler: unknown) => void
+          post: (path: string, handler: unknown) => void
+        }
+        app.securityStrategy = { shouldAllowPut: () => true }
+        const postHandlers: Record<
+          string,
+          (req: unknown, res: unknown) => Promise<void>
+        > = {}
+        app.get = () => undefined
+        app.post = (path, handler) => {
+          postHandlers[path] = handler as (typeof postHandlers)[string]
+        }
+
+        const registry = makeRegistry(app)
+        registry.registerHistoryApiProvider('kip', provider('kip'))
+        registry.registerHistoryApiProvider('questdb', provider('questdb'))
+        registry.start()
+
+        let statusCode = 0
+        const res = {
+          status(code: number) {
+            statusCode = code
+            return this
+          },
+          json() {
+            return this
+          }
+        }
+        await postHandlers['/signalk/v2/api/history/_providers/_default/:id'](
+          { params: { id: 'questdb' }, method: 'POST', path: '' },
+          res
+        )
+
+        statusCode.should.equal(500)
+        // the failed save must not have switched the default nor
+        // mutated the persisted settings
+        ;(await defaultOf(app)).should.equal(providerContext('kip'))
+        chai.expect(app.config.settings.historyApi).to.equal(undefined)
+      } finally {
+        config.writeSettingsFile = origWriteSettingsFile
+      }
     })
   })
 })

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -389,6 +389,69 @@ describe('History API v2', () => {
       app.notifications.length.should.equal(0)
     })
 
+    it('clears a stale warning when the default is switched to a registered provider', async function () {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const config = require('../dist/config/config')
+      const origWriteSettingsFile = config.writeSettingsFile
+      config.writeSettingsFile = (
+        _app: unknown,
+        _settings: unknown,
+        cb: (err?: Error) => void
+      ) => cb()
+      try {
+        const app = makeApp('questdb') as TestApp & {
+          securityStrategy: { shouldAllowPut: () => boolean }
+          get: (path: string, handler: unknown) => void
+          post: (path: string, handler: unknown) => void
+        }
+        app.securityStrategy = { shouldAllowPut: () => true }
+        const postHandlers: Record<
+          string,
+          (req: unknown, res: unknown) => Promise<void>
+        > = {}
+        app.get = () => undefined
+        app.post = (path, handler) => {
+          postHandlers[path] = handler as (typeof postHandlers)[string]
+        }
+
+        const registry = makeRegistry(app)
+        registry.registerHistoryApiProvider('kip', provider('kip'))
+        registry.start()
+
+        // configured questdb is unavailable: first request warns
+        await defaultOf(app)
+        app.notifications.length.should.equal(1)
+        app.notifications[0].state.should.equal('warn')
+
+        // switching the default to the registered kip resolves the
+        // situation and must clear the warning
+        const res = {
+          status() {
+            return this
+          },
+          json() {
+            return this
+          }
+        }
+        await postHandlers['/signalk/v2/api/history/_providers/_default/:id'](
+          { params: { id: 'kip' }, method: 'POST', path: '' },
+          res
+        )
+        app.notifications.length.should.equal(2)
+        app.notifications[1].state.should.equal('normal')
+
+        // a later unavailability must warn again, not be swallowed
+        registry.unregisterHistoryApiProvider('kip')
+        registry.registerHistoryApiProvider('questdb', provider('questdb'))
+        await defaultOf(app)
+        app.notifications.length.should.equal(3)
+        app.notifications[2].state.should.equal('warn')
+        app.notifications[2].message.should.contain('kip')
+      } finally {
+        config.writeSettingsFile = origWriteSettingsFile
+      }
+    })
+
     it('does not change the active provider when persisting fails', async function () {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const config = require('../dist/config/config')

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -389,7 +389,19 @@ describe('History API v2', () => {
       app.notifications.length.should.equal(0)
     })
 
-    it('clears a stale warning when the default is switched to a registered provider', async function () {
+    // Drives the POST default-provider route directly: stubs
+    // writeSettingsFile with the given outcome, captures the registry's
+    // route handlers and provides a postDefault(id) helper returning the
+    // response status code. Restores the stub afterwards.
+    const withDefaultProviderRoute = async (
+      configuredDefault: string | undefined,
+      writeSettings: (cb: (err?: Error) => void) => void,
+      run: (ctx: {
+        app: TestApp
+        registry: ReturnType<typeof makeRegistry>
+        postDefault: (id: string) => Promise<number>
+      }) => Promise<void>
+    ) => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const config = require('../dist/config/config')
       const origWriteSettingsFile = config.writeSettingsFile
@@ -397,9 +409,9 @@ describe('History API v2', () => {
         _app: unknown,
         _settings: unknown,
         cb: (err?: Error) => void
-      ) => cb()
+      ) => writeSettings(cb)
       try {
-        const app = makeApp('questdb') as TestApp & {
+        const app = makeApp(configuredDefault) as TestApp & {
           securityStrategy: { shouldAllowPut: () => boolean }
           get: (path: string, handler: unknown) => void
           post: (path: string, handler: unknown) => void
@@ -415,96 +427,76 @@ describe('History API v2', () => {
         }
 
         const registry = makeRegistry(app)
-        registry.registerHistoryApiProvider('kip', provider('kip'))
         registry.start()
 
-        // configured questdb is unavailable: first request warns
-        await defaultOf(app)
-        app.notifications.length.should.equal(1)
-        app.notifications[0].state.should.equal('warn')
-
-        // switching the default to the registered kip resolves the
-        // situation and must clear the warning
-        const res = {
-          status() {
-            return this
-          },
-          json() {
-            return this
+        const postDefault = async (id: string): Promise<number> => {
+          let statusCode = 0
+          const res = {
+            status(code: number) {
+              statusCode = code
+              return this
+            },
+            json() {
+              return this
+            }
           }
+          await postHandlers['/signalk/v2/api/history/_providers/_default/:id'](
+            { params: { id }, method: 'POST', path: '' },
+            res
+          )
+          return statusCode
         }
-        await postHandlers['/signalk/v2/api/history/_providers/_default/:id'](
-          { params: { id: 'kip' }, method: 'POST', path: '' },
-          res
-        )
-        app.notifications.length.should.equal(2)
-        app.notifications[1].state.should.equal('normal')
 
-        // a later unavailability must warn again, not be swallowed
-        registry.unregisterHistoryApiProvider('kip')
-        registry.registerHistoryApiProvider('questdb', provider('questdb'))
-        await defaultOf(app)
-        app.notifications.length.should.equal(3)
-        app.notifications[2].state.should.equal('warn')
-        app.notifications[2].message.should.contain('kip')
+        await run({ app, registry, postDefault })
       } finally {
         config.writeSettingsFile = origWriteSettingsFile
       }
+    }
+
+    it('clears a stale warning when the default is switched to a registered provider', async function () {
+      await withDefaultProviderRoute(
+        'questdb',
+        (cb) => cb(),
+        async ({ app, registry, postDefault }) => {
+          registry.registerHistoryApiProvider('kip', provider('kip'))
+
+          // configured questdb is unavailable: first request warns
+          await defaultOf(app)
+          app.notifications.length.should.equal(1)
+          app.notifications[0].state.should.equal('warn')
+
+          // switching the default to the registered kip resolves the
+          // situation and must clear the warning
+          ;(await postDefault('kip')).should.equal(200)
+          app.notifications.length.should.equal(2)
+          app.notifications[1].state.should.equal('normal')
+
+          // a later unavailability must warn again, not be swallowed
+          registry.unregisterHistoryApiProvider('kip')
+          registry.registerHistoryApiProvider('questdb', provider('questdb'))
+          await defaultOf(app)
+          app.notifications.length.should.equal(3)
+          app.notifications[2].state.should.equal('warn')
+          app.notifications[2].message.should.contain('kip')
+        }
+      )
     })
 
     it('does not change the active provider when persisting fails', async function () {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const config = require('../dist/config/config')
-      const origWriteSettingsFile = config.writeSettingsFile
-      config.writeSettingsFile = (
-        _app: unknown,
-        _settings: unknown,
-        cb: (err?: Error) => void
-      ) => cb(new Error('disk full'))
-      try {
-        const app = makeApp() as TestApp & {
-          securityStrategy: { shouldAllowPut: () => boolean }
-          get: (path: string, handler: unknown) => void
-          post: (path: string, handler: unknown) => void
-        }
-        app.securityStrategy = { shouldAllowPut: () => true }
-        const postHandlers: Record<
-          string,
-          (req: unknown, res: unknown) => Promise<void>
-        > = {}
-        app.get = () => undefined
-        app.post = (path, handler) => {
-          postHandlers[path] = handler as (typeof postHandlers)[string]
-        }
+      await withDefaultProviderRoute(
+        undefined,
+        (cb) => cb(new Error('disk full')),
+        async ({ app, registry, postDefault }) => {
+          registry.registerHistoryApiProvider('kip', provider('kip'))
+          registry.registerHistoryApiProvider('questdb', provider('questdb'))
+          ;(await postDefault('questdb')).should.equal(500)
 
-        const registry = makeRegistry(app)
-        registry.registerHistoryApiProvider('kip', provider('kip'))
-        registry.registerHistoryApiProvider('questdb', provider('questdb'))
-        registry.start()
-
-        let statusCode = 0
-        const res = {
-          status(code: number) {
-            statusCode = code
-            return this
-          },
-          json() {
-            return this
-          }
+          // the failed save must not have switched the default nor
+          // mutated the persisted settings
+          ;(await defaultOf(app)).should.equal(providerContext('kip'))
+          chai.expect(app.config.settings.historyApi).to.equal(undefined)
         }
-        await postHandlers['/signalk/v2/api/history/_providers/_default/:id'](
-          { params: { id: 'questdb' }, method: 'POST', path: '' },
-          res
-        )
-
-        statusCode.should.equal(500)
-        // the failed save must not have switched the default nor
-        // mutated the persisted settings
-        ;(await defaultOf(app)).should.equal(providerContext('kip'))
-        chai.expect(app.config.settings.historyApi).to.equal(undefined)
-      } finally {
-        config.writeSettingsFile = origWriteSettingsFile
-      }
+      )
     })
   })
 })

--- a/test/history-api.ts
+++ b/test/history-api.ts
@@ -12,6 +12,11 @@ import { startServerP } from './servertestutilities'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Server = require('../dist/')
+import { HistoryApiHttpRegistry } from '../dist/api/history/index.js'
+import type {
+  HistoryProvider,
+  ValuesResponse
+} from '@signalk/server-api/history'
 
 chai.should()
 
@@ -134,6 +139,25 @@ describe('History API v2', () => {
       body.should.have.property('id', 'testplugin')
     })
 
+    it('sets and reports the default provider', async function () {
+      const postRes = await fetch(
+        `${api}/history/_providers/_default/testplugin`,
+        { method: 'POST' }
+      )
+      postRes.status.should.equal(200)
+      const res = await fetch(`${api}/history/_providers/_default`)
+      const body = await res.json()
+      body.should.have.property('id', 'testplugin')
+      body.should.have.property('configured', 'testplugin')
+    })
+
+    it('returns 400 when setting an unregistered provider as default', async function () {
+      const res = await fetch(`${api}/history/_providers/_default/nosuch`, {
+        method: 'POST'
+      })
+      res.status.should.equal(400)
+    })
+
     it('returns values from the provider', async function () {
       const res = await fetch(
         `${api}/history/values?paths=navigation.position&from=${FROM}&to=${TO}&resolution=60`
@@ -208,6 +232,82 @@ describe('History API v2', () => {
       // mention of "duration", to avoid false greens from unrelated
       // validators that also mention the word.
       body.error.should.contain('ISO 8601')
+    })
+  })
+
+  describe('default provider selection', () => {
+    const provider = (name: string): HistoryProvider => ({
+      getValues: async () => name as unknown as ValuesResponse,
+      getContexts: async () => [],
+      getPaths: async () => []
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const makeApp = (configuredDefault?: string): any => ({
+      config: {
+        settings: {
+          historyApi: configuredDefault
+            ? { defaultProvider: configuredDefault }
+            : undefined
+        }
+      }
+    })
+
+    const defaultOf = async (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: any
+    ) => (await (await app.getHistoryApi()).getValues({})) as unknown as string
+
+    it('uses the configured provider even when it registers last', async function () {
+      const app = makeApp('questdb')
+      const registry = new HistoryApiHttpRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      ;(await defaultOf(app)).should.equal('questdb')
+    })
+
+    it('falls back to the first registered provider when the configured one is not registered', async function () {
+      const app = makeApp('questdb')
+      const registry = new HistoryApiHttpRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      ;(await defaultOf(app)).should.equal('kip')
+    })
+
+    it('reverts to the configured provider when the fallback unregisters', async function () {
+      const app = makeApp('questdb')
+      const registry = new HistoryApiHttpRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      registry.unregisterHistoryApiProvider('kip')
+      ;(await defaultOf(app)).should.equal('questdb')
+    })
+
+    it('falls back when the configured provider unregisters', async function () {
+      const app = makeApp('questdb')
+      const registry = new HistoryApiHttpRegistry(app)
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      registry.unregisterHistoryApiProvider('questdb')
+      ;(await defaultOf(app)).should.equal('kip')
+    })
+
+    it('defaults to the first registered provider without configuration', async function () {
+      const app = makeApp()
+      const registry = new HistoryApiHttpRegistry(app)
+      registry.registerHistoryApiProvider('kip', provider('kip'))
+      registry.registerHistoryApiProvider('questdb', provider('questdb'))
+      ;(await defaultOf(app)).should.equal('kip')
+    })
+
+    it('rejects when no provider is registered', async function () {
+      const app = makeApp('questdb')
+      new HistoryApiHttpRegistry(app)
+      await app
+        .getHistoryApi()
+        .then(() => chai.assert.fail('should have rejected'))
+        .catch((err: Error) =>
+          err.message.should.contain('No history api provider')
+        )
     })
   })
 })


### PR DESCRIPTION
The default history provider is first-come-first-served: whichever plugin registers first (e.g. KIP) becomes the default, and a choice made via `POST /_providers/_default` is lost on restart. A provider registering later (e.g. QuestDB) cannot be selected persistently.

The selection is now persisted in server settings (`historyApi.defaultProvider`) and resolved dynamically: the configured provider serves as default whenever it is registered, with the first registered provider as fallback when it is not (e.g. its plugin is disabled). This makes the default independent of plugin load order and stable across plugin enable/disable and server restarts.

The Admin UI gets a History Provider card under Data → Preferences with a pull-down of the registered providers. A warning is shown when the configured provider is currently unavailable. `GET /_providers/_default` additionally reports the persisted choice as `configured`.

closes #2835

<img width="868" height="121" alt="image" src="https://github.com/user-attachments/assets/1fc7a4cc-390f-48e8-b944-ab48fe628f72" />


Tested: added unit tests for order independence and fallback plus endpoint tests for set/persist. I also verified manually against a running server with two test history-provider plugins plus KIP: set the default via the UI, restarted, and the default survived load order; disabling the configured provider's plugin falls back to another provider with a warning shown in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a persisted default History API provider configuration.

- Stores the configured default provider in `historyApi.defaultProvider` and resolves the effective default dynamically: it uses the configured provider when available, otherwise it falls back to the first registered provider (independent of plugin load order).
- Persists the configured choice across restarts and across provider enable/disable and registration/unregistration changes.
- Updates `GET /_providers/_default` to return both the effective `id` and the persisted `configured` provider id, and updates `POST /_providers/_default/:id` to persist the configured default via settings (returning an error and not changing in-memory state when settings persistence fails).
- Emits an unavailable-provider warning for default-resolving requests when the configured provider is unavailable, and clears the warning once the configured provider registers again.
- Adds Admin UI support: a “Default History Provider” settings card under Data → Preferences with provider selection and an unavailable-provider warning, plus sidebar/configuration badges reflecting availability; shared provider-fetching and unavailability logic lives in `useHistoryProviders` / `useHistoryProviderUnavailable`.
- Updates the OpenAPI documentation for the default-provider endpoints.
- Adds unit and endpoint tests covering configured-vs-effective behavior, ordering/fallback rules, persistence success/failure, validation errors, and notification warning/clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->