### PR TITLE
fix(mdns): log advertisement errors at debug level when no active network available

### DIFF
--- a/src/mdns.js
+++ b/src/mdns.js
@@ -108,9 +108,12 @@ module.exports = function mdnsResponder(app) {
         type.port
     )
     const ad = new Advertisement(type.type, type.port, options)
+    // mDNS advertisement is best-effort; without a network interface the
+    // library emits errors such as "Timed out getting default route". Log
+    // them at debug level instead of the console so an isolated (offline)
+    // server does not surface a scary, seemingly-fatal error.
     ad.on('error', (err) => {
-      console.log(type.type)
-      console.error(err)
+      debug(`mDNS advertisement error for ${type.type}: ${err.message || err}`)
     })
     ad.start()
     ads.push(ad)

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -109,7 +109,10 @@ module.exports = function mdnsResponder(app) {
     )
     const ad = new Advertisement(type.type, type.port, options)
     ad.on('error', (err) => {
-      debug(`mDNS advertisement error for ${type.type}: ${err.message || err}`)
+      debug.enabled &&
+        debug(
+          `mDNS advertisement error for ${type.type}: ${err.message || err}`
+        )
     })
     ad.start()
     ads.push(ad)

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -108,10 +108,6 @@ module.exports = function mdnsResponder(app) {
         type.port
     )
     const ad = new Advertisement(type.type, type.port, options)
-    // mDNS advertisement is best-effort; without a network interface the
-    // library emits errors such as "Timed out getting default route". Log
-    // them at debug level instead of the console so an isolated (offline)
-    // server does not surface a scary, seemingly-fatal error.
     ad.on('error', (err) => {
       debug(`mDNS advertisement error for ${type.type}: ${err.message || err}`)
     })

