### PR TITLE
feat: resolve core modules to the server's copy

### DIFF
--- a/src/baconjs-compat.ts
+++ b/src/baconjs-compat.ts
@@ -10,41 +10,16 @@
  * plugin's 1.x code subscribes to a server 3.x Bus, it receives 3.x Events
  * and crashes with "TypeError: e.isEnd is not a function".
  *
- * This module solves the problem by:
- * 1. Hooking Node's module resolution so ALL require('baconjs') calls in the
- *    process return the server's 3.x version — eliminating version mismatches
- * 2. Patching 3.x to restore the .map('.property') string shorthand that
- *    existed in 1.x (used by plugins like signalk-to-nmea2000)
+ * ./host-modules redirects every require('baconjs') in the process to the
+ * server's 3.x copy, eliminating version mismatches. This module patches
+ * that copy to restore the .map('.property') string shorthand that existed
+ * in 1.x (used by plugins like signalk-to-nmea2000).
  *
- * This module MUST be imported before any other module that uses BaconJS.
+ * This module MUST be imported after ./host-modules and before any other
+ * module that uses BaconJS.
  */
 
-import Module from 'module'
 import * as Bacon from 'baconjs'
-
-const serverBaconPath = require.resolve('baconjs')
-
-type ResolveFilename = (
-  request: string,
-  parent: NodeModule | undefined,
-  isMain: boolean,
-  options: Record<string, unknown>
-) => string
-
-const ModuleInternal = Module as unknown as Record<string, unknown>
-
-const origResolveFilename = ModuleInternal._resolveFilename as ResolveFilename
-ModuleInternal._resolveFilename = function (
-  request: string,
-  parent: NodeModule | undefined,
-  isMain: boolean,
-  options: Record<string, unknown>
-) {
-  if (request === 'baconjs') {
-    return serverBaconPath
-  }
-  return origResolveFilename.call(this, request, parent, isMain, options)
-}
 
 type Mappable = { map: (f: unknown) => unknown }
 

--- a/src/host-modules.ts
+++ b/src/host-modules.ts
@@ -1,0 +1,81 @@
+/*
+ * Host-provided modules
+ *
+ * Plugins installed in the server's data directory resolve their
+ * dependencies from <configPath>/node_modules, never from the server's own
+ * tree. For core interface packages this is harmful: dual copies break
+ * object identity between plugin and server code, and one plugin's tight
+ * version pin holds the hoisted copy back for every other plugin that would
+ * accept a newer version (npm optimizes for dedupe, not freshness).
+ *
+ * This module hooks Node's CJS module resolution so that require() of the
+ * packages listed below — including exported subpaths such as
+ * '@signalk/server-api/history' — always resolves to the server's own copy,
+ * no matter what npm installed in the plugin tree: the same model as
+ * require('vscode') in VS Code extensions. Plugin-bundled copies remain on
+ * disk but are never loaded.
+ *
+ * This module MUST be imported before any other module that may load one of
+ * the host-provided packages.
+ */
+
+import Module from 'module'
+import { createDebug } from './debug'
+
+const debug = createDebug('signalk-server:host-modules')
+
+const HOST_PROVIDED_MODULES = ['baconjs', '@signalk/server-api']
+
+const hostModulePaths = new Map<string, string | null>(
+  HOST_PROVIDED_MODULES.map((name) => [name, require.resolve(name)])
+)
+
+function isHostProvided(request: string): boolean {
+  return HOST_PROVIDED_MODULES.some(
+    (name) => request === name || request.startsWith(name + '/')
+  )
+}
+
+function resolveHostPath(request: string): string | null {
+  let hostPath = hostModulePaths.get(request)
+  if (hostPath === undefined) {
+    try {
+      // resolve from this module's context via the original resolver:
+      // require.resolve() would re-enter the hook and recurse
+      hostPath = origResolveFilename.call(Module, request, module, false)
+    } catch {
+      // subpath not exported by the host copy: leave resolution alone, so
+      // requires that only work against a bundled copy keep working
+      hostPath = null
+    }
+    hostModulePaths.set(request, hostPath)
+  }
+  return hostPath
+}
+
+type ResolveFilename = (
+  request: string,
+  parent: NodeModule | undefined,
+  isMain: boolean,
+  options?: Record<string, unknown>
+) => string
+
+const ModuleInternal = Module as unknown as Record<string, unknown>
+
+const origResolveFilename = ModuleInternal._resolveFilename as ResolveFilename
+ModuleInternal._resolveFilename = function (
+  request: string,
+  parent: NodeModule | undefined,
+  isMain: boolean,
+  options: Record<string, unknown>
+) {
+  if (isHostProvided(request)) {
+    const hostPath = resolveHostPath(request)
+    if (hostPath !== null) {
+      debug.enabled &&
+        debug(`resolving ${request} for ${parent?.filename} to the host copy`)
+      return hostPath
+    }
+  }
+  return origResolveFilename.call(this, request, parent, isMain, options)
+}

