### PR TITLE
fix(resources): skip corrupt file instead of failing listing

### DIFF
--- a/packages/resources-provider-plugin/src/lib/filestorage.ts
+++ b/packages/resources-provider-plugin/src/lib/filestorage.ts
@@ -158,6 +158,8 @@ export class FileStore implements IResourceStore {
       // return matching resources
       const rt = this.resources[type]
       const files = await readdir(rt.path, { withFileTypes: true })
+      // Enumerate in a stable order so `limit` returns a deterministic subset.
+      files.sort((a, b) => a.name.localeCompare(b.name))
       // check resource count
       const fcount =
         params.limit && files.length > params.limit
@@ -169,26 +171,40 @@ export class FileStore implements IResourceStore {
           this.debug(`${files[f].name} is not a File => ignore.`)
           continue
         }
-        if (++count > fcount) {
+        if (count >= fcount) {
           break
         }
+        let res
         try {
-          const res = JSON.parse(
+          res = JSON.parse(
             await readFile(path.join(rt.path, files[f].name), 'utf8')
           )
-          // apply param filters
-          if (passFilter(res, type, params)) {
-            const uuid = files[f].name
-            const stats = await stat(path.join(rt.path, files[f].name))
-            result[uuid] = {
-              ...res,
-              timestamp: stats.mtime,
-              $source: this.pkg.id
-            }
-          }
         } catch (err) {
-          console.error(err)
-          throw new Error(`Invalid file contents: ${files[f]}`)
+          // A single unparseable file (e.g. truncated by an interrupted
+          // write) must not hide the rest of the collection. Log which file
+          // is bad and skip it rather than failing the whole listing. Only
+          // read/parse failures are caught here so genuine filter/metadata
+          // bugs still surface instead of being silently swallowed.
+          console.warn(
+            `Skipping resource file with invalid contents: ${path.join(
+              rt.path,
+              files[f].name
+            )}`,
+            err
+          )
+          continue
+        }
+        if (passFilter(res, type, params)) {
+          const uuid = files[f].name
+          const stats = await stat(path.join(rt.path, files[f].name))
+          result[uuid] = {
+            ...res,
+            timestamp: stats.mtime,
+            $source: this.pkg.id
+          }
+          // Count only resources actually returned, so neither a skipped
+          // corrupt file nor a filtered-out entry consumes a `limit` slot.
+          count++
         }
       }
       return result

--- a/test/resources.ts
+++ b/test/resources.ts
@@ -1,10 +1,22 @@
 import { Resource, Waypoint } from '@signalk/server-api'
 import chai from 'chai'
+import fs from 'fs'
+import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
+import { serverTestConfigDirectory } from './servertestutilities'
 import { startServer } from './ts-servertestutilities'
 chai.should()
 
 export const skUuid = () => `${uuidv4()}`
+
+const waypointsDir = () =>
+  path.join(
+    serverTestConfigDirectory(),
+    'plugin-config-data',
+    'resources-provider',
+    'resources',
+    'waypoints'
+  )
 
 describe('Resources Api', () => {
   it('can put and get a waypoint', async function () {
@@ -37,6 +49,99 @@ describe('Resources Api', () => {
       timestamp: resData.timestamp,
       $source: 'resources-provider'
     })
+
+    stop()
+  })
+
+  const postWaypoint = async (
+    post: (path: string, body: object) => Promise<Response>,
+    [latitude, longitude]: [number, number]
+  ) => {
+    const r = await post(`/resources/waypoints/`, {
+      feature: {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [longitude, latitude]
+        }
+      }
+    })
+    const { id } = (await r.json()) as { id: string }
+    return id
+  }
+
+  // Write a waypoint file directly with a chosen filename. The store lists
+  // files in sorted order, so the name controls enumeration order.
+  const writeWaypointFile = (
+    name: string,
+    [longitude, latitude]: [number, number]
+  ) => {
+    fs.mkdirSync(waypointsDir(), { recursive: true })
+    fs.writeFileSync(
+      path.join(waypointsDir(), name),
+      JSON.stringify({
+        feature: {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [longitude, latitude] }
+        }
+      })
+    )
+  }
+
+  it('a corrupt resource file does not hide the other waypoints', async function () {
+    const { get, post, stop } = await startServer()
+
+    const validIds = await Promise.all(
+      (
+        [
+          [60.151672, 24.891637],
+          [60.251672, 24.891637]
+        ] as [number, number][]
+      ).map((coords) => postWaypoint(post, coords))
+    )
+
+    // Simulate an interrupted write leaving a truncated (empty) file on disk.
+    fs.writeFileSync(path.join(waypointsDir(), skUuid()), '')
+
+    const listed = (await (await get('/resources/waypoints')).json()) as {
+      [id: string]: object
+    }
+    Object.keys(listed).should.have.members(validIds)
+
+    stop()
+  })
+
+  it('a corrupt file does not consume a limit slot', async function () {
+    const { get, post, stop } = await startServer()
+
+    // The store lists files sorted by name, so '00000000-corrupt' is visited
+    // before the posted (UUID-named) waypoint. If the skipped corrupt file
+    // consumed the single requested slot, the valid waypoint would be missed.
+    fs.mkdirSync(waypointsDir(), { recursive: true })
+    fs.writeFileSync(path.join(waypointsDir(), '00000000-corrupt'), '')
+    const validId = await postWaypoint(post, [60.151672, 24.891637])
+
+    const listed = (await (
+      await get('/resources/waypoints?limit=1')
+    ).json()) as { [id: string]: object }
+    Object.keys(listed).should.deep.equal([validId])
+
+    stop()
+  })
+
+  it('a filtered-out entry does not consume a limit slot', async function () {
+    const { get, stop } = await startServer()
+
+    // The out-of-bounds waypoint sorts first and is visited before the match.
+    // If a valid-but-filtered-out entry consumed the single requested slot,
+    // the in-bounds match would be missed.
+    writeWaypointFile('00000000-out', [25.5, 61.0])
+    writeWaypointFile('11111111-in', [24.85, 60.2])
+
+    const listed = (await (
+      await get('/resources/waypoints?bbox=[24.8,60.16,24.899,60.3]&limit=1')
+    ).json()) as { [id: string]: object }
+    Object.keys(listed).should.deep.equal(['11111111-in'])
 
     stop()
   })


### PR DESCRIPTION
## Motivation

A Freeboard-SK user reported that newly added waypoints and notes never appeared
on the chart. The server log showed `SyntaxError: Unexpected end of JSON input` in
`FileStore.getResources()`. The cause was a single truncated (0-byte) resource file
left behind by an interrupted write.

`getResources()` iterates every file in a resource-type directory and `JSON.parse`s
each one. A single unparseable file made it throw, and `ResourcesApi.listFromAll()`
silently drops a rejected provider — so **one bad file returned an empty list for the
entire resource type**. To the user, every waypoint vanished, not just the bad one.

## Change

Skip an unparseable file (logging a `console.warn` that names the offending file) and
continue listing the rest, instead of aborting the whole collection. A skipped file
does not consume a `limit` slot, and only read/parse failures are caught so genuine
filter/metadata bugs still surface. This also fixes a latent logging bug where the
error stringified an `fs.Dirent` as `[object Object]`.

Includes regression tests: a corrupt file no longer hides the other waypoints, and a
corrupt file does not consume a requested `limit` slot.

Closes #2862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Skips corrupt or unparseable resource files while continuing to list valid resources.
- Logs warnings that include the offending filename and isolates read/JSON parsing failures.
- Ensures skipped files do not consume `limit` slots, while other filter/metadata errors still surface; iteration stops only after collecting enough valid returned entries.
- Adds regression tests confirming that corrupt waypoint files do not hide valid waypoints and do not consume `limit` or filter `bbox`-scoped limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->