### PR TITLE
chore(docker): install linux-headers in alpine base for SocketCAN addon

### DIFF
--- a/docker/Dockerfile_base_alpine
+++ b/docker/Dockerfile_base_alpine
@@ -6,7 +6,7 @@ RUN deluser node 2>/dev/null || true && \
 
 RUN apk add --no-cache \
     sudo git bash \
-    python3 py3-virtualenv py3-pip build-base \
+    python3 py3-virtualenv py3-pip build-base linux-headers \
     procps-ng nano curl libcap-setcap bluez \
  && addgroup -g 991 -S docker \
  && addgroup -g 990 -S i2c \


### PR DESCRIPTION
The @canboat/canboatjs native canSocket addon includes <linux/can.h> and <linux/can/raw.h>. Alpine's build-base does not ship the Linux userspace kernel headers (unlike Ubuntu's build-essential via linux-libc-dev), so node-gyp failed to build canSocket.node and the Dockerfile assertion aborted every Alpine image build. Install the linux-headers apk package to provide the SocketCAN headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Installs Alpine’s `linux-headers` package so the `@canboat/canboatjs` native `canSocket` addon can compile SocketCAN headers and avoid `node-gyp` build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->