### PR TITLE
feat: fail plugin CI when a shared core package range is stale

### DIFF
--- a/.github/scripts/check-core-ranges.ts
+++ b/.github/scripts/check-core-ranges.ts
@@ -1,0 +1,330 @@
+/*
+ * Plugin CI: shared core package range check.
+ *
+ * The App Store installs every plugin into one shared tree
+ * (~/.signalk/node_modules), where npm keeps a single hoisted copy of
+ * packages shared across the server ecosystem. npm resolves that copy to the
+ * newest version that satisfies EVERY installed plugin's range, so one
+ * plugin's tight range holds the shared copy back for all plugins on the
+ * server. This check errors when a plugin's declared range excludes the
+ * newest release in the major line the range itself targets. A newer major
+ * is never an error — staying on the current major is a legitimate
+ * compatibility choice — it only gets an advisory notice.
+ *
+ * The pure logic (checkCoreRanges) takes an injected registry accessor so it
+ * can be unit-tested without a live npm/registry. The CLI wrapper at the
+ * bottom wires it to `npm view` and the GitHub Actions annotation protocol.
+ */
+
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { basename, resolve } from 'path'
+
+// @canboat/ts-pgns is deliberately excluded: its own version policy states
+// minor releases may include breaking changes and recommends pinning to a
+// minor ("~1.10.0"). "Widen to a caret" would be wrong advice for it, so the
+// shared-copy check does not apply.
+export const CORE_PACKAGES = [
+  '@canboat/canboatjs',
+  '@signalk/n2k-signalk',
+  '@signalk/nmea0183-signalk',
+  '@signalk/path-metadata',
+  '@signalk/server-admin-ui',
+  '@signalk/server-api',
+  '@signalk/streams'
+]
+
+const CORE_PACKAGE_SET = new Set(CORE_PACKAGES)
+
+const EXACT_VERSION_RE = /^=?\s*\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+const SEMVER_PARTS = 3
+
+export interface PackageManifest {
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+export type FindingLevel = 'error' | 'warning' | 'notice'
+
+export interface Finding {
+  level: FindingLevel
+  message: string
+}
+
+export interface CheckResult {
+  findings: Finding[]
+  errors: number
+  skipped: number
+}
+
+/**
+ * Registry accessor, injected so the check runs without a live npm.
+ * `matching` throws a NoMatchError when the range matches no published
+ * version, and any other error for a lookup failure that should be skipped.
+ */
+export interface Registry {
+  latest(name: string): string
+  releases(name: string): string[]
+  matching(name: string, range: string): string[]
+}
+
+export class NoMatchError extends Error {
+  readonly noMatch = true
+}
+
+function major(version: string): number {
+  return parseInt(version, 10)
+}
+
+// release-version compare on the numeric triple — prereleases are already
+// excluded by npm's range matching ('*' and plain ranges never admit them)
+function compareVersions(a: string, b: string): number {
+  const aParts = a.split('.').map((n) => parseInt(n, 10))
+  const bParts = b.split('.').map((n) => parseInt(n, 10))
+  for (let i = 0; i < SEMVER_PARTS; i++) {
+    if (aParts[i] !== bParts[i]) return aParts[i] - bParts[i]
+  }
+  return 0
+}
+
+function newest(versions: string[]): string {
+  return versions.reduce((a, b) => (compareVersions(a, b) >= 0 ? a : b))
+}
+
+export function checkCoreRanges(
+  pkg: PackageManifest,
+  registry: Registry
+): CheckResult {
+  const declared = [
+    ...Object.entries(pkg.dependencies ?? {}),
+    ...Object.entries(pkg.peerDependencies ?? {})
+  ]
+  const seen = new Set<string>()
+  const findings: Finding[] = []
+  let errors = 0
+  let skipped = 0
+
+  for (const [name, range] of declared) {
+    if (!CORE_PACKAGE_SET.has(name)) continue
+    if (seen.has(name + '@' + range)) continue
+    seen.add(name + '@' + range)
+
+    let latest: string
+    let releases: string[]
+    try {
+      latest = registry.latest(name)
+      releases = registry.releases(name)
+    } catch {
+      skipped++
+      findings.push({
+        level: 'notice',
+        message:
+          'Could not fetch the versions of ' +
+          name +
+          ' from the npm registry — skipping'
+      })
+      continue
+    }
+
+    const reportNoMatch = () => {
+      errors++
+      findings.push({
+        level: 'error',
+        message:
+          name +
+          ' range "' +
+          range +
+          '" matches no published version — npm install will fail. ' +
+          'Use a range that includes the latest release, e.g. "^' +
+          latest +
+          '"'
+      })
+    }
+
+    let matching: string[]
+    try {
+      matching = registry.matching(name, range)
+    } catch (err) {
+      if (err instanceof Error && (err as { noMatch?: boolean }).noMatch) {
+        reportNoMatch()
+      } else {
+        skipped++
+        findings.push({
+          level: 'notice',
+          message:
+            name +
+            '@' +
+            range +
+            ' could not be checked against the npm registry ' +
+            '(non-registry spec or network error) — skipping'
+        })
+      }
+      continue
+    }
+    if (matching.length === 0) {
+      reportNoMatch()
+      continue
+    }
+
+    // A range may target more than one major (e.g. "2.5.0 - 2.9.0 || ^3.0.0").
+    // Every targeted major must reach the newest release in that major line —
+    // a stale lower-major arm still holds the shared copy back for a plugin
+    // pinned to that major. Judge each targeted major independently; use the
+    // highest only for the exact-pin warning and newer-major advisory.
+    const targetMajors = [...new Set(matching.map(major))].sort((a, b) => a - b)
+    let heldBack = false
+    for (const targetMajor of targetMajors) {
+      const inMajor = releases.filter((v) => major(v) === targetMajor)
+      if (inMajor.length === 0) continue
+      const newestInMajor = newest(inMajor)
+      if (!matching.includes(newestInMajor)) {
+        heldBack = true
+        errors++
+        findings.push({
+          level: 'error',
+          message:
+            name +
+            ' range "' +
+            range +
+            '" excludes ' +
+            newestInMajor +
+            ', the newest ' +
+            targetMajor +
+            '.x release. All plugins on a server share one hoisted copy of ' +
+            name +
+            ', ' +
+            "resolved to the newest version that satisfies every installed plugin's range — this range " +
+            'holds the shared copy back for every other plugin. Widen the ' +
+            targetMajor +
+            '.x bound (e.g. "^' +
+            newestInMajor +
+            '")'
+        })
+      }
+    }
+    if (heldBack) continue
+
+    // The exact-pin and newer-major advisories reference the newest stable
+    // release in the highest targeted major. When that major has only
+    // prereleases (matching() admits them, releases() filters them out) there
+    // is nothing stable to advise against, so skip both.
+    const highestMajor = targetMajors[targetMajors.length - 1]
+    const highestStable = releases.filter((v) => major(v) === highestMajor)
+    if (highestStable.length === 0) continue
+    const newestInHighest = newest(highestStable)
+    if (EXACT_VERSION_RE.test(range.trim())) {
+      findings.push({
+        level: 'warning',
+        message:
+          name +
+          ' is pinned to the exact version ' +
+          range +
+          '. ' +
+          'That equals the newest ' +
+          highestMajor +
+          '.x release today, but as soon as a newer version is ' +
+          'published this pin holds the shared hoisted copy back for every plugin on the server. ' +
+          'Use "^' +
+          newestInHighest +
+          '" instead'
+      })
+    }
+    if (major(latest) > highestMajor) {
+      findings.push({
+        level: 'notice',
+        message:
+          name +
+          ' ' +
+          latest +
+          ' is available, a newer major than this plugin\'s range "' +
+          range +
+          '" targets. Staying on ' +
+          highestMajor +
+          '.x is fine for compatibility — consider ' +
+          'evaluating an update when convenient'
+      })
+    }
+  }
+
+  return { findings, errors, skipped }
+}
+
+// Bound each npm lookup so a stalled registry connection can't eat the whole
+// job — a timeout throws and is handled as a skip.
+const NPM_VIEW_TIMEOUT_MS = 30000
+
+export function npmRegistry(): Registry {
+  // 'name'/'name@range' resolves through npm, so no semver dependency is
+  // needed.
+  function viewField(spec: string, field: string): string[] {
+    const out = execFileSync('npm', ['view', spec, field, '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: NPM_VIEW_TIMEOUT_MS
+    }).trim()
+    if (!out) return []
+    const parsed = JSON.parse(out)
+    return Array.isArray(parsed) ? parsed : [parsed]
+  }
+
+  // npm prints its error as JSON on stdout under --json; E404/ETARGET are its
+  // "no version matches" answers, anything else is a lookup failure to skip.
+  function npmErrorCode(err: unknown): string | undefined {
+    try {
+      return JSON.parse((err as { stdout: string }).stdout).error.code
+    } catch {
+      return undefined
+    }
+  }
+
+  return {
+    latest: (name) => viewField(name, 'version')[0],
+    releases: (name) =>
+      viewField(name, 'versions').filter((v) => !v.includes('-')),
+    matching: (name, range) => {
+      try {
+        return viewField(name + '@' + range, 'version')
+      } catch (err) {
+        const code = npmErrorCode(err)
+        if (code === 'E404' || code === 'ETARGET') {
+          throw new NoMatchError('no match')
+        }
+        throw err
+      }
+    }
+  }
+}
+
+// A finding message embeds the plugin's own range text, which is untrusted;
+// escape the workflow-command data characters so it can't break out of the
+// annotation line and inject another command.
+function escapeCommandData(message: string): string {
+  return message
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+}
+
+function main(): void {
+  const manifest = readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')
+  const pkg = JSON.parse(manifest) as PackageManifest
+  const { findings, errors, skipped } = checkCoreRanges(pkg, npmRegistry())
+  for (const { level, message } of findings) {
+    console.log('::' + level + '::' + escapeCommandData(message))
+  }
+  if (errors > 0) process.exit(1)
+  console.log(
+    skipped > 0
+      ? 'Shared core package range check completed with ' +
+          skipped +
+          ' skipped lookup(s)'
+      : 'Shared core package ranges OK'
+  )
+}
+
+// Run only when executed directly (node/tsx/ts-node), not when imported.
+// Compares the invoked script's basename rather than __filename, which is
+// undefined when a plugin repo's "type": "module" makes tsx load this as ESM.
+if (basename(process.argv[1] ?? '').startsWith('check-core-ranges')) {
+  main()
+}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -85,6 +85,23 @@ jobs:
       - name: Checkout plugin
         uses: actions/checkout@v7
 
+      # The reusable workflow only checks out the plugin repo, so CI helper
+      # scripts it runs must be fetched from signalk-server itself. The job
+      # context (job.workflow_repository / job.workflow_sha) identifies the
+      # repo and exact commit of the workflow file defining this job — the
+      # reusable workflow's own origin, not the caller's — so the scripts
+      # always match this workflow version with no drift.
+      - name: Checkout CI scripts
+        if: runner.os == 'Linux'
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: .signalk-ci
+          persist-credentials: false
+
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v6
         with:
@@ -295,6 +312,16 @@ jobs:
           console.log('Plugin package.json validation passed');
           VALIDATE
           node /tmp/validate-pkg.js
+
+      - name: Check shared core package ranges
+        id: core-ranges
+        # The registry answer is platform-independent, and spawning npm from
+        # node is fragile on Windows — Linux jobs only. Run the checked-out
+        # TypeScript helper with tsx (no build/tsconfig needed); pin the tsx
+        # version so CI doesn't pull whatever npm serves at runtime.
+        if: runner.os == 'Linux'
+        shell: bash
+        run: npx --yes tsx@4.23.1 "$GITHUB_WORKSPACE/.signalk-ci/.github/scripts/check-core-ranges.ts"
 
       - name: Install dependencies
         # Retry once on transient failure. npm install / npm ci occasionally
@@ -1439,7 +1466,8 @@ jobs:
         shell: bash
         run: |
           # Plugins should not leave stray files in the repo after install/build/test.
-          UNTRACKED=$(git ls-files --others --exclude-standard -- ':!node_modules' ':!.npm')
+          # .signalk-ci is this workflow's own scripts checkout, not plugin output.
+          UNTRACKED=$(git ls-files --others --exclude-standard -- ':!node_modules' ':!.npm' ':!.signalk-ci')
           if [ -n "$UNTRACKED" ]; then
             echo "::warning::Build/test left untracked files in the repository:"
             echo "$UNTRACKED" | while read -r f; do echo "  $f"; done
@@ -1454,6 +1482,7 @@ jobs:
         shell: bash
         env:
           VALIDATE_PKG: ${{ steps.validate-pkg.outcome }}
+          CORE_RANGES: ${{ steps.core-ranges.outcome }}
           VALIDATE_ENTRY: ${{ steps.validate-entry.outcome }}
           VALIDATE_SCHEMA: ${{ steps.validate-schema.outcome }}
           LIFECYCLE_CHECK: ${{ steps.lifecycle-check.outcome }}
@@ -1491,6 +1520,7 @@ jobs:
             echo "| Check | Result |"
             echo "|-------|--------|"
             echo "| package.json valid | $(icon "$VALIDATE_PKG") |"
+            echo "| Core package range check | $(icon "$CORE_RANGES") |"
             echo "| Entry point exports function | $(icon "$VALIDATE_ENTRY") |"
             echo "| plugin.schema() valid | $(icon "$VALIDATE_SCHEMA") |"
             echo "| start/stop/restart lifecycle | $(icon "$LIFECYCLE_CHECK") |"

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -52,6 +52,8 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **package.json** — `signalk-node-server-plugin` keyword, `main` or `exports` field, `engines.node` declaration
 
+**Shared core package ranges** (Linux desktop jobs only) — Errors when a `dependencies`/`peerDependencies` range on a core package shared across the server ecosystem (`@signalk/server-api`, `@signalk/streams`, `@canboat/canboatjs`, …) excludes the newest release in the major version line the range targets. All plugins on a server share one hoisted copy of these, resolved to the newest version that satisfies every installed plugin's range — a single tight range holds the shared copy back for every other plugin. Exact pins get a warning (they cause the same hold-back on the next release), and a newer major being available is an advisory notice, never an error — staying on the current major is a legitimate compatibility choice. Restricted to the Linux jobs because the registry answer is platform-independent.
+
 **Entry point** — After build, verifies the plugin exports a constructor function
 
 **plugin.schema()** — Calls `schema()` and checks it returns a JSON-serializable schema-like object without crashing (not fully validated against the JSON Schema meta-schema)

--- a/test/plugin-ci-core-ranges.ts
+++ b/test/plugin-ci-core-ranges.ts
@@ -1,0 +1,286 @@
+import { expect } from 'chai'
+import {
+  checkCoreRanges,
+  CheckResult,
+  NoMatchError,
+  Registry
+} from '../.github/scripts/check-core-ranges'
+
+const SEMVER_PARTS = 3
+
+// A fake registry driven by a fixture map, so the range logic is tested
+// without touching the network. Each package entry lists its published
+// stable versions; latest() is the highest, releases() is all of them, and
+// matching() replays npm's range semantics closely enough for these cases.
+function fakeRegistry(catalog: Record<string, string[]>): Registry {
+  function compareVersions(a: string, b: string): number {
+    const aParts = a.split('.').map(Number)
+    const bParts = b.split('.').map(Number)
+    for (let i = 0; i < SEMVER_PARTS; i++) {
+      if (aParts[i] !== bParts[i]) return aParts[i] - bParts[i]
+    }
+    return 0
+  }
+  // A single comparator arm (no '||'); union ranges are split before this.
+  function admitsArm(arm: string, version: string): boolean {
+    const trimmed = arm.trim()
+    const [versionMajor, versionMinor] = version.split('.').map(Number)
+    if (trimmed === '*') return true
+    let m: RegExpMatchArray | null
+    if ((m = trimmed.match(/^\^(\d+)\.(\d+)\.(\d+)$/))) {
+      return (
+        Number(m[1]) === versionMajor &&
+        compareVersions(version, m[1] + '.' + m[2] + '.' + m[3]) >= 0
+      )
+    }
+    if ((m = trimmed.match(/^~(\d+)\.(\d+)\.(\d+)$/))) {
+      return (
+        Number(m[1]) === versionMajor &&
+        Number(m[2]) === versionMinor &&
+        compareVersions(version, m[1] + '.' + m[2] + '.' + m[3]) >= 0
+      )
+    }
+    // inclusive hyphen range "a.b.c - d.e.f"
+    if ((m = trimmed.match(/^(\d+\.\d+\.\d+)\s+-\s+(\d+\.\d+\.\d+)$/))) {
+      return (
+        compareVersions(version, m[1]) >= 0 &&
+        compareVersions(version, m[2]) <= 0
+      )
+    }
+    if ((m = trimmed.match(/^(\d+)\.(\d+)$/))) {
+      return Number(m[1]) === versionMajor && Number(m[2]) === versionMinor
+    }
+    if ((m = trimmed.match(/^=?(\d+)\.(\d+)\.(\d+)$/))) {
+      return version === m[1] + '.' + m[2] + '.' + m[3]
+    }
+    return false
+  }
+  function admits(range: string, version: string): boolean {
+    return range.split('||').some((arm) => admitsArm(arm, version))
+  }
+  return {
+    latest(name) {
+      const versions = catalog[name]
+      if (!versions) throw new Error('unknown ' + name)
+      return versions[versions.length - 1]
+    },
+    releases(name) {
+      const versions = catalog[name]
+      if (!versions) throw new Error('unknown ' + name)
+      return versions
+    },
+    matching(name, range) {
+      const versions = catalog[name]
+      if (!versions) throw new Error('unknown ' + name)
+      const hits = versions.filter((version) => admits(range, version))
+      if (hits.length === 0) throw new NoMatchError('no match')
+      return hits
+    }
+  }
+}
+
+const CATALOG: Record<string, string[]> = {
+  '@signalk/server-api': ['2.5.0', '2.9.0', '2.29.0', '2.30.0'],
+  '@canboat/canboatjs': ['2.0.0', '2.9.0', '2.12.3', '3.0.0', '3.20.0']
+}
+
+function levels(result: CheckResult): FindingLevelList {
+  return result.findings.map((f) => f.level)
+}
+type FindingLevelList = ('error' | 'warning' | 'notice')[]
+
+describe('plugin-ci core package range check', () => {
+  const registry = fakeRegistry(CATALOG)
+
+  it('ignores non-core dependencies', () => {
+    const r = checkCoreRanges({ dependencies: { lodash: '^4.0.0' } }, registry)
+    expect(r.errors).to.equal(0)
+    expect(r.findings).to.be.empty
+  })
+
+  it('ignores @canboat/ts-pgns (deliberate version-policy exception)', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@canboat/ts-pgns': '~1.10.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(0)
+    expect(r.findings).to.be.empty
+  })
+
+  it('errors (no crash) when matching() returns an empty result', () => {
+    const emptyMatch: Registry = {
+      latest: registry.latest,
+      releases: registry.releases,
+      matching: () => []
+    }
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '2.9' } },
+      emptyMatch
+    )
+    expect(r.errors).to.equal(1)
+    expect(r.findings[0].message).to.include('matches no published version')
+  })
+
+  it('errors when a range excludes the newest release in its major', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '2.9' } },
+      registry
+    )
+    expect(r.errors).to.equal(1)
+    expect(levels(r)).to.include('error')
+    expect(r.findings[0].message).to.include('excludes 2.30.0')
+  })
+
+  it('passes a healthy caret range that admits the newest', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '^2.5.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(0)
+    expect(r.findings).to.be.empty
+  })
+
+  it('errors when the range matches no published version', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '^99.0.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(1)
+    expect(r.findings[0].message).to.include('matches no published version')
+  })
+
+  it('warns on an exact pin that equals the newest in its major', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '2.30.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(0)
+    expect(levels(r)).to.include('warning')
+  })
+
+  it('emits an advisory notice (never an error) when only a newer major exists', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@canboat/canboatjs': '^2.0.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(0)
+    expect(levels(r)).to.deep.equal(['notice'])
+    expect(r.findings[0].message).to.include('newer major')
+  })
+
+  it('errors on a union range with a stale lower-major arm', () => {
+    // ^3.0.0 arm is fine (reaches 3.20.0), but 2.5.0 - 2.9.0 caps 2.x below
+    // the newest 2.x (2.12.3) — still holds the shared copy back for a
+    // plugin pinned to 2.x.
+    const r = checkCoreRanges(
+      { dependencies: { '@canboat/canboatjs': '2.5.0 - 2.9.0 || ^3.0.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(1)
+    expect(r.findings[0].message).to.include('excludes 2.12.3')
+    expect(r.findings[0].message).to.include('the newest 2.x release')
+  })
+
+  it('passes a union range where every targeted major reaches its newest', () => {
+    const r = checkCoreRanges(
+      { dependencies: { '@canboat/canboatjs': '^2.0.0 || ^3.0.0' } },
+      registry
+    )
+    expect(r.errors).to.equal(0)
+    expect(levels(r)).to.not.include('error')
+  })
+
+  it('does not crash when the target major has only prereleases', () => {
+    // matching() admits a prerelease that releases() filters out, so the
+    // highest targeted major has no stable release — must not throw.
+    const prereleaseOnly: Registry = {
+      latest: () => '2.30.0',
+      releases: () => ['2.5.0', '2.30.0'],
+      matching: () => ['3.0.0-beta.1']
+    }
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '^3.0.0-beta' } },
+      prereleaseOnly
+    )
+    expect(r.errors).to.equal(0)
+    expect(levels(r)).to.not.include('error')
+  })
+
+  it('checks peerDependencies as well as dependencies', () => {
+    const r = checkCoreRanges(
+      { peerDependencies: { '@signalk/server-api': '2.9' } },
+      registry
+    )
+    expect(r.errors).to.equal(1)
+  })
+
+  it('skips (does not error) on a registry lookup failure', () => {
+    const flaky: Registry = {
+      latest() {
+        throw new Error('network')
+      },
+      releases() {
+        throw new Error('network')
+      },
+      matching() {
+        throw new Error('network')
+      }
+    }
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': '2.9' } },
+      flaky
+    )
+    expect(r.errors).to.equal(0)
+    expect(r.skipped).to.equal(1)
+    expect(levels(r)).to.deep.equal(['notice'])
+  })
+
+  it('skips a non-registry spec (git/tarball) without erroring', () => {
+    const withGit: Registry = {
+      latest: registry.latest,
+      releases: registry.releases,
+      matching() {
+        // a git/tarball spec is not a range npm can evaluate against the
+        // registry; the accessor rethrows a plain (non-NoMatch) error
+        throw new Error('not a registry version')
+      }
+    }
+    const r = checkCoreRanges(
+      { dependencies: { '@signalk/server-api': 'github:foo/bar' } },
+      withGit
+    )
+    expect(r.errors).to.equal(0)
+    expect(r.skipped).to.equal(1)
+  })
+
+  it('skips a tarball spec without erroring', () => {
+    const withTarball: Registry = {
+      latest: registry.latest,
+      releases: registry.releases,
+      matching() {
+        throw new Error('not a registry version')
+      }
+    }
+    const r = checkCoreRanges(
+      {
+        dependencies: {
+          '@signalk/server-api': 'https://example.invalid/server-api.tgz'
+        }
+      },
+      withTarball
+    )
+    expect(r.errors).to.equal(0)
+    expect(r.skipped).to.equal(1)
+  })
+
+  it('deduplicates identical name@range declarations', () => {
+    const r = checkCoreRanges(
+      {
+        dependencies: { '@signalk/server-api': '2.9' },
+        peerDependencies: { '@signalk/server-api': '2.9' }
+      },
+      registry
+    )
+    expect(r.errors).to.equal(1)
+  })
+})


