### PR TITLE
fix: declare path-to-regexp as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "ncp": "^2.0.0",
     "openid-client": "^6.8.4",
     "ora": "^5.4.1",
+    "path-to-regexp": "^0.1.12",
     "primus": "^7.3.5",
     "prompts": "^2.4.2",
     "rehype-parse": "^9.0.1",


### PR DESCRIPTION
Closes #2841.

src/tokensecurity.ts requires `path-to-regexp` but package.json never declared it. In the repo tree it resolves only as a phantom dependency — express 4's transitive `path-to-regexp@0.1.13` happens to be hoisted to the top of node_modules. In installs where that copy is nested elsewhere, the server crashes at boot with `MODULE_NOT_FOUND`.

I pinned `^0.1.12` deliberately: it is the same major express 4 uses, so the default export is the bare function matching the existing call site, route pattern semantics stay identical to express routing, and it dedupes against express's own copy (no extra install weight). Newer majors changed both the export shape and the pattern syntax. 0.1.12+ is also clear of the path-to-regexp ReDoS advisories.

Tested: `npm run format`, `npm run build:all`, and `npm test` pass. I also reproduced the reported scenario end-to-end: packed the server with `npm pack`, installed the tarball into a fresh directory, and confirmed the previously failing require chain (`dist/tokensecurity.js` via `dist/index.js`) now loads, with `path-to-regexp` resolved as a direct dependency of signalk-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds `path-to-regexp` as a direct runtime dependency, pinned to `^0.1.12`, so standalone installations load reliably without relying on Express’s transitive dependency hoisting.

The selected version preserves existing route-permission behavior and avoids affected ReDoS advisories. Formatting, build, tests, and fresh-directory packed-server verification pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->