### PR TITLE
feat(plugin-ci): build plugin once using a pinned node version (build-node-version)

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1387,10 +1387,10 @@ jobs:
           # Read the tarball name from --json: a plugin "prepare" script (e.g. tsc)
           # prints a lifecycle banner to stdout that would pollute a bare
           # $(npm pack) capture (npm < 11 runs prepare here despite --ignore-scripts).
+          # Split into two steps (rather than piping straight into `node -e`) so a
+          # failure in `npm pack` itself isn't swallowed by the pipe.
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
-          # PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" \
-          #   | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -1802,12 +1802,12 @@ jobs:
           # Pack the plugin and install it into the test server. Read the tarball
           # name from --json so a plugin "prepare" lifecycle banner on stdout can't
           # corrupt it (npm < 11 runs prepare here despite --ignore-scripts).
+          # Split into two steps (rather than piping straight into `node -e`) so a
+          # failure in `npm pack` itself isn't swallowed by the pipe.
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
-          # PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination /tmp \
-          #   | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
           cd /tmp/sk-test
-          npm install "/tmp/$(basename "$PLUGIN_TGZ")"
+          npm install "$RUNNER_TEMP/$(basename "$PLUGIN_TGZ")"
 
       - name: Configure plugin to auto-start
         run: |

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -14,11 +14,15 @@
 # Usage in your plugin repo:
 #   See docs/develop/plugins/examples/plugin-caller-example.yml
 #
-# By default the plugin is built once per matrix Node version (whatever
-# is under test). Pass `build-node-version` to pin the Build step to a
-# single fixed Node version (e.g. to match a production target like an
-# ARMv6l Pi Zero W) regardless of which versions are listed in
-# `node-versions` for testing.
+# The plugin is built exactly once (see the `build` job below), and every
+# platform/Node combination tested downstream installs and tests that same
+# build output. `build-node-version` picks which Node version runs that one
+# build; it defaults to '24' (set in the input schema below) — a deliberate
+# fixed choice, not derived from `node-versions`. Modern build tooling
+# (TypeScript, bundlers, etc.) commonly requires a current Node, and
+# `node-versions` may legitimately list older versions you still want to
+# *test* against. If '24' doesn't suit your build, set `build-node-version`
+# explicitly.
 
 name: SignalK Plugin CI
 
@@ -47,9 +51,9 @@ on:
         type: string
         default: '["22", "24"]'
       build-node-version:
-        description: 'Pin the Node version used only for the Build step, independent of node-versions. Leave empty to build with whichever matrix Node version is under test (default behavior).'
+        description: 'Node version used to Build the plugin'
         type: string
-        default: ''
+        default: '24'
 
       # ── armv7 / Cerbo GX options ────────────────────────────
       enable-armv7:
@@ -87,7 +91,7 @@ jobs:
   #  works downstream. Only the transpile/bundle step is shared.
   # ════════════════════════════════════════════════════════════
   build:
-    name: Build (Node ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }})
+    name: Build (Node ${{ inputs.build-node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -97,7 +101,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }}
+          node-version: ${{ inputs.build-node-version }}
           cache: ${{ hashFiles('**/package-lock.json') != '' && 'npm' || '' }}
 
       - name: Install dependencies
@@ -1979,7 +1983,7 @@ jobs:
             echo ""
             echo "| Job | Result | Notes |"
             echo "|-----|--------|-------|"
-            echo "| Build | $(icon "$BUILD_RESULT") | Node ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }} — shared by all jobs below |"
+            echo "| Build | $(icon "$BUILD_RESULT") | Node ${{ inputs.build-node-version }} — shared by all jobs below |"
             echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node 22, 24 |"
             echo "| armv7 — Cerbo GX (QEMU) | $(icon "$ARMV7_RESULT") | Node 20 (Venus OS 3.70) — advisory, non-blocking |"
             if [[ "$INTEGRATION_RESULT" != "skipped" ]]; then

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1387,10 +1387,14 @@ jobs:
           # Read the tarball name from --json: a plugin "prepare" script (e.g. tsc)
           # prints a lifecycle banner to stdout that would pollute a bare
           # $(npm pack) capture (npm < 11 runs prepare here despite --ignore-scripts).
-          # Split into two steps (rather than piping straight into `node -e`) so a
-          # failure in `npm pack` itself isn't swallowed by the pipe.
+          # `npm pack` is captured on its own line (not piped straight into
+          # `node -e`) so a failure there isn't swallowed by a pipe's exit
+          # status. The captured JSON is then handed to `node -e` over stdin,
+          # not as a CLI argument — a plugin with a large file count (e.g. a
+          # bundled webapp) makes --json's `files` array big enough to blow
+          # past Windows' argv-length limit ("Argument list too long").
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
-          PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
+          PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -1802,10 +1806,14 @@ jobs:
           # Pack the plugin and install it into the test server. Read the tarball
           # name from --json so a plugin "prepare" lifecycle banner on stdout can't
           # corrupt it (npm < 11 runs prepare here despite --ignore-scripts).
-          # Split into two steps (rather than piping straight into `node -e`) so a
-          # failure in `npm pack` itself isn't swallowed by the pipe.
+          # `npm pack` is captured on its own line (not piped straight into
+          # `node -e`) so a failure there isn't swallowed by a pipe's exit
+          # status. The captured JSON is then handed to `node -e` over stdin,
+          # not as a CLI argument — a plugin with a large file count (e.g. a
+          # bundled webapp) makes --json's `files` array big enough to blow
+          # past Windows' argv-length limit ("Argument list too long").
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
-          PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
+          PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
           cd /tmp/sk-test
           npm install "$RUNNER_TEMP/$(basename "$PLUGIN_TGZ")"
 

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -13,6 +13,12 @@
 #
 # Usage in your plugin repo:
 #   See docs/develop/plugins/examples/plugin-caller-example.yml
+#
+# By default the plugin is built once per matrix Node version (whatever
+# is under test). Pass `build-node-version` to pin the Build step to a
+# single fixed Node version (e.g. to match a production target like an
+# ARMv6l Pi Zero W) regardless of which versions are listed in
+# `node-versions` for testing.
 
 name: SignalK Plugin CI
 
@@ -40,6 +46,10 @@ on:
         description: 'JSON array of Node versions for desktop platforms (default: ["22", "24"])'
         type: string
         default: '["22", "24"]'
+      build-node-version:
+        description: 'Pin the Node version used only for the Build step, independent of node-versions. Leave empty to build with whichever matrix Node version is under test (default behavior).'
+        type: string
+        default: ''
 
       # ── armv7 / Cerbo GX options ────────────────────────────
       enable-armv7:
@@ -65,6 +75,60 @@ permissions:
 
 jobs:
   # ════════════════════════════════════════════════════════════
+  #  Build once — produces a single build artifact that every
+  #  platform/Node test job below installs and tests, instead of
+  #  each of them re-running `build-command` independently.
+  #
+  #  Note: this uploads the working tree post-build (minus
+  #  node_modules), NOT `npm pack` output — node_modules is
+  #  platform/arch/Node-ABI specific (native addons) and must be
+  #  installed fresh in every downstream job via its own `npm ci`.
+  #  .git is retained so the stray-files check (git ls-files) still
+  #  works downstream. Only the transpile/bundle step is shared.
+  # ════════════════════════════════════════════════════════════
+  build:
+    name: Build (Node ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }}
+          cache: ${{ hashFiles('**/package-lock.json') != '' && 'npm' || '' }}
+
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+        shell: bash
+
+      - name: Build
+        env:
+          BUILD_CMD: ${{ inputs.build-command }}
+        shell: bash
+        run: eval "$BUILD_CMD"
+
+      - name: Package build output
+        shell: bash
+        run: |
+          rm -rf node_modules
+          tar -czf "$RUNNER_TEMP/built-plugin.tar.gz" .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: built-plugin
+          path: ${{ runner.temp }}/built-plugin.tar.gz
+          retention-days: 1
+
+  # ════════════════════════════════════════════════════════════
   #  Desktop platforms matrix: Linux x64, Linux arm64, macOS, Windows
   # ════════════════════════════════════════════════════════════
   desktop:
@@ -75,6 +139,7 @@ jobs:
           matrix.os == 'windows-latest' && 'Windows' ||
           matrix.os }} / Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
+    needs: build
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -82,11 +147,24 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, windows-latest]
         node: ${{ fromJson(inputs.node-versions) }}
     steps:
-      - name: Checkout plugin
-        uses: actions/checkout@v7
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: built-plugin
+          path: _artifact-download
+
+      - name: Extract build artifact
+        shell: bash
+        # Use a plain relative path here, not ${{ runner.temp }} — on
+        # Windows runners that resolves to e.g. "D:\a\_temp", and GNU
+        # tar (bundled with Git Bash) misparses the leading "D:" as
+        # hostname:path remote-tar syntax ("Cannot connect to D:").
+        run: |
+          tar -xzf _artifact-download/built-plugin.tar.gz
+          rm -rf _artifact-download
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ hashFiles('**/package-lock.json') != '' && 'npm' || '' }}
@@ -320,12 +398,6 @@ jobs:
             npm_install_with_retry "npm install"
           fi
         shell: bash
-
-      - name: Build
-        env:
-          BUILD_CMD: ${{ inputs.build-command }}
-        shell: bash
-        run: eval "$BUILD_CMD"
 
       - name: Validate plugin entry point
         id: validate-entry
@@ -1520,6 +1592,7 @@ jobs:
   armv7:
     name: armv7 (Cerbo GX) / Node 20
     runs-on: ubuntu-latest
+    needs: build
     timeout-minutes: 30
     if: ${{ inputs.enable-armv7 }}
     # Advisory: armv7 is non-blocking. continue-on-error at the job level lets
@@ -1529,8 +1602,21 @@ jobs:
     outputs:
       advisory-outcome: ${{ steps.armv7-test.outcome }}
     steps:
-      - name: Checkout plugin
-        uses: actions/checkout@v7
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: built-plugin
+          path: _artifact-download
+
+      - name: Extract build artifact
+        shell: bash
+        # Use a plain relative path here, not ${{ runner.temp }} — on
+        # Windows runners that resolves to e.g. "D:\a\_temp", and GNU
+        # tar (bundled with Git Bash) misparses the leading "D:" as
+        # hostname:path remote-tar syntax ("Cannot connect to D:").
+        run: |
+          tar -xzf _artifact-download/built-plugin.tar.gz
+          rm -rf _artifact-download
 
       - name: Set up QEMU for ARM emulation
         # Advisory: a QEMU setup failure must not block the workflow — the
@@ -1556,14 +1642,12 @@ jobs:
         # job as truly red rather than emitting a confusing red annotation
         # under a green check.
         env:
-          BUILD_CMD: ${{ inputs.build-command }}
           TEST_CMD: ${{ inputs.test-command }}
         run: |
           docker run --rm --platform linux/arm/v7 \
             -v "${{ github.workspace }}:/plugin" \
             -v "/tmp/.npm-armv7-cache:/root/.npm" \
             -w /plugin \
-            -e BUILD_CMD \
             -e TEST_CMD \
             node:20-bookworm-slim \
             bash -c '
@@ -1572,15 +1656,13 @@ jobs:
               echo "arch: $(uname -m)  node: $(node -v)  npm: $(npm -v)"
               echo "── Installing build tools (python3, make, g++) ──"
               apt-get update -qq && apt-get install -y -qq python3 make g++ > /dev/null 2>&1
-              echo "── Installing dependencies ──"
+              echo "── Installing dependencies (build already done centrally) ──"
               if [ -f package-lock.json ]; then
                 npm ci --ignore-scripts
               else
                 npm install --ignore-scripts
               fi
               npm rebuild
-              echo "── Building ──"
-              eval "$BUILD_CMD"
 
               echo "── Checking for native addons ──"
               node -e "
@@ -1645,6 +1727,7 @@ jobs:
   signalk-integration:
     name: Integration / signalk-server ${{ matrix.signalk-server-version }} / Node ${{ matrix.node }}
     runs-on: ubuntu-latest