### PR DESCRIPTION
## Why

The App Store installs every plugin into one shared tree (`~/.signalk/node_modules`), where npm keeps a single hoisted copy of packages shared across the server ecosystem. npm resolves that copy to the newest version satisfying **every** installed plugin's range — so one plugin's tight range on `@signalk/server-api` (or canboatjs, streams, …) silently holds that shared copy back for every other plugin on the server, even ones that would happily accept a newer version.

A real field case: `@signalk/server-api` stuck at 2.9.0 (latest 2.30.0) on a boat because a single plugin declared `"2.9"`, while three other installed plugins would all have accepted 2.30.0. The plugin author can't always fix it (the offending release may be the latest), and the server shouldn't depend on every author's diligence — but plugin CI can catch the range before it ships.

## What

A new plugin-CI check that inspects each `dependencies`/`peerDependencies` range on a shared core package and:

- **errors** when the range excludes the newest release **in the major line the range targets** (the hold-back case), or matches no published version at all;
- **warns** on an exact pin that still equals that newest release (it becomes a hold-back on the next release);
- emits an **advisory notice**, never an error, when only a *newer major* is available — staying on the current major is a legitimate compatibility choice, so a core major release does not fail every well-ranged plugin at once.

`npm view` does the range evaluation, so no semver dependency is needed. Non-registry specs (git/tarball) and network/timeout failures skip with a notice. Runs on the Linux jobs only — the registry answer is platform-independent — and each lookup is bounded by a 30s subprocess timeout.

