### PR TITLE
fix(test): retry config-dir cleanup to fix flaky ENOTEMPTY teardown

### DIFF
--- a/test/ts-servertestutilities.ts
+++ b/test/ts-servertestutilities.ts
@@ -17,7 +17,14 @@ const emptyConfigDirectory = () =>
   Promise.all(
     [SERVERSTATEDIRNAME, 'resources', 'plugin-config-data', 'baseDeltas.json']
       .map((subDir) => path.join(serverTestConfigDirectory(), subDir))
-      .map((dir) => rimraf(dir).then(() => console.error(dir)))
+      // Retry on ENOTEMPTY/EBUSY: a plugin from the previous test (e.g. the
+      // resources provider) can still be flushing files when the next test
+      // clears the config directory.
+      .map((dir) =>
+        rimraf(dir, { maxRetries: 5, retryDelay: 100 }).then(() =>
+          console.error(dir)
+        )
+      )
   )
 
 export const startServer = async (extraSettings: object = {}) => {


### PR DESCRIPTION
Fixes #2849.

`startServer()` clears the shared test config directory at the start of every test. Cleanup relies on `server.stop()`, which resolves when the HTTP socket closes but does not await plugin shutdown — so a plugin from the previous test (the resources provider) can still be flushing files under `plugin-config-data/resources-provider/resources` when the next test runs `rimraf`. The concurrent write makes `rmdir` see a transiently non-empty directory and throw `ENOTEMPTY`, failing whichever test happened to be running.

This makes the harness cleanup tolerate the race by retrying the removal (`rimraf` `maxRetries`/`retryDelay`) rather than failing on the first `ENOTEMPTY`/`EBUSY`.

## Tested

- `npm run build` passes.
- `npm test` (course suite) runs green across repeated local runs.
