### PR TITLE
chore(docker): add Node 26 to Docker image builds

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -31,7 +31,18 @@
     }
   ],
   "node_versions": [
-    { "id": "24", "default_enabled": true, "extra_platforms": {} }
+    {
+      "id": "24",
+      "primary": true,
+      "default_enabled": true,
+      "extra_platforms": {}
+    },
+    {
+      "id": "26",
+      "primary": false,
+      "default_enabled": true,
+      "extra_platforms": {}
+    }
   ],
   "editions": [
     { "id": "full", "tag_suffix": "", "default_enabled": true },

--- a/.github/docs/build-matrix.md
+++ b/.github/docs/build-matrix.md
@@ -17,6 +17,7 @@
   - `default_enabled` — when scheduled / push / tag runs occur (i.e. when no `workflow_dispatch` inputs are provided), the variant is included only if this is `true` on both the OS row and the Node row.
 - `node_versions` — list of Node major versions. Each entry:
   - `id` — Node major (e.g. `24`).
+  - `primary` — exactly one row must be `true`: it owns the bare release tags (`latest`, `vX.Y.Z`, `latest-alpine`, …). `release.yml` prepends the node label (`-<node>.x` for ubuntu, `-<node>` otherwise) to every tag of a non-primary row (e.g. `latest-26.x`, `v2.21.3-26-alpine`) so two Node majors never collide on the same release tags. `build-base-image.yml` and `build-docker.yml` ignore this field — their tags already include the node label.
   - `default_enabled` — see above.
   - `extra_platforms` — optional `{ <arch.id>: <platform string> }` appended to that arch's base platform for this Node major.
   - `exclude_archs` — optional `[<arch.id>, …]` listing archs that should not be built for this Node major.
@@ -33,7 +34,7 @@
 ## Adding things
 
 - **New OS:** append a row to `os_variants`. Each Docker workflow exposes one `workflow_dispatch` toggle per row (keyed by `family` + `id`, see Naming conventions), so the row needs a matching input in every workflow where it should be independently selectable. If the row shares a `family` with an existing row, give it a non-empty `tag_suffix` — otherwise the two rows resolve to the same manifest tags and each build silently overwrites the other's `latest` / `vX.Y.Z` image.
-- **New Node major:** append a row to `node_versions` and add inputs to the same three workflows.
+- **New Node major:** append a row to `node_versions` (with `primary: false` — promote it later by swapping which row is `primary`) and add inputs to the same three workflows.
 - **New arch:** append a row to `architectures`. No workflow input changes needed — arches aren't part of the dispatch input UI.
 - **New edition:** append a row to `editions` with its `tag_suffix`, and add a matching `case` branch keyed on `EDITION` in `./docker/Dockerfile` (dev) and `./docker/Dockerfile_rel` (release). No workflow input changes needed — editions aren't part of the dispatch input UI.
 

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -17,6 +17,18 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
+        type: boolean
+        default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
 
 env:
   GHCR_REGISTRY: ghcr.io

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -26,6 +26,18 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
+        type: boolean
+        default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
 
 env:
   GHCR_REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
+        type: boolean
+        default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
 
 permissions:
   id-token: write # Required for OIDC
@@ -191,14 +203,16 @@ jobs:
           # .github/build-matrix.json, then filter by the per-row dispatch
           # checkbox (or by default_enabled for tag runs); editions are not
           # dispatch inputs and follow their own default_enabled. The release
-          # manifest tag convention puts ubuntu full on the bare semver tags
-          # (v2.21.3, latest, v2, v2.21) and adds '-<family>' for non-ubuntu
-          # variants (v2.21.3-alpine, latest-alpine); each os_variant's own
-          # tag_suffix ('' for the primary row of a family, e.g. '-26.04' for
-          # a secondary ubuntu row) is appended so rows sharing a family don't
-          # collide on the same tags, and finally the edition tag_suffix (''
-          # for full, '-core' for core) is appended (v2.21.3-core,
-          # latest-core, v2.21.3-alpine-core).
+          # manifest tag convention puts ubuntu full on the primary node's
+          # bare semver tags (v2.21.3, latest, v2, v2.21); a non-primary node
+          # major prepends its node label ('-26.x' for ubuntu, '-26'
+          # otherwise, e.g. v2.21.3-26.x); '-<family>' is added for
+          # non-ubuntu variants (v2.21.3-alpine, latest-26-alpine); each
+          # os_variant's own tag_suffix ('' for the primary row of a family,
+          # e.g. '-26.04' for a secondary ubuntu row) is appended so rows
+          # sharing a family don't collide on the same tags, and finally the
+          # edition tag_suffix ('' for full, '-core' for core) is appended
+          # (v2.21.3-core, latest-core, v2.21.3-alpine-core).
           variants=$(jq -c \
             --argjson enabled "${ENABLED_JSON:-null}" '
             (if ($enabled | type) == "object" then $enabled else {} end) as $en
@@ -214,7 +228,7 @@ jobs:
                   node_id:   $n.id,
                   edition:   $e.id,
                   tag_suffix: $e.tag_suffix,
-                  suffix:    ((if $o.family == "ubuntu" then "" else "-\($o.family)" end) + $o.tag_suffix + $e.tag_suffix)
+                  suffix:    ((if ($n.primary // false) then "" else (if $o.family == "ubuntu" then "-\($n.id).x" else "-\($n.id)" end) end) + (if $o.family == "ubuntu" then "" else "-\($o.family)" end) + $o.tag_suffix + $e.tag_suffix)
                 }
               ]
             | map(select(.enabled == "true" and .ed_enabled))


### PR DESCRIPTION
Build all OS variants (Ubuntu 24.04, 26.04, Alpine) with Node 26 alongside Node 24 in the base-image, dev and release Docker workflows.

Node 24 stays the primary version and keeps the bare release tags (latest, vX.Y.Z, -alpine). A new 'primary' field in build-matrix.json marks which Node major owns them; non-primary majors get node-suffixed release tags (latest-26.x, vX.Y.Z-26-alpine), matching the convention used when Node 22 and 24 were built side by side. Dev and base-image tags already include the Node label, so only dispatch inputs were added there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds Node 26 Docker image builds for Ubuntu 24.04, Ubuntu 26.04, and Alpine across base-image, development, and release workflows.

- Extends the build matrix with Node 26 while keeping Node 24 as the primary version.
- Preserves bare release tags for Node 24 and applies Node-specific suffixes to Node 26 release tags.
- Adds Node 26 workflow dispatch inputs, enabled by default.
- Documents primary Node version and tag ownership rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->