### PR TITLE
fix(docker): allow canboatjs install script under npm 12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,13 @@ COPY --chown=node:node *.tgz .
 # the .signalk layer, so the image must carry them.
 ARG EDITION=full
 
+# npm 12 gates dependency install-time lifecycle scripts behind an allowlist
+# (allow-scripts defaults to empty). @canboat/canboatjs builds its native
+# SocketCAN addon (canSocket.node) from an "install" script and ships no
+# prebuilt binaries, so without this the CAN interface silently disappears.
+# The install is asserted below so a future regression fails the build loudly.
+RUN printf 'allow-scripts[]=@canboat/canboatjs\n' > /home/node/signalk/.npmrc
+
 # Install workspace tarballs locally (not globally) to avoid permission issues,
 # then install signalk-server. The grep excludes the top-level signalk-server
 # tarball (installed separately below); the admin UI tarball is intentionally
@@ -52,7 +59,12 @@ RUN case "$EDITION" in \
        && cp -rf node_modules/@signalk/* node_modules/signalk-server/node_modules/@signalk/ \
        && rm -rf node_modules/@signalk/; \
      fi \
-  && rm *.tgz
+  && rm *.tgz \
+  && can_socket=$(find node_modules -path '*/@canboat/canboatjs/build/Release/canSocket.node' -print -quit) \
+  && if [ -z "$can_socket" ]; then \
+       echo "canSocket.node missing — canboatjs install script did not build the native CAN addon (npm allow-scripts gate skipped it, or node-gyp rebuild failed)" >&2; \
+       exit 1; \
+     fi
 
 FROM base
 

--- a/docker/Dockerfile_rel
+++ b/docker/Dockerfile_rel
@@ -28,6 +28,13 @@ ARG TAG
 # server's optionalDependencies so they cannot drift from the full image.
 ARG EDITION=full
 
+# npm 12 gates dependency install-time lifecycle scripts behind an allowlist
+# (allow-scripts defaults to empty). @canboat/canboatjs builds its native
+# SocketCAN addon (canSocket.node) from an "install" script and ships no
+# prebuilt binaries, so without this the CAN interface silently disappears.
+# The install is asserted below so a future regression fails the build loudly.
+RUN printf 'allow-scripts[]=@canboat/canboatjs\n' > /home/node/signalk/.npmrc
+
 # Install locally (not globally) to avoid permission issues, then relocate
 # nested packages to where webapp/plugin discovery expects them. The @signalk
 # packages are required in both editions, so that relocation always runs. The
@@ -51,6 +58,11 @@ RUN case "$EDITION" in \
        mkdir -p node_modules/signalk-server/node_modules/@mxtommy/ \
        && cp -rf node_modules/@mxtommy/kip node_modules/signalk-server/node_modules/@mxtommy/ \
        && rm -rf node_modules/@mxtommy/; \
+     fi \
+  && can_socket=$(find node_modules -path '*/@canboat/canboatjs/build/Release/canSocket.node' -print -quit) \
+  && if [ -z "$can_socket" ]; then \
+       echo "canSocket.node missing — canboatjs install script did not build the native CAN addon (npm allow-scripts gate skipped it, or node-gyp rebuild failed)" >&2; \
+       exit 1; \
      fi
 
 COPY --chown=node:node --chmod=755 docker/startup.sh startup.sh


### PR DESCRIPTION
## Why

npm 12 gates dependency install-time lifecycle scripts behind an `allow-scripts` allowlist that defaults to empty. `@canboat/canboatjs` compiles its native SocketCAN addon (`canSocket.node`) from an `install` script and ships no prebuilt binaries, so once npm 12 becomes the base image default (via `npm install npm@latest -g`), the script is skipped and the CAN interface silently disappears from the images. `@serialport/bindings-cpp` also has an install script but ships prebuilds, so it degrades gracefully and needs no allowlist.

## How

Add a project-scoped `.npmrc` in the install stage allowlisting `@canboat/canboatjs`, and assert `canSocket.node` exists after install so a silent regression fails the build loudly instead of shipping a broken CAN interface.

The config is inert under npm 11, so this is safe to land ahead of the npm 12 rollout and activates automatically with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates both Docker install stages to support npm 12 lifecycle-script allowlisting by writing a project-scoped `.npmrc` that permits `@canboat/canboatjs` install scripts. After `npm install`, the build verifies that `canSocket.node` was produced and fails the image build with a clear error when the native CAN addon is missing, preventing images that would otherwise lack CAN support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->