### PR TITLE
fix: allow canboatjs install script under npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,9 @@
     "signalk-n2kais-to-nmea0183": "^2.0.3",
     "signalk-to-nmea2000": "^2.24.0"
   },
+  "allowScripts": {
+    "@canboat/canboatjs": true
+  },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^1.53.1",
     "@eslint/js": "^9.24.0",


### PR DESCRIPTION
## Why

npm 12 blocks dependency install-time lifecycle scripts unless the root project's `package.json` allowlists them. `@canboat/canboatjs` builds its native SocketCAN addon (`canSocket.node`) from an `install` script and ships no prebuilt binaries, so a repo-root `npm install` / `npm ci` under npm 12 silently omits it and CAN support disappears.

npm 12 is now `latest`, so this affects fresh installs of this repo's workspace on Node 26 / npm 12 today.

## How

Add `@canboat/canboatjs` to an `allowScripts` field in the root `package.json`. npm reads this allowlist only from the install root, so it covers the server's own workspace installs (development, CI). The field is ignored by npm < 11, so it is safe on current toolchains. Verified end-to-end against the real workspace under npm 12.0.1: `canSocket.node` is built.

This is the repo-side counterpart to the container-image fix (#2863), which carries an equivalent allow-scripts entry in the image install stage. Neither can cover end-user `npm install signalk-server`, since npm 12's allowlist is honored only from the consumer's own root project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates the root `package.json` to allow the `@canboat/canboatjs` install script under npm 12.
- Enables building the native `canSocket.node` addon during root `npm install` and `npm ci`, preserving CAN support for development and CI.
- Remains compatible with npm versions below 11, which ignore `allowScripts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->