+    needs: build
     timeout-minutes: 15
     if: ${{ inputs.enable-signalk-integration }}
     strategy:
@@ -1653,11 +1736,24 @@ jobs:
         node: ${{ fromJson(inputs.node-versions) }}
         signalk-server-version: ${{ fromJson(inputs.signalk-server-versions) }}
     steps:
-      - name: Checkout plugin
-        uses: actions/checkout@v7
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: built-plugin
+          path: _artifact-download
+
+      - name: Extract build artifact
+        shell: bash
+        # Use a plain relative path here, not ${{ runner.temp }} — on
+        # Windows runners that resolves to e.g. "D:\a\_temp", and GNU
+        # tar (bundled with Git Bash) misparses the leading "D:" as
+        # hostname:path remote-tar syntax ("Cannot connect to D:").
+        run: |
+          tar -xzf _artifact-download/built-plugin.tar.gz
+          rm -rf _artifact-download
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: ${{ hashFiles('**/package-lock.json') != '' && 'npm' || '' }}
@@ -1684,9 +1780,9 @@ jobs:
             echo "::endgroup::"
           done <<< "$REQUIRES"
 
-      - name: Build plugin
-        env:
-          BUILD_CMD: ${{ inputs.build-command }}
+      - name: Install plugin dependencies
+        # Build already happened centrally in the `build` job — this only
+        # needs to install node_modules (native deps compiled for this Node).
         shell: bash
         run: |
           if [ -f package-lock.json ]; then
@@ -1694,7 +1790,6 @@ jobs:
           else
             npm install
           fi
-          eval "$BUILD_CMD"
 
       - name: Install plugin into SignalK
         run: |
@@ -1837,7 +1932,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [desktop, armv7, signalk-integration]
+    needs: [build, desktop, armv7, signalk-integration]
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -1846,6 +1941,7 @@ jobs:
 
       - name: Write CI summary report
         env:
+          BUILD_RESULT: ${{ needs.build.result }}
           DESKTOP_RESULT: ${{ needs.desktop.result }}
           # Prefer the armv7 test-step outcome when the job ran — it records
           # whether the advisory tests actually passed. Falls back to
@@ -1869,7 +1965,7 @@ jobs:
           PLUGIN_VER=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "?")
 
           OVERALL="pass"
-          if [[ "$DESKTOP_RESULT" == "failure" ]] || [[ "$INTEGRATION_RESULT" == "failure" ]]; then
+          if [[ "$BUILD_RESULT" == "failure" ]] || [[ "$DESKTOP_RESULT" == "failure" ]] || [[ "$INTEGRATION_RESULT" == "failure" ]]; then
             OVERALL="FAIL"
           fi
 
@@ -1883,6 +1979,7 @@ jobs:
             echo ""
             echo "| Job | Result | Notes |"
             echo "|-----|--------|-------|"
+            echo "| Build | $(icon "$BUILD_RESULT") | Node ${{ inputs.build-node-version != '' && inputs.build-node-version || '24' }} — shared by all jobs below |"
             echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node 22, 24 |"
             echo "| armv7 — Cerbo GX (QEMU) | $(icon "$ARMV7_RESULT") | Node 20 (Venus OS 3.70) — advisory, non-blocking |"
             if [[ "$INTEGRATION_RESULT" != "skipped" ]]; then
@@ -1926,9 +2023,16 @@ jobs:
           fi
 
           echo ""
+          echo "Build:                $BUILD_RESULT"
           echo "Desktop:              $DESKTOP_RESULT"
           echo "armv7 (Cerbo GX):     $ARMV7_RESULT"
           echo "SignalK integration:  $INTEGRATION_RESULT"
+
+          # Build is mandatory — every other job depends on its artifact
+          if [[ "$BUILD_RESULT" == "failure" ]]; then
+            echo "::error::Build failed — all downstream jobs were skipped"
+            exit 1
+          fi
 
           # Desktop is mandatory
           if [[ "$DESKTOP_RESULT" == "failure" ]]; then

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1387,8 +1387,10 @@ jobs:
           # Read the tarball name from --json: a plugin "prepare" script (e.g. tsc)
           # prints a lifecycle banner to stdout that would pollute a bare
           # $(npm pack) capture (npm < 11 runs prepare here despite --ignore-scripts).
-          PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" \
-            | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
+          PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
+          PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
+          # PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" \
+          #   | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -1800,8 +1802,10 @@ jobs:
           # Pack the plugin and install it into the test server. Read the tarball
           # name from --json so a plugin "prepare" lifecycle banner on stdout can't
           # corrupt it (npm < 11 runs prepare here despite --ignore-scripts).
-          PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination /tmp \
-            | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
+          PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
+          PLUGIN_TGZ=$(node -e 'const s=process.argv[1]; process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)' "$PACK_JSON")
+          # PLUGIN_TGZ=$(npm pack --ignore-scripts --json --pack-destination /tmp \
+          #   | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
           cd /tmp/sk-test
           npm install "/tmp/$(basename "$PLUGIN_TGZ")"
 

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1411,8 +1411,21 @@ jobs:
           # not as a CLI argument — a plugin with a large file count (e.g. a
           # bundled webapp) makes --json's `files` array big enough to blow
           # past Windows' argv-length limit ("Argument list too long").
+          #
+          # Beyond the stdout-corruption risk above, npm 10.x (bundled with
+          # Node 22) actually *runs* "prepare" here despite --ignore-scripts
+          # — not just prints its banner — once the tarball is reinstalled
+          # from a local path below (confirmed empirically; npm 11+ does not
+          # do this; armv7's npm 10.8.2 is unaffected since it never packs
+          # and reinstalls itself). The plugin was already built once,
+          # centrally, so prepare has no legitimate work left to do here —
+          # strip it before packing rather than depend on --ignore-scripts
+          # alone to suppress it.
+          cp package.json "$RUNNER_TEMP/package.json.orig"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
+          mv "$RUNNER_TEMP/package.json.orig" package.json
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -1905,8 +1918,17 @@ jobs:
           # not as a CLI argument — a plugin with a large file count (e.g. a
           # bundled webapp) makes --json's `files` array big enough to blow
           # past Windows' argv-length limit ("Argument list too long").
+          #
+          # npm 10.x (Node 22) actually runs "prepare" here despite
+          # --ignore-scripts once the tarball is reinstalled below — same
+          # issue and fix as the desktop job's App Store simulation step.
+          # Strip it before packing rather than depend on --ignore-scripts
+          # alone to suppress it.
+          cp package.json "$RUNNER_TEMP/package.json.orig"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
+          mv "$RUNNER_TEMP/package.json.orig" package.json
           cd /tmp/sk-test
           # --ignore-scripts matches how the real SignalK server installs
           # plugins (src/modules.ts:223) — a required native addon that

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -66,7 +66,7 @@ on:
         type: string
         default: '["22", "24", "26"]'
       build-node-version:
-        description: 'Node version used to Build the plugin'
+        description: 'Node version used to build the plugin'
         type: string
         default: '24'
       artifact-name-suffix:
@@ -124,6 +124,10 @@ jobs:
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
+        with:
+          # The build output tarball below includes .git; without this the
+          # persisted http.extraheader token would ship inside the artifact.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -1697,10 +1701,10 @@ jobs:
           # strip it before packing rather than depend on --ignore-scripts
           # alone to suppress it.
           cp package.json "$RUNNER_TEMP/package.json.orig"
+          trap 'mv "$RUNNER_TEMP/package.json.orig" package.json' EXIT
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
-          mv "$RUNNER_TEMP/package.json.orig" package.json
 
           mkdir -p "$APPSTORE_DIR"
           cd "$APPSTORE_DIR"
@@ -2109,7 +2113,7 @@ jobs:
             echo "**Environment**: Venus OS 3.70 emulation (QEMU armv7, Debian Bookworm, python3, make, g++)"
             echo ""
             if [[ "$RESULT" == "success" ]]; then
-              echo "Install, build, and tests completed successfully under armv7 emulation."
+              echo "Install and tests completed successfully under armv7 emulation (the plugin was built centrally)."
             else
               echo "The armv7 job **failed**. Your plugin may not work on 32-bit ARM devices (Cerbo GX, Raspberry Pi OS 32-bit)."
             fi
@@ -2275,10 +2279,10 @@ jobs:
           # Strip it before packing rather than depend on --ignore-scripts
           # alone to suppress it.
           cp package.json "$RUNNER_TEMP/package.json.orig"
+          trap 'mv "$RUNNER_TEMP/package.json.orig" package.json' EXIT
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
-          mv "$RUNNER_TEMP/package.json.orig" package.json
           cd /tmp/sk-test
           # --ignore-scripts matches how the real SignalK server installs
           # plugins (src/modules.ts:223) — a required native addon that
@@ -2434,6 +2438,8 @@ jobs:
           # step outcome exists.
           ARMV7_RESULT: ${{ needs.armv7.outputs.advisory-outcome || needs.armv7.result }}
           INTEGRATION_RESULT: ${{ needs.signalk-integration.result }}
+          BUILD_NODE_VERSION: ${{ inputs.build-node-version }}
+          NODE_VERSIONS: ${{ inputs.node-versions }}
         shell: bash
         run: |
           icon() {
@@ -2464,8 +2470,9 @@ jobs:
             echo ""
             echo "| Job | Result | Notes |"
             echo "|-----|--------|-------|"
-            echo "| Build | $(icon "$BUILD_RESULT") | Node ${{ inputs.build-node-version }} — shared by all jobs below |"
-            echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node 22, 24, 26 |"
+            DESKTOP_NODES=$(node -e 'process.stdout.write(JSON.parse(process.env.NODE_VERSIONS).join(", "))')
+            echo "| Build | $(icon "$BUILD_RESULT") | Node $BUILD_NODE_VERSION — shared by all jobs below |"
+            echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node $DESKTOP_NODES |"
             echo "| armv7 — Cerbo GX (QEMU) | $(icon "$ARMV7_RESULT") | Node 20 (Venus OS 3.70) — advisory, non-blocking |"
             if [[ "$INTEGRATION_RESULT" != "skipped" ]]; then
               echo "| SignalK integration | $(icon "$INTEGRATION_RESULT") | Server install + plugin load |"

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1799,8 +1799,8 @@ jobs:
               else
                 npm install --ignore-scripts
               fi
-              # Bare npm rebuild (no args) also re-runs the *root* package's
-              # own preinstall/install/postinstall scripts, not just
+              # Bare npm rebuild (no args) also re-runs preinstall/install/
+              # postinstall scripts on the *root* package itself, not just
               # dependency native addons. Naming only the dependencies that
               # actually need rebuilding avoids that, and skips the call
               # entirely when nothing needs compiling.

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1701,7 +1701,7 @@ jobs:
           # strip it before packing rather than depend on --ignore-scripts
           # alone to suppress it.
           cp package.json "$RUNNER_TEMP/package.json.orig"
-          trap 'mv "$RUNNER_TEMP/package.json.orig" package.json' EXIT
+          trap 'mv "$RUNNER_TEMP/package.json.orig" "$GITHUB_WORKSPACE/package.json"' EXIT
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
@@ -2279,7 +2279,7 @@ jobs:
           # Strip it before packing rather than depend on --ignore-scripts
           # alone to suppress it.
           cp package.json "$RUNNER_TEMP/package.json.orig"
-          trap 'mv "$RUNNER_TEMP/package.json.orig" package.json' EXIT
+          trap 'mv "$RUNNER_TEMP/package.json.orig" "$GITHUB_WORKSPACE/package.json"' EXIT
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));if(p.scripts)delete p.scripts.prepare;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -4,10 +4,10 @@
 # Plugin developers reference it with a single line in their own workflow.
 #
 # Platforms tested:
-#   - Linux x64    (Node 22, 24)
-#   - Linux arm64  (Node 22, 24) — Raspberry Pi 4/5
-#   - macOS        (Node 22, 24)
-#   - Windows      (Node 22, 24)
+#   - Linux x64    (Node 22, 24, 26)
+#   - Linux arm64  (Node 22, 24, 26) — Raspberry Pi 4/5
+#   - macOS        (Node 22, 24, 26)
+#   - Windows      (Node 22, 24, 26)
 #   - armv7/armhf  (Node 20 — matches Venus OS 3.70 on Cerbo GX)
 #                    Runs under QEMU emulation with python3, make, g++
 #
@@ -23,6 +23,14 @@
 # `node-versions` may legitimately list older versions you still want to
 # *test* against. If '24' doesn't suit your build, set `build-node-version`
 # explicitly.
+#
+# One consequence: this workflow no longer verifies that `build-command`
+# itself succeeds on Windows/macOS, or on any Node version other than
+# `build-node-version` — only that the resulting build *output* installs
+# and runs correctly there. That trade is deliberate: build failures are
+# overwhelmingly Node/tooling-version issues, not OS issues, while install
+# and runtime behavior (native addons, path handling, ESM/CJS interop)
+# genuinely varies by platform — that's what the matrix below is for.
 
 name: SignalK Plugin CI
 
@@ -47,13 +55,17 @@ on:
         type: string
         default: ''
       node-versions:
-        description: 'JSON array of Node versions for desktop platforms (default: ["22", "24"])'
+        description: 'JSON array of Node versions for desktop platforms (default: ["22", "24", "26"])'
         type: string
-        default: '["22", "24"]'
+        default: '["22", "24", "26"]'
       build-node-version:
         description: 'Node version used to Build the plugin'
         type: string
         default: '24'
+      artifact-name-suffix:
+        description: 'Optional suffix appended to the shared build artifact name — set this if your caller workflow invokes this reusable workflow more than once in a single run, to avoid an artifact name collision'
+        type: string
+        default: ''
 
       # ── armv7 / Cerbo GX options ────────────────────────────
       enable-armv7:
@@ -70,6 +82,10 @@ on:
         description: 'JSON array of signalk-server versions to fan the integration test out over (e.g. ''["2.23.0", "latest"]'')'
         type: string
         default: '["latest"]'
+      signalk-integration-matrix:
+        description: 'JSON array of {"node-version": ..., "signalk-server-version": ...} pairs to test in the integration job, overriding the node-versions × signalk-server-versions cartesian product — use this when only some combinations are valid (e.g. an older signalk-server version that does not support a newer Node)'
+        type: string
+        default: ''
 
 # Least-privilege token for the jobs in this reusable workflow. We only
 # read the caller's repository — install, build, and test steps never
@@ -107,10 +123,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            npm ci --ignore-scripts
           else
-            npm install
+            npm install --ignore-scripts
           fi
+          npm rebuild
         shell: bash
 
       - name: Build
@@ -128,7 +145,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
-          name: built-plugin
+          name: built-plugin${{ inputs.artifact-name-suffix }}
           path: ${{ runner.temp }}/built-plugin.tar.gz
           retention-days: 1
 
@@ -154,7 +171,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
-          name: built-plugin
+          name: built-plugin${{ inputs.artifact-name-suffix }}
           path: _artifact-download
 
       - name: Extract build artifact
@@ -396,11 +413,12 @@ jobs:
             return 1
           }
           if [ -f package-lock.json ]; then
-            npm_install_with_retry "npm ci"
+            npm_install_with_retry "npm ci --ignore-scripts"
           else
             echo "No package-lock.json found — using npm install instead of npm ci"
-            npm_install_with_retry "npm install"
+            npm_install_with_retry "npm install --ignore-scripts"
           fi
+          npm rebuild
         shell: bash
 
       - name: Validate plugin entry point
@@ -1615,7 +1633,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
-          name: built-plugin
+          name: built-plugin${{ inputs.artifact-name-suffix }}
           path: _artifact-download
 
       - name: Extract build artifact
@@ -1734,22 +1752,62 @@ jobs:
   # ════════════════════════════════════════════════════════════
   #  Optional: SignalK server integration test
   # ════════════════════════════════════════════════════════════
-  signalk-integration:
-    name: Integration / signalk-server ${{ matrix.signalk-server-version }} / Node ${{ matrix.node }}
+  #  Computes the node/signalk-server-version pairs the integration job
+  #  below fans out over. Always runs (even when the integration test is
+  #  disabled) so `signalk-integration`'s `fromJson(...)` below never has
+  #  to deal with an empty/skipped upstream output.
+  integration-matrix:
+    name: Compute integration test matrix
     runs-on: ubuntu-latest
-    needs: build
+    timeout-minutes: 2
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Compute node × signalk-server-version pairs
+        id: compute
+        shell: bash
+        env:
+          NODE_VERSIONS: ${{ inputs.node-versions }}
+          SK_VERSIONS: ${{ inputs.signalk-server-versions }}
+          EXPLICIT_MATRIX: ${{ inputs.signalk-integration-matrix }}
+        run: |
+          node -e '
+            const explicit = process.env.EXPLICIT_MATRIX.trim();
+            let matrix;
+            if (explicit !== "") {
+              // Caller gave an explicit list of {node-version, signalk-server-version}
+              // pairs — use it as-is instead of cross-producting the two
+              // separate arrays below, so combinations that do not make
+              // sense together are never generated.
+              matrix = JSON.parse(explicit);
+            } else {
+              const nodeVersions = JSON.parse(process.env.NODE_VERSIONS);
+              const skVersions = JSON.parse(process.env.SK_VERSIONS);
+              matrix = [];
+              for (const node of nodeVersions) {
+                for (const signalkServerVersion of skVersions) {
+                  matrix.push({ "node-version": node, "signalk-server-version": signalkServerVersion });
+                }
+              }
+            }
+            require("fs").appendFileSync(process.env.GITHUB_OUTPUT, "matrix=" + JSON.stringify(matrix) + "\n");
+          '
+
+  signalk-integration:
+    name: Integration / signalk-server ${{ matrix.signalk-server-version }} / Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    needs: [build, integration-matrix]
     timeout-minutes: 15
     if: ${{ inputs.enable-signalk-integration }}
     strategy:
       fail-fast: false
       matrix:
-        node: ${{ fromJson(inputs.node-versions) }}
-        signalk-server-version: ${{ fromJson(inputs.signalk-server-versions) }}
+        include: ${{ fromJson(needs.integration-matrix.outputs.matrix) }}
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
-          name: built-plugin
+          name: built-plugin${{ inputs.artifact-name-suffix }}
           path: _artifact-download
 
       - name: Extract build artifact
@@ -1762,10 +1820,10 @@ jobs:
           tar -xzf _artifact-download/built-plugin.tar.gz
           rm -rf _artifact-download
 
-      - name: Setup Node.js ${{ matrix.node }}
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
           cache: ${{ hashFiles('**/package-lock.json') != '' && 'npm' || '' }}
 
       - name: Install SignalK server ${{ matrix.signalk-server-version }}
@@ -1796,10 +1854,11 @@ jobs:
         shell: bash
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            npm ci --ignore-scripts
           else
-            npm install
+            npm install --ignore-scripts
           fi
+          npm rebuild
 
       - name: Install plugin into SignalK
         run: |
@@ -1996,7 +2055,7 @@ jobs:
             echo "| Job | Result | Notes |"
             echo "|-----|--------|-------|"
             echo "| Build | $(icon "$BUILD_RESULT") | Node ${{ inputs.build-node-version }} — shared by all jobs below |"
-            echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node 22, 24 |"
+            echo "| Desktop (Linux, Linux arm64, macOS, Windows) | $(icon "$DESKTOP_RESULT") | Node 22, 24, 26 |"
             echo "| armv7 — Cerbo GX (QEMU) | $(icon "$ARMV7_RESULT") | Node 20 (Venus OS 3.70) — advisory, non-blocking |"
             if [[ "$INTEGRATION_RESULT" != "skipped" ]]; then
               echo "| SignalK integration | $(icon "$INTEGRATION_RESULT") | Server install + plugin load |"

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1204,6 +1204,20 @@ jobs:
           // Get list of files that npm pack would include
           // --ignore-scripts: don't re-run prepack (we already built in a prior step)
           // stdio pipe suppresses stderr cross-platform (2>/dev/null breaks on Windows)
+          //
+          // npm 10.x (Node 22) actually *runs* "prepare" during npm pack
+          // despite --ignore-scripts (npm 11+ does not — see the same fix
+          // in the App Store simulation step below) — strip it from
+          // package.json before either dry-run call, and restore it once
+          // we have the file list, rather than depend on --ignore-scripts
+          // alone to suppress it.
+          const fs = require('fs');
+          const pkgJsonPath = path.join(process.cwd(), 'package.json');
+          const pkgJsonOrig = fs.readFileSync(pkgJsonPath, 'utf8');
+          const pkgForPack = JSON.parse(pkgJsonOrig);
+          if (pkgForPack.scripts) delete pkgForPack.scripts.prepare;
+          fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgForPack, null, 2));
+
           let packOutput;
           try {
             packOutput = execSync('npm pack --dry-run --json --ignore-scripts', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
@@ -1224,6 +1238,7 @@ jobs:
             }
             files = raw.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('npm') && !l.startsWith('Tarball'));
           }
+          fs.writeFileSync(pkgJsonPath, pkgJsonOrig);
 
           const errors = [];
           const warnings = [];

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -38,6 +38,13 @@ on:
   workflow_call:
     inputs:
       # ── Test configuration ──────────────────────────────────
+      # External dependency: SignalK/signalk-plugin-registry reads a caller
+      # workflow's `with: test-command` / `with: build-command` values
+      # directly out of its `.github/workflows/*.yml` (test-harness/
+      # plugin-ci-commands.ts) as a fallback when a plugin's published
+      # tarball can't run its own tests. Renaming these inputs, or
+      # restructuring how a caller declares them, silently breaks that
+      # parser — nothing in either repo's test suite currently catches it.
       test-command:
         description: 'Command to run tests (default: npm test)'
         type: string
@@ -154,6 +161,56 @@ jobs:
             npm rebuild $NATIVE_MODULES
           fi
         shell: bash
+
+      - name: Run npm audit
+        shell: bash
+        run: |
+          # npm audit exits non-zero whenever it finds anything at all —
+          # capture into a variable first (not a pipe) so that exit code
+          # never reaches this step's own exit status under the default
+          # `set -e -o pipefail` shell; stdout is still valid JSON either way.
+          AUDIT_JSON=$(npm audit --json 2>/dev/null || true)
+          printf '%s' "$AUDIT_JSON" | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk; });
+            process.stdin.on("end", () => {
+              let data;
+              try {
+                data = JSON.parse(input);
+              } catch (e) {
+                console.log("npm audit produced no parseable output — skipping");
+                return;
+              }
+              // npm audit itself can fail (e.g. ENOLOCK) and still print
+              // valid JSON — an {error: ...} shape, not {metadata: ...}.
+              // Treating that as "0 vulnerabilities" would be a false
+              // all-clear, so surface it distinctly instead of falling
+              // through to the normal count logic below.
+              if (data.error) {
+                console.log("npm audit could not run: " + (data.error.summary || JSON.stringify(data.error)));
+                return;
+              }
+              if (!data.metadata || !data.metadata.vulnerabilities) {
+                console.log("npm audit output missing the expected metadata.vulnerabilities shape — skipping");
+                return;
+              }
+              const v = data.metadata.vulnerabilities;
+              const critical = v.critical || 0;
+              const high = v.high || 0;
+              const moderate = v.moderate || 0;
+              const low = v.low || 0;
+              const total = critical + high + moderate + low;
+              if (total === 0) {
+                console.log("npm audit: no known vulnerabilities");
+                return;
+              }
+              console.log(
+                "::warning::npm audit found " + total + " known vulnerabilit" + (total === 1 ? "y" : "ies") +
+                " in dependencies (critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + "). " +
+                "Run npm audit locally for details, and npm audit fix where a safe upgrade exists."
+              );
+            });
+          '
 
       - name: Build
         env:
@@ -883,6 +940,29 @@ jobs:
             return /\w+ is not a function/.test(msg) || /Cannot read propert/.test(msg);
           }
 
+          // Mirrors signalk-plugin-registry's test-harness/schema-defaults.ts —
+          // a config-shaped object built from the plugin's own declared
+          // defaults, not an arbitrary probe. {} alone can pass activation
+          // while a real default value (e.g. an assumed-present default
+          // array/object field) breaks start() the first time a user
+          // actually saves the config screen with its defaults intact.
+          function extractSchemaDefaults(schema) {
+            if (!schema || typeof schema !== 'object') return {};
+            if (schema.type !== 'object' || !schema.properties) return {};
+            const result = {};
+            for (const key of Object.keys(schema.properties)) {
+              const prop = schema.properties[key];
+              if (!prop || typeof prop !== 'object') continue;
+              if (prop.type === 'object' && prop.properties) {
+                const nested = extractSchemaDefaults(prop);
+                if (Object.keys(nested).length > 0) result[key] = nested;
+              } else if ('default' in prop) {
+                result[key] = prop.default;
+              }
+            }
+            return result;
+          }
+
           // Wrap in an async IIFE so that Promise-returning start()/stop()
           // hooks surface rejections via await — a sync try/catch around
           // `plugin.start({})` would silently swallow them.
@@ -934,6 +1014,34 @@ jobs:
           }
 
           try { await Promise.resolve(plugin.stop()); } catch (e) { /* ignore */ }
+
+          // Also activate once with the plugin's own schema defaults, not
+          // just {} — see extractSchemaDefaults above for why. Skipped
+          // entirely when the schema has no default values to extract.
+          let schemaForDefaults;
+          try {
+            schemaForDefaults = typeof plugin.schema === 'function' ? plugin.schema() : plugin.schema;
+          } catch (e) {
+            schemaForDefaults = undefined; // a throwing schema() is check-schema.js's own check to report
+          }
+          const schemaDefaults = extractSchemaDefaults(schemaForDefaults);
+          if (Object.keys(schemaDefaults).length > 0) {
+            try {
+              await Promise.resolve(plugin.start(schemaDefaults));
+              console.log('start(<schema defaults>) — ok');
+            } catch (e) {
+              const msg = e.message || String(e);
+              if (isMockGap(msg)) {
+                console.log('::warning::plugin.start(<schema defaults>) threw: ' + msg);
+                console.log('::warning::This looks like a missing CI mock method, not a plugin bug. Please report at https://github.com/SignalK/signalk-server/issues');
+                process.exit(0);
+              }
+              console.log('::error::plugin.start(<schema defaults>) threw: ' + msg);
+              console.log("::error::This only surfaces once a user saves the config screen with the plugin's own default values intact — start({}) alone would not catch it.");
+              process.exit(1);
+            }
+            try { await Promise.resolve(plugin.stop()); } catch (e) { /* ignore */ }
+          }
 
           // ── Report delta validation results ─────────────────────
           if (deltaWarnings.length > 0 || deltaErrors.length > 0) {

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -171,6 +171,13 @@ jobs:
           # `set -e -o pipefail` shell; stdout is still valid JSON either way.
           AUDIT_JSON=$(npm audit --json 2>/dev/null || true)
           printf '%s' "$AUDIT_JSON" | node -e '
+            const fs = require("fs");
+            function summary(line) {
+              console.log(line);
+              if (process.env.GITHUB_STEP_SUMMARY) {
+                fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, "### Dependency audit\n\n" + line + "\n");
+              }
+            }
             let input = "";
             process.stdin.on("data", (chunk) => { input += chunk; });
             process.stdin.on("end", () => {
@@ -187,7 +194,7 @@ jobs:
               // all-clear, so surface it distinctly instead of falling
               // through to the normal count logic below.
               if (data.error) {
-                console.log("npm audit could not run: " + (data.error.summary || JSON.stringify(data.error)));
+                summary("⚠️ npm audit could not run: " + (data.error.summary || JSON.stringify(data.error)));
                 return;
               }
               if (!data.metadata || !data.metadata.vulnerabilities) {
@@ -201,13 +208,18 @@ jobs:
               const low = v.low || 0;
               const total = critical + high + moderate + low;
               if (total === 0) {
-                console.log("npm audit: no known vulnerabilities");
+                summary("✅ No known vulnerabilities.");
                 return;
               }
               console.log(
                 "::warning::npm audit found " + total + " known vulnerabilit" + (total === 1 ? "y" : "ies") +
                 " in dependencies (critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + "). " +
                 "Run npm audit locally for details, and npm audit fix where a safe upgrade exists."
+              );
+              summary(
+                "⚠️ **" + total + " known vulnerabilit" + (total === 1 ? "y" : "ies") + "** in dependencies " +
+                "(critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + "). " +
+                "Run `npm audit` locally for details, and `npm audit fix` where a safe upgrade exists."
               );
             });
           '
@@ -235,12 +247,19 @@ jobs:
   #  Desktop platforms matrix: Linux x64, Linux arm64, macOS, Windows
   # ════════════════════════════════════════════════════════════
   desktop:
+    # No "/" in this name (unlike armv7's "armv7 (Cerbo GX) / Node 20" below,
+    # which is a single non-matrix job with nothing to disambiguate) — the
+    # Actions sidebar's compact matrix-job list appears to extract only the
+    # last "/"-delimited segment of a custom matrix name, which collapsed
+    # every OS down to a bare "Node 22"/"Node 24"/"Node 26" with no way to
+    # tell them apart. Matches "Build (Node 24)"'s existing parenthetical
+    # style above instead.
     name: >-
       ${{ matrix.os == 'ubuntu-latest' && 'Linux' ||
           matrix.os == 'ubuntu-24.04-arm' && 'Linux arm64' ||
           matrix.os == 'macos-15' && 'macOS' ||
           matrix.os == 'windows-latest' && 'Windows' ||
-          matrix.os }} / Node ${{ matrix.node }}
+          matrix.os }} (Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     needs: build
     timeout-minutes: 15
@@ -274,6 +293,13 @@ jobs:
 
       - name: Validate plugin package.json
         id: validate-pkg
+        # Pure static analysis of package.json/source files — the result
+        # cannot differ by OS or Node version, so running it on all 12
+        # desktop combinations is 12x redundant work and, worse, 12x
+        # duplicate ::warning:: annotations for the exact same finding.
+        # Runs on one representative combination; a failure there still
+        # fails the overall desktop matrix (and ci-status) the same way.
+        if: matrix.os == 'ubuntu-latest' && matrix.node == fromJson(inputs.node-versions)[0]
         shell: bash
         run: |
           cat << 'VALIDATE' > /tmp/validate-pkg.js
@@ -469,6 +495,9 @@ jobs:
           }
 
           warnings.forEach(w => console.log('::warning::' + w));
+          if (process.env.GITHUB_OUTPUT) {
+            require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'warning-count=' + warnings.length + '\n');
+          }
           if (errors.length > 0) {
             errors.forEach(e => console.log('::error::' + e));
             process.exit(1);
@@ -680,8 +709,10 @@ jobs:
           }
 
           // Basic JSON Schema structure check (rjsf compatibility)
+          let schemaWarningCount = 0;
           if (!schema.type && !schema.properties && !schema.oneOf && !schema.anyOf) {
             console.log('::warning::' + label + ' has no type, properties, oneOf, or anyOf — is this a valid JSON Schema?');
+            schemaWarningCount++;
           }
 
           // Check for JSON-hostile values that would be silently dropped or
@@ -724,6 +755,9 @@ jobs:
             process.exit(1);
           }
 
+          if (process.env.GITHUB_OUTPUT) {
+            require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'warning-count=' + schemaWarningCount + '\n');
+          }
           console.log(label + ' is a valid JSON Schema object');
           process.exit(0);
           SCHEMACHECK
@@ -1068,6 +1102,10 @@ jobs:
 
       - name: Scan for deprecated and misused SignalK APIs
         id: deprecated-api
+        # Same reasoning as "Validate plugin package.json" above — pure
+        # static source-file analysis, platform/Node-invariant, so it
+        # only needs to run once instead of 12x duplicating every finding.
+        if: matrix.os == 'ubuntu-latest' && matrix.node == fromJson(inputs.node-versions)[0]
         shell: bash
         run: |
           cat << 'APISCAN' > /tmp/check-api-usage.js
@@ -1317,6 +1355,10 @@ jobs:
           notices.forEach(n => console.log('::notice::' + n));
           warnings.forEach(w => console.log('::warning::' + w));
           errors.forEach(e => console.log('::error::' + e));
+
+          if (process.env.GITHUB_OUTPUT) {
+            require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'warning-count=' + warnings.length + '\n');
+          }
 
           if (errors.length > 0) {
             console.log('');
@@ -1771,10 +1813,13 @@ jobs:
         shell: bash
         env:
           VALIDATE_PKG: ${{ steps.validate-pkg.outcome }}
+          VALIDATE_PKG_WARNINGS: ${{ steps.validate-pkg.outputs.warning-count }}
           VALIDATE_ENTRY: ${{ steps.validate-entry.outcome }}
           VALIDATE_SCHEMA: ${{ steps.validate-schema.outcome }}
+          VALIDATE_SCHEMA_WARNINGS: ${{ steps.validate-schema.outputs.warning-count }}
           LIFECYCLE_CHECK: ${{ steps.lifecycle-check.outcome }}
           DEPRECATED_API: ${{ steps.deprecated-api.outcome }}
+          DEPRECATED_API_WARNINGS: ${{ steps.deprecated-api.outputs.warning-count }}
           PACK_CHECK: ${{ steps.pack-check.outcome }}
           APPSTORE_CHECK: ${{ steps.appstore-check.outcome }}
           # When coverage-command is set, steps.tests is skipped and the
@@ -1799,6 +1844,21 @@ jobs:
             esac
           }
 
+          # A step's `outcome` is "success" even when it logged ::warning::
+          # annotations — only exit 1 changes it. Without this, a check that
+          # found real problems (missing CHANGELOG, deprecated API usage,
+          # etc.) reports a flat "pass" here, and the only place the
+          # warnings themselves are visible is the Annotations panel at the
+          # very bottom of the run page — easy to miss entirely.
+          result() {
+            local outcome="$1" count="${2:-0}"
+            if [ "$outcome" = "success" ] && [ "$count" -gt 0 ] 2>/dev/null; then
+              echo "⚠️ $count warning$([ "$count" != "1" ] && echo s)"
+            else
+              icon "$outcome"
+            fi
+          }
+
           PLUGIN_NAME=$(node -e "console.log(require('./package.json').name)" 2>/dev/null || echo "unknown")
           PLUGIN_VER=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "?")
 
@@ -1807,11 +1867,11 @@ jobs:
             echo ""
             echo "| Check | Result |"
             echo "|-------|--------|"
-            echo "| package.json valid | $(icon "$VALIDATE_PKG") |"
+            echo "| package.json valid | $(result "$VALIDATE_PKG" "$VALIDATE_PKG_WARNINGS") |"
             echo "| Entry point exports function | $(icon "$VALIDATE_ENTRY") |"
-            echo "| plugin.schema() valid | $(icon "$VALIDATE_SCHEMA") |"
+            echo "| plugin.schema() valid | $(result "$VALIDATE_SCHEMA" "$VALIDATE_SCHEMA_WARNINGS") |"
             echo "| start/stop/restart lifecycle | $(icon "$LIFECYCLE_CHECK") |"
-            echo "| API usage (no deprecated/internal) | $(icon "$DEPRECATED_API") |"
+            echo "| API usage (no deprecated/internal) | $(result "$DEPRECATED_API" "$DEPRECATED_API_WARNINGS") |"
             echo "| npm pack includes all files | $(icon "$PACK_CHECK") |"
             echo "| App Store compatible (no native addons) | $(icon "$APPSTORE_CHECK") |"
             echo "| Tests / coverage | $(icon "$TESTS") |"