--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -71,10 +71,14 @@ describe('mdnsResponder', () => {
       }
       if (request === './debug') {
         return {
-          createDebug: () => (message: unknown) => {
-            if (typeof message === 'string') {
-              debugMessages.push(message)
+          createDebug: () => {
+            const debug = (message: unknown) => {
+              if (typeof message === 'string') {
+                debugMessages.push(message)
+              }
             }
+            debug.enabled = true
+            return debug
           }
         }
       }

--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -56,7 +56,7 @@ describe('mdnsResponder', () => {
     delete require.cache[mdnsModulePath]
   })
 
-  function loadResponder(): (app: App) => unknown {
+  function loadResponder(debugEnabled = true): (app: App) => unknown {
     debugMessages = []
 
     Module._load = ((request, parent, isMain) => {
@@ -77,7 +77,7 @@ describe('mdnsResponder', () => {
                 debugMessages.push(message)
               }
             }
-            debug.enabled = true
+            debug.enabled = debugEnabled
             return debug
           }
         }
@@ -143,5 +143,23 @@ describe('mdnsResponder', () => {
       console.error = originalConsoleError
       console.log = originalConsoleLog
     }
+  })
+
+  it('does not log advertisement errors when debug is disabled', () => {
+    const mdnsResponder = loadResponder(false)
+    mdnsResponder(makeApp())
+
+    expect(FakeAdvertisement.instances).to.have.length(1)
+
+    FakeAdvertisement.instances[0].emit(
+      'error',
+      new Error('Timed out getting default route')
+    )
+
+    expect(
+      debugMessages.some((message) =>
+        message.includes('Timed out getting default route')
+      )
+    ).to.equal(false)
   })
 })

--- a/test/mdns.ts
+++ b/test/mdns.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+
+type LoadFn = (
+  request: string,
+  parent: NodeModule | null,
+  isMain: boolean
+) => unknown
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Module = require('node:module') as typeof import('node:module') & {
+  _load: LoadFn
+}
+
+const mdnsModulePath = require.resolve('../dist/mdns.js')
+
+class FakeAdvertisement extends EventEmitter {
+  static instances: FakeAdvertisement[] = []
+
+  readonly serviceType: string
+
+  constructor(serviceType: string) {
+    super()
+    this.serviceType = serviceType
+    FakeAdvertisement.instances.push(this)
+  }
+
+  start() {
+    return this
+  }
+
+  stop() {
+    return this
+  }
+}
+
+type App = {
+  config: {
+    settings: Record<string, unknown>
+    name: string
+    version: string
+    getExternalHostname: () => string
+    isExternalSsl: () => boolean
+  }
+  selfId: string
+  interfaces: Record<string, unknown>
+}
+
+describe('mdnsResponder', () => {
+  const originalLoad = Module._load
+  let debugMessages: string[]
+
+  afterEach(() => {
+    Module._load = originalLoad
+    FakeAdvertisement.instances = []
+    delete require.cache[mdnsModulePath]
+  })
+
+  function loadResponder(): (app: App) => unknown {
+    debugMessages = []
+
+    Module._load = ((request, parent, isMain) => {
+      if (request === '@astronautlabs/mdns') {
+        return { Advertisement: FakeAdvertisement }
+      }
+      if (request === './mdnsPatch') {
+        return { patchAstronautLabsMdns: () => {} }
+      }
+      if (request === './ports') {
+        return { getExternalPort: () => 3000 }
+      }
+      if (request === './debug') {
+        return {
+          createDebug: () => (message: unknown) => {
+            if (typeof message === 'string') {
+              debugMessages.push(message)
+            }
+          }
+        }
+      }
+      if (request === 'os') {
+        return { hostname: () => 'testhost' }
+      }
+      return originalLoad(request, parent, isMain)
+    }) as LoadFn
+
+    delete require.cache[mdnsModulePath]
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('../dist/mdns.js') as (app: App) => unknown
+  }
+
+  function makeApp(): App {
+    return {
+      config: {
+        settings: {},
+        name: 'signalk-server',
+        version: '2.0.0',
+        getExternalHostname: () => 'testhost',
+        isExternalSsl: () => false
+      },
+      selfId: 'urn:mrn:signalk:uuid:test',
+      interfaces: {}
+    }
+  }
+
+  it('logs advertisement errors at debug level, not to the console', () => {
+    const logged: unknown[][] = []
+    const originalConsoleError = console.error
+    const originalConsoleLog = console.log
+
+    console.error = (...args: unknown[]) => {
+      logged.push(args)
+    }
+    console.log = (...args: unknown[]) => {
+      logged.push(args)
+    }
+
+    try {
+      const mdnsResponder = loadResponder()
+      mdnsResponder(makeApp())
+
+      expect(FakeAdvertisement.instances).to.have.length(1)
+
+      FakeAdvertisement.instances[0].emit(
+        'error',
+        new Error('Timed out getting default route')
+      )
+
+      expect(logged).to.have.length(0)
+      expect(
+        debugMessages.some(
+          (message) =>
+            message.includes('_http._tcp') &&
+            message.includes('Timed out getting default route')
+        )
+      ).to.equal(true)
+    } finally {
+      console.error = originalConsoleError
+      console.log = originalConsoleLog
+    }
+  })
+})


### PR DESCRIPTION
Fix issue #2860

Without an active network interface the @astronautlabs/mdns library
emits errors such as "Timed out getting default route". The advertisement
error handler logged these via console.log/console.error, surfacing a
scary, seemingly-fatal error on an isolated (offline) server even though
mDNS advertisement is a best-effort, non-critical feature.

Log advertisement errors at debug level instead so an offline server
starts cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates mDNS advertisement error handling to log at debug level instead of using `console.log`/`console.error`, gated by `debug.enabled`.
- Preserves best-effort mDNS behavior for servers without an active network interface by avoiding “seemingly fatal” console output for common timeout errors.
- Adds unit tests that stub the mDNS `Advertisement` to emit an `'error'` event and verify no console output occurs while debug logs include the service type (e.g. `_http._tcp`) and the timeout text when debug is enabled, and that the timeout text does not appear in debug output when debug is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->