### PR TITLE
fix: make vessel identity values (name, mmsi, ...) subscribable by their leaf paths

### DIFF
--- a/docs/develop/plugins/deltas.md
+++ b/docs/develop/plugins/deltas.md
@@ -111,6 +111,34 @@ The final argument is a function that will be called every time an update is rec
 
 In the `stop()` method each subcription in the `unsubscribes` array is _unsubscribed_ and the resources released.
 
+### Subscribing to `name`, `mmsi` and other root values
+
+Not all data in the model lives under a leaf path. Vessel identity fields — `name`, `mmsi`, `communication.callsignVhf` and similar attributes, typically sourced from AIS static reports — sit at the vessel root and are delivered as a _root delta_: a single update whose `path` is the empty string and whose `value` is an object holding the fields:
+
+```javascript
+{
+  path: '',
+  value: { name: 'Boaty McBoatface', mmsi: '230099999' }
+}
+```
+
+There are two ways to subscribe to these values (both via `app.subscriptionmanager.subscribe()` and over WebSocket):
+
+**By leaf path.** Subscribe to the field's path as if it were a regular leaf and the server flattens matching root deltas into ordinary per-path updates:
+
+```javascript
+subscribe: [
+  { path: 'name' }, // delivers { path: 'name', value: 'Boaty McBoatface' }
+  { path: 'communication.*' } // delivers e.g. { path: 'communication.callsignVhf', value: 'OH1234' }
+]
+```
+
+**By empty path.** Subscribe with `path: ''` to receive the root delta as-is — one update with the whole object as its value. A wildcard `'*'` subscription also matches the empty path and likewise receives the unflattened root delta (in addition to all leaf paths).
+
+A root delta is never delivered twice to the same subscription: flattening applies only when the subscribed pattern does not itself match the empty path.
+
+Note that `period` and `minPeriod` are not applied to root values, flattened or not — they arrive at the rate the source emits them (for AIS static data, typically every few minutes).
+
 ### Path Discovery with `announceNewPaths`
 
 When using granular subscriptions (subscribing to specific paths rather than `*`), you may want to discover what paths are available without receiving continuous updates for all of them. The `announceNewPaths` option solves this:

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -27,7 +27,10 @@ import {
   SubscribeCallback,
   RelativePositionOrigin,
   Delta,
-  SourceRef
+  SourceRef,
+  Update,
+  PathValue,
+  Value
 } from '@signalk/server-api'
 import * as Bacon from 'baconjs'
 import { isPointWithinRadius } from 'geolib'
