### PR TITLE
fix: key PGN 130310 instance conflicts by published leaf paths

### DIFF
--- a/packages/server-admin-ui/src/utils/sourceLabels.test.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.test.ts
@@ -746,6 +746,97 @@ describe('detectInstanceConflicts', () => {
       detectInstanceConflicts(devices, undefined, pgnSourceKeys)
     ).toHaveLength(0)
   })
+
+  // PGN 130310 (legacy combined Environmental Parameters) has no
+  // instance or source field — the only meaningful key is which fixed
+  // fields a device populates, visible as disjoint SK leaf paths. A
+  // DST810 (sea temperature) and an SCX-20 (outside temperature +
+  // pressure) both on device instance 0 are not in conflict.
+  it('DST810 vs SCX-20 on instance 0 is not a 130310 conflict', () => {
+    const devices: N2kDeviceEntry[] = [
+      makeDevice({
+        sourceRef: 'IPG100.35',
+        connection: 'IPG100',
+        src: '35',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      }),
+      makeDevice({
+        sourceRef: 'IPG100.4',
+        connection: 'IPG100',
+        src: '4',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      })
+    ]
+    const pgnSourceKeys = {
+      'IPG100.35': {
+        '130310': ['environment.water.temperature']
+      },
+      'IPG100.4': {
+        '130310': [
+          'environment.outside.pressure',
+          'environment.outside.temperature'
+        ]
+      }
+    }
+    expect(
+      detectInstanceConflicts(devices, undefined, pgnSourceKeys)
+    ).toHaveLength(0)
+  })
+
+  it('still flags 130310 when published leaf paths overlap', () => {
+    const devices: N2kDeviceEntry[] = [
+      makeDevice({
+        sourceRef: 'IPG100.4',
+        connection: 'IPG100',
+        src: '4',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      }),
+      makeDevice({
+        sourceRef: 'IPG100.7',
+        connection: 'IPG100',
+        src: '7',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      })
+    ]
+    const pgnSourceKeys = {
+      'IPG100.4': {
+        '130310': ['environment.outside.pressure']
+      },
+      'IPG100.7': {
+        '130310': [
+          'environment.outside.pressure',
+          'environment.outside.temperature'
+        ]
+      }
+    }
+    const conflicts = detectInstanceConflicts(devices, undefined, pgnSourceKeys)
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0].sharedPGNs).toEqual(['130310'])
+  })
+
+  it('flags 130310 conservatively when no source-key data exists', () => {
+    const devices: N2kDeviceEntry[] = [
+      makeDevice({
+        sourceRef: 'IPG100.35',
+        connection: 'IPG100',
+        src: '35',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      }),
+      makeDevice({
+        sourceRef: 'IPG100.4',
+        connection: 'IPG100',
+        src: '4',
+        deviceInstance: 0,
+        pgns: { '130310': '' }
+      })
+    ]
+    expect(detectInstanceConflicts(devices)).toHaveLength(1)
+  })
 })
 
 describe('isProprietaryPGN', () => {

--- a/packages/server-admin-ui/src/utils/sourceLabels.ts
+++ b/packages/server-admin-ui/src/utils/sourceLabels.ts
@@ -319,11 +319,20 @@ export function isProprietaryPGN(pgn: string | number): boolean {
 }
 
 /**
- * Temperature/humidity PGNs where the unique key is instance + source,
- * not just instance. Two devices sending the same PGN with the same
- * instance but different source types are NOT in conflict.
+ * Environmental PGNs where the unique key is the published SK leaf
+ * path, not the device instance. Two devices sending the same PGN with
+ * the same instance but different source types (or different populated
+ * fields, for the combined 130310/130311) are NOT in conflict.
  */
 const COMPOUND_KEY_PGNS = new Set([
+  // 130310/130311 (combined Environmental Parameters) carry no
+  // instance field at all, but their fixed fields route to disjoint SK
+  // paths (environment.water.temperature vs environment.outside.*), so
+  // the leaf-path comparison below is the only meaningful key — bare
+  // device instance would flag a sea-temp sender against an air-temp
+  // sender.
+  '130310', // Environmental Parameters (legacy combined)
+  '130311', // Environmental Parameters (combined, source enums)
   '130312', // Temperature
   '130313', // Humidity
   '130316' // Temperature Extended Range

--- a/src/n2k-discovery-instances.ts
+++ b/src/n2k-discovery-instances.ts
@@ -20,6 +20,12 @@
  * (temperature/humidity) carry an additional `source` enum that splits
  * the path as `<prefix>.<source>.<instance>.<...>`. We treat that as
  * the compound key the conflict detector already understands.
+ *
+ * PGN 130310 (legacy combined Environmental Parameters) has no source
+ * enum and no instance field at all, but its fixed fields route to
+ * disjoint SK paths (environment.water.temperature vs
+ * environment.outside.temperature/pressure), so the same leaf-path
+ * comparison distinguishes a water-temp sender from an air-temp sender.
  */
 
 // Map PGN → list of `<prefix>:<shape>` describing where in the SK tree
@@ -45,6 +51,7 @@ const PGN_TREE_PATHS: Record<
   127506: [{ prefix: 'electrical.batteries', shape: 'inst' }],
   127508: [{ prefix: 'electrical.batteries', shape: 'inst' }],
   127513: [{ prefix: 'electrical.batteries', shape: 'inst' }],
+  130310: [{ prefix: 'environment', shape: 'source-inst' }],
   130311: [{ prefix: 'environment', shape: 'source-inst' }],
   130312: [{ prefix: 'environment', shape: 'source-inst' }],
   130316: [{ prefix: 'environment', shape: 'source-inst' }]

--- a/test/n2k-discovery-instances.ts
+++ b/test/n2k-discovery-instances.ts
@@ -162,6 +162,32 @@ describe('buildPgnSourceKeysFromTree', function () {
     ])
   })
 
+  it('keys 130310 (combined Environmental Parameters) by leaf path', function () {
+    // A DST810 populates only the water-temperature field of 130310;
+    // an SCX-20 populates only outside temperature + pressure. Their
+    // leaf paths are disjoint, so sharing device instance 0 must not
+    // read as a conflict.
+    const tree = {
+      environment: {
+        water: {
+          temperature: { value: 293, $source: 'IPG100.35' }
+        },
+        outside: {
+          temperature: { value: 288, $source: 'IPG100.4' },
+          pressure: { value: 101325, $source: 'IPG100.4' }
+        }
+      }
+    }
+    const out = buildPgnSourceKeysFromTree(tree)
+    expect(out['IPG100.35']['130310']).to.deep.equal([
+      'environment.water.temperature'
+    ])
+    expect(out['IPG100.4']['130310']).to.deep.equal([
+      'environment.outside.pressure',
+      'environment.outside.temperature'
+    ])
+  })
+
   it('returns empty object for tree without temp/humidity paths', function () {
     expect(
       buildPgnSourceKeysFromTree({ electrical: { batteries: {} } })

--- a/test/n2k-discovery-source-keys.ts
+++ b/test/n2k-discovery-source-keys.ts
@@ -1,0 +1,165 @@
+// End-to-end coverage for PGN 130310 conflict handling: deltas land in
+// the SK tree, GET /skServer/n2kDeviceStatus derives pgnSourceKeys from
+// that tree, and the admin UI's detectInstanceConflicts consumes the
+// payload. A DST810 (sea temperature) and an SCX-20 (outside
+// temperature + pressure) both on device instance 0 share PGN 130310
+// but publish disjoint leaf paths — no conflict. A second barometer
+// publishing the same leaf path still flags.
+
+import { expect } from 'chai'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { freeport } from './ts-servertestutilities'
+import { startServerP, sendDelta } from './servertestutilities'
+import type { N2kDeviceEntry } from '../packages/server-admin-ui/src/utils/sourceLabels'
+
+type SourceLabelsModule =
+  typeof import('../packages/server-admin-ui/src/utils/sourceLabels')
+
+// server-admin-ui is `"type": "module"`, so its .ts files can't be
+// require()d from this CJS suite — and ts-node downlevels a plain
+// import() into exactly that require. The Function constructor hides
+// the import() from ts-node so Node's native ESM loader (with built-in
+// type stripping) handles the file instead.
+const importEsm = new Function('specifier', 'return import(specifier)') as (
+  specifier: string
+) => Promise<SourceLabelsModule>
+
+const loadSourceLabels = () =>
+  importEsm(
+    pathToFileURL(
+      path.join(
+        __dirname,
+        '../packages/server-admin-ui/src/utils/sourceLabels.ts'
+      )
+    ).href
+  )
+
+type DeviceStatusPayload = {
+  pgnDataInstances: Record<string, Record<string, number[]>>
+  pgnSourceKeys: Record<string, Record<string, string[]>>
+}
+
+const SOURCE_KEYS_TIMEOUT_MS = 5_000
+const SOURCE_KEYS_POLL_INTERVAL_MS = 25
+const SERVER_STARTUP_TIMEOUT_MS = 60_000
+
+const n2kDelta = (src: string, values: { path: string; value: number }[]) => ({
+  updates: [
+    {
+      source: { label: 'IPG100', type: 'NMEA2000', src, pgn: 130310 },
+      values
+    }
+  ]
+})
+
+const device = (src: string): N2kDeviceEntry => ({
+  sourceRef: `IPG100.${src}`,
+  connection: 'IPG100',
+  srcAddr: src,
+  src,
+  deviceInstance: 0,
+  pgns: { '130310': '' }
+})
+
+describe('GET /skServer/n2kDeviceStatus 130310 source keys', function () {
+  let url: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let detectInstanceConflicts: SourceLabelsModule['detectInstanceConflicts']
+
+  const fetchDeviceStatus = async (): Promise<DeviceStatusPayload> => {
+    const res = await fetch(`${url}/skServer/n2kDeviceStatus`)
+    expect(res.status).to.equal(200)
+    return res.json()
+  }
+
+  // Ingestion is asynchronous (streambundle pumps on the next tick), so
+  // poll until every expected sourceRef shows up in pgnSourceKeys.
+  const waitForSourceKeys = async (
+    sourceRefs: string[]
+  ): Promise<DeviceStatusPayload> => {
+    const deadline = Date.now() + SOURCE_KEYS_TIMEOUT_MS
+    for (;;) {
+      const payload = await fetchDeviceStatus()
+      if (sourceRefs.every((ref) => payload.pgnSourceKeys[ref]?.['130310'])) {
+        return payload
+      }
+      if (Date.now() > deadline) {
+        throw new Error(
+          'pgnSourceKeys never populated for ' +
+            sourceRefs.join(', ') +
+            '; got ' +
+            JSON.stringify(payload.pgnSourceKeys)
+        )
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, SOURCE_KEYS_POLL_INTERVAL_MS)
+      )
+    }
+  }
+
+  before(async function () {
+    // Server startup dominates; on a loaded machine it can exceed the
+    // suite-wide 20 s default.
+    this.timeout(SERVER_STARTUP_TIMEOUT_MS)
+    ;({ detectInstanceConflicts } = await loadSourceLabels())
+    const port = await freeport()
+    url = `http://0.0.0.0:${port}`
+    server = await startServerP(port, false)
+    const deltaUrl = `${url}/signalk/v1/api/_test/delta`
+    // DST810: populates only the water-temperature field of 130310
+    await sendDelta(
+      n2kDelta('35', [{ path: 'environment.water.temperature', value: 293.5 }]),
+      deltaUrl
+    )
+    // SCX-20: populates outside temperature + pressure
+    await sendDelta(
+      n2kDelta('4', [
+        { path: 'environment.outside.temperature', value: 288.15 },
+        { path: 'environment.outside.pressure', value: 101325 }
+      ]),
+      deltaUrl
+    )
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  it('keys each 130310 sender by its published leaf paths', async function () {
+    const payload = await waitForSourceKeys(['IPG100.35', 'IPG100.4'])
+    expect(payload.pgnSourceKeys['IPG100.35']['130310']).to.deep.equal([
+      'environment.water.temperature'
+    ])
+    expect(payload.pgnSourceKeys['IPG100.4']['130310']).to.deep.equal([
+      'environment.outside.pressure',
+      'environment.outside.temperature'
+    ])
+  })
+
+  it('sea-temp vs outside-temp senders on instance 0 do not conflict', async function () {
+    const payload = await waitForSourceKeys(['IPG100.35', 'IPG100.4'])
+    const conflicts = detectInstanceConflicts(
+      [device('35'), device('4')],
+      payload.pgnDataInstances,
+      payload.pgnSourceKeys
+    )
+    expect(conflicts).to.deep.equal([])
+  })
+
+  it('a second sender of the same 130310 field still conflicts', async function () {
+    await sendDelta(
+      n2kDelta('7', [{ path: 'environment.outside.pressure', value: 101300 }]),
+      `${url}/signalk/v1/api/_test/delta`
+    )
+    const payload = await waitForSourceKeys(['IPG100.4', 'IPG100.7'])
+    const conflicts = detectInstanceConflicts(
+      [device('4'), device('7')],
+      payload.pgnDataInstances,
+      payload.pgnSourceKeys
+    )
+    expect(conflicts).to.have.lengthOf(1)
+    expect(conflicts[0].sharedPGNs).to.deep.equal(['130310'])
+  })
+})


### PR DESCRIPTION
The NMEA Discovery instance-conflict detector flagged my Airmar DST810 (sea temperature) against my Furuno SCX-20 (outside temperature + pressure) because both claim device instance 0 and both transmit PGN 130310. 130310 is the legacy combined Environmental Parameters PGN — it has no instance field and no source enum — so the detector could only compare bare device instance and flagged conservatively.

The fields a device actually populates land on disjoint Signal K leaf paths (`environment.water.temperature` vs `environment.outside.*`), and the leaf-path comparison already used for 130312/130316 handles exactly this case. This keys 130310 the same way: senders of disjoint fields no longer conflict, while two senders of the same field still flag. 130311 gets the same treatment on the client side — the server already derived leaf-path keys for it, but the client never consulted them.

Tested: new unit tests for the tree-derived source keys and the detector (disjoint paths clear, overlapping paths flag, missing key data stays conservative), plus an e2e test that starts a server, injects deltas for both devices, fetches `/skServer/n2kDeviceStatus`, and runs the admin UI detector on the live payload. Full repo chain (format, build:all, npm test) passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates PGN 130310 instance-conflict detection to use published Signal K leaf paths, allowing devices with disjoint fields to share an instance while detecting overlapping fields.
- Adds client-side compound-key handling for PGN 130311.
- Extends source-key discovery and adds unit and end-to-end coverage for derived keys and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->