### PR TITLE
chore(docker): add Ubuntu 26.04 base image variant

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -10,6 +10,15 @@
       "family": "ubuntu",
       "os_arg": "24.04",
       "dockerfile_base": "./docker/Dockerfile_base_24.04",
+      "tag_suffix": "",
+      "default_enabled": true
+    },
+    {
+      "id": "26.04",
+      "family": "ubuntu",
+      "os_arg": "26.04",
+      "dockerfile_base": "./docker/Dockerfile_base_26.04",
+      "tag_suffix": "-26.04",
       "default_enabled": true
     },
     {
@@ -17,6 +26,7 @@
       "family": "alpine",
       "os_arg": "alpine",
       "dockerfile_base": "./docker/Dockerfile_base_alpine",
+      "tag_suffix": "",
       "default_enabled": true
     }
   ],

--- a/.github/docs/build-matrix.md
+++ b/.github/docs/build-matrix.md
@@ -13,6 +13,7 @@
   - `family` — OS family (e.g. `ubuntu`, `alpine`). Used for image-tag rendering and dispatch-input naming.
   - `os_arg` — value passed to Docker build-args / used in image tags as the `os_label`.
   - `dockerfile_base` — path to the OS-specific base Dockerfile.
+  - `tag_suffix` — appended to `build-docker.yml` / `release.yml` image tags for this row, after the family-based rendering described in Naming conventions. Empty for the primary row of a family (the one that owns the bare `latest` / `vX.Y.Z` tags); set on any additional row that shares a `family` with another row (e.g. `-26.04`) so the two don't collide on the same tags. `build-base-image.yml` doesn't use this field — its tags already key on `os_label` directly.
   - `default_enabled` — when scheduled / push / tag runs occur (i.e. when no `workflow_dispatch` inputs are provided), the variant is included only if this is `true` on both the OS row and the Node row.
 - `node_versions` — list of Node major versions. Each entry:
   - `id` — Node major (e.g. `24`).
@@ -26,12 +27,12 @@
 
 ## Naming conventions
 
-- **Image tags.** For the ubuntu family the node label is rendered as `<node>.x` (e.g. `24.x`); for other families it is `<node>` (e.g. `24`). Arch suffix (`amd`, `arm`) comes from `architectures[].id`. The edition `tag_suffix` (e.g. `-core`) is appended last, so the core variant rolls up as `latest-core` / `latest-alpine-core` and pins as `X.Y.Z-core` / `X.Y.Z-alpine-core`.
+- **Image tags.** For the ubuntu family the node label is rendered as `<node>.x` (e.g. `24.x`); for other families it is `<node>` (e.g. `24`). Arch suffix (`amd`, `arm`) comes from `architectures[].id`. Each os_variant's own `tag_suffix` is appended next (e.g. `-26.04` for a secondary ubuntu row), then the edition `tag_suffix` (e.g. `-core`) last, so the core variant rolls up as `latest-core` / `latest-alpine-core` / `latest-26.04-core` and pins as `X.Y.Z-core` / `X.Y.Z-alpine-core` / `X.Y.Z-26.04-core`.
 - **Dispatch input names.** `<family>_<id_with_-_and_._mapped_to__>_node_<node_id>` when `family != id`, otherwise `<id>_node_<node_id>`. Examples: `ubuntu_24_04_node_24`, `alpine_node_24`. The leading `<family>_` segment exists because GitHub Actions input names must start with a letter — `24_04_…` would be rejected.
 
 ## Adding things
 
-- **New OS:** append a row to `os_variants` and manually add a corresponding `workflow_dispatch` input to `build-base-image.yml`, `build-docker.yml`, and `release.yml`.
+- **New OS:** append a row to `os_variants`. Each Docker workflow exposes one `workflow_dispatch` toggle per row (keyed by `family` + `id`, see Naming conventions), so the row needs a matching input in every workflow where it should be independently selectable. If the row shares a `family` with an existing row, give it a non-empty `tag_suffix` — otherwise the two rows resolve to the same manifest tags and each build silently overwrites the other's `latest` / `vX.Y.Z` image.
 - **New Node major:** append a row to `node_versions` and add inputs to the same three workflows.
 - **New arch:** append a row to `architectures`. No workflow input changes needed — arches aren't part of the dispatch input UI.
 - **New edition:** append a row to `editions` with its `tag_suffix`, and add a matching `case` branch keyed on `EDITION` in `./docker/Dockerfile` (dev) and `./docker/Dockerfile_rel` (release). No workflow input changes needed — editions aren't part of the dispatch input UI.

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -9,6 +9,10 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
       alpine_node_24:
         description: 'Alpine + Node 24'
         type: boolean

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,6 +18,10 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
       alpine_node_24:
         description: 'Alpine + Node 24'
         type: boolean
