### PR TITLE
chore: ignore generated test sources-cache.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test/server-test-config/unitpreferences/
 test/server-test-config/ssl-cert.pem
 test/server-test-config/ssl-key.pem
 test/server-test-config/plugin-config-data/
+test/server-test-config/sources-cache.json
 
 docs/built
 


### PR DESCRIPTION
Running the test suite makes the server write `sources-cache.json` into `test/server-test-config` (used as configPath by servertestutilities), leaving an untracked file behind in every checkout. Ignore it like the other server-generated files already listed for that directory (ssl certs, plugin-config-data, unitpreferences).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `.gitignore` to exclude the generated `test/server-test-config/sources-cache.json` file, keeping test-generated artifacts from appearing as untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->