@@ -2360,7 +2420,11 @@ jobs:
             echo "- **React version** — Plugins with webapp keywords must use React >= 19 for Module Federation compatibility"
             echo "- **Stray files** — Build/test does not leave untracked files in the repo"
             echo ""
-            echo "See the individual job summaries above for per-platform details."
+            echo "**⚠️ next to a check below means it passed but found something worth fixing** —"
+            echo "package.json/schema/API-usage checks report a warning count instead of a bare"
+            echo "pass when they have non-blocking findings (missing CHANGELOG, deprecated API"
+            echo "usage, etc.). See the individual job summaries above for per-platform details"
+            echo "and the actual warning text."
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$INTEGRATION_RESULT" == "skipped" ]]; then

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -73,6 +73,10 @@ on:
         description: 'Optional suffix appended to the shared build artifact name — set this if your caller workflow invokes this reusable workflow more than once in a single run, to avoid an artifact name collision'
         type: string
         default: ''
+      fail-on-warning:
+        description: 'Treat non-blocking findings (missing CHANGELOG/screenshots, deprecated API usage, npm audit findings, ES2023/Cerbo GX syntax, stray files, etc.) as failures instead of warnings. Off by default — these checks are advisory by design. Does NOT apply to the lifecycle check''s "mock gap" warnings (registerWithRouter()/start()/stop() hitting a method our test harness does not model) — those indicate a gap in this workflow''s mock, not necessarily a defect in your plugin, so failing on them would be unfair to enable.'
+        type: boolean
+        default: false
 
       # ── armv7 / Cerbo GX options ────────────────────────────
       enable-armv7:
@@ -163,6 +167,8 @@ jobs:
         shell: bash
 
       - name: Run npm audit
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         run: |
           # npm audit exits non-zero whenever it finds anything at all —
@@ -211,16 +217,46 @@ jobs:
                 summary("✅ No known vulnerabilities.");
                 return;
               }
+              // data.vulnerabilities (distinct from data.metadata.vulnerabilities
+              // above) is keyed by package name, each with its own severity —
+              // pull those out so the message says *what* is vulnerable, not
+              // just how many. Worst severity first, capped so one plugin with
+              // a huge advisory list cannot produce an unreadable annotation.
+              const severityRank = { critical: 4, high: 3, moderate: 2, low: 1 };
+              const vulnPkgs = data.vulnerabilities && typeof data.vulnerabilities === "object"
+                ? Object.keys(data.vulnerabilities).map((name) => ({
+                    name,
+                    severity: (data.vulnerabilities[name] && data.vulnerabilities[name].severity) || "unknown"
+                  }))
+                : [];
+              vulnPkgs.sort((a, b) =>
+                (severityRank[b.severity] || 0) - (severityRank[a.severity] || 0) || a.name.localeCompare(b.name)
+              );
+              const MAX_PKGS_SHOWN = 10;
+              let pkgList = vulnPkgs.slice(0, MAX_PKGS_SHOWN).map((p) => p.name + " (" + p.severity + ")").join(", ");
+              if (vulnPkgs.length > MAX_PKGS_SHOWN) {
+                pkgList += ", and " + (vulnPkgs.length - MAX_PKGS_SHOWN) + " more";
+              }
+              const pkgSuffix = pkgList ? ": " + pkgList : "";
               console.log(
                 "::warning::npm audit found " + total + " known vulnerabilit" + (total === 1 ? "y" : "ies") +
-                " in dependencies (critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + "). " +
+                " in dependencies (critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + ")" + pkgSuffix + ". " +
                 "Run npm audit locally for details, and npm audit fix where a safe upgrade exists."
               );
               summary(
                 "⚠️ **" + total + " known vulnerabilit" + (total === 1 ? "y" : "ies") + "** in dependencies " +
-                "(critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + "). " +
+                "(critical: " + critical + ", high: " + high + ", moderate: " + moderate + ", low: " + low + ")" + pkgSuffix + ". " +
                 "Run `npm audit` locally for details, and `npm audit fix` where a safe upgrade exists."
               );
+              if (process.env.FAIL_ON_WARNING === "true") {
+                // This fails the build job itself, not just this step — every
+                // downstream job (desktop/armv7/integration) needs its
+                // artifact, so a vulnerable dependency skips the whole run
+                // past this point when fail-on-warning is on. Same blast
+                // radius a real build-command failure already has today.
+                console.log("::error::fail-on-warning is enabled — the vulnerabilit" + (total === 1 ? "y" : "ies") + " above " + (total === 1 ? "is" : "are") + " treated as a failure.");
+                process.exit(1);
+              }
             });
           '
 
@@ -247,15 +283,15 @@ jobs:
   #  Desktop platforms matrix: Linux x64, Linux arm64, macOS, Windows
   # ════════════════════════════════════════════════════════════
   desktop:
-    # No "/" in this name (unlike armv7's "armv7 (Cerbo GX) / Node 20" below,
-    # which is a single non-matrix job with nothing to disambiguate) — the
-    # Actions sidebar's compact matrix-job list appears to extract only the
-    # last "/"-delimited segment of a custom matrix name, which collapsed
-    # every OS down to a bare "Node 22"/"Node 24"/"Node 26" with no way to
-    # tell them apart. Matches "Build (Node 24)"'s existing parenthetical
-    # style above instead.
+    # No "/" — the Actions sidebar's compact matrix-job list appears to
+    # extract only the last "/"-delimited segment of a custom matrix
+    # name, which collapsed every OS down to a bare "Node 22"/"Node
+    # 24"/"Node 26" with no way to tell them apart. The "Install & Test:"
+    # prefix mirrors "Build (Node 24)" above — this job downloads the
+    # build artifact and validates/tests it, it doesn't build anything.
     name: >-
