### PR TITLE
v3.4.0 radar API

### DIFF
--- a/docs/develop/plugins/wasm/integration_guide.md
+++ b/docs/develop/plugins/wasm/integration_guide.md
@@ -387,7 +387,8 @@ function processSpokeData(radarId: string, spokeProtobuf: Uint8Array): void {
 Clients connect to the WebSocket stream:
 
 ```javascript
-const wsUrl = `ws://${location.host}/signalk/v2/api/vessels/self/radars/radar-0/spokes`
+const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+const wsUrl = `${wsProto}//${location.host}/signalk/v2/api/vessels/self/radars/radar-0/spokes`
 const ws = new WebSocket(wsUrl)
 ws.binaryType = 'arraybuffer'
 

--- a/docs/develop/plugins/wasm/integration_guide.md
+++ b/docs/develop/plugins/wasm/integration_guide.md
@@ -340,17 +340,10 @@ export function radar_get_radars(): string {
 // Return RadarInfo JSON for a specific radar
 export function radar_get_radar_info(requestJson: string): string {
   const info = {
-    id: 'radar-0',
     name: 'Furuno DRS4D-NXT',
     brand: 'Furuno',
-    status: 'transmit',
-    spokesPerRevolution: 2048,
-    maxSpokeLen: 1024,
-    range: 2000,
-    controls: {
-      gain: { auto: false, value: 50 },
-      sea: { auto: true, value: 30 }
-    }
+    model: 'DRS4D-NXT',
+    radarIpAddress: '192.168.1.50'
   }
   return JSON.stringify(info)
 }
@@ -358,20 +351,25 @@ export function radar_get_radar_info(requestJson: string): string {
 
 ### RadarInfo Interface
 
+`RadarInfo` is a lean discovery object — it identifies the radar and carries no
+live state. Operational status and control values are served from
+`GET /radars/{id}/state` (and `/controls`), static parameters such as
+`spokesPerRevolution`, `maxSpokeLen` and the display `legend` from
+`GET /radars/{id}/capabilities`. Stream URLs are not part of the object; clients
+construct them by convention from the host they fetched the radar list from.
+
 ```typescript
 interface RadarInfo {
-  id: string // Unique radar ID
-  name: string // Display name
-  brand?: string // Manufacturer
-  status: 'off' | 'standby' | 'transmit' | 'warming'
-  spokesPerRevolution: number // Spokes per rotation
-  maxSpokeLen: number // Max spoke samples
-  range: number // Current range (meters)
-  controls: RadarControls // Current control values
-  legend?: LegendEntry[] // Color legend for display
-  streamUrl?: string // Optional external WebSocket URL
+  name: string // User-defined name, or the auto-detected model name
+  brand: string // Manufacturer (Navico, Furuno, Raymarine, Garmin, Emulator)
+  model?: string // Radar model name, if detected
+  radarIpAddress: string // IP address of the radar unit on the network
 }
 ```
+
+The radar's ID is the key it is listed under in the `GET /radars` response
+(`{ version, radars: { [id]: RadarInfo } }`) — the same ID `radar_get_radars()`
+returns.
 
 ### Streaming Radar Spokes
 
@@ -389,7 +387,7 @@ function processSpokeData(radarId: string, spokeProtobuf: Uint8Array): void {
 Clients connect to the WebSocket stream:
 
 ```javascript
-const wsUrl = `ws://${location.host}/signalk/v2/api/vessels/self/radars/radar-0/stream`
+const wsUrl = `ws://${location.host}/signalk/v2/api/vessels/self/radars/radar-0/spokes`
 const ws = new WebSocket(wsUrl)
 ws.binaryType = 'arraybuffer'
 

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -944,7 +944,6 @@ This a Javascript example how to set up the connection to receive spokes:
 
 ```javascript
 async function connectToSpokes() {
-  // Fetch radars
   const response = await fetch('/signalk/v2/api/vessels/self/radars/')
   const data = await response.json()
 

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -947,8 +947,12 @@ This a Javascript example how to set up the connection to receive spokes:
 const response = await fetch('/signalk/v2/api/vessels/self/radars/')
 const data = await response.json()
 
-// Choose a radar_id from the returned radars
+// Choose a radar_id from the returned radars. The map is empty when no radar
+// has been discovered yet, so there is nothing to connect to.
 const radarId = Object.keys(data.radars)[0]
+if (!radarId) {
+  return
+}
 
 // Connect to spoke data stream (wss: when the page itself is served over HTTPS)
 const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:'

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -6,7 +6,15 @@ title: Radar API
 
 The Signal K server Radar API provides a unified interface for viewing and controlling marine radar equipment from any manufacturer. The API is **(web)app-friendly**: clients can build dynamic UIs that automatically adapt to any radar's capabilities without hardcoding support for specific brands or models.
 
-This is version v3.1.0 of the API. The version will use semver for version updates.
+This is version **3.4.0** of the API. The version uses semver for version updates.
+
+The Radar API version is reported in the `version` field of the `GET /radars`
+response (see [Listing All Radars](#listing-all-radars)). Every conforming
+implementation reports the **same** version for the same API — signalk-server and
+the reference provider (mayara-server) are kept in lockstep — so a client sees an
+identical `version`, and identical response shapes, whether it talks to a provider
+directly or through a Signal K server. Bump the version in both implementations
+together whenever the Radar API changes.
 
 Radar functionality is provided by "provider plugins" that handle the interaction with radar hardware and stream spoke data to connected clients.
 
@@ -131,28 +139,35 @@ Retrieve all available radars with their current info:
 HTTP GET "/signalk/v2/api/vessels/self/radars"
 ```
 
+The response is a `{ version, radars }` envelope: the Radar API `version` (see
+above) plus the discovered radars keyed by radar ID.
+
 _Response:_
 
 ```json
 {
-  "nav1034A": {
-    "brand": "Navico",
-    "model": "HALO",
-    "name": "HALO 034A",
-    "radarIpAddress": "192.168.1.50",
-    "spokeDataUrl": "ws://192.168.1.100:8080/signalk/v2/api/vessels/self/radars/nav1034A/spokes",
-    "streamUrl": "ws://192.168.1.100:8080/signalk/v1/stream"
-  },
-  "nav1034B": {
-    "brand": "Navico",
-    "model": "HALO",
-    "name": "HALO 034B",
-    "radarIpAddress": "192.168.1.50",
-    "spokeDataUrl": "ws://192.168.1.100:8080/signalk/v2/api/vessels/self/radars/nav1034B/spokes",
-    "streamUrl": "ws://192.168.1.100:8080/signalk/v1/stream"
+  "version": "3.4.0",
+  "radars": {
+    "nav1034A": {
+      "brand": "Navico",
+      "model": "HALO",
+      "name": "HALO 034A",
+      "radarIpAddress": "192.168.1.50"
+    },
+    "nav1034B": {
+      "brand": "Navico",
+      "model": "HALO",
+      "name": "HALO 034B",
+      "radarIpAddress": "192.168.1.50"
+    }
   }
 }
 ```
+
+A radar entry carries no stream URLs — the spoke and control-stream WebSockets are
+always reached by convention from the host serving the response
+(`…/radars/{id}/spokes` and `/signalk/v1/stream`), so a client constructs the same
+URL whether it talks to a provider directly or through a Signal K server.
 
 ### Network Interfaces
 
@@ -998,8 +1013,10 @@ interface RadarInfo {
   brand: string
   model?: string
   radarIpAddress: string
-  spokeDataUrl: string
-  streamUrl: string
+  // The spoke and control-stream WebSockets are reached by convention from the
+  // host serving this response (…/radars/{id}/spokes and /signalk/v1/stream),
+  // so no URLs are listed. A provider may add implementation-specific fields
+  // (e.g. mayara-server's `replay`); clients ignore unknown fields.
 }
 ```
 

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -692,7 +692,7 @@ There are two types of websocket:
 
 The JSON data websocket provides real-time control value updates for all radars via the standard Signal K stream.
 
-The URI is found in the radar response as `streamUrl` or can be constructed as:
+The URI is constructed by convention from the host serving the radar list:
 
 ```text
 ws://{host}:{port}/signalk/v1/stream
@@ -932,7 +932,7 @@ message RadarMessage {
 }
 ```
 
-The URL is found in the `radars` REST response as `spokeDataUrl` or can be constructed as:
+The URL is constructed by convention from the host serving the radar list:
 
 ```text
 /signalk/v2/api/vessels/self/radars/{radar_id}/spokes
@@ -948,13 +948,10 @@ const response = await fetch('/signalk/v2/api/vessels/self/radars/')
 const data = await response.json()
 
 // Choose a radar_id from the returned radars
-const radarId = Object.keys(data)[0]
-const radar = data[radarId]
+const radarId = Object.keys(data.radars)[0]
 
 // Connect to spoke data stream
-const wsUrl =
-  radar.spokeDataUrl ??
-  `ws://${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
+const wsUrl = `ws://${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
 
 const socket = new WebSocket(wsUrl)
 socket.binaryType = 'arraybuffer'

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -950,8 +950,9 @@ const data = await response.json()
 // Choose a radar_id from the returned radars
 const radarId = Object.keys(data.radars)[0]
 
-// Connect to spoke data stream
-const wsUrl = `ws://${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
+// Connect to spoke data stream (wss: when the page itself is served over HTTPS)
+const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+const wsUrl = `${wsProto}//${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
 
 const socket = new WebSocket(wsUrl)
 socket.binaryType = 'arraybuffer'

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -943,27 +943,29 @@ The URL is constructed by convention from the host serving the radar list:
 This a Javascript example how to set up the connection to receive spokes:
 
 ```javascript
-// Fetch radars
-const response = await fetch('/signalk/v2/api/vessels/self/radars/')
-const data = await response.json()
+async function connectToSpokes() {
+  // Fetch radars
+  const response = await fetch('/signalk/v2/api/vessels/self/radars/')
+  const data = await response.json()
 
-// Choose a radar_id from the returned radars. The map is empty when no radar
-// has been discovered yet, so there is nothing to connect to.
-const radarId = Object.keys(data.radars)[0]
-if (!radarId) {
-  return
-}
+  // Choose a radar_id from the returned radars. The map is empty when no radar
+  // has been discovered yet, so there is nothing to connect to.
+  const radarId = Object.keys(data.radars)[0]
+  if (!radarId) {
+    return
+  }
 
-// Connect to spoke data stream (wss: when the page itself is served over HTTPS)
-const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:'
-const wsUrl = `${wsProto}//${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
+  // Connect to spoke data stream (wss: when the page is served over HTTPS)
+  const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const wsUrl = `${wsProto}//${location.host}/signalk/v2/api/vessels/self/radars/${radarId}/spokes`
 
-const socket = new WebSocket(wsUrl)
-socket.binaryType = 'arraybuffer'
+  const socket = new WebSocket(wsUrl)
+  socket.binaryType = 'arraybuffer'
 
-socket.onmessage = (event) => {
-  const spokeData = new Uint8Array(event.data)
-  // Process binary spoke data...
+  socket.onmessage = (event) => {
+    const spokeData = new Uint8Array(event.data)
+    // Process binary spoke data...
+  }
 }
 ```
 

--- a/packages/server-api/src/radarapi.ts
+++ b/packages/server-api/src/radarapi.ts
@@ -456,9 +456,7 @@ export interface ArpaSettings {
  *   "name": "HALO 034A",
  *   "brand": "Navico",
  *   "model": "HALO",
- *   "radarIpAddress": "192.168.1.50",
- *   "spokeDataUrl": "ws://192.168.1.100:8080/signalk/v2/api/vessels/self/radars/nav1034A/spokes",
- *   "streamUrl": "ws://192.168.1.100:8080/signalk/v1/stream"
+ *   "radarIpAddress": "192.168.1.50"
  * }
  * ```
  */
@@ -471,34 +469,14 @@ export interface RadarInfo {
   model?: string
   /** IP address of the radar unit on the network */
   radarIpAddress: string
-  /**
-   * WebSocket URL for receiving raw binary radar spoke data.
-   *
-   * Optional. When **absent**, the radar's spokes are served by signalk-server
-   * itself and the client uses the built-in endpoint, constructed from the host
-   * it is already talking to:
-   * `ws://{host}/signalk/v2/api/vessels/self/radars/{id}/spokes`.
-   * This is the normal case: the provider pipes spokes into the server and every
-   * client reaches them through the server, so deployments where the radar/
-   * provider is on another host or container work with only the server port open.
-   *
-   * When **present**, it is an absolute URL a client may connect to directly
-   * (e.g. an external provider on the same LAN), bypassing the server.
-   */
-  spokeDataUrl?: string
-  /**
-   * WebSocket URL for the **control/target stream**: this is the standard
-   * Signal K delta/PUT stream, not a radar-specific socket. Radar state is
-   * modelled as Signal K paths (`radars.{id}.controls.*`, target data) — a
-   * client subscribes to receive control-value and ARPA-target deltas and sends
-   * Signal K PUTs to change controls. Distinct from `spokeDataUrl`, which carries
-   * one-way binary spoke image data.
-   *
-   * Optional. When absent, the client uses the server's own Signal K stream:
-   * `ws://{host}/signalk/v1/stream`. When present, it is an external URL
-   * (e.g. a provider's own Signal K stream) for direct connection.
-   */
-  streamUrl?: string
+  // The radar's two WebSocket streams are not listed here: they are always
+  // reached by convention from the host serving this response, so a client uses
+  // the same construction whether it talks to a provider directly or through
+  // this server:
+  //   - binary spoke data: `ws://{host}/signalk/v2/api/vessels/self/radars/{id}/spokes`
+  //   - control/target (deltas + PUTs): the standard Signal K stream at
+  //     `ws://{host}/signalk/v1/stream`, with radar state modelled as
+  //     `radars.{id}.controls.*` paths.
 }
 
 /**
@@ -512,7 +490,7 @@ export interface RadarInfo {
  * {
  *   "version": "3.1.0",
  *   "radars": {
- *     "nav1034A": { "name": "HALO 034A", "brand": "Navico", "radarIpAddress": "192.168.1.50", "spokeDataUrl": "...", "streamUrl": "..." }
+ *     "nav1034A": { "name": "HALO 034A", "brand": "Navico", "radarIpAddress": "192.168.1.50" }
  *   }
  * }
  * ```
@@ -543,9 +521,7 @@ export interface RadarsResponse {
  *       name: 'Furuno DRS4D-NXT',
  *       brand: 'Furuno',
  *       model: 'DRS4D-NXT',
- *       radarIpAddress: '192.168.1.50',
- *       spokeDataUrl: 'ws://192.168.1.100:3001/radars/radar-0/spokes',
- *       streamUrl: 'ws://192.168.1.100:3001/signalk/v1/stream'
+ *       radarIpAddress: '192.168.1.50'
  *     }),
  *     setPower: async (id, state) => { ... },
  *     setRange: async (id, range) => { ... },
@@ -641,7 +617,8 @@ export interface RadarProviderMethods {
 
   /**
    * Handle WebSocket stream connection (optional).
-   * Only needed if provider doesn't expose external streamUrl.
+   * Only needed if the provider serves spoke data itself rather than piping it
+   * into the server's binary stream manager.
    * @param radarId The radar ID
    * @param ws WebSocket connection to send spoke data to
    */

--- a/packages/server-api/src/radarapi.ts
+++ b/packages/server-api/src/radarapi.ts
@@ -441,8 +441,9 @@ export interface ArpaSettings {
 /**
  * Radar discovery information — the entries of the `GET /radars` response.
  *
- * This is a *lean* discovery object: it identifies the radar and points at its
- * two stream URLs, but carries no live state. Dynamic values live on separate
+ * This is a *lean* discovery object: it identifies the radar but carries neither
+ * live state nor stream URLs — the radar's two streams are always reached by
+ * convention from the host serving this response. Dynamic values live on separate
  * endpoints — operational status and control values at `GET /radars/{id}/state`
  * (and `/controls`), and static parameters such as `spokesPerRevolution` /
  * `maxSpokeLength` at `GET /radars/{id}/capabilities`. This matches the Radar API
@@ -488,7 +489,7 @@ export interface RadarInfo {
  * @example
  * ```json
  * {
- *   "version": "3.1.0",
+ *   "version": "3.4.0",
  *   "radars": {
  *     "nav1034A": { "name": "HALO 034A", "brand": "Navico", "radarIpAddress": "192.168.1.50" }
  *   }

--- a/packages/server-api/src/radarapi.ts
+++ b/packages/server-api/src/radarapi.ts
@@ -439,59 +439,89 @@ export interface ArpaSettings {
 // ============================================================================
 
 /**
- * Radar information returned by GET /radars/{id}
+ * Radar discovery information — the entries of the `GET /radars` response.
+ *
+ * This is a *lean* discovery object: it identifies the radar and points at its
+ * two stream URLs, but carries no live state. Dynamic values live on separate
+ * endpoints — operational status and control values at `GET /radars/{id}/state`
+ * (and `/controls`), and static parameters such as `spokesPerRevolution` /
+ * `maxSpokeLength` at `GET /radars/{id}/capabilities`. This matches the Radar API
+ * specification (`radar_api.md`) and the mayara-server reference implementation.
  *
  * @category Radar API
  *
  * @example
  * ```json
  * {
- *   "id": "radar-0",
- *   "name": "Furuno DRS4D-NXT",
- *   "brand": "Furuno",
- *   "status": "transmit",
- *   "spokesPerRevolution": 2048,
- *   "maxSpokeLen": 1024,
- *   "range": 2000,
- *   "controls": {
- *     "gain": { "auto": false, "value": 50 },
- *     "sea": { "auto": true, "value": 30 }
- *   },
- *   "streamUrl": "ws://192.168.1.100:3001/v1/api/stream/radar-0"
+ *   "name": "HALO 034A",
+ *   "brand": "Navico",
+ *   "model": "HALO",
+ *   "radarIpAddress": "192.168.1.50",
+ *   "spokeDataUrl": "ws://192.168.1.100:8080/signalk/v2/api/vessels/self/radars/nav1034A/spokes",
+ *   "streamUrl": "ws://192.168.1.100:8080/signalk/v1/stream"
  * }
  * ```
  */
 export interface RadarInfo {
-  /** Unique identifier for this radar */
-  id: string
-  /** Display name */
+  /** User-defined name, or the auto-detected model name */
   name: string
-  /** Radar brand/manufacturer */
-  brand?: string
-  /** Current operational status */
-  status: RadarStatus
-  /** Number of spokes per full rotation */
-  spokesPerRevolution: number
-  /** Maximum spoke length in samples */
-  maxSpokeLen: number
-  /** Current range in meters */
-  range: number
-  /** Current control settings */
-  controls: RadarControls
-  /** Color legend for radar display */
-  legend?: LegendEntry[]
+  /** Radar manufacturer brand (Navico, Furuno, Raymarine, Garmin, Emulator) */
+  brand: string
+  /** Radar model name, if detected */
+  model?: string
+  /** IP address of the radar unit on the network */
+  radarIpAddress: string
   /**
-   * WebSocket URL for radar spoke streaming.
+   * WebSocket URL for receiving raw binary radar spoke data.
    *
-   * - If **absent**: Clients use the built-in stream endpoint:
-   *   `ws://server/signalk/v2/api/vessels/self/radars/{id}/stream`
-   *   or `ws://server/signalk/v2/api/streams/radars/{id}`
-   *   (WASM plugins emit spokes via `sk_radar_emit_spokes()` FFI binding)
+   * Optional. When **absent**, the radar's spokes are served by signalk-server
+   * itself and the client uses the built-in endpoint, constructed from the host
+   * it is already talking to:
+   * `ws://{host}/signalk/v2/api/vessels/self/radars/{id}/spokes`.
+   * This is the normal case: the provider pipes spokes into the server and every
+   * client reaches them through the server, so deployments where the radar/
+   * provider is on another host or container work with only the server port open.
    *
-   * - If **present**: Clients connect directly to external URL (backward compat)
-   *   @example "ws://192.168.1.100:3001/stream" (external mayara-server)
+   * When **present**, it is an absolute URL a client may connect to directly
+   * (e.g. an external provider on the same LAN), bypassing the server.
+   */
+  spokeDataUrl?: string
+  /**
+   * WebSocket URL for the **control/target stream**: this is the standard
+   * Signal K delta/PUT stream, not a radar-specific socket. Radar state is
+   * modelled as Signal K paths (`radars.{id}.controls.*`, target data) — a
+   * client subscribes to receive control-value and ARPA-target deltas and sends
+   * Signal K PUTs to change controls. Distinct from `spokeDataUrl`, which carries
+   * one-way binary spoke image data.
+   *
+   * Optional. When absent, the client uses the server's own Signal K stream:
+   * `ws://{host}/signalk/v1/stream`. When present, it is an external URL
+   * (e.g. a provider's own Signal K stream) for direct connection.
    */
   streamUrl?: string
+}
+
+/**
+ * The `GET /radars` response: the API version plus the discovered radars keyed
+ * by radar ID.
+ *
+ * @category Radar API
+ *
+ * @example
+ * ```json
+ * {
+ *   "version": "3.1.0",
+ *   "radars": {
+ *     "nav1034A": { "name": "HALO 034A", "brand": "Navico", "radarIpAddress": "192.168.1.50", "spokeDataUrl": "...", "streamUrl": "..." }
+ *   }
+ * }
+ * ```
+ */
+export interface RadarsResponse {
+  /** Radar API version (semver) this response conforms to */
+  version: string
+  /** Discovered radars, keyed by radar ID */
+  radars: Record<string, RadarInfo>
 }
 
 // ============================================================================
@@ -510,14 +540,12 @@ export interface RadarInfo {
  *   methods: {
  *     getRadars: async () => ['radar-0'],
  *     getRadarInfo: async (id) => ({
- *       id: 'radar-0',
  *       name: 'Furuno DRS4D-NXT',
- *       status: 'transmit',
- *       spokesPerRevolution: 2048,
- *       maxSpokeLen: 1024,
- *       range: 2000,
- *       controls: { gain: { auto: false, value: 50 } },
- *       streamUrl: 'ws://192.168.1.100:3001/stream'
+ *       brand: 'Furuno',
+ *       model: 'DRS4D-NXT',
+ *       radarIpAddress: '192.168.1.50',
+ *       spokeDataUrl: 'ws://192.168.1.100:3001/radars/radar-0/spokes',
+ *       streamUrl: 'ws://192.168.1.100:3001/signalk/v1/stream'
  *     }),
  *     setPower: async (id, state) => { ... },
  *     setRange: async (id, range) => { ... },

--- a/packages/server-api/src/typebox/radar-schemas.ts
+++ b/packages/server-api/src/typebox/radar-schemas.ts
@@ -71,33 +71,52 @@ export type RadarControlsSchemaType = Static<typeof RadarControlsSchema>
 
 export const RadarInfoSchema = Type.Object(
   {
-    id: Type.String({ description: 'Unique radar identifier' }),
-    name: Type.String({ description: 'Display name' }),
-    brand: Type.Optional(Type.String({ description: 'Manufacturer/brand' })),
-    status: RadarStatusSchema,
-    spokesPerRevolution: Type.Integer({
-      description: 'Number of spokes per full rotation (e.g. 512, 1024, 2048)',
-      examples: [2048]
+    name: Type.String({
+      description: 'User-defined name, or the auto-detected model name'
     }),
-    maxSpokeLen: Type.Integer({
-      description: 'Maximum spoke length in samples (e.g. 512, 1024)',
-      examples: [1024]
+    brand: Type.String({
+      description:
+        'Radar manufacturer brand (Navico, Furuno, Raymarine, Garmin, Emulator)'
     }),
-    range: Type.Number({
-      description: 'Current range in meters',
-      units: 'm'
+    model: Type.Optional(
+      Type.String({ description: 'Radar model name, if detected' })
+    ),
+    radarIpAddress: Type.String({
+      description: 'IP address of the radar unit on the network'
     }),
-    controls: RadarControlsSchema,
+    spokeDataUrl: Type.Optional(
+      Type.String({
+        description:
+          'WebSocket URL for one-way binary spoke image data. Absent = served by this server at …/radars/{id}/spokes; present = an external URL for direct client connection.'
+      })
+    ),
     streamUrl: Type.Optional(
       Type.String({
         description:
-          'WebSocket URL for spoke stream. If absent, use /radars/{id}/stream'
+          'WebSocket URL for the Signal K delta/PUT stream carrying radars.{id}.controls.* and target data (distinct from spokeDataUrl). Absent = use this server at /signalk/v1/stream; present = an external URL.'
       })
     )
   },
   {
     $id: 'RadarInfoModel',
-    description: 'Information about a radar device'
+    description:
+      'Discovery information for a radar device. Live state (status, controls) is on /state; static parameters on /capabilities.'
   }
 )
 export type RadarInfoSchemaType = Static<typeof RadarInfoSchema>
+
+export const RadarsResponseSchema = Type.Object(
+  {
+    version: Type.String({
+      description: 'Radar API version (semver) this response conforms to'
+    }),
+    radars: Type.Record(Type.String(), RadarInfoSchema, {
+      description: 'Discovered radars, keyed by radar ID'
+    })
+  },
+  {
+    $id: 'RadarsResponse',
+    description: 'Response for GET /radars'
+  }
+)
+export type RadarsResponseSchemaType = Static<typeof RadarsResponseSchema>

--- a/packages/server-api/src/typebox/radar-schemas.ts
+++ b/packages/server-api/src/typebox/radar-schemas.ts
@@ -83,24 +83,15 @@ export const RadarInfoSchema = Type.Object(
     ),
     radarIpAddress: Type.String({
       description: 'IP address of the radar unit on the network'
-    }),
-    spokeDataUrl: Type.Optional(
-      Type.String({
-        description:
-          'WebSocket URL for one-way binary spoke image data. Absent = served by this server at …/radars/{id}/spokes; present = an external URL for direct client connection.'
-      })
-    ),
-    streamUrl: Type.Optional(
-      Type.String({
-        description:
-          'WebSocket URL for the Signal K delta/PUT stream carrying radars.{id}.controls.* and target data (distinct from spokeDataUrl). Absent = use this server at /signalk/v1/stream; present = an external URL.'
-      })
-    )
+    })
+    // No stream URLs: the spoke WS (…/radars/{id}/spokes) and the control/target
+    // stream (/signalk/v1/stream) are always reached by convention from the host
+    // serving this response.
   },
   {
     $id: 'RadarInfoModel',
     description:
-      'Discovery information for a radar device. Live state (status, controls) is on /state; static parameters on /capabilities.'
+      'Discovery information for a radar device. Live state (status, controls) is on /state; static parameters on /capabilities. Stream URLs are reached by convention, not listed here.'
   }
 )
 export type RadarInfoSchemaType = Static<typeof RadarInfoSchema>

--- a/src/api/radar/asyncApi.ts
+++ b/src/api/radar/asyncApi.ts
@@ -29,12 +29,12 @@ For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
       host: 'localhost:3000',
       protocol: 'ws',
       description: 'Signal K server WebSocket endpoint',
-      pathname: '/signalk/v2/api/vessels/self/radars/{radarId}/stream'
+      pathname: '/signalk/v2/api/vessels/self/radars/{radarId}/spokes'
     }
   },
   channels: {
-    'radars.stream': {
-      address: 'radars/{radarId}/stream',
+    'radars.spokes': {
+      address: 'radars/{radarId}/spokes',
       description: 'Radar spoke data stream. Binary spoke data for rendering.',
       parameters: {
         radarId: {
@@ -60,7 +60,7 @@ For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
   operations: {
     receiveSpokeData: {
       action: 'receive',
-      channel: { $ref: '#/channels/radars.stream' },
+      channel: { $ref: '#/channels/radars.spokes' },
       summary: 'Receive radar spoke data'
     }
   },

--- a/src/api/radar/asyncApi.ts
+++ b/src/api/radar/asyncApi.ts
@@ -51,7 +51,8 @@ For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
           // frame verbatim as one WebSocket binary message (mayara-server emits
           // protobuf-encoded spokes). It is not JSON, so the payload is opaque
           // octet data rather than an { angle, data } object.
-          payload: Type.Any({
+          payload: Type.String({
+            format: 'binary',
             description:
               'Raw binary spoke frame — one WebSocket binary message per spoke, in the provider-defined encoding (mayara-server: protobuf). Not JSON.'
           })

--- a/src/api/radar/asyncApi.ts
+++ b/src/api/radar/asyncApi.ts
@@ -47,11 +47,13 @@ For the REST API documentation, see OpenAPI at \`/admin/openapi/\`.
           title: 'Spoke Data',
           summary: 'Raw radar spoke data for display rendering',
           contentType: 'application/octet-stream',
-          payload: Type.Object({
-            angle: Type.Number({ description: 'Spoke angle in degrees' }),
-            data: Type.String({
-              description: 'Base64-encoded spoke sample data'
-            })
+          // The spoke stream is raw binary: signalk-server relays each provider
+          // frame verbatim as one WebSocket binary message (mayara-server emits
+          // protobuf-encoded spokes). It is not JSON, so the payload is opaque
+          // octet data rather than an { angle, data } object.
+          payload: Type.Any({
+            description:
+              'Raw binary spoke frame — one WebSocket binary message per spoke, in the provider-defined encoding (mayara-server: protobuf). Not JSON.'
           })
         }
       }

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -12,8 +12,12 @@ import { radar } from '@signalk/server-api'
 
 const RADAR_API_PATH = `/signalk/v2/api/vessels/self/radars`
 // Version of the Radar API this server implements (radar_api.md). Surfaced in the
-// GET /radars discovery envelope so clients can negotiate shape.
-const RADAR_API_VERSION = '3.1.0'
+// GET /radars discovery envelope so clients can negotiate shape. Kept in lockstep
+// with the reference provider (mayara-server's `api-version`) so a client sees the
+// same `version` whether it talks to a provider directly or through Signal K —
+// bump both together when the Radar API changes. Also used as the OpenAPI
+// info.version in openApi.ts.
+export const RADAR_API_VERSION = '3.4.0'
 const TWO_PI = 2 * Math.PI
 
 interface RadarApplication

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -99,10 +99,19 @@ export class RadarApi {
    */
   async getRadars(): Promise<radar.RadarsResponse> {
     const radars: Record<string, radar.RadarInfo> = {}
+    // First provider to claim an ID wins, so a collision resolves the same way
+    // here as in getRadarInfo()/findProviderForRadar() — otherwise GET /radars
+    // and GET /radars/{id} would silently disagree about the same radar.
+    const claimed = new Set<string>()
     for (const [pluginId, provider] of this.radarProviders) {
       try {
         const radarIds = await provider.methods.getRadars()
         for (const radarId of radarIds) {
+          if (claimed.has(radarId)) {
+            debug(`Duplicate radar id ${radarId} from ${pluginId}: ignored`)
+            continue
+          }
+          claimed.add(radarId)
           const info = await provider.methods.getRadarInfo(radarId)
           if (info) {
             radars[radarId] = info
@@ -824,9 +833,8 @@ export class RadarApi {
     // - Control/target: the standard Signal K delta/PUT stream at
     //   /signalk/v1/stream, with radar state modelled as `radars.{id}.controls.*`
     //   paths and PUT handlers registered by the provider plugin.
-    // A provider may still advertise an external spokeDataUrl/streamUrl in
-    // RadarInfo for direct connection; when absent, the above server endpoints
-    // are used.
+    // Neither URL appears in RadarInfo: a client always constructs both by
+    // convention from the host it fetched the radar list from.
 
     // ============================================
     // ARPA Target Endpoints

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -11,6 +11,9 @@ import { SignalKMessageHub } from '../../app'
 import { radar } from '@signalk/server-api'
 
 const RADAR_API_PATH = `/signalk/v2/api/vessels/self/radars`
+// Version of the Radar API this server implements (radar_api.md). Surfaced in the
+// GET /radars discovery envelope so clients can negotiate shape.
+const RADAR_API_VERSION = '3.1.0'
 const TWO_PI = 2 * Math.PI
 
 interface RadarApplication
@@ -87,24 +90,25 @@ export class RadarApi {
   // ***** Server API methods *****
 
   /**
-   * Get list of all radars from all providers.
+   * Get all radars from all providers as the keyed discovery response
+   * `{ version, radars: { [id]: RadarInfo } }` (per radar_api.md).
    */
-  async getRadars(): Promise<radar.RadarInfo[]> {
-    const radars: radar.RadarInfo[] = []
+  async getRadars(): Promise<radar.RadarsResponse> {
+    const radars: Record<string, radar.RadarInfo> = {}
     for (const [pluginId, provider] of this.radarProviders) {
       try {
         const radarIds = await provider.methods.getRadars()
         for (const radarId of radarIds) {
           const info = await provider.methods.getRadarInfo(radarId)
           if (info) {
-            radars.push(info)
+            radars[radarId] = info
           }
         }
       } catch (err: any) {
         debug(`Error getting radars from ${pluginId}: ${err.message}`)
       }
     }
-    return radars
+    return { version: RADAR_API_VERSION, radars }
   }
 
   /**
@@ -809,9 +813,16 @@ export class RadarApi {
       }
     )
 
-    // Note: WebSocket stream endpoint (/radars/:id/stream) would require
-    // additional WebSocket handling infrastructure. For now, providers
-    // should expose their own streamUrl for direct client connection.
+    // Note: the radar streams are served outside this module.
+    // - Binary spokes: `…/radars/{id}/spokes` — handled by the binary stream
+    //   manager (src/api/streams/index.ts), fed by the provider via
+    //   app.binaryStreamManager.emitData('radars/{id}', buf).
+    // - Control/target: the standard Signal K delta/PUT stream at
+    //   /signalk/v1/stream, with radar state modelled as `radars.{id}.controls.*`
+    //   paths and PUT handlers registered by the provider plugin.
+    // A provider may still advertise an external spokeDataUrl/streamUrl in
+    // RadarInfo for direct connection; when absent, the above server endpoints
+    // are used.
 
     // ============================================
     // ARPA Target Endpoints

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -417,6 +417,26 @@ const radarApiDoc = {
         }
       }
     },
+    '/signalk/v2/api/vessels/self/radars/{radar_id}': {
+      get: {
+        tags: ['Radars'],
+        summary: 'Get a single radar',
+        description:
+          'Returns the discovery information for one radar by ID. Live state (status, controls) is at /state and /controls; static parameters at /capabilities.',
+        parameters: [radarIdParam],
+        responses: {
+          '200': {
+            description: 'Radar discovery information',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/RadarInfo' }
+              }
+            }
+          },
+          '404': { description: 'Radar not found' }
+        }
+      }
+    },
     '/signalk/v2/api/vessels/self/radars/interfaces': {
       get: {
         tags: ['Configuration'],

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -1,4 +1,5 @@
 import { OpenApiDescription } from '../swagger'
+import { RADAR_API_VERSION } from './index'
 
 const radarIdParam = {
   name: 'radar_id',
@@ -13,7 +14,7 @@ const radarApiDoc = {
   openapi: '3.0.0',
   info: {
     title: 'Signal K Radar API',
-    version: '3.1.0',
+    version: RADAR_API_VERSION,
     description:
       'REST API for controlling marine radars. Supports Navico (Simrad, B&G, Lowrance), ' +
       'Furuno, Raymarine, and Garmin radar systems. Provides endpoints for discovering radars, ' +
@@ -385,7 +386,8 @@ const radarApiDoc = {
           'Returns the API version and all radars detected on the network, keyed by radar ID. Spoke/control stream URLs are optional per entry; when absent the client uses this server (spokes at …/radars/{id}/spokes, control via /signalk/v1/stream).',
         responses: {
           '200': {
-            description: 'API version and map of radar IDs to radar information',
+            description:
+              'API version and map of radar IDs to radar information',
             content: {
               'application/json': {
                 schema: {

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -50,19 +50,13 @@ const radarApiDoc = {
             type: 'string',
             description: 'Radar model name if detected'
           },
-          spokeDataUrl: {
-            type: 'string',
-            description:
-              'WebSocket URL for receiving raw radar spoke data (binary)'
-          },
-          streamUrl: {
-            type: 'string',
-            description: 'WebSocket URL for Signal K control stream (JSON)'
-          },
           radarIpAddress: {
             type: 'string',
             description: 'IP address of the radar unit on the network'
           }
+          // Stream URLs are not listed: the spoke WS (…/radars/{id}/spokes) and
+          // the control stream (/signalk/v1/stream) are reached by convention
+          // from the host serving this response.
         },
         required: ['name', 'brand', 'radarIpAddress']
       },

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -383,7 +383,7 @@ const radarApiDoc = {
         tags: ['Radars'],
         summary: 'List all active radars',
         description:
-          'Returns the API version and all radars detected on the network, keyed by radar ID. Spoke/control stream URLs are optional per entry; when absent the client uses this server (spokes at …/radars/{id}/spokes, control via /signalk/v1/stream).',
+          'Returns the API version and all radars detected on the network, keyed by radar ID. Entries carry no stream URLs; the client constructs both by convention from this server (spokes at …/radars/{id}/spokes, control via /signalk/v1/stream).',
         responses: {
           '200': {
             description:

--- a/src/api/radar/openApi.ts
+++ b/src/api/radar/openApi.ts
@@ -64,13 +64,7 @@ const radarApiDoc = {
             description: 'IP address of the radar unit on the network'
           }
         },
-        required: [
-          'name',
-          'brand',
-          'spokeDataUrl',
-          'streamUrl',
-          'radarIpAddress'
-        ]
+        required: ['name', 'brand', 'radarIpAddress']
       },
       Capabilities: {
         type: 'object',
@@ -394,17 +388,28 @@ const radarApiDoc = {
         tags: ['Radars'],
         summary: 'List all active radars',
         description:
-          'Returns all radars detected on the network. Each entry includes WebSocket URLs for spoke data and control streams.',
+          'Returns the API version and all radars detected on the network, keyed by radar ID. Spoke/control stream URLs are optional per entry; when absent the client uses this server (spokes at …/radars/{id}/spokes, control via /signalk/v1/stream).',
         responses: {
           '200': {
-            description: 'Map of radar IDs to radar information',
+            description: 'API version and map of radar IDs to radar information',
             content: {
               'application/json': {
                 schema: {
                   type: 'object',
-                  additionalProperties: {
-                    $ref: '#/components/schemas/RadarInfo'
-                  }
+                  properties: {
+                    version: {
+                      type: 'string',
+                      description:
+                        'Radar API version (semver) this response conforms to'
+                    },
+                    radars: {
+                      type: 'object',
+                      additionalProperties: {
+                        $ref: '#/components/schemas/RadarInfo'
+                      }
+                    }
+                  },
+                  required: ['version', 'radars']
                 }
               }
             }

--- a/src/api/streams/index.ts
+++ b/src/api/streams/index.ts
@@ -106,7 +106,7 @@ export function initializeBinaryStreams(app: StreamApplication): void {
           debug('Matched stream pattern: %s', streamId)
         } else if (radarMatch) {
           // Alias: map the radar spokes endpoint to the radars/{radarId} stream
-          const radarId = radarMatch[1]
+          const radarId = decodeURIComponent(radarMatch[1])
           streamId = `radars/${radarId}`
           debug('Matched radar spokes pattern: %s', streamId)
         } else {

--- a/src/api/streams/index.ts
+++ b/src/api/streams/index.ts
@@ -91,9 +91,12 @@ export function initializeBinaryStreams(app: StreamApplication): void {
           /^\/signalk\/v2\/api\/streams\/(.+)$/
         )
 
-        // Match: /signalk/v2/api/vessels/self/radars/:id/stream (convenience alias)
+        // Match: /signalk/v2/api/vessels/self/radars/:id/spokes (binary spoke
+        // image data; the radar_api.md endpoint name). This is the binary spoke
+        // stream — distinct from the control/target channel, which rides the
+        // standard Signal K delta/PUT stream at /signalk/v1/stream.
         const radarMatch = pathname.match(
-          /^\/signalk\/v2\/api\/vessels\/self\/radars\/([^\/]+)\/stream$/
+          /^\/signalk\/v2\/api\/vessels\/self\/radars\/([^\/]+)\/spokes$/
         )
 
         let streamId: string | null = null
@@ -102,10 +105,10 @@ export function initializeBinaryStreams(app: StreamApplication): void {
           streamId = decodeURIComponent(streamMatch[1])
           debug('Matched stream pattern: %s', streamId)
         } else if (radarMatch) {
-          // Alias: map radar endpoint to radars/{radarId} stream
+          // Alias: map the radar spokes endpoint to the radars/{radarId} stream
           const radarId = radarMatch[1]
           streamId = `radars/${radarId}`
-          debug('Matched radar stream pattern: %s', streamId)
+          debug('Matched radar spokes pattern: %s', streamId)
         } else {
           // Not a binary stream endpoint, let other handlers process
           debug('No match for path, ignoring: %s', pathname)

--- a/test/binary-stream-auth.ts
+++ b/test/binary-stream-auth.ts
@@ -13,7 +13,7 @@ import WebSocket from 'ws'
 // authorizeWS() — otherwise a browser's same-origin HttpOnly
 // JAUTHENTICATION cookie is ignored and every connection is rejected.
 describe('Binary stream WebSocket authentication', function () {
-  const RADAR_STREAM = '/signalk/v2/api/vessels/self/radars/test-radar/spokes'
+  const RADAR_SPOKES = '/signalk/v2/api/vessels/self/radars/test-radar/spokes'
 
   let host: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,31 +54,31 @@ describe('Binary stream WebSocket authentication', function () {
   }
 
   it('rejects an unauthenticated connection with 401', async function () {
-    const status = await upgradeStatus(RADAR_STREAM)
+    const status = await upgradeStatus(RADAR_SPOKES)
     status.should.equal(401)
   })
 
   it('rejects an invalid token with 401', async function () {
-    const status = await upgradeStatus(RADAR_STREAM, {
+    const status = await upgradeStatus(RADAR_SPOKES, {
       Cookie: 'JAUTHENTICATION=not-a-real-token'
     })
     status.should.equal(401)
   })
 
   it('accepts a valid token via the JAUTHENTICATION cookie', async function () {
-    const status = await upgradeStatus(RADAR_STREAM, {
+    const status = await upgradeStatus(RADAR_SPOKES, {
       Cookie: `JAUTHENTICATION=${adminToken}`
     })
     status.should.equal(101)
   })
 
   it('accepts a valid token via the ?token= query parameter', async function () {
-    const status = await upgradeStatus(`${RADAR_STREAM}?token=${adminToken}`)
+    const status = await upgradeStatus(`${RADAR_SPOKES}?token=${adminToken}`)
     status.should.equal(101)
   })
 
   it('accepts a valid token via the Authorization header', async function () {
-    const status = await upgradeStatus(RADAR_STREAM, {
+    const status = await upgradeStatus(RADAR_SPOKES, {
       Authorization: `Bearer ${adminToken}`
     })
     status.should.equal(101)

--- a/test/binary-stream-auth.ts
+++ b/test/binary-stream-auth.ts
@@ -7,13 +7,13 @@ import WebSocket from 'ws'
 ;(chai as any).Should()
 
 // The radar spoke stream is served as a binary-stream WebSocket at the
-// alias path /signalk/v2/api/vessels/self/radars/:id/stream. WebSocket
+// alias path /signalk/v2/api/vessels/self/radars/:id/spokes. WebSocket
 // upgrade requests bypass the Express middleware chain, so the handler
 // must parse the cookie header and query string itself before calling
 // authorizeWS() — otherwise a browser's same-origin HttpOnly
 // JAUTHENTICATION cookie is ignored and every connection is rejected.
 describe('Binary stream WebSocket authentication', function () {
-  const RADAR_STREAM = '/signalk/v2/api/vessels/self/radars/test-radar/stream'
+  const RADAR_STREAM = '/signalk/v2/api/vessels/self/radars/test-radar/spokes'
 
   let host: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Part of the coordinated **v3.4.0 Radar API** convergence (with [mayara-server] and the [signalk-plugin]) so a radar client sees an identical API surface whether it talks to a provider directly or through Signal K.

- **Lean `RadarInfo`** — `{ name, brand, model?, radarIpAddress }`; `GET /radars` returns the `{ version, radars }` envelope (`RadarsResponse`); add a single `GET /radars/{id}`.
- **Drop `spokeDataUrl`/`streamUrl`** — the spoke (`…/radars/{id}/spokes`) and control (`/signalk/v1/stream`) streams are reached by convention from the host.
- **Serve binary spokes at `/spokes`** (was `/stream`); AsyncAPI describes the payload as binary octet data, not JSON.
- **Version aligned to 3.4.0** — single source `RADAR_API_VERSION` (also the OpenAPI `info.version`), matching the reference provider (mayara-server) so the `version` field is identical everywhere.
- `radar_api.md` updated to match (version, envelope, single-GET, dropped URLs).

**Breaking**: `RadarInfo` loses `id`/`status`/`spokesPerRevolution`/`maxSpokeLen`/`range`/`controls`/`spokeDataUrl`/`streamUrl`; `GET /radars` is now the `{ version, radars }` envelope. Radar-provider plugins move live state behind `/state` + `/capabilities`. The `@signalk/server-api` version bump is left to maintainers.

## Tested

- `tsc -b` clean; `test:server-api` (47 passing) and the radar binary-stream auth test (5 passing) green; full CI (`build 22.x`/`24.x`) green.
- Live on a boat: verified against mayara-server through this server — converged list/single/capabilities shapes, `/spokes`, and the `radars.*` control stream, with the mayara GUI rendering identically direct vs. via Signal K.

[mayara-server]: https://github.com/MarineYachtRadar/mayara-server/pull/467
[signalk-plugin]: https://github.com/MarineYachtRadar/mayara-server-signalk-plugin/pull/90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the Signal K Radar API to version 3.4.0.

- Simplifies `RadarInfo` to discovery fields: `name`, required `brand`, optional `model`, and `radarIpAddress` (removing `streamUrl`/`spokeDataUrl` and other live/static radar fields from the discovery payload).
- Changes `GET /radars` to return `{ version, radars }` as a versioned discovery envelope.
- Adds and documents `GET /radars/{id}` for single-radar discovery.
- Serves radar spokes at `/radars/{id}/spokes` as binary `application/octet-stream` and updates AsyncAPI to describe the spoke payload as opaque binary.
- Centralizes the API/OpenAPI version via `RADAR_API_VERSION = '3.4.0'` and uses it in runtime/OpenAPI metadata.
- Updates routing and WebSocket handling so radar spokes use the `/spokes` endpoint, including decoding percent-encoded radar IDs and continuing to handle duplicate radar IDs by keeping the first provider’s entry.
- Aligns TypeBox schemas, OpenAPI, docs (including the integration guide), and client/WebSocket examples with the “discovery-only + stream URLs by host convention” model (so clients derive spoke URLs from the current host).
- Updates documentation/examples to avoid requesting a WebSocket with an undefined radar ID, and fixes the radar spoke documentation example code by preventing top-level-`await`/bare-`return` syntax issues.

This is a breaking contract change: live radar state and capabilities move behind dedicated endpoints, and removed fields no longer appear in `RadarInfo`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->