### PR TITLE
feat: webapp warn/error status badges in Webapps list and sidebar

### DIFF
--- a/docs/develop/webapps.md
+++ b/docs/develop/webapps.md
@@ -49,6 +49,45 @@ where:
 
 See also [Working Offline](./README.md#offline-use).
 
+## Reporting Status Counts (Badges)
+
+A webapp can report warning and error counts to the server. The counts are displayed in the Admin UI as badges on the webapp's icon in the _Webapps_ list — red for errors, yellow for warnings — and summed across all webapps as badges on the _Webapps_ item in the sidebar. This lets users see at a glance that a webapp needs attention without opening it.
+
+There are two ways to report counts:
+
+**1. From the webapp (browser):**
+
+```
+PUT /skServer/webapps/:name/status
+{
+  "warnCount": 2,
+  "errorCount": 1
+}
+```
+
+`:name` is the webapp's package name, URL-encoded (`@signalk/freeboard-sk` → `%40signalk%2Ffreeboard-sk`). For example:
+
+```javascript
+fetch(`/skServer/webapps/${encodeURIComponent('my-signalk-webapp')}/status`, {
+  method: 'PUT',
+  credentials: 'include',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ warnCount: 2, errorCount: 1 })
+})
+```
+
+When security is enabled the request must be made by a user with _read/write_ permission. Responses: `404` if the named webapp is not installed, `400` if the counts are not non-negative integers.
+
+**2. From a plugin:**
+
+```javascript
+app.setWebappStatus('my-signalk-webapp', { warnCount: 2, errorCount: 1 })
+```
+
+If your webapp has a plugin backend, prefer this method: the plugin runs continuously, so it can keep the badges up to date while the webapp itself is not open in any browser.
+
+Reporting zero for both counts clears the badges. The counts are held in memory only and are cleared when the server restarts.
+
 ## Application Data: Storing Webapp Data on the Server
 
 Application Data is only supported if security is turned on. It supports two namespaces, one for _global data_ and one for _user specific data_. For example, a client might want to store boat specific gauge configuration globally so that other users have access to it. Otherwise, it could use the user area to store user specific preferences.

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -23,7 +23,8 @@ import {
   usePriorityOverrides,
   usePriorityGroups,
   useActiveConflictCount,
-  useUnconfiguredGnssSources
+  useUnconfiguredGnssSources,
+  useWebappStatus
 } from '../../store'
 import classNames from 'classnames'
 import { isOverrideDormantUnderGroups } from '../../utils/sourceGroups'
@@ -75,6 +76,7 @@ export default function Sidebar({ location }: SidebarProps) {
   const loginStatus = useLoginStatus()
   const plugins = usePlugins()
   const conflictCount = useActiveConflictCount()
+  const webappStatus = useWebappStatus()
 
   const multiSourcePaths = useMultiSourcePaths()
   const reconciled = useReconciledGroups()
@@ -286,11 +288,27 @@ export default function Sidebar({ location }: SidebarProps) {
         url: '/dashboard',
         icon: 'icon-speedometer'
       },
-      {
-        name: 'Webapps',
-        url: '/webapps',
-        icon: 'icon-grid'
-      },
+      ((): NavItemData => {
+        let webappErrorSum = 0
+        let webappWarnSum = 0
+        for (const status of Object.values(webappStatus)) {
+          webappErrorSum += status.errorCount
+          webappWarnSum += status.warnCount
+        }
+        return {
+          name: 'Webapps',
+          url: '/webapps',
+          icon: 'icon-grid',
+          badges: [
+            webappErrorSum > 0
+              ? { variant: 'danger', text: `${webappErrorSum}` }
+              : null,
+            webappWarnSum > 0
+              ? { variant: 'warning', text: `${webappWarnSum}` }
+              : null
+          ]
+        }
+      })(),
       ((): NavItemData => {
         const dataBadgeCount = isAdmin
           ? prioritiesAttentionCount + conflictCount + unconfiguredGnssCount
@@ -439,7 +457,8 @@ export default function Sidebar({ location }: SidebarProps) {
     unconfiguredPriorityCount,
     overridesWithMissingSourcesCount,
     unconfiguredGnssCount,
-    historyProviderUnavailable
+    historyProviderUnavailable,
+    webappStatus
   ])
 
   const [openDropdowns, setOpenDropdowns] = useState<Set<string>>(

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -1,5 +1,6 @@
 import { useStore, type SignalKStore } from '../store'
 import { sanitizeGnssConfig } from '../store/slices/gnssPositionSlice'
+import { sanitizeWebappStatusMap } from '../store/types'
 import { fetchAllData } from '../dataFetching'
 
 export type WebSocketStatus =
@@ -238,6 +239,11 @@ export class WebSocketService {
         break
       case 'PROVIDERSTATUS':
         this.zustandSetState({ providerStatus: data } as Partial<SignalKStore>)
+        break
+      case 'WEBAPPS_STATUS':
+        this.zustandSetState({
+          webappStatus: sanitizeWebappStatusMap(data)
+        } as Partial<SignalKStore>)
         break
       case 'DEBUG_SETTINGS':
         this.zustandSetState((state) => ({

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -182,6 +182,10 @@ export function useWebapps() {
   return useStore((s) => s.webapps)
 }
 
+export function useWebappStatus() {
+  return useStore((s) => s.webappStatus)
+}
+
 export function useAddons() {
   return useStore((s) => s.addons)
 }

--- a/packages/server-admin-ui/src/store/slices/appSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.test.ts
@@ -8,6 +8,7 @@ describe('appSlice', () => {
     useStore.setState({
       plugins: [],
       webapps: [],
+      webappStatus: {},
       addons: [],
       appStore: {
         updates: [],
@@ -65,6 +66,19 @@ describe('appSlice', () => {
       useStore.getState().setWebapps(webapps)
 
       expect(useStore.getState().webapps).toEqual(webapps)
+    })
+  })
+
+  describe('setWebappStatus', () => {
+    it('should update webapp status state', () => {
+      const webappStatus = {
+        'Webapp 1': { warnCount: 2, errorCount: 1 },
+        'Webapp 2': { warnCount: 0, errorCount: 3 }
+      }
+
+      useStore.getState().setWebappStatus(webappStatus)
+
+      expect(useStore.getState().webappStatus).toEqual(webappStatus)
     })
   })
 

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -18,7 +18,8 @@ import type {
   ServerStatistics,
   PathPriority,
   LogState,
-  NodeInfo
+  NodeInfo,
+  WebappStatusMap
 } from '../types'
 import type { SourcesData } from '../../utils/sourceLabels'
 
@@ -39,6 +40,7 @@ export type AppstoreView = 'All' | 'Installed' | 'Updates' | 'Installing'
 export interface AppSliceState {
   plugins: Plugin[]
   webapps: Webapp[]
+  webappStatus: WebappStatusMap
   addons: Addon[]
   appStore: AppStoreState
   loginStatus: LoginStatus
@@ -121,6 +123,7 @@ export interface AppSliceState {
 export interface AppSliceActions {
   setPlugins: (plugins: Plugin[]) => void
   setWebapps: (webapps: Webapp[]) => void
+  setWebappStatus: (webappStatus: WebappStatusMap) => void
   setAddons: (addons: Addon[]) => void
   setAppStore: (appStore: AppStoreState) => void
   setLoginStatus: (status: LoginStatus) => void
@@ -196,6 +199,7 @@ export type AppSlice = AppSliceState & AppSliceActions
 const initialAppState: AppSliceState = {
   plugins: [],
   webapps: [],
+  webappStatus: {},
   addons: [],
   appStore: {
     updates: [],
@@ -254,6 +258,10 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
 
   setWebapps: (webapps) => {
     set({ webapps })
+  },
+
+  setWebappStatus: (webappStatus) => {
+    set({ webappStatus })
   },
 
   setAddons: (addons) => {

--- a/packages/server-admin-ui/src/store/types.test.ts
+++ b/packages/server-admin-ui/src/store/types.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeWebappStatusMap } from './types'
+
+describe('sanitizeWebappStatusMap', () => {
+  it('keeps entries with finite numeric counts', () => {
+    const input = {
+      'app-a': {
+        warnCount: 2,
+        errorCount: 1,
+        timeStamp: '2026-07-17T00:00:00Z'
+      },
+      'app-b': { warnCount: 0, errorCount: 3 }
+    }
+    expect(sanitizeWebappStatusMap(input)).toEqual({
+      'app-a': {
+        warnCount: 2,
+        errorCount: 1,
+        timeStamp: '2026-07-17T00:00:00Z'
+      },
+      'app-b': { warnCount: 0, errorCount: 3, timeStamp: undefined }
+    })
+  })
+
+  it('drops null and malformed entries so badge renderers never read off null', () => {
+    const input = {
+      'null-entry': null,
+      'missing-counts': { timeStamp: 'x' },
+      'string-count': { warnCount: '2', errorCount: 1 },
+      'nan-count': { warnCount: NaN, errorCount: 1 },
+      good: { warnCount: 1, errorCount: 0 }
+    }
+    expect(sanitizeWebappStatusMap(input)).toEqual({
+      good: { warnCount: 1, errorCount: 0, timeStamp: undefined }
+    })
+  })
+
+  it('returns an empty map for non-object payloads', () => {
+    expect(sanitizeWebappStatusMap(null)).toEqual({})
+    expect(sanitizeWebappStatusMap(undefined)).toEqual({})
+    expect(sanitizeWebappStatusMap('nope')).toEqual({})
+  })
+})

--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -217,6 +217,41 @@ export interface Webapp {
   [key: string]: unknown
 }
 
+export interface WebappStatus {
+  warnCount: number
+  errorCount: number
+  timeStamp?: string
+}
+
+export type WebappStatusMap = Record<string, WebappStatus>
+
+// The server is the only writer, but the payload arrives over the wire, so
+// drop any entry that would make the badge renderers read a count off null.
+export function sanitizeWebappStatusMap(data: unknown): WebappStatusMap {
+  if (typeof data !== 'object' || data === null) {
+    return {}
+  }
+  const result: WebappStatusMap = {}
+  for (const [name, entry] of Object.entries(data as Record<string, unknown>)) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue
+    }
+    const { warnCount, errorCount, timeStamp } = entry as Record<
+      string,
+      unknown
+    >
+    if (!Number.isFinite(warnCount) || !Number.isFinite(errorCount)) {
+      continue
+    }
+    result[name] = {
+      warnCount: warnCount as number,
+      errorCount: errorCount as number,
+      timeStamp: typeof timeStamp === 'string' ? timeStamp : undefined
+    }
+  }
+  return result
+}
+
 export interface Addon {
   name: string
   [key: string]: unknown

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
@@ -11,7 +11,7 @@ describe('Webapp', () => {
         />
       )
 
-      const iconBox = container.querySelector('.float-start') as HTMLElement
+      const iconBox = container.querySelector('.font-2xl') as HTMLElement
       expect(iconBox).toBeInTheDocument()
       expect(iconBox.style.backgroundImage).toContain('test-app/icon.png')
       // No background colour, so the icon's transparent regions show the card.
@@ -21,7 +21,7 @@ describe('Webapp', () => {
     it('renders a blue placeholder box with a grid icon when neither appIcon nor displayName is set', () => {
       const { container } = render(<Webapp webAppInfo={{ name: 'test-app' }} />)
 
-      const iconBox = container.querySelector('.float-start') as HTMLElement
+      const iconBox = container.querySelector('.font-2xl') as HTMLElement
       expect(iconBox).toHaveClass('bg-primary')
       expect(
         container.querySelector('[data-icon="table-cells"]')
@@ -38,11 +38,64 @@ describe('Webapp', () => {
         />
       )
 
-      const iconBox = container.querySelector('.float-start') as HTMLElement
+      const iconBox = container.querySelector('.font-2xl') as HTMLElement
       expect(iconBox).toHaveClass('bg-primary')
       expect(
         container.querySelector('[data-icon="table-cells"]')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('status badges', () => {
+    const badgeTexts = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('.badge')).map((b) => b.textContent)
+
+    it('renders no badges when there is no status', () => {
+      const { container } = render(<Webapp webAppInfo={{ name: 'test-app' }} />)
+      expect(container.querySelectorAll('.badge')).toHaveLength(0)
+    })
+
+    it('renders no badges when both counts are zero', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{ name: 'test-app' }}
+          status={{ warnCount: 0, errorCount: 0 }}
+        />
+      )
+      expect(container.querySelectorAll('.badge')).toHaveLength(0)
+    })
+
+    it('renders only a warning badge for warn-only status', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{ name: 'test-app' }}
+          status={{ warnCount: 3, errorCount: 0 }}
+        />
+      )
+      expect(badgeTexts(container)).toEqual(['3'])
+      expect(container.querySelector('.badge')).toHaveClass('bg-warning')
+    })
+
+    it('renders only an error badge for error-only status', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{ name: 'test-app' }}
+          status={{ warnCount: 0, errorCount: 2 }}
+        />
+      )
+      expect(badgeTexts(container)).toEqual(['2'])
+      expect(container.querySelector('.badge')).toHaveClass('bg-danger')
+    })
+
+    it('renders both badges when there are warnings and errors', () => {
+      const { container } = render(
+        <Webapp
+          webAppInfo={{ name: 'test-app' }}
+          status={{ warnCount: 3, errorCount: 2 }}
+        />
+      )
+      expect(container.querySelector('.bg-danger')?.textContent).toEqual('2')
+      expect(container.querySelector('.bg-warning')?.textContent).toEqual('3')
     })
   })
 })

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from 'react'
+import Badge from 'react-bootstrap/Badge'
 import Card from 'react-bootstrap/Card'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTableCells } from '@fortawesome/free-solid-svg-icons/faTableCells'
 import classNames from 'classnames'
 import { toSafeModuleId } from './dynamicutilities'
+import type { WebappStatus } from '../../store/types'
 
 const ICON_BOX_SIZE = '72px'
 
@@ -21,6 +23,7 @@ interface WebAppInfo {
 
 interface WebappProps {
   webAppInfo: WebAppInfo
+  status?: WebappStatus
   children?: ReactNode
 }
 
@@ -30,7 +33,11 @@ export function urlToWebapp(webAppInfo: WebAppInfo): string {
     : `/${webAppInfo.name}/`
 }
 
-export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
+export default function Webapp({
+  webAppInfo,
+  status,
+  ...attributes
+}: WebappProps) {
   const padding = { card: 'p-3', icon: 'p-3', lead: 'mt-2' }
 
   const card = {
@@ -56,7 +63,7 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
     const classes = classNames(
       !appIcon && 'bg-primary',
       padding.icon,
-      'font-2xl me-3 float-start'
+      'font-2xl'
     )
     const style: React.CSSProperties = {
       backgroundSize: 'cover',
@@ -77,11 +84,43 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
     )
   }
 
+  const errorCount = status?.errorCount ?? 0
+  const warnCount = status?.warnCount ?? 0
+  const statusBadge = (
+    count: number,
+    variant: 'danger' | 'warning',
+    style: React.CSSProperties
+  ) => (
+    <Badge
+      pill
+      bg={variant}
+      text={variant === 'warning' ? 'dark' : undefined}
+      style={{ position: 'absolute', right: 0, ...style }}
+    >
+      {count}
+    </Badge>
+  )
+
   return (
     <a href={url}>
       <Card>
         <Card.Body className={card.style} {...attributes}>
-          {blockIcon()}
+          <span
+            className="float-start me-3"
+            style={{ position: 'relative', display: 'inline-block' }}
+          >
+            {blockIcon()}
+            {errorCount > 0 &&
+              statusBadge(errorCount, 'danger', {
+                top: 0,
+                transform: 'translate(40%, -40%)'
+              })}
+            {warnCount > 0 &&
+              statusBadge(warnCount, 'warning', {
+                bottom: 0,
+                transform: 'translate(40%, 40%)'
+              })}
+          </span>
           <div className={lead.classes}>{header}</div>
           <div className="text-muted font-xs">{webAppInfo.description}</div>
         </Card.Body>

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
@@ -5,7 +5,7 @@ import {
   createElement,
   ComponentType
 } from 'react'
-import { useWebapps, useAddons } from '../../store'
+import { useWebapps, useWebappStatus, useAddons } from '../../store'
 import { fetchWebapps } from '../../actions'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
@@ -33,6 +33,7 @@ interface AddonPanelProps {
 
 export default function Webapps() {
   const webapps = useWebapps() as WebAppInfo[]
+  const webappStatus = useWebappStatus()
   const addons = useAddons() as AddonModule[]
 
   useEffect(() => {
@@ -64,7 +65,11 @@ export default function Webapps() {
               .map((webAppInfo) => {
                 return (
                   <Col xs="12" md="12" lg="6" xl="4" key={webAppInfo.name}>
-                    <Webapp key={webAppInfo.name} webAppInfo={webAppInfo} />
+                    <Webapp
+                      key={webAppInfo.name}
+                      webAppInfo={webAppInfo}
+                      status={webappStatus[webAppInfo.name]}
+                    />
                   </Col>
                 )
               })}

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -267,6 +267,32 @@ export interface ServerAPI
   setPluginError(msg: string): void
 
   /**
+   * Report warning and error counts for an installed webapp.
+   *
+   * The counts are displayed as badges on the webapp's icon in the
+   * _Webapps_ list of the Admin UI (red for errors, yellow for warnings)
+   * and summed on the _Webapps_ item in the Admin UI sidebar.
+   *
+   * Reporting zero for both counts clears the webapp's badges. The counts
+   * are held in memory only and are cleared when the server restarts.
+   *
+   * Webapps without a plugin backend can report their counts via
+   * `PUT /skServer/webapps/:name/status` instead.
+   *
+   * @example
+   * ```javascript
+   * app.setWebappStatus('@signalk/freeboard-sk', {
+   *   warnCount: 2,
+   *   errorCount: 1
+   * });
+   * ```
+   *
+   * @param webappName the name of an installed webapp, e.g. `@signalk/freeboard-sk`
+   * @category Status and Debugging
+   */
+  setWebappStatus?(webappName: string, status: WebappStatus): void
+
+  /**
    * Emit a delta message.
    *
    * _Note: These deltas are handled by the server in the same way as any other incoming deltas._
@@ -512,6 +538,16 @@ export interface SelfIdentity {
   selfType: string
   selfId: string
   selfContext: string
+}
+
+/**
+ * Warning and error counts reported for a webapp, displayed as badges
+ * in the Admin UI. See {@link ServerAPI.setWebappStatus}.
+ * @category Server API
+ */
+export interface WebappStatus {
+  warnCount: number
+  errorCount: number
 }
 
 /** @category Server API */

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Delta, ServerAPI, SKVersion, FullSignalK } from '@signalk/server-api'
+import {
+  Delta,
+  ServerAPI,
+  SKVersion,
+  FullSignalK,
+  WebappStatus
+} from '@signalk/server-api'
 import { EventEmitter } from 'node:events'
 
 import { Config } from './config/config'
@@ -23,6 +29,7 @@ export interface ServerApp extends ServerAPI {
   stalenessEnforcer?: StalenessEnforcer
   getMaxFailoverTimeoutMs?: (path: string) => number
   getProviderStatus: () => any
+  webappsStatus: { [webappName: string]: WebappStatus & { timeStamp: string } }
   lastServerEvents: { [key: string]: any }
   clients: number
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   SourceRef,
   Timestamp,
   Update,
+  WebappStatus,
   WithFeatures
 } from '@signalk/server-api'
 import { randomUUID } from 'crypto'
@@ -273,6 +274,32 @@ class Server {
         from: 'signalk-server',
         data: app.getProviderStatus()
       })
+    }
+
+    app.webappsStatus = {}
+    app.setWebappStatus = (webappName: string, status: WebappStatus) => {
+      const warnCount = sanitizeCount(status?.warnCount)
+      const errorCount = sanitizeCount(status?.errorCount)
+      if (warnCount === 0 && errorCount === 0) {
+        delete app.webappsStatus[webappName]
+      } else {
+        app.webappsStatus[webappName] = {
+          warnCount,
+          errorCount,
+          timeStamp: new Date().toISOString()
+        }
+      }
+      app.emit('serverevent', {
+        type: 'WEBAPPS_STATUS',
+        from: 'signalk-server',
+        data: app.webappsStatus
+      })
+    }
+
+    function sanitizeCount(value: number | undefined) {
+      return Number.isSafeInteger(value) && (value as number) > 0
+        ? (value as number)
+        : 0
     }
 
     app.getProviderStatus = () => {
@@ -723,6 +750,14 @@ class Server {
       if (event.type) {
         app.lastServerEvents[event.type] = event
       }
+    })
+
+    // seed the replay-on-connect cache so clients reset webapp badges
+    // after a server restart
+    app.emit('serverevent', {
+      type: 'WEBAPPS_STATUS',
+      from: 'signalk-server',
+      data: app.webappsStatus
     })
 
     app.intervals.push(startDeltaStatistics(app))

--- a/src/interfaces/webapps.ts
+++ b/src/interfaces/webapps.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { WebappStatus } from '@signalk/server-api'
 import express, { Application, Request, Response } from 'express'
 import fs from 'fs'
 import { uniqBy } from 'lodash'
@@ -22,6 +23,7 @@ import { Config } from '../config/config'
 import { SERVERROUTESPREFIX } from '../constants'
 import { createDebug } from '../debug'
 import { modulesWithKeyword, NpmPackageData } from '../modules'
+import { SecurityStrategy } from '../security'
 
 const debug = createDebug('signalk-server:interfaces:webapps')
 
@@ -47,6 +49,8 @@ interface WebappsApp extends Application {
   pluginconfigurators: NpmPackageData[]
   plugins?: PluginEntry[]
   getPluginOptions?: (id: string) => PluginOptions
+  securityStrategy: SecurityStrategy
+  setWebappStatus: (webappName: string, status: WebappStatus) => void
 }
 
 function isPluginWebapp(metadata: NpmPackageData): boolean {
@@ -100,6 +104,32 @@ function mountApis(app: WebappsApp): void {
   app.get(`${SERVERROUTESPREFIX}/addons`, (_req: Request, res: Response) => {
     res.json(app.addons)
   })
+
+  const statusPath = `${SERVERROUTESPREFIX}/webapps/:name/status`
+  app.securityStrategy.addWriteMiddleware(statusPath)
+  app.put(statusPath, (req: Request, res: Response) => {
+    const name = req.params.name
+    const installed =
+      app.webapps.some((webapp) => webapp.name === name) ||
+      app.embeddablewebapps.some((webapp) => webapp.name === name)
+    if (!installed) {
+      res.status(404).json({ error: `Unknown webapp: ${name}` })
+      return
+    }
+    const { warnCount, errorCount } = req.body ?? {}
+    if (!isCount(warnCount) || !isCount(errorCount)) {
+      res.status(400).json({
+        error: 'warnCount and errorCount must be non-negative integers'
+      })
+      return
+    }
+    app.setWebappStatus(name, { warnCount, errorCount })
+    res.json({ ok: true })
+  })
+}
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
 }
 
 module.exports = (app: WebappsApp) => {

--- a/test/webapp-status.ts
+++ b/test/webapp-status.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai'
+import WebSocket from 'ws'
+import { startServer } from './ts-servertestutilities'
+import { WebappStatus } from '@signalk/server-api'
+
+const SERVER_START_TIMEOUT_MS = 60000
+const WEBAPP_NAME = '@signalk/server-admin-ui'
+
+type WebappStatusMap = Record<string, WebappStatus>
+
+const statusUrl = (host: string, name: string) =>
+  `${host}/skServer/webapps/${encodeURIComponent(name)}/status`
+
+const putStatus = (host: string, name: string, body: unknown) =>
+  fetch(statusUrl(host, name), {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  })
+
+// Read the first WEBAPPS_STATUS event replayed to a freshly-connected
+// serverevents client — this is the mechanism the sidebar relies on to show
+// badges without visiting the Webapps view.
+const firstReplayedStatus = (host: string): Promise<WebappStatusMap> => {
+  const wsUrl =
+    host.replace(/^http/, 'ws') + '/signalk/v1/stream?serverevents=all'
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl)
+    const timer = setTimeout(() => {
+      ws.close()
+      reject(new Error('no WEBAPPS_STATUS event replayed'))
+    }, 5000)
+    ws.on('message', (raw: WebSocket.RawData) => {
+      const msg = JSON.parse(raw.toString())
+      if (msg.type === 'WEBAPPS_STATUS') {
+        clearTimeout(timer)
+        ws.close()
+        resolve(msg.data)
+      }
+    })
+    ws.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+describe('Webapp status counts', function () {
+  this.timeout(SERVER_START_TIMEOUT_MS)
+
+  it('reports counts and clears them on zero counts', async () => {
+    const { host, stop } = await startServer()
+    try {
+      const response = await putStatus(host, WEBAPP_NAME, {
+        warnCount: 2,
+        errorCount: 1
+      })
+      expect(response.status).to.equal(200)
+      expect(await response.json()).to.deep.equal({ ok: true })
+
+      const afterReport = await firstReplayedStatus(host)
+      expect(afterReport[WEBAPP_NAME]).to.include({
+        warnCount: 2,
+        errorCount: 1
+      })
+
+      const clearResponse = await putStatus(host, WEBAPP_NAME, {
+        warnCount: 0,
+        errorCount: 0
+      })
+      expect(clearResponse.status).to.equal(200)
+
+      const afterClear = await firstReplayedStatus(host)
+      expect(afterClear).to.not.have.property(WEBAPP_NAME)
+    } finally {
+      await stop()
+    }
+  })
+
+  it('rejects unknown webapps and invalid counts', async () => {
+    const { host, stop } = await startServer()
+    try {
+      const unknownResponse = await putStatus(host, 'not-installed-webapp', {
+        warnCount: 1,
+        errorCount: 0
+      })
+      expect(unknownResponse.status).to.equal(404)
+
+      for (const body of [
+        { warnCount: -1, errorCount: 0 },
+        { warnCount: 0, errorCount: 'x' },
+        { warnCount: 1.5, errorCount: 0 },
+        { warnCount: Number.MAX_SAFE_INTEGER + 1, errorCount: 0 },
+        {}
+      ]) {
+        const response = await putStatus(host, WEBAPP_NAME, body)
+        expect(response.status).to.equal(400)
+      }
+    } finally {
+      await stop()
+    }
+  })
+})


### PR DESCRIPTION
## Motivation

Today a plugin or webapp that needs the user's attention — a failed backup, an anchor alarm, and similar conditions — is only discoverable by scrolling through the Dashboard, which with 20+ plugins installed means a lot of scrolling, or by walking through notifications in the Data Browser. This makes such conditions visible at a glance: iOS-style badges on each webapp's icon in the _Webapps_ list (red = errors, yellow = warnings) and summed badges on the _Webapps_ sidebar item, so nothing important gets buried. It modernizes the Admin UI and matches current user expectations for an app list.

Once merged I plan to add badge reporting to [app-dock](https://github.com/SignalK/app-dock) as a first consumer.

## Solution

Two reporting channels feed one in-memory map on the server:

- `app.setWebappStatus(webappName, { warnCount, errorCount })` for plugins — the channel that matters most, since a plugin backend runs while the webapp is closed
- `PUT /skServer/webapps/:name/status` for browser webapps (write-level auth, webapp name validated against installed webapps)

Updates reach the Admin UI via a new `WEBAPPS_STATUS` serverevent carrying the full map, so the existing replay-on-connect gives correct sidebar badges on first load without visiting the Webapps page. The payload is validated at the WebSocket boundary before it reaches the store. Counts are held in memory only; reporting zero for both clears the badges. Developer documentation is added to `docs/develop/webapps.md`.

## Tested

- New server test `test/webapp-status.ts`: reporting counts and clearing on zero (asserted through the replayed `WEBAPPS_STATUS` serverevent), 404 for unknown webapps, 400 for invalid/unsafe counts
- New admin-ui unit tests: `setWebappStatus` store action and `sanitizeWebappStatusMap` boundary guard (null/malformed entries dropped)
- Full `npm test` at repo root; `npm run build`
- End-to-end in the Admin UI: badges appear on the sidebar and webapp icons after a report, update live over WebSocket without reload, show correct state on a fresh page load via serverevent replay, and clear on zero counts and after server restart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds warning and error status badges to the Admin UI’s Webapps list and sidebar.

- Plugins report statuses through `app.setWebappStatus()`, and browser webapps update statuses through `PUT /skServer/webapps/:name/status`.
- The server validates `warnCount`/`errorCount`, stores per-webapp status counts in memory (with a timestamp for nonzero entries), clears a webapp entry when both counts reach zero, and emits `WEBAPPS_STATUS` server events (including an initial event on startup so newly connected clients can replay current state).
- The Admin UI sanitizes `WEBAPPS_STATUS` payloads, replays them into a Zustand store, renders per-webapp badge pills for nonzero warning/error counts, and aggregates up to two badge counts on the Webapps sidebar item.
- Documentation, server API tests, Admin UI unit tests, and an end-to-end WebSocket/REST test suite verify payload validation, event replay, and clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->