-      ${{ matrix.os == 'ubuntu-latest' && 'Linux' ||
+      Install & Test: ${{
+          matrix.os == 'ubuntu-latest' && 'Linux' ||
           matrix.os == 'ubuntu-24.04-arm' && 'Linux arm64' ||
           matrix.os == 'macos-15' && 'macOS' ||
           matrix.os == 'windows-latest' && 'Windows' ||
@@ -300,6 +336,8 @@ jobs:
         # Runs on one representative combination; a failure there still
         # fails the overall desktop matrix (and ci-status) the same way.
         if: matrix.os == 'ubuntu-latest' && matrix.node == fromJson(inputs.node-versions)[0]
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         run: |
           cat << 'VALIDATE' > /tmp/validate-pkg.js
@@ -502,6 +540,10 @@ jobs:
             errors.forEach(e => console.log('::error::' + e));
             process.exit(1);
           }
+          if (process.env.FAIL_ON_WARNING === 'true' && warnings.length > 0) {
+            console.log('::error::fail-on-warning is enabled — the ' + warnings.length + ' warning(s) above are treated as failures.');
+            process.exit(1);
+          }
           console.log('Plugin package.json validation passed');
           VALIDATE
           node /tmp/validate-pkg.js
@@ -602,6 +644,8 @@ jobs:
 
       - name: Validate plugin.schema() if defined
         id: validate-schema
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         timeout-minutes: 2
         run: |
@@ -757,6 +801,10 @@ jobs:
 
           if (process.env.GITHUB_OUTPUT) {
             require('fs').appendFileSync(process.env.GITHUB_OUTPUT, 'warning-count=' + schemaWarningCount + '\n');
+          }
+          if (process.env.FAIL_ON_WARNING === 'true' && schemaWarningCount > 0) {
+            console.log('::error::fail-on-warning is enabled — the warning above is treated as a failure.');
+            process.exit(1);
           }
           console.log(label + ' is a valid JSON Schema object');
           process.exit(0);
@@ -1106,6 +1154,8 @@ jobs:
         # static source-file analysis, platform/Node-invariant, so it
         # only needs to run once instead of 12x duplicating every finding.
         if: matrix.os == 'ubuntu-latest' && matrix.node == fromJson(inputs.node-versions)[0]
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         run: |
           cat << 'APISCAN' > /tmp/check-api-usage.js
@@ -1369,6 +1419,10 @@ jobs:
             console.log('See: https://signalk.org/signalk-server/develop/plugins/server_api.html');
             process.exit(1);
           }
+          if (process.env.FAIL_ON_WARNING === 'true' && warnings.length > 0) {
+            console.log('::error::fail-on-warning is enabled — the ' + warnings.length + ' warning(s) above are treated as failures.');
+            process.exit(1);
+          }
           process.exit(0);
           APISCAN
           node /tmp/check-api-usage.js
@@ -1525,6 +1579,8 @@ jobs:
       - name: Check ES2023 compatibility (Cerbo GX / Node 20)
         id: es-check
         if: always() && steps.pack-check.outcome != 'skipped'
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         run: |
           # Cerbo GX (Venus OS) runs Node 20 which supports ES2023 syntax.
@@ -1605,6 +1661,10 @@ jobs:
           if ! npx --yes es-check@8 es2023 $MODULE_FLAG $FILES 2>&1; then
             echo ""
             echo "::warning::Plugin uses ES2024+ syntax not supported by Node 20 (Cerbo GX / Venus OS). Consider targeting ES2023 in your TypeScript/build config or tsconfig.json to maintain Cerbo GX compatibility."
+            if [ "$FAIL_ON_WARNING" = "true" ]; then
+              echo "::error::fail-on-warning is enabled — the ES2023 compatibility warning above is treated as a failure."
+              exit 1
+            fi
           fi
 
       - name: Simulate App Store install (--ignore-scripts)
@@ -1795,6 +1855,8 @@ jobs:
 
       - name: Check for untracked files after build/test
         id: stray-files
+        env:
+          FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
         shell: bash
         run: |
           # Plugins should not leave stray files in the repo after install/build/test.
@@ -1806,6 +1868,10 @@ jobs:
             echo "These files would pollute the signalk-server git directory when"
             echo "the plugin is installed. Add them to .gitignore or fix the build"
             echo "to write output into node_modules or a temp directory."
+            if [ "$FAIL_ON_WARNING" = "true" ]; then
+              echo "::error::fail-on-warning is enabled — the stray files above are treated as a failure."
+              exit 1
+            fi
           fi
 
       - name: Write job summary
@@ -1895,7 +1961,8 @@ jobs:
   #  armv7 — Cerbo GX / Raspberry Pi (32-bit ARM via QEMU)
   # ════════════════════════════════════════════════════════════
   armv7:
-    name: armv7 (Cerbo GX) / Node 20
+    # No "/" — see the identical note on desktop's name below.
+    name: "Install & Test: armv7 (Cerbo GX, Node 20)"
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 30
@@ -2095,7 +2162,8 @@ jobs:
           '
 
   signalk-integration:
-    name: Integration / signalk-server ${{ matrix.signalk-server-version }} / Node ${{ matrix.node-version }}
+    # No "/" — see the identical note on desktop's name below.
+    name: "Integration Test: SK ${{ matrix.signalk-server-version }} (Node ${{ matrix.node-version }})"
     runs-on: ubuntu-latest
     needs: [build, integration-matrix]
     timeout-minutes: 15

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -127,7 +127,32 @@ jobs:
           else
             npm install --ignore-scripts
           fi
-          npm rebuild
+          # Bare `npm rebuild` (no args) also re-runs the *root* package's
+          # own preinstall/install/postinstall scripts, not just dependency
+          # native addons — rebuild doesn't honor --ignore-scripts the way
+          # install does. Naming only the dependencies that actually need
+          # rebuilding avoids touching the root package's scripts at all,
+          # and skips the call entirely when nothing needs compiling.
+          NATIVE_MODULES=$(node -e '
+            const fs = require("fs");
+            const path = require("path");
+            function scan(dir, prefix) {
+              const names = [];
+              if (!fs.existsSync(dir)) return names;
+              for (const entry of fs.readdirSync(dir)) {
+                if (entry === ".package-lock.json" || entry === ".bin") continue;
+                const full = path.join(dir, entry);
+                if (entry.startsWith("@")) { names.push(...scan(full, entry + "/")); continue; }
+                if (fs.existsSync(path.join(full, "binding.gyp"))) names.push(prefix + entry);
+                names.push(...scan(path.join(full, "node_modules"), ""));
+              }
+              return names;
+            }
+            process.stdout.write(scan("node_modules", "").join(" "));
+          ')
+          if [ -n "$NATIVE_MODULES" ]; then
+            npm rebuild $NATIVE_MODULES
+          fi
         shell: bash
 
       - name: Build
@@ -418,7 +443,32 @@ jobs:
             echo "No package-lock.json found — using npm install instead of npm ci"
             npm_install_with_retry "npm install --ignore-scripts"
           fi
-          npm rebuild
+          # Bare `npm rebuild` (no args) also re-runs the *root* package's
+          # own preinstall/install/postinstall scripts, not just dependency
+          # native addons — rebuild doesn't honor --ignore-scripts the way
+          # install does. Naming only the dependencies that actually need
+          # rebuilding avoids touching the root package's scripts at all,
+          # and skips the call entirely when nothing needs compiling.
+          NATIVE_MODULES=$(node -e '
+            const fs = require("fs");
+            const path = require("path");
+            function scan(dir, prefix) {
+              const names = [];
+              if (!fs.existsSync(dir)) return names;
+              for (const entry of fs.readdirSync(dir)) {
+                if (entry === ".package-lock.json" || entry === ".bin") continue;
+                const full = path.join(dir, entry);
+                if (entry.startsWith("@")) { names.push(...scan(full, entry + "/")); continue; }
+                if (fs.existsSync(path.join(full, "binding.gyp"))) names.push(prefix + entry);
+                names.push(...scan(path.join(full, "node_modules"), ""));
+              }
+              return names;
+            }
+            process.stdout.write(scan("node_modules", "").join(" "));
+          ')
+          if [ -n "$NATIVE_MODULES" ]; then
+            npm rebuild $NATIVE_MODULES
+          fi
         shell: bash
 
       - name: Validate plugin entry point
@@ -1749,7 +1799,31 @@ jobs:
               else
                 npm install --ignore-scripts
               fi
-              npm rebuild
+              # Bare npm rebuild (no args) also re-runs the *root* package's
+              # own preinstall/install/postinstall scripts, not just
+              # dependency native addons. Naming only the dependencies that
+              # actually need rebuilding avoids that, and skips the call
+              # entirely when nothing needs compiling.
+              NATIVE_MODULES=$(node -e "
+                const fs = require(\"fs\");
+                const path = require(\"path\");
+                function scan(dir, prefix) {
+                  const names = [];
+                  if (!fs.existsSync(dir)) return names;
+                  for (const entry of fs.readdirSync(dir)) {
+                    if (entry === \".package-lock.json\" || entry === \".bin\") continue;
+                    const full = path.join(dir, entry);
+                    if (entry.startsWith(\"@\")) { names.push(...scan(full, entry + \"/\")); continue; }
+                    if (fs.existsSync(path.join(full, \"binding.gyp\"))) names.push(prefix + entry);
+                    names.push(...scan(path.join(full, \"node_modules\"), \"\"));
+                  }
+                  return names;
+                }
+                process.stdout.write(scan(\"node_modules\", \"\").join(\" \"));
+              ")
+              if [ -n "$NATIVE_MODULES" ]; then
+                npm rebuild $NATIVE_MODULES
+              fi
 
               echo "── Checking for native addons ──"
               node -e "
@@ -1920,7 +1994,32 @@ jobs:
           else
             npm install --ignore-scripts
           fi
-          npm rebuild
+          # Bare `npm rebuild` (no args) also re-runs the *root* package's
+          # own preinstall/install/postinstall scripts, not just dependency
+          # native addons — rebuild doesn't honor --ignore-scripts the way
+          # install does. Naming only the dependencies that actually need
+          # rebuilding avoids touching the root package's scripts at all,
+          # and skips the call entirely when nothing needs compiling.
+          NATIVE_MODULES=$(node -e '
+            const fs = require("fs");
+            const path = require("path");
+            function scan(dir, prefix) {
+              const names = [];
+              if (!fs.existsSync(dir)) return names;
+              for (const entry of fs.readdirSync(dir)) {
+                if (entry === ".package-lock.json" || entry === ".bin") continue;
+                const full = path.join(dir, entry);
+                if (entry.startsWith("@")) { names.push(...scan(full, entry + "/")); continue; }
+                if (fs.existsSync(path.join(full, "binding.gyp"))) names.push(prefix + entry);
+                names.push(...scan(path.join(full, "node_modules"), ""));
+              }
+              return names;
+            }
+            process.stdout.write(scan("node_modules", "").join(" "));
+          ')
+          if [ -n "$NATIVE_MODULES" ]; then
+            npm rebuild $NATIVE_MODULES
+          fi
 
       - name: Install plugin into SignalK
         run: |

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1483,6 +1483,37 @@ jobs:
           CHECKSCRIPT
           node "$RUNNER_TEMP/check-native.js"
 
+      - name: Reinstall without native compilation (App Store fidelity)
+        # The checks above needed `npm rebuild` (from "Install
+        # dependencies") to load the plugin at all. From here on we
+        # deliberately give that up, so lint/format/tests below run
+        # against a tree installed exactly like the real server installs
+        # it (--ignore-scripts, no rebuild — see src/modules.ts:349-351)
+        # — the only place a required or poorly-guarded optional native
+        # addon actually gets exercised at runtime, not just statically
+        # detected above. Matters most since enable-signalk-integration
+        # defaults to false, so most plugins never hit this otherwise.
+        run: |
+          npm_install_with_retry() {
+            local cmd="$1"
+            local attempts=2
+            for i in $(seq 1 $attempts); do
+              if $cmd; then return 0; fi
+              if [ "$i" -lt "$attempts" ]; then
+                echo "::warning::$cmd failed (attempt $i/$attempts), retrying in 5s..."
+                sleep 5
+              fi
+            done
+            return 1
+          }
+          rm -rf node_modules
+          if [ -f package-lock.json ]; then
+            npm_install_with_retry "npm ci --ignore-scripts"
+          else
+            npm_install_with_retry "npm install --ignore-scripts"
+          fi
+        shell: bash
+
       - name: Lint (if available)
         run: npm run lint --if-present
         continue-on-error: true
@@ -1841,10 +1872,13 @@ jobs:
             exit 0
           fi
           cd /tmp/sk-test
+          # --ignore-scripts matches how the real server installs plugins
+          # (src/modules.ts:223) — see the "Install plugin into SignalK"
+          # step below for the full rationale.
           while IFS= read -r pkg; do
             [ -z "$pkg" ] && continue
             echo "::group::npm install $pkg (signalk.requires)"
-            npm install "$pkg"
+            npm install --ignore-scripts "$pkg"
             echo "::endgroup::"
           done <<< "$REQUIRES"
 
@@ -1874,7 +1908,11 @@ jobs:
           PACK_JSON=$(npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP")
           PLUGIN_TGZ=$(printf '%s' "$PACK_JSON" | node -e 'const s=require("fs").readFileSync(0,"utf8");process.stdout.write(JSON.parse(s.slice(s.search(/^\s*\[/m)))[0].filename)')
           cd /tmp/sk-test
-          npm install "$RUNNER_TEMP/$(basename "$PLUGIN_TGZ")"
+          # --ignore-scripts matches how the real SignalK server installs
+          # plugins (src/modules.ts:223) — a required native addon that
+          # would fail to compile there must fail here too, not silently
+          # succeed because this step compiled it for real.
+          npm install --ignore-scripts "$RUNNER_TEMP/$(basename "$PLUGIN_TGZ")"
 
       - name: Configure plugin to auto-start
         run: |
@@ -2071,7 +2109,7 @@ jobs:
             echo "- **API usage** — No deprecated (\`setProviderStatus\`), internal (\`app.server\`), file storage, or security anti-patterns"
             echo "- **Node built-in modules** — \`node:sqlite\` requires \`engines.node >= 22.5.0\` declared in package.json"
             echo "- **npm pack** — All files referenced by \`main\`/\`exports\` are included in the package"
-            echo "- **App Store install** — No native addons that break with \`--ignore-scripts\`"
+            echo "- **App Store install** — No native addons that break with \`--ignore-scripts\`; lint/format/tests then re-run against that same uncompiled install"
             echo "- **Hardcoded paths** — No \`/home/user/...\` literals in source files"
             echo "- **ES2023 compatibility** — Built JS checked for Cerbo GX (Node 20) syntax compatibility"
             echo "- **baconjs** — Plugins must not bundle their own baconjs; the server provides >= 3.x"

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -69,7 +69,7 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **npm pack** — Verifies all files referenced by `main`/`exports` are included in the published package
 
-**App Store compatibility** — Installs the plugin with `--ignore-scripts` (as the App Store does) and checks for native addon dependencies
+**App Store compatibility** — Installs the plugin with `--ignore-scripts` (as the App Store does) and checks for native addon dependencies. Lint, formatting, and the test run below all then run against that same uncompiled install (not the earlier, fully-built one) — this is the only place a required or poorly-guarded optional native addon actually gets exercised at runtime, which matters most since `enable-signalk-integration` defaults to off.
 
 **Stray files** — Warns when build and test steps leave untracked files
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -56,7 +56,7 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **plugin.schema()** — Calls `schema()` and checks it returns a JSON-serializable schema-like object without crashing (not fully validated against the JSON Schema meta-schema)
 
-**Lifecycle** — Runs `start()` → `stop()` → `start()` (restart) with an empty configuration. Validates delta messages emitted during startup and checks that `registerDeltaInputHandler` handlers forward deltas correctly.
+**Lifecycle** — Runs `start()` → `stop()` → `start()` (restart) with an empty configuration, then once more with a configuration built from your `schema`'s own declared `default` values (skipped if your schema declares none). The empty-config pass alone can miss a bug that only fires once a real default value is present — e.g. an assumed-present default array field. Validates delta messages emitted during startup and checks that `registerDeltaInputHandler` handlers forward deltas correctly.
 
 **API usage** — Scans source files for:
 
@@ -72,6 +72,8 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 **App Store compatibility** — Installs the plugin with `--ignore-scripts` (as the App Store does) and checks for native addon dependencies. Lint, formatting, and the test run below all then run against that same uncompiled install (not the earlier, fully-built one) — this is the only place a required or poorly-guarded optional native addon actually gets exercised at runtime, which matters most since `enable-signalk-integration` defaults to off.
 
 **Stray files** — Warns when build and test steps leave untracked files
+
+**npm audit** — Runs once, in the `build` job (not per desktop platform/Node combination, since results don't vary by OS/arch). Warns — does not fail the build — with a severity breakdown when `npm audit` finds known vulnerabilities in your dependency tree.
 
 ## Configuration
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -86,6 +86,8 @@ nothing gets notified. This is a deliberate split — the blocking checks are th
 the plugin or the App Store listing outright; the advisory ones are best-practice nudges that
 don't stop the plugin from working.
 
+These lists summarize check severity for readers — the authoritative source is the workflow itself: [.github/workflows/plugin-ci.yml](https://github.com/SignalK/signalk-server/blob/master/.github/workflows/plugin-ci.yml). If this page and the workflow ever disagree, the workflow wins.
+
 **Blocking (fails the run):**
 
 - Missing `signalk-node-server-plugin` keyword, missing `main`/`exports`, or a missing/invalid `version`
@@ -157,7 +159,7 @@ jobs:
 
 ### Build once, test broadly
 
-The plugin is built exactly once — on `build-node-version`, `ubuntu-latest` — and every platform/Node combination below installs and tests that same build output, instead of rebuilding it. This means CI no longer verifies that `build-command` itself succeeds on Windows, macOS, or on Node versions other than `build-node-version` — only that the built output installs and runs correctly there. That's a deliberate trade: build failures are overwhelmingly Node/tooling-version issues, not OS issues, whereas install and runtime behavior (native addon compilation, path handling, ESM/CJS interop) genuinely varies by platform — that's where the matrix's breadth pays for itself. If your build process itself needs verifying across platforms or Node versions, that's no longer covered here.
+The plugin is built exactly once — on `build-node-version`, `ubuntu-latest` — and every platform/Node combination below installs and tests that same build output. CI therefore verifies that `build-command` succeeds only on `build-node-version`, and that the resulting output installs and runs correctly on every other platform and Node version. This is a deliberate trade: build failures are overwhelmingly Node/tooling-version issues, not OS issues, whereas install and runtime behavior (native addon compilation, path handling, ESM/CJS interop) genuinely varies by platform. If your build process itself needs verifying across platforms or Node versions, cover that in your own workflow.
 
 ### Formatting and coverage
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -40,10 +40,10 @@ See [`examples/plugin-caller-example.yml`](examples/plugin-caller-example.yml) f
 
 | Platform | Architecture     | Node versions | Notes                                            |
 | -------- | ---------------- | ------------- | ------------------------------------------------ |
-| Linux    | x64              | 22, 24        | GitHub-hosted runner                             |
-| Linux    | arm64            | 22, 24        | GitHub-hosted runner — Raspberry Pi 4/5          |
-| macOS    | arm64            | 22, 24        | GitHub-hosted runner                             |
-| Windows  | x64              | 22, 24        | GitHub-hosted runner                             |
+| Linux    | x64              | 22, 24, 26    | GitHub-hosted runner                             |
+| Linux    | arm64            | 22, 24, 26    | GitHub-hosted runner — Raspberry Pi 4/5          |
+| macOS    | arm64            | 22, 24, 26    | GitHub-hosted runner                             |
+| Windows  | x64              | 22, 24, 26    | GitHub-hosted runner                             |
 | Linux    | armv7 (Cerbo GX) | 20            | QEMU emulation — matches Venus OS 3.70 (Node 20) |
 
 ### Validation Checks
@@ -89,16 +89,23 @@ jobs:
       node-versions: '["22"]'
 ```
 
-| Input                        | Default                      | Description                                                                                                              |
-| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `test-command`               | `npm test`                   | Command to run your test suite                                                                                           |
-| `build-command`              | `npm run build --if-present` | Build command                                                                                                            |
-| `format-check-command`       | _(empty)_                    | Blocking format check (e.g. `npm run prettier:check`, `npx biome check .`); skipped when empty                           |
-| `coverage-command`           | _(empty)_                    | Runs tests with coverage (e.g. `npm run coverage`); replaces the standard test run and writes output to the step summary |
-| `node-versions`              | `["22", "24"]`               | Node versions for desktop platforms                                                                                      |
-| `enable-armv7`               | `true`                       | Test on armv7 (Cerbo GX) via QEMU                                                                                        |
-| `enable-signalk-integration` | `false`                      | Start SignalK server for integration tests                                                                               |
-| `signalk-server-versions`    | `["latest"]`                 | JSON array of signalk-server versions; the integration job fans out over each                                            |
+| Input                        | Default                      | Description                                                                                                                                                                                 |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test-command`               | `npm test`                   | Command to run your test suite                                                                                                                                                              |
+| `build-command`              | `npm run build --if-present` | Build command                                                                                                                                                                               |
+| `build-node-version`         | `24`                         | Node version used to run `build-command` — the plugin is built once, on this version, and every job below tests that same build output                                                      |
+| `artifact-name-suffix`       | _(empty)_                    | Suffix appended to the shared build artifact name; set this only if your caller workflow invokes this reusable workflow more than once in a single run, to avoid an artifact name collision |
+| `format-check-command`       | _(empty)_                    | Blocking format check (e.g. `npm run prettier:check`, `npx biome check .`); skipped when empty                                                                                              |
+| `coverage-command`           | _(empty)_                    | Runs tests with coverage (e.g. `npm run coverage`); replaces the standard test run and writes output to the step summary                                                                    |
+| `node-versions`              | `["22", "24", "26"]`         | Node versions for desktop platforms                                                                                                                                                         |
+| `enable-armv7`               | `true`                       | Test on armv7 (Cerbo GX) via QEMU                                                                                                                                                           |
+| `enable-signalk-integration` | `false`                      | Start SignalK server for integration tests                                                                                                                                                  |
+| `signalk-server-versions`    | `["latest"]`                 | JSON array of signalk-server versions; the integration job fans out over each                                                                                                               |
+| `signalk-integration-matrix` | _(empty)_                    | JSON array of explicit `{node-version, signalk-server-version}` pairs for the integration job, overriding the `node-versions` × `signalk-server-versions` cross product                     |
+
+### Build once, test broadly
+
+The plugin is built exactly once — on `build-node-version`, `ubuntu-latest` — and every platform/Node combination below installs and tests that same build output, instead of rebuilding it. This means CI no longer verifies that `build-command` itself succeeds on Windows, macOS, or on Node versions other than `build-node-version` — only that the built output installs and runs correctly there. That's a deliberate trade: build failures are overwhelmingly Node/tooling-version issues, not OS issues, whereas install and runtime behavior (native addon compilation, path handling, ESM/CJS interop) genuinely varies by platform — that's where the matrix's breadth pays for itself. If your build process itself needs verifying across platforms or Node versions, that's no longer covered here.
 
 ### Formatting and coverage
 
@@ -126,7 +133,7 @@ Plugins without a `test` script still get all validation checks — tests are sk
 
 The Cerbo GX runs an Allwinner dual-core Cortex-A7 (ARMv7, 32-bit) with Venus OS. The CI emulates this environment using QEMU with a `node:20-bookworm-slim` Docker image plus `python3`, `make`, and `g++` — matching Venus OS 3.70 which ships Node 20 and has build tools available via opkg.
 
-The armv7 job runs install, build, and tests — it does not repeat the full validation suite (that's covered by the desktop jobs). The armv7 Node version is fixed to match the Cerbo GX and is not user-configurable. Expect armv7 jobs to take 3-5x longer than native x64. armv7 failures are **advisory and non-blocking**.
+The armv7 job downloads the centrally-built artifact and runs install and tests — build already happened once, centrally (see [Build once, test broadly](#build-once-test-broadly)) — and it does not repeat the full validation suite (that's covered by the desktop jobs). The armv7 Node version is fixed to match the Cerbo GX and is not user-configurable. Expect armv7 jobs to take 3-5x longer than native x64. armv7 failures are **advisory and non-blocking**.
 
 ### Limitations
 
@@ -149,7 +156,15 @@ with:
   signalk-server-versions: '["2.23.0", "latest"]'
 ```
 
-The integration job runs the full Cartesian product of `node-versions × signalk-server-versions`. The default `["22", "24"] × ["latest"]` is 2 jobs; `["22", "24"] × ["2.23.0", "latest"]` is 4. To keep the matrix small, shrink either dimension — integration coverage often only needs a single Node version (`node-versions: '["22"]'`) even when the desktop jobs exercise several.
+The integration job runs the full Cartesian product of `node-versions × signalk-server-versions`. The default `["22", "24", "26"] × ["latest"]` is 3 jobs; `["22", "24", "26"] × ["2.23.0", "latest"]` is 6. To keep the matrix small, shrink either dimension — integration coverage often only needs a single Node version (`node-versions: '["22"]'`) even when the desktop jobs exercise several.
+
+Some combinations may not make sense together — e.g. a Node version an older `signalk-server` release doesn't support. Pass `signalk-integration-matrix` as an explicit JSON array of `{node-version, signalk-server-version}` pairs to test exactly the combinations you want instead of the full cross product:
+
+```yaml
+with:
+  enable-signalk-integration: true
+  signalk-integration-matrix: '[{"node-version": "20", "signalk-server-version": "2.14.0"}, {"node-version": "22", "signalk-server-version": "latest"}]'
+```
 
 ### Provider API Verification
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -75,6 +75,55 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **npm audit** — Runs once, in the `build` job (not per desktop platform/Node combination, since results don't vary by OS/arch). Warns — does not fail the build — with a severity breakdown when `npm audit` finds known vulnerabilities in your dependency tree.
 
+### Failures vs. warnings
+
+Not every check above can fail your build. Some findings are treated as **blocking** (they fail
+the job, turn the run red, and — if you have GitHub's own Actions notification setting enabled
+for your account — trigger the notification GitHub already sends by default when a run you
+triggered fails). Everything else is **advisory**: logged as a `::warning::` annotation in the
+run, visible in the job summary and the Annotations panel, but the run still succeeds and
+nothing gets notified. This is a deliberate split — the blocking checks are things that break
+the plugin or the App Store listing outright; the advisory ones are best-practice nudges that
+don't stop the plugin from working.
+
+**Blocking (fails the run):**
+
+- Missing `signalk-node-server-plugin` keyword, missing `main`/`exports`, or a missing/invalid `version`
+- A hardcoded `/home/user/...` path in source
+- Entry point doesn't export a constructor function
+- `plugin.schema()` throws, returns a non-object, or returns values that can't survive `JSON.stringify` (functions, symbols, circular references, `undefined` properties)
+- `stop()`, or the restart `start()` call, throws a genuine error (not a "mock gap" — see below)
+- Access to an internal server property (`app.server`, `app.deltaCache`, `app.pluginsMap`, `historyApiHttpRegistry`)
+- Malformed delta messages emitted while the plugin runs during lifecycle testing
+- A file referenced by `main`/`exports` is missing from the published package
+- A required native addon dependency, or an optional one used unconditionally with no fallback once tested against a real, uncompiled App Store-style install
+- `format-check-command`, if you set one, failing
+
+**Advisory only (warns, does not fail the run, by default):**
+
+- Missing `CHANGELOG.md`/`.github/release.yml`, missing `signalk.screenshots`, or an `appIcon`/`screenshots` path that doesn't resolve to a real file
+- Missing `engines.node`
+- `preinstall`/`postinstall`/`install` scripts declared (informational — the App Store install step is the real enforcement)
+- Bundling `baconjs` < 3.x, or React < 19 on a `webapp`-keyword plugin
+- `plugin.schema()` missing `type`/`properties`/`oneOf`/`anyOf`
+- Deprecated calls (`setProviderStatus`, `setProviderError`) and the other API-usage anti-patterns (direct Express routes, file-storage anti-patterns, security anti-patterns)
+- `node:sqlite`/`node:test` used with an `engines.node` that allows an older Node, if the usage is already wrapped in a try/catch
+- ES2024+ syntax that would crash on Cerbo GX (Node 20)
+- `npm audit` findings
+- Stray untracked files left after build/test
+- Lint failures (`npm run lint --if-present` is always advisory)
+- The lifecycle check's "mock gap" warnings — `registerWithRouter()` throwing, or `start()`/`stop()` hitting a `"X is not a function"`/`"Cannot read propert…"` pattern. These specifically mean this workflow's test harness doesn't model something your plugin depends on, not necessarily a defect in your plugin — see `fail-on-warning` below for why these are the one category that stays advisory no matter what.
+
+Set `fail-on-warning: true` to promote every advisory item above **except** the lifecycle
+mock-gap warnings into a blocking failure. Off by default, since these checks are advisory by
+design — turn it on if you'd rather your CI (and GitHub's own failure notification) catch them
+than rely on someone reading the job summary.
+
+```yaml
+with:
+  fail-on-warning: true
+```
+
 ## Configuration
 
 Override defaults by passing inputs to the shared workflow:
@@ -104,6 +153,7 @@ jobs:
 | `enable-signalk-integration` | `false`                      | Start SignalK server for integration tests                                                                                                                                                  |
 | `signalk-server-versions`    | `["latest"]`                 | JSON array of signalk-server versions; the integration job fans out over each                                                                                                               |
 | `signalk-integration-matrix` | _(empty)_                    | JSON array of explicit `{node-version, signalk-server-version}` pairs for the integration job, overriding the `node-versions` × `signalk-server-versions` cross product                     |
+| `fail-on-warning`            | `false`                      | Treat advisory findings as failures instead of warnings — see [Failures vs. warnings](#failures-vs-warnings). Never applies to the lifecycle check's mock-gap warnings                       |
 
 ### Build once, test broadly
 

--- a/docs/develop/plugins/examples/plugin-caller-example.yml
+++ b/docs/develop/plugins/examples/plugin-caller-example.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: '["22", "24"]'
         type: string
+      build-node-version:
+        description: 'Node version used to Build the plugin'
+        required: false
+        default: '24'
+        type: string
       enable-armv7:
         description: Run armv7 (Cerbo GX) tests via QEMU
         required: false
@@ -75,6 +80,7 @@ jobs:
       test-command: npm test
       build-command: npm run build --if-present
       node-versions: '["22", "24"]'
+      build-node-version: '24'
       enable-armv7: false
       enable-signalk-integration: false
       signalk-server-versions: '["latest"]'
@@ -89,6 +95,7 @@ jobs:
       format-check-command: ${{ inputs.format-check-command }}
       coverage-command: ${{ inputs.coverage-command }}
       node-versions: ${{ inputs.node-versions }}
+      build-node-version: ${{ inputs.build-node-version }}
       enable-armv7: ${{ inputs.enable-armv7 }}
       enable-signalk-integration: ${{ inputs.enable-signalk-integration }}
       signalk-server-versions: ${{ inputs.signalk-server-versions }}

--- a/docs/develop/plugins/examples/plugin-caller-example.yml
+++ b/docs/develop/plugins/examples/plugin-caller-example.yml
@@ -51,7 +51,7 @@ on:
         default: '["22", "24", "26"]'
         type: string
       build-node-version:
-        description: 'Node version used to Build the plugin'
+        description: 'Node version used to build the plugin'
         required: false
         default: '24'
         type: string

--- a/docs/develop/plugins/examples/plugin-caller-example.yml
+++ b/docs/develop/plugins/examples/plugin-caller-example.yml
@@ -5,7 +5,7 @@
 #   .github/workflows/signalk-ci.yml
 #
 # It calls the shared SignalK workflow which tests your plugin
-# across Linux, macOS, and Windows (Node 22 + 24). armv7/Cerbo GX
+# across Linux, macOS, and Windows (Node 22, 24, 26). armv7/Cerbo GX
 # and the Signal K integration test are opt-in — the auto-run job
 # below disables them; use the manual trigger to enable per-run.
 #
@@ -46,9 +46,9 @@ on:
         default: ''
         type: string
       node-versions:
-        description: 'JSON array of Node versions, example: ["22","24"]'
+        description: 'JSON array of Node versions, example: ["22","24","26"]'
         required: false
-        default: '["22", "24"]'
+        default: '["22", "24", "26"]'
         type: string
       build-node-version:
         description: 'Node version used to Build the plugin'
@@ -79,7 +79,7 @@ jobs:
     with:
       test-command: npm test
       build-command: npm run build --if-present
-      node-versions: '["22", "24"]'
+      node-versions: '["22", "24", "26"]'
       build-node-version: '24'
       enable-armv7: false
       enable-signalk-integration: false


### PR DESCRIPTION
## What problem does this solve?

This PR permits plugin-ci to build the plugin once on a version of Node used solely for building (`build-node-version`) - independent of the platforms and versions of Node where the plugin is being deployed and tested (`node-versions`). This ensures that we can use modern build tooling, not constrained by the lowest common denominator resulting from `node-versions`. It also improves efficiency by just building the plugin once - and reusing the build artifacts across all of the tests. This is also closer to the real world situation, where developers (or gh actions) build the plugin once and publish the artifacts to npm - where users then consume that single build.

The real world example of the problem that I encountered that let to this PR: I was setting up plugin-ci to test a plugin against node18 + sk2.0.0 - and found that the version of Vite I was using to build was not supported on node18. But this is an artificial problem created by the current plugin-ci script - as no one really has any intention of trying to build the plugin on node18. Thus the proposed change.

Closes #2807. 

## Summary of Changes:

**Core build-once architecture:**

- Adds a `build-node-version` input to pin the Node version used for `build-command`, independent of `node-versions`.
- Restructures the workflow to build once (in a new `build` job) and share that output as a GitHub Actions artifact with `desktop`, `armv7`, and `signalk-integration`, which now download and install it instead of re-running the build. Each job still runs its own `npm ci` locally, since native addons still need to compile per OS/arch/Node ABI — only the transpile/bundle step is shared.
- `ci-status` now depends on `build` directly and reports a build failure as an overall failure.
- New structured `signalk-integration-matrix` input: an explicit JSON array of `{node-version, signalk-server-version}` pairs, overriding the `node-versions` × `signalk-server-versions` cartesian product for callers where only some combinations are valid (e.g. an older `signalk-server` that doesn't support a newer Node).
- Fixed `prepare` scripts running twice: npm 10.x runs `prepare` during `npm pack` despite `--ignore-scripts` — now stripped before packing and restored after, in both the App Store install simulation and the npm-pack-file-check dry run.

**Review feedback (thanks @dirkwa):**

- `--ignore-scripts` + targeted `npm rebuild` (by package name, not bare) applied consistently across `build`, `desktop`, and `signalk-integration`'s install steps — previously only `armv7` had this, so a plugin's own `prepare` script could silently double-build or a bare `npm rebuild` could re-run the root package's own install-family scripts.
- `npm pack`'s JSON output is now captured to a variable and piped to the file-list parser over stdin instead of passed as a process argument, avoiding Windows' ~32K command-line length cap for plugins that pack many files.
- New `artifact-name-suffix` input for callers that invoke this reusable workflow more than once in a single run, to avoid an artifact-name collision.
- The workflow header comment now states the build/deploy trade-off explicitly: `build-command` is no longer verified to succeed on Windows/macOS or on Node versions other than `build-node-version` — only that the resulting build output installs and runs correctly there.
- Node 26 added to the default `node-versions` matrix.

**New checks:**

- `npm audit` now runs once, in `build` (results don't vary by OS/arch), warning with a severity breakdown and the actual affected package name(s) when it finds known vulnerabilities — never blocking by default.
- The lifecycle check now also activates the plugin with a config built from its own `schema`-declared `default` values, not just an empty `{}` — a bug that only fires once a real default value is populated (e.g. an assumed-present default array field) previously had no way to surface here.

**CI result visibility** (a real gap found by walking through a run end-to-end with a fixture that produces warnings — see the fixture suite below):

- The per-job summary table showed a flat "pass" for package.json/schema/API-usage checks even when they logged `::warning::` annotations — a step's `outcome` only changes on `exit 1`, never on warnings. It now shows `⚠️ N warnings` instead, so a passing run doesn't read as fully clean when it isn't.
- `validate-pkg.js` and the API-usage scan are pure static analysis (the result can't differ by OS or Node version), but ran on all 12 desktop combinations — producing up to 144 near-duplicate annotations for the same ~12 findings. Both now run on one representative combination only; the overall `desktop`/`ci-status` result is unaffected, since one failing instance still fails the whole matrix.
- Fixed `desktop`/`armv7`/`signalk-integration` job naming — the Actions sidebar was collapsing custom matrix job names down to their last `/`-delimited segment, showing indistinguishable "Node 22" entries with no platform info.
- New `fail-on-warning` input (default `false`) promotes every advisory finding (package.json warnings, schema structure, API-usage anti-patterns, npm audit, ES2023/Cerbo GX compatibility, stray files) into a build failure. Deliberately excludes the lifecycle check's "mock gap" warnings — those indicate a gap in this workflow's test harness, not necessarily a defect in the plugin, so failing on them would be unfair to enable.

`docs/develop/plugins/ci.md` updated throughout to match, including a new "Failures vs. warnings" section listing exactly which checks block a run versus which are advisory-only.

## How was this tested?

Tested against the following sample of plugins (re-verified against all fixes above):

- signalk-ais-target-prioritizer - https://github.com/jaffadog/signalk-ais-target-prioritizer/actions/runs/31916396729
- signalk-gpio-beeper-plugin - https://github.com/jaffadog/signalk-gpio-beeper-plugin/actions/runs/31916400113
- signalk-daily-gpx-plugin - https://github.com/jaffadog/signalk-daily-gpx-plugin/actions/runs/31916402859
- hoekens-anchor-alarm - https://github.com/jaffadog/hoekens-anchor-alarm/actions/runs/31916405990
- freeboard-sk - https://github.com/jaffadog/freeboard-sk/actions/runs/31916409100 (build + Node 22/24 pass on all platforms, armv7 passes; Node 26 fails on all platforms for reasons unrelated to this PR — see note below)

**freeboard-sk note**: Node 26 fails because `localStorage` is undefined in Vitest's jsdom environment for two spec files (`whats-new.spec.ts`, `plotterext.embedding-host.spec.ts`) — a gap in freeboard-sk's own test setup, not this workflow. Confirmed unchanged by re-checking the actual test output after this PR's latest round of changes (schema-derived-defaults activation, `fail-on-warning`, etc.) — same two files, same root cause.

### Regression fixture suite

Real plugins only exercise the code paths they happen to hit, so I also built a standalone [regression fixture suite](https://github.com/jaffadog/plugin-ci-fixtures) purpose-built for `plugin-ci.yml` itself. Each fixture is a minimal, deliberately good-or-broken plugin on its own branch, isolating exactly one behavior the workflow should catch (or correctly allow). All 21 currently match their expected result:

- fixture/good-plugin - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863158665
- fixture/bad-package-metadata - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912124812 (expected to fail)
- fixture/bad-entry-point - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912151426 (expected to fail)
- fixture/prepare-double-build - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863114763
- fixture/malicious-install-scripts - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863141409
- fixture/integration-smoke - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863091125
- fixture/vite-build-node-split - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31907007880 (reproduces the node18+vite scenario described above end-to-end: build-node-version 24, node-versions 18/20/22/24/26, signalk-integration-matrix pinning sk2.0.0+node18 and sk-latest+node24)
- fixture/native-optional-broken - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863057421 (expected to fail)
- fixture/requires-cascade - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863407593
- fixture/requires-cascade-dep - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863345064
- fixture/bad-schema - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912180536 (expected to fail)
- fixture/bad-lifecycle - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912203009 (expected to fail)
- fixture/restart-broken - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912224015 (expected to fail)
- fixture/bad-schema-default - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912249466 (expected to fail — proves the schema-derived-defaults activation check works)
- fixture/api-misuse - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912271292 (expected to fail)
- fixture/api-usage-warnings - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912557924 (green with 11 warning annotations)
- fixture/vulnerable-dependency - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31915684562 (green with an npm audit warning naming the real CVE)
- fixture/fail-on-warning - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31915683024 (expected to fail — same content as api-usage-warnings, but with fail-on-warning: true set)
- fixture/missing-pack-files - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31912412190 (expected to fail)
- fixture/stray-files - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31864126960
- fixture/native-required - https://github.com/jaffadog/plugin-ci-fixtures/actions/runs/31863992944 (expected to fail)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates `plugin-ci` to build plugins once on a pinned `build-node-version`. Desktop, armv7, and Signal K integration jobs reuse the shared artifact while testing supported Node.js versions and platforms.

### Key changes

- Adds Node.js 26 to the default test matrix.
- Adds configurable build Node.js versions, artifact-name suffixes, explicit Signal K integration matrices, and warning escalation.
- Prevents duplicate `prepare` execution during artifact installation.
- Rebuilds native dependencies selectively for each test environment.
- Makes `npm pack` handling safe on Windows.
- Centralizes `npm audit` checks.
- Tests schema-derived default configuration lifecycle behavior.
- Reports warning categories and supports `fail-on-warning`, while keeping lifecycle mock-gap warnings advisory.
- Reduces duplicate annotations.
- Updates job names, workflow examples, and plugin CI documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->