--- a/src/host-modules.ts
+++ b/src/host-modules.ts
@@ -67,7 +67,7 @@ ModuleInternal._resolveFilename = function (
   request: string,
   parent: NodeModule | undefined,
   isMain: boolean,
-  options: Record<string, unknown>
+  options?: Record<string, unknown>
 ) {
   if (isHostProvided(request)) {
     const hostPath = resolveHostPath(request)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@
 */
 
 import './networkConfig'
+import './host-modules'
 import './baconjs-compat'
 import {
   Context,

--- a/test/host-modules.ts
+++ b/test/host-modules.ts
@@ -1,0 +1,87 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import '../dist/host-modules.js'
+import { importOrRequire } from '../dist/modules.js'
+
+function writeModule(dir: string, pkg: object, files: Record<string, string>) {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg))
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content)
+  }
+}
+
+describe('host-provided modules', () => {
+  let testDir: string | undefined
+  let plugin: {
+    serverApi: Record<string, unknown>
+    historyApi: Record<string, unknown>
+    deep: { BUNDLED_STALE_COPY?: boolean }
+    bacon: Record<string, unknown>
+  }
+
+  before(async () => {
+    testDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), '_skservertest_host_modules')
+    )
+    const pluginDir = path.join(testDir, 'node_modules', 'testplugin')
+    writeModule(
+      pluginDir,
+      { name: 'testplugin', version: '1.0.0', main: 'index.js' },
+      {
+        'index.js': `module.exports = {
+          serverApi: require('@signalk/server-api'),
+          historyApi: require('@signalk/server-api/history'),
+          deep: require('@signalk/server-api/deep.js'),
+          bacon: require('baconjs')
+        }`
+      }
+    )
+    // stale bundled copy without an exports map, like server-api 2.9.x
+    writeModule(
+      path.join(pluginDir, 'node_modules', '@signalk', 'server-api'),
+      { name: '@signalk/server-api', version: '0.0.1', main: 'index.js' },
+      {
+        'index.js': `module.exports = { BUNDLED_STALE_COPY: true }`,
+        'history.js': `module.exports = { BUNDLED_STALE_COPY: true }`,
+        'deep.js': `module.exports = { BUNDLED_STALE_COPY: true }`
+      }
+    )
+    writeModule(
+      path.join(pluginDir, 'node_modules', 'baconjs'),
+      { name: 'baconjs', version: '0.0.1', main: 'index.js' },
+      { 'index.js': `module.exports = { BUNDLED_STALE_COPY: true }` }
+    )
+    plugin = await importOrRequire(pluginDir)
+  })
+
+  after(() => {
+    if (testDir !== undefined) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('plugin bundling its own @signalk/server-api gets the host copy', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expect(plugin.serverApi).to.equal(require('@signalk/server-api'))
+    expect(plugin.serverApi.BUNDLED_STALE_COPY).to.equal(undefined)
+  })
+
+  it('exported subpaths resolve to the host copy', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expect(plugin.historyApi).to.equal(require('@signalk/server-api/history'))
+    expect(plugin.historyApi.BUNDLED_STALE_COPY).to.equal(undefined)
+  })
+
+  it('subpaths the host copy does not export resolve normally', () => {
+    expect(plugin.deep.BUNDLED_STALE_COPY).to.equal(true)
+  })
+
+  it('plugin bundling its own baconjs gets the host copy', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expect(plugin.bacon).to.equal(require('baconjs'))
+    expect(plugin.bacon.BUNDLED_STALE_COPY).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
https://discord.com/channels/1170433917761892493/1527439504871260211


Plugins installed from the App Store resolve their dependencies from the data dir's `node_modules`, so a single plugin's tight pin on a core interface package holds the hoisted copy back for every other plugin whose range would accept a newer version, and dual copies break object identity between plugin and server code. Field case: `@signalk/server-api` held at 2.9.0 (latest 2.30.0) by one plugin declaring `"2.9"`, while three other installed plugins would have accepted 2.30.0.

This generalizes the baconjs-compat resolution hook into a host-provided modules list (the `require('vscode')` model from VS Code extensions): `require()` of `baconjs` and `@signalk/server-api` — including exported subpaths such as `@signalk/server-api/history` — always resolves to the server's own copy, regardless of what npm installed in the plugin tree. Subpaths the host copy does not export resolve normally, so deep requires into bundled copies keep working. baconjs-compat keeps only the `.map('.property')` shorthand patch.

Caveats:
- A plugin compiled against older 2.x typings runs against the host copy at runtime — safe by server-api's additive-within-major discipline, and no worse than the baconjs shim, which redirects across majors.
- Coverage is the CJS `_resolveFilename` hook, same as the baconjs precedent; plugin loading flows through `require()` first. Pure `import` in ESM plugins bypasses it — `module.registerHooks` is a feature-detected follow-up (engines allow Node 22.0–22.14, which lack it).
- `@signalk/streams` is deliberately not on the list: same identity hazard, but 5.x→6.x has breaking API changes and may need compat shims like baconjs got; to be assessed in its own PR.

Tested: new mocha suite loads a fixture plugin that bundles stale copies of both packages through `importOrRequire` and asserts module identity with the server's copies, including exported-subpath redirection and unexported-subpath fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CommonJS host-module resolution for `baconjs` and `@signalk/server-api`, redirecting `require()` calls (including exported subpaths) to the server’s copies to prevent dependency pinning and duplicate module identities while letting unexported subpaths fall back to bundled plugin dependencies.  

It preserves the `baconjs-compat` `.map('.property')` shorthand patch and initializes the host-module hook during startup by importing `host-modules` before `baconjs-compat`. It excludes `@signalk/streams` due to breaking changes between major versions.  

Mocha coverage uses a fixture plugin with bundled stale copies to test module identity, exported-subpath redirection, and unexported-subpath fallback; pure ESM imports are not covered by the hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->