`@canboat/ts-pgns` is deliberately excluded: its own version policy states minor releases may break and recommends `~` pinning to a minor, so "widen to a caret" would be wrong advice for it.

Docs updated in `docs/develop/plugins/ci.md`.

## Tested

Ran the check's script against live-registry fixtures covering: tight range behind latest-in-major (errors), healthy caret (passes), `~` pin behind newest-in-major (errors), caret one major behind (advisory notice, passes), exact pin at newest (warns), range matching nothing (errors), ts-pgns `~` pin (ignored), non-registry git spec (skips), and a non-core dependency (ignored). Full `npm run format` / `build:all` / `test` chain passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a Linux-only CI validation that checks shared Signal K core `dependencies`/`peerDependencies` semver ranges to prevent plugins from holding back the shared hoisted core copies.
- Reports an **error** when a core package range excludes the newest published release in its targeted major line or when the range matches no published version.
- Reports a **warning** when a core dependency is pinned to the exact newest release in its targeted major line, and emits a **notice/advisory** when only a newer major is available.
- Skips non-registry/evaluable specifications and treats registry lookup failures as skips while emitting non-error notices; the registry adapter uses `npm view --json` with a 30-second timeout and explicitly excludes `@canboat/ts-pgns` due to its version policy.
- Implements the core logic in `.github/scripts/check-core-ranges.ts`, including typed/exported `checkCoreRanges` with deduplication across `dependencies` and `peerDependencies`, GitHub Actions workflow-command annotation output, and exit code `1` when any errors exist.
- Executes the script from a Linux-only sparse checkout of the reusable workflow’s own `.github/scripts` into `.signalk-ci`, using `job.workflow_repository`/`job.workflow_sha`, runs it via `npx tsx@4.23.1`, surfaces the outcome as **“Core package range check”** in the desktop job summary, and excludes `.signalk-ci` from the untracked-files scan.
- Adds a comprehensive unit test suite in `test/plugin-ci-core-ranges.ts` covering stale-range errors, no-match errors, exact-pin warnings, newer-major notices, union range behavior, prerelease-only target major handling, deduplication, peer dependencies, skipped registry/evaluable-spec cases, and the deliberate `@canboat/ts-pgns` exclusion.
- Updates `docs/develop/plugins/ci.md` with a **“Shared core package ranges”** description of the error/warning/notice behavior and the Linux-only scope for registry-based resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->