@@ -83,8 +87,11 @@ jobs:
           # checkbox (or by default_enabled for non-dispatch runs); editions
           # are not dispatch inputs and follow their own default_enabled.
           # The per-variant suffix preserves the existing SignalK manifest tag
-          # convention ('-<node>' for ubuntu, '-<node_id>-<family>' otherwise)
-          # with the edition tag_suffix ('' for full, '-core' for core) appended.
+          # convention ('-<node>' for ubuntu, '-<node_id>-<family>' otherwise),
+          # then appends each os_variant's own tag_suffix ('' for the primary
+          # row of a family, e.g. '-26.04' for a secondary ubuntu row) so rows
+          # sharing a family don't collide, and finally the edition tag_suffix
+          # ('' for full, '-core' for core).
           variants=$(jq -c \
             --argjson enabled "${ENABLED_JSON:-null}" '
             (if ($enabled | type) == "object" then $enabled else {} end) as $en
@@ -100,7 +107,7 @@ jobs:
                   node_id:   $n.id,
                   edition:   $e.id,
                   tag_suffix: $e.tag_suffix,
-                  suffix:    ((if $o.family == "ubuntu" then "-\($n.id).x" else "-\($n.id)-\($o.family)" end) + $e.tag_suffix)
+                  suffix:    ((if $o.family == "ubuntu" then "-\($n.id).x" else "-\($n.id)-\($o.family)" end) + $o.tag_suffix + $e.tag_suffix)
                 }
               ]
             | map(select(.enabled == "true" and .ed_enabled))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
       alpine_node_24:
         description: 'Alpine + Node 24'
         type: boolean
@@ -189,8 +193,11 @@ jobs:
           # dispatch inputs and follow their own default_enabled. The release
           # manifest tag convention puts ubuntu full on the bare semver tags
           # (v2.21.3, latest, v2, v2.21) and adds '-<family>' for non-ubuntu
-          # variants (v2.21.3-alpine, latest-alpine); the edition tag_suffix
-          # ('' for full, '-core' for core) is appended (v2.21.3-core,
+          # variants (v2.21.3-alpine, latest-alpine); each os_variant's own
+          # tag_suffix ('' for the primary row of a family, e.g. '-26.04' for
+          # a secondary ubuntu row) is appended so rows sharing a family don't
+          # collide on the same tags, and finally the edition tag_suffix (''
+          # for full, '-core' for core) is appended (v2.21.3-core,
           # latest-core, v2.21.3-alpine-core).
           variants=$(jq -c \
             --argjson enabled "${ENABLED_JSON:-null}" '
@@ -207,7 +214,7 @@ jobs:
                   node_id:   $n.id,
                   edition:   $e.id,
                   tag_suffix: $e.tag_suffix,
-                  suffix:    ((if $o.family == "ubuntu" then "" else "-\($o.family)" end) + $e.tag_suffix)
+                  suffix:    ((if $o.family == "ubuntu" then "" else "-\($o.family)" end) + $o.tag_suffix + $e.tag_suffix)
                 }
               ]
             | map(select(.enabled == "true" and .ed_enabled))

--- a/docker/Dockerfile_base_26.04
+++ b/docker/Dockerfile_base_26.04
@@ -1,0 +1,28 @@
+FROM ubuntu:26.04
+ARG NODE
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN userdel -r ubuntu \
+  && groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+RUN groupadd -r docker -g 991 \
+  && groupadd -r i2c -g 990 \
+  && groupadd -r spi -g 989 \
+  && apt-get update \
+  && apt-get -y install --no-install-recommends git \
+  python3 python3-venv python3-pip build-essential \
+  sysstat procps nano curl libcap2-bin sudo bluez \
+  && usermod -a -G dialout,i2c,spi,docker node \
+  && chmod u+s /usr/bin/date
+
+RUN curl -fsSL https://deb.nodesource.com/setup_$NODE | bash - \
+  && apt-get -y install --no-install-recommends nodejs \
+  && npm config rm proxy \
+  && npm config rm https-proxy \
+  && npm config set fetch-retries 5 \
+  && npm config set fetch-retry-mintimeout 60000 \
+  && npm config set fetch-retry-maxtimeout 120000 \
+  && npm cache clean -f \
+  && npm install npm@latest -g \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,7 +78,7 @@ See `docker/docker-compose.yml` for reference / example if you want to use docke
 
 # Image details and used tags
 