@@ -325,9 +328,25 @@ function handleSubscribeRow(
   const matcher = pathMatcher(subscribeRow.path)
   // iterate over all the buses, checking if we want to subscribe to its values
   forOwn(buses, (bus, key) => {
-    if (matcher(key)) {
+    // Root deltas (path '') carry vessel identity fields (name, mmsi,
+    // communication.callsignVhf, ...) as one object value, mirroring their
+    // attribute form in the full model. A row asking for such a leaf path
+    // can never match the '' bus directly, so flatten root values into
+    // per-leaf deltas for it. Rows whose pattern matches '' itself ('' and
+    // wildcards) keep receiving the original root delta, so nothing is
+    // delivered twice.
+    const flattenRootValues = key === '' && !matcher(key)
+    if (matcher(key) || flattenRootValues) {
       debug('Subscribing to key ' + key)
       let filteredBus: Bacon.EventStream<NormalizedDelta> = bus.filter(filter)
+      if (flattenRootValues) {
+        filteredBus = filteredBus.flatMap(
+          (normalizedDelta: NormalizedDelta) =>
+            Bacon.fromArray(
+              flattenRootDelta(normalizedDelta, matcher)
+            ) as Bacon.EventStream<NormalizedDelta>
+        )
+      }
       if (subscribeRow.minPeriod) {
         if (subscribeRow.policy && subscribeRow.policy !== 'instant') {
           errorCallback(
@@ -413,12 +432,16 @@ function handleSubscribeRow(
       // would carry the global preferred winner — which may BE the
       // excluded source — and the subscriber would see it once on
       // startup.
-      const latest = app.deltaCache.getCachedDeltas(
+      const cached = app.deltaCache.getCachedDeltas(
         filter,
         user,
         key,
         perSubEngine ? 'all' : sourcePolicy
       )
+      const latest =
+        flattenRootValues && cached
+          ? flattenCachedRootDeltas(cached, matcher)
+          : cached
       if (latest) {
         if (perSubEngine) {
           const now = new Date()
@@ -446,6 +469,74 @@ function pathMatcher(path: string = '*') {
     .replace(/\*/g, '.*')
   const matcher = new RegExp('^' + pattern + '$')
   return (aPath: string) => matcher.test(aPath)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function collectLeaves(
+  obj: Record<string, unknown>,
+  prefix: string,
+  accept: (path: string) => boolean,
+  leaves: PathValue[]
+) {
+  for (const key of Object.keys(obj)) {
+    const path = prefix === '' ? key : `${prefix}.${key}`
+    const value = obj[key]
+    if (isPlainObject(value)) {
+      collectLeaves(value, path, accept, leaves)
+    } else if (accept(path)) {
+      leaves.push({ path: path as Path, value: value as Value })
+    }
+  }
+}
+
+function flattenRootDelta(
+  normalizedDelta: NormalizedDelta,
+  accept: (path: string) => boolean
+): NormalizedDelta[] {
+  if (normalizedDelta.isMeta || !isPlainObject(normalizedDelta.value)) {
+    return []
+  }
+  const leaves: PathValue[] = []
+  collectLeaves(normalizedDelta.value, '', accept, leaves)
+  return leaves.map((leaf) => ({
+    context: normalizedDelta.context,
+    source: normalizedDelta.source,
+    $source: normalizedDelta.$source,
+    timestamp: normalizedDelta.timestamp,
+    path: leaf.path,
+    value: leaf.value,
+    state: normalizedDelta.state,
+    isMeta: false
+  }))
+}
+
+function flattenCachedRootDeltas(
+  deltas: Delta[],
+  accept: (path: string) => boolean
+): Delta[] {
+  return deltas.reduce<Delta[]>((acc, delta) => {
+    const updates = delta.updates.reduce<Update[]>((updatesAcc, update) => {
+      if ('values' in update) {
+        const values: PathValue[] = []
+        for (const pathValue of update.values) {
+          if (pathValue.path === '' && isPlainObject(pathValue.value)) {
+            collectLeaves(pathValue.value, '', accept, values)
+          }
+        }
+        if (values.length > 0) {
+          updatesAcc.push({ ...update, values })
+        }
+      }
+      return updatesAcc
+    }, [])
+    if (updates.length > 0) {
+      acc.push({ context: delta.context, updates })
+    }
+    return acc
+  }, [])
 }
 
 function contextMatcher(

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -337,7 +337,7 @@ function handleSubscribeRow(
     // delivered twice.
     const flattenRootValues = key === '' && !matcher(key)
     if (matcher(key) || flattenRootValues) {
-      debug('Subscribing to key ' + key)
+      debug.enabled && debug('Subscribing to key ' + key)
       let filteredBus: Bacon.EventStream<NormalizedDelta> = bus.filter(filter)
       if (flattenRootValues) {
         filteredBus = filteredBus.flatMap(

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -360,7 +360,11 @@ function handleSubscribeRow(
             `invalid minPeriod value '${subscribeRow.minPeriod}', ignoring`
           )
         } else if (key !== '') {
-          // we can not apply minPeriod for empty path subscriptions
+          // Timing policies are not applied on the '' bus (flattened rows
+          // included): the stream carries values for multiple paths, so a
+          // shared debounce would drop values of one path because another
+          // path delivered first. Root identity data also arrives on AIS
+          // static-report cadence, far slower than any practical period.
           debug('debouncing')
           filteredBus = filteredBus.debounceImmediate(minPeriodValue)
         }

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -497,6 +497,10 @@ describe('Subscriptions', (_) => {
       )
   }
 
+  function settle() {
+    return new Promise((resolve) => setTimeout(resolve, 30))
+  }
+
   it('leaf path subscription receives flattened root values', async function () {
     await serverP
     const wsPromiser = new WsPromiser(
@@ -510,13 +514,13 @@ describe('Subscriptions', (_) => {
       context: 'vessels.flat-live',
       subscribe: [{ path: 'name' }]
     })
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     await sendDelta(
       getEmptyPathDelta({ context: 'vessels.flat-live' }),
       deltaUrl
     )
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     const values = collectValues(wsPromiser)
     assert(
@@ -544,7 +548,7 @@ describe('Subscriptions', (_) => {
       context: 'vessels.flat-nested',
       subscribe: [{ path: 'communication.*' }]
     })
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     await sendDelta(
       getEmptyPathDelta({
@@ -567,7 +571,7 @@ describe('Subscriptions', (_) => {
       }),
       deltaUrl
     )
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     const values = collectValues(wsPromiser)
     assert(
@@ -595,13 +599,13 @@ describe('Subscriptions', (_) => {
       context: 'vessels.flat-wild',
       subscribe: [{ path: '*' }]
     })
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     await sendDelta(
       getEmptyPathDelta({ context: 'vessels.flat-wild' }),
       deltaUrl
     )
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     const values = collectValues(wsPromiser)
     // getEmptyPathDelta carries two root values (mmsi and name); the
@@ -624,7 +628,7 @@ describe('Subscriptions', (_) => {
       getEmptyPathDelta({ context: 'vessels.flat-cached' }),
       deltaUrl
     )
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     const wsPromiser = new WsPromiser(
       'ws://localhost:' +
@@ -637,7 +641,7 @@ describe('Subscriptions', (_) => {
       context: 'vessels.flat-cached',
       subscribe: [{ path: 'name' }]
     })
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await settle()
 
     const values = collectValues(wsPromiser)
     assert(

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -497,8 +497,10 @@ describe('Subscriptions', (_) => {
       )
   }
 
+  const SETTLE_DELAY_MS = 30
+
   function settle() {
-    return new Promise((resolve) => setTimeout(resolve, 30))
+    return new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY_MS))
   }
 
   it('leaf path subscription receives flattened root values', async function () {

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -479,6 +479,179 @@ describe('Subscriptions', (_) => {
     )
   })
 
+  // Root deltas (path '') carry vessel identity fields as one object value.
+  // Subscriptions to the corresponding leaf paths (name, mmsi,
+  // communication.callsignVhf, ...) receive them flattened into per-leaf
+  // deltas; '' and wildcard subscriptions keep the original root delta.
+  // Each test uses its own context so cached data from other tests cannot
+  // leak into the bootstrap snapshot.
+
+  function collectValues(wsPromiser) {
+    return wsPromiser
+      .parsedMessages()
+      .slice(1)
+      .flatMap((delta) =>
+        delta.updates.flatMap((update) =>
+          (update.values || []).map((vp) => ({ context: delta.context, ...vp }))
+        )
+      )
+  }
+
+  it('leaf path subscription receives flattened root values', async function () {
+    await serverP
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+    await wsPromiser.nthMessage(1)
+
+    await wsPromiser.send({
+      context: 'vessels.flat-live',
+      subscribe: [{ path: 'name' }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    await sendDelta(
+      getEmptyPathDelta({ context: 'vessels.flat-live' }),
+      deltaUrl
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const values = collectValues(wsPromiser)
+    assert(
+      values.length === 1,
+      `Expected exactly one value, got ${values.length}`
+    )
+    assert(values[0].context === 'vessels.flat-live')
+    assert(
+      values[0].path === 'name',
+      `Expected path 'name', got '${values[0].path}'`
+    )
+    assert(values[0].value === 'SomeBoat')
+  })
+
+  it('wildcard leaf subscription receives nested flattened root values', async function () {
+    await serverP
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+    await wsPromiser.nthMessage(1)
+
+    await wsPromiser.send({
+      context: 'vessels.flat-nested',
+      subscribe: [{ path: 'communication.*' }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    await sendDelta(
+      getEmptyPathDelta({
+        context: 'vessels.flat-nested',
+        updates: [
+          {
+            timestamp: '2014-05-03T09:14:11.000Z',
+            $source: 'ais',
+            values: [
+              {
+                path: '',
+                value: {
+                  name: 'SomeBoat',
+                  communication: { callsignVhf: 'MIPR2' }
+                }
+              }
+            ]
+          }
+        ]
+      }),
+      deltaUrl
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const values = collectValues(wsPromiser)
+    assert(
+      values.length === 1,
+      `Expected exactly one value, got ${values.length}`
+    )
+    assert(values[0].context === 'vessels.flat-nested')
+    assert(
+      values[0].path === 'communication.callsignVhf',
+      `Expected path 'communication.callsignVhf', got '${values[0].path}'`
+    )
+    assert(values[0].value === 'MIPR2')
+  })
+
+  it('wildcard subscription receives the root delta once, not flattened duplicates', async function () {
+    await serverP
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+    await wsPromiser.nthMessage(1)
+
+    await wsPromiser.send({
+      context: 'vessels.flat-wild',
+      subscribe: [{ path: '*' }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    await sendDelta(
+      getEmptyPathDelta({ context: 'vessels.flat-wild' }),
+      deltaUrl
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const values = collectValues(wsPromiser)
+    // getEmptyPathDelta carries two root values (mmsi and name); the
+    // subscriber must see exactly those, unflattened and undupped.
+    assert(
+      values.length === 2,
+      `Expected exactly two values, got ${values.length}`
+    )
+    values.forEach((vp) => {
+      assert(vp.context === 'vessels.flat-wild')
+      assert(vp.path === '', `Unexpected non-root path '${vp.path}'`)
+    })
+  })
+
+  it('leaf path subscription replays flattened cached root values', async function () {
+    await serverP
+
+    // Prime the cache before the client connects.
+    await sendDelta(
+      getEmptyPathDelta({ context: 'vessels.flat-cached' }),
+      deltaUrl
+    )
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const wsPromiser = new WsPromiser(
+      'ws://localhost:' +
+        port +
+        '/signalk/v1/stream?subscribe=none&metaDeltas=none'
+    )
+    await wsPromiser.nthMessage(1)
+
+    await wsPromiser.send({
+      context: 'vessels.flat-cached',
+      subscribe: [{ path: 'name' }]
+    })
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const values = collectValues(wsPromiser)
+    assert(
+      values.length === 1,
+      `Expected exactly one value, got ${values.length}`
+    )
+    assert(values[0].context === 'vessels.flat-cached')
+    assert(
+      values[0].path === 'name',
+      `Expected path 'name', got '${values[0].path}'`
+    )
+    assert(values[0].value === 'SomeBoat')
+  })
+
   it('relativePosition subscription serves correct data', function () {
     let wsPromiser
 


### PR DESCRIPTION
Vessel identity fields (name, mmsi, communication.callsignVhf, registrations.imo, ...) arrive as path-'' deltas carrying an object value, mirroring their attribute form in the full model. A subscription to such a leaf path never matched the empty-path bus, so the only ways to get these values were a '*' subscription (all deltas of all vessels) or the REST full tree — both far too heavy for use cases like tracking the names of AIS targets.

Subscription rows that ask for specific paths now receive root values flattened into per-leaf deltas (e.g. path 'name', value 'RYSTRAUM'), both live and in the bootstrap snapshot from the delta cache. Rows whose pattern matches the empty path itself ('' and wildcards) keep receiving the original root delta unchanged, so existing subscribers see exactly what they saw before and nothing is delivered twice.

Tested with e2e WebSocket subscription tests covering live flattening, nested values with wildcard rows, cached bootstrap replay, and no double delivery for '*' subscribers.

fixes #2829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR enables subscriptions to vessel identity leaf paths, such as `name`, `mmsi`, `communication.callsignVhf`, and `registrations.imo`, to receive values from pathless root updates (`path: ''`) by flattening root-delta objects into per-leaf `NormalizedDelta`s.

- In `src/subscriptionmanager.ts`, it flattens matching leaf paths for live delivery and `latest` bootstrap replay.
- It keeps root-matching subscriptions, including `''` and `'*'`, on the original root delta and prevents duplicate delivery.
- It adds WebSocket tests for live flattening, nested wildcard matching, cached bootstrap replay, and duplicate prevention.
- It documents root-value and leaf-path subscription behavior, including throttling limitations for root values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->