### PR TITLE
fix: allow canboatjs install script on server self-update

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -27,6 +27,12 @@ import { pluginConfigPath, pluginDataDir } from './plugin-paths'
 const debug = createDebug('signalk:modules')
 const npmDebug = createDebug('signalk:modules:npm')
 
+// npm 12 blocks dependency install scripts unless allowlisted. The server
+// depends on @canboat/canboatjs, which builds its native SocketCAN addon from
+// an install script; without this the CAN interface disappears after a global
+// self-update. Older npm ignores the flag with a warning.
+const SERVER_ALLOW_SCRIPTS = '--allow-scripts=@canboat/canboatjs'
+
 interface ModuleData {
   module: string
   metadata: object
@@ -347,7 +353,9 @@ export function runNpm(
   debug(`${command}: ${packageString}`)
 
   const npmArgs = isTheServerModule(name, config)
-    ? [command, '-g']
+    ? command === 'install' || command === 'update'
+      ? [command, '-g', SERVER_ALLOW_SCRIPTS]
+      : [command, '-g']
     : ['--save', '--ignore-scripts', command]
 
   if (packageString) {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -27,12 +27,6 @@ import { pluginConfigPath, pluginDataDir } from './plugin-paths'
 const debug = createDebug('signalk:modules')
 const npmDebug = createDebug('signalk:modules:npm')
 
-// npm 12 blocks dependency install scripts unless allowlisted. The server
-// depends on @canboat/canboatjs, which builds its native SocketCAN addon from
-// an install script; without this the CAN interface disappears after a global
-// self-update. Older npm ignores the flag with a warning.
-const SERVER_ALLOW_SCRIPTS = '--allow-scripts=@canboat/canboatjs'
-
 interface ModuleData {
   module: string
   metadata: object
@@ -352,9 +346,13 @@ export function runNpm(
 
   debug(`${command}: ${packageString}`)
 
+  // npm 12 blocks dependency install scripts unless allowlisted. The server
+  // depends on @canboat/canboatjs, which builds its native SocketCAN addon from
+  // an install script; without this the CAN interface disappears after a global
+  // self-update. Older npm ignores the flag with a warning.
   const npmArgs = isTheServerModule(name, config)
     ? command === 'install' || command === 'update'
-      ? [command, '-g', SERVER_ALLOW_SCRIPTS]
+      ? [command, '-g', '--allow-scripts=@canboat/canboatjs']
       : [command, '-g']
     : ['--save', '--ignore-scripts', command]
 

--- a/test/modules-npm.ts
+++ b/test/modules-npm.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai'
+import { ChildProcess } from 'child_process'
+import { runNpm } from '../src/modules'
+import { Config } from '../src/config/config'
+
+// runNpm calls the spawn bound from child_process; mocking requires the mutable
+// CommonJS module object (the ESM namespace exposes read-only getters), so this
+// test reassigns spawn on the required module and restores it afterwards.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const childProcess = require('child_process')
+
+type SpawnMock = (command: string, args: string[]) => ChildProcess
+
+describe('runNpm allow-scripts', () => {
+  const config = { configPath: '/tmp', name: 'signalk-server' } as Config
+
+  const capturedArgs = (name: string, command: string): string[] => {
+    const originalSpawn: SpawnMock = childProcess.spawn
+    let args: string[] = []
+    const spawnMock: SpawnMock = (_cmd, spawnArgs) => {
+      args = spawnArgs
+      return {
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        on: (event: string, cb: (code: number) => void) => {
+          if (event === 'close') cb(0)
+        }
+      } as unknown as ChildProcess
+    }
+    childProcess.spawn = spawnMock
+    try {
+      runNpm(
+        config,
+        name,
+        null,
+        command,
+        () => {},
+        () => {},
+        () => {}
+      )
+    } finally {
+      childProcess.spawn = originalSpawn
+    }
+    // On non-Windows the server path spawns `sudo npm <args>`, so args already
+    // omit the leading npm; the plugin path spawns npm directly.
+    return args
+  }
+
+  it('allows the canboatjs install script when self-updating the server', () => {
+    const args = capturedArgs('signalk-server', 'install')
+    expect(args).to.include('--allow-scripts=@canboat/canboatjs')
+    expect(args).to.include('-g')
+  })
+
+  it('allows the canboatjs install script when updating the server', () => {
+    const args = capturedArgs('signalk-server', 'update')
+    expect(args).to.include('--allow-scripts=@canboat/canboatjs')
+    expect(args).to.include('-g')
+  })
+
+  it('does not pass allow-scripts when removing the server', () => {
+    const args = capturedArgs('signalk-server', 'remove')
+    expect(args).to.not.include('--allow-scripts=@canboat/canboatjs')
+    expect(args).to.include('-g')
+  })
+
+  it('does not pass allow-scripts when installing a plugin', () => {
+    const args = capturedArgs('some-plugin', 'install')
+    expect(args).to.not.include('--allow-scripts=@canboat/canboatjs')
+    expect(args).to.include('--ignore-scripts')
+  })
+})


### PR DESCRIPTION
## Why

npm 12 no longer runs dependency install scripts by default. The server's self-update runs a global `npm install -g signalk-server`, and `@canboat/canboatjs` builds its native SocketCAN addon (`canSocket.node`) from an install script. Under npm 12 that script is skipped, so CAN/NMEA 2000 support disappears after an update. The previously documented `--foreground-scripts` workaround no longer helps — it does not bypass the npm 12 gate.

## How

Pass `--allow-scripts=@canboat/canboatjs` when installing or updating the server module. This is the only allowlist form npm 12 honors for a global install; older npm ignores the flag with a warning, so it is safe across versions. Plugin installs are unchanged — they keep `--ignore-scripts`.

Verified end-to-end against the real published server under npm 12.0.1: `npm install -g --allow-scripts=@canboat/canboatjs signalk-server@latest` builds `canSocket.node`.

Addresses the self-update part of #2865. Container image builds are handled by #2863.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates server self-update module installations to pass `--allow-scripts=`@canboat/canboatjs``. This enables the native SocketCAN addon to build under npm 12 while keeping plugin installation behavior unchanged with `--ignore-scripts`.

## Tests

Adds coverage that verifies `runNpm` includes `--allow-scripts=`@canboat/canboatjs`` for server `install` and `update`, and excludes it for server `remove` and plugin `install`. The tests also verify the expected `-g` and `--ignore-scripts` arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->