-Signal K Server docker images are based on Ubuntu 24.04 LTS. During build process, Node.js is installed including tools required to install or compile plugins. Signal K supports mDNS from docker, uses avahi for e.g. mDNS discovery. All required avahi tools and settings are available for user `node`, also from command line.
+Signal K Server docker images are based on Ubuntu 24.04 LTS, with an Ubuntu 26.04 LTS variant (tagged with a `-26.04` suffix) and an Alpine variant (tagged with a `-alpine` suffix) also published. During build process, Node.js is installed including tools required to install or compile plugins. Signal K supports mDNS from docker, uses avahi for e.g. mDNS discovery. All required avahi tools and settings are available for user `node`, also from command line.
 
 ## Directory structure
 
@@ -118,12 +118,12 @@ The **core** variant strips the bundled webapps and plugins from the image, keep
 
 ### Tags
 
-| Variant | Ubuntu rolling | Alpine rolling        | Ubuntu pinned | Alpine pinned        |
-| ------- | -------------- | --------------------- | ------------- | -------------------- |
-| Full    | `:latest`      | `:latest-alpine`      | `:X.Y.Z`      | `:X.Y.Z-alpine`      |
-| Core    | `:latest-core` | `:latest-alpine-core` | `:X.Y.Z-core` | `:X.Y.Z-alpine-core` |
+| Variant | Ubuntu 24.04 rolling | Ubuntu 26.04 rolling | Alpine rolling        | Ubuntu 24.04 pinned | Ubuntu 26.04 pinned | Alpine pinned        |
+| ------- | -------------------- | -------------------- | --------------------- | ------------------- | ------------------- | -------------------- |
+| Full    | `:latest`            | `:latest-26.04`      | `:latest-alpine`      | `:X.Y.Z`            | `:X.Y.Z-26.04`      | `:X.Y.Z-alpine`      |
+| Core    | `:latest-core`       | `:latest-26.04-core` | `:latest-alpine-core` | `:X.Y.Z-core`       | `:X.Y.Z-26.04-core` | `:X.Y.Z-alpine-core` |
 
-The core `-core` suffix is appended after the full variant's tag, so core mirrors every full tag. Versioned core tags follow the existing major / major.minor pattern (`:v2-core`, `:v2.27-core`, plus `-alpine-core` siblings).
+The core `-core` suffix is appended after the full variant's tag, so core mirrors every full tag. Versioned core tags follow the existing major / major.minor pattern (`:v2-core`, `:v2.27-core`, plus `-alpine-core` / `-26.04-core` siblings). `:latest` / `:X.Y.Z` (no OS suffix) always refer to the Ubuntu 24.04 build.
 
 ### What's stripped
 


### PR DESCRIPTION
Adds Dockerfile_base_26.04 and wires it into the build matrix and all three Docker workflows. Groups (docker/i2c/spi) must be created before installing bluez, since bluez on 26.04 auto-creates a system 'bluetooth' group that otherwise grabs the docker group's pinned GID 991.

Each os_variants row now carries its own tag_suffix so rows sharing a family don't collide on the same manifest tags: without it, 26.04 would have produced 'latest'/'vX.Y.Z' identically to 24.04, and whichever manifest job finished last would silently overwrite the other's multi-arch image on GHCR/Docker Hub. 24.04 keeps the bare tags (tag_suffix ""); 26.04 gets '-26.04'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds an Ubuntu 26.04 Docker base image and publishes corresponding Node 24 development and release variants.
- Creates the `docker`, `i2c`, and `spi` groups before installing `bluez` to preserve pinned GIDs.
- Adds per-variant `tag_suffix` values to prevent manifest collisions, keeping Ubuntu 24.04 tags unchanged and using `-26.04` for Ubuntu 26.04.
- Updates Docker workflows, build-matrix documentation, and image tag documentation for the new variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->