### PR TITLE
fix(appstore): prevent app store hang when npm search returns an empty page

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -388,6 +388,11 @@ const modulesByKeyword: Record<
   { time: number; packages: NpmModuleData[] }
 > = {}
 
+// Coalesces concurrent searches for the same keyword so parallel
+// /appstore/available requests share one npm search instead of each
+// paging through the registry on their own.
+const searchInFlight: Map<string, Promise<NpmModuleData[]>> = new Map()
+
 async function findModulesWithKeyword(
   keyword: string
 ): Promise<NpmModuleData[]> {
@@ -398,39 +403,58 @@ async function findModulesWithKeyword(
     return modulesByKeyword[keyword].packages
   }
 
-  const moduleData = await searchByKeyword(keyword)
-  npmDebug(
-    `npm search returned ${moduleData.length} modules with keyword ${keyword}`
-  )
+  const existing = searchInFlight.get(keyword)
+  if (existing) {
+    return existing
+  }
 
-  const result = moduleData.reduce(
-    (acc: Record<string, NpmModuleData>, module: NpmModuleData) => {
-      const name = module.package.name
-      if (
-        !acc[name] ||
-        semver.gt(module.package.version, acc[name].package.version)
-      ) {
-        acc[name] = module
-      }
-      return acc
-    },
-    {}
-  )
+  const search = (async () => {
+    const moduleData = await searchByKeyword(keyword)
+    npmDebug(
+      `npm search returned ${moduleData.length} modules with keyword ${keyword}`
+    )
 
-  const packages = Object.values(result)
-  modulesByKeyword[keyword] = { time: Date.now(), packages }
-  return packages
+    // Map, not a plain object: package names like 'constructor' would
+    // collide with Object.prototype keys
+    const result = moduleData.reduce(
+      (acc: Map<string, NpmModuleData>, module: NpmModuleData) => {
+        const name = module.package.name
+        const current = acc.get(name)
+        if (
+          !current ||
+          semver.gt(module.package.version, current.package.version)
+        ) {
+          acc.set(name, module)
+        }
+        return acc
+      },
+      new Map<string, NpmModuleData>()
+    )
+
+    const packages = [...result.values()]
+    modulesByKeyword[keyword] = { time: Date.now(), packages }
+    return packages
+  })()
+  searchInFlight.set(keyword, search)
+  try {
+    return await search
+  } finally {
+    searchInFlight.delete(keyword)
+  }
 }
 
 const NPM_SEARCH_TIMEOUT_MS = 60_000
 const NPM_DIST_TAGS_TIMEOUT_MS = 20_000
+const NPM_SEARCH_MAX_PAGES = 20
 
 async function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
   let fetchedCount = 0
   let toFetchCount = 1
+  let pageCount = 0
   let moduleData: NpmModuleData[] = []
 
-  while (fetchedCount < toFetchCount) {
+  while (fetchedCount < toFetchCount && pageCount < NPM_SEARCH_MAX_PAGES) {
+    pageCount++
     npmDebug(`searching ${keyword} from ${fetchedCount + 1} of ${toFetchCount}`)
     const res = await fetch(
       `https://registry.npmjs.org/-/v1/search?size=250&from=${
@@ -444,7 +468,23 @@ async function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
     }
     const parsed = (await res.json()) as NpmSearchResponse
 
-    moduleData = moduleData.concat(parsed.objects)
+    if (!Array.isArray(parsed?.objects) || parsed.objects.length === 0) {
+      // npm's total is an estimate that can exceed what the search
+      // actually delivers; treat an empty (or malformed) page as the
+      // end instead of retrying the same offset forever
+      npmDebug(
+        `npm search for ${keyword} ended early at ${fetchedCount} of ${toFetchCount}`
+      )
+      break
+    }
+
+    moduleData = moduleData.concat(
+      parsed.objects.filter(
+        (entry) =>
+          typeof entry?.package?.name === 'string' &&
+          typeof entry.package.version === 'string'
+      )
+    )
     fetchedCount += parsed.objects.length
     toFetchCount = parsed.total
   }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -410,9 +410,10 @@ async function findModulesWithKeyword(
 
   const search = (async () => {
     const moduleData = await searchByKeyword(keyword)
-    npmDebug(
-      `npm search returned ${moduleData.length} modules with keyword ${keyword}`
-    )
+    npmDebug.enabled &&
+      npmDebug(
+        `npm search returned ${moduleData.length} modules with keyword ${keyword}`
+      )
 
     // Map, not a plain object: package names like 'constructor' would
     // collide with Object.prototype keys
@@ -472,9 +473,10 @@ async function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
       // npm's total is an estimate that can exceed what the search
       // actually delivers; treat an empty (or malformed) page as the
       // end instead of retrying the same offset forever
-      npmDebug(
-        `npm search for ${keyword} ended early at ${fetchedCount} of ${toFetchCount}`
-      )
+      npmDebug.enabled &&
+        npmDebug(
+          `npm search for ${keyword} ended early at ${fetchedCount} of ${toFetchCount}`
+        )
       break
     }
 
@@ -482,7 +484,7 @@ async function searchByKeyword(keyword: string): Promise<NpmModuleData[]> {
       parsed.objects.filter(
         (entry) =>
           typeof entry?.package?.name === 'string' &&
-          typeof entry.package.version === 'string'
+          semver.valid(entry.package.version) !== null
       )
     )
     fetchedCount += parsed.objects.length

--- a/test/modules-search.ts
+++ b/test/modules-search.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { findModulesWithKeyword } = require('../dist/modules')
+
+interface SearchObject {
+  package: { name: string; version: string }
+}
+
+const NPM_PAGE_SIZE = 250
+const NPM_SEARCH_MAX_PAGES = 20
+
+describe('findModulesWithKeyword', () => {
+  // each test uses its own keyword because results are cached per
+  // keyword for 60s at module level
+  const originalFetch = global.fetch
+  let fetchCalls: number[] = []
+
+  function searchPage(objects: SearchObject[], total: number) {
+    return { ok: true, json: () => Promise.resolve({ objects, total }) }
+  }
+
+  function searchObjects(
+    prefix: string,
+    count: number,
+    start = 0
+  ): SearchObject[] {
+    return Array.from({ length: count }, (_, i) => ({
+      package: { name: `${prefix}-${start + i}`, version: '1.0.0' }
+    }))
+  }
+
+  // the stub serves pages by the requested from= offset so an
+  // implementation stuck re-requesting the same offset cannot pass
+  function stubFetch(pageForOffset: (from: number) => unknown) {
+    fetchCalls = []
+    global.fetch = ((url: string) => {
+      const from = Number(new URL(url).searchParams.get('from'))
+      fetchCalls.push(from)
+      return Promise.resolve(pageForOffset(from))
+    }) as unknown as typeof fetch
+  }
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('pages through multi-page search results', async () => {
+    const lastPageSize = 50
+    const total = 2 * NPM_PAGE_SIZE + lastPageSize
+    stubFetch((from) => {
+      if (from < 2 * NPM_PAGE_SIZE) {
+        return searchPage(searchObjects('multi', NPM_PAGE_SIZE, from), total)
+      }
+      if (from === 2 * NPM_PAGE_SIZE) {
+        return searchPage(searchObjects('multi', lastPageSize, from), total)
+      }
+      return searchPage([], total)
+    })
+    const packages = await findModulesWithKeyword('test-multi-page')
+    expect(packages).to.have.length(total)
+    expect(fetchCalls).to.deep.equal([0, NPM_PAGE_SIZE, 2 * NPM_PAGE_SIZE])
+  })
+
+  it('resolves with partial results when npm returns an empty page below total', async () => {
+    // npm's total is an estimate: an empty page below the claimed
+    // total must end pagination with the accumulated results
+    const total = NPM_PAGE_SIZE + 50
+    stubFetch((from) =>
+      from === 0
+        ? searchPage(searchObjects('short', NPM_PAGE_SIZE), total)
+        : searchPage([], total)
+    )
+    const packages = await findModulesWithKeyword('test-empty-page')
+    expect(packages).to.have.length(NPM_PAGE_SIZE)
+    expect(fetchCalls).to.deep.equal([0, NPM_PAGE_SIZE])
+  })
+
+  it('stops paging at the page cap when total keeps growing', async () => {
+    stubFetch((from) => searchPage(searchObjects('grow', 1, from), 1000))
+    const packages = await findModulesWithKeyword('test-page-cap')
+    expect(packages).to.have.length(NPM_SEARCH_MAX_PAGES)
+    expect(fetchCalls).to.deep.equal(
+      Array.from({ length: NPM_SEARCH_MAX_PAGES }, (_, i) => i)
+    )
+  })
+
+  it('drops entries with invalid or missing versions', async () => {
+    stubFetch(() =>
+      searchPage(
+        [
+          { package: { name: 'valid-pkg', version: '1.0.0' } },
+          { package: { name: 'valid-pkg', version: 'not-semver' } },
+          { package: { name: 'invalid-only', version: 'also-bad' } },
+          {} as SearchObject
+        ],
+        4
+      )
+    )
+    const packages = await findModulesWithKeyword('test-invalid-version')
+    expect(packages).to.have.length(1)
+    expect(packages[0].package.name).to.equal('valid-pkg')
+    expect(packages[0].package.version).to.equal('1.0.0')
+  })
+
+  it('coalesces concurrent searches for the same keyword', async () => {
+    stubFetch(() => searchPage(searchObjects('single', 1), 1))
+    const [first, second] = await Promise.all([
+      findModulesWithKeyword('test-coalesce'),
+      findModulesWithKeyword('test-coalesce')
+    ])
+    expect(fetchCalls).to.have.length(1)
+    expect(first).to.equal(second)
+    const third = await findModulesWithKeyword('test-coalesce')
+    expect(third).to.equal(first)
+    expect(fetchCalls).to.have.length(1)
+  })
+})

--- a/test/modules-search.ts
+++ b/test/modules-search.ts
@@ -16,8 +16,8 @@ describe('findModulesWithKeyword', () => {
   const originalFetch = global.fetch
   let fetchCalls: number[] = []
 
-  function searchPage(objects: SearchObject[], total: number) {
-    return { ok: true, json: () => Promise.resolve({ objects, total }) }
+  function searchPage(objects: unknown[], total: number): Response {
+    return Response.json({ objects, total })
   }
 
   function searchObjects(
@@ -32,13 +32,13 @@ describe('findModulesWithKeyword', () => {
 
   // the stub serves pages by the requested from= offset so an
   // implementation stuck re-requesting the same offset cannot pass
-  function stubFetch(pageForOffset: (from: number) => unknown) {
+  function stubFetch(pageForOffset: (from: number) => Response) {
     fetchCalls = []
-    global.fetch = ((url: string) => {
-      const from = Number(new URL(url).searchParams.get('from'))
+    global.fetch = (input: RequestInfo | URL) => {
+      const from = Number(new URL(String(input)).searchParams.get('from'))
       fetchCalls.push(from)
       return Promise.resolve(pageForOffset(from))
-    }) as unknown as typeof fetch
+    }
   }
 
   afterEach(() => {
@@ -92,7 +92,7 @@ describe('findModulesWithKeyword', () => {
           { package: { name: 'valid-pkg', version: '1.0.0' } },
           { package: { name: 'valid-pkg', version: 'not-semver' } },
           { package: { name: 'invalid-only', version: 'also-bad' } },
-          {} as SearchObject
+          {}
         ],
         4
       )

--- a/test/modules.js
+++ b/test/modules.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const {
   modulesWithKeyword,
+  findModulesWithKeyword,
   checkForNewServerVersion,
   getLatestServerVersion,
   importOrRequire,
@@ -66,6 +67,85 @@ describe('modulesWithKeyword', () => {
       (moduleInfo) => moduleInfo.module === updateInstalledModule
     )
     chai.expect(installedModuleInfo.location).to.eql(tempNodeModules)
+  })
+})
+
+describe('findModulesWithKeyword', () => {
+  // each test uses its own keyword because results are cached per
+  // keyword for 60s at module level
+  const originalFetch = global.fetch
+  let fetchCalls
+
+  function searchPage(objects, total) {
+    return { ok: true, json: () => Promise.resolve({ objects, total }) }
+  }
+
+  function searchObjects(prefix, count, start = 0) {
+    return Array.from({ length: count }, (_, i) => ({
+      package: { name: `${prefix}-${start + i}`, version: '1.0.0' }
+    }))
+  }
+
+  // the stub serves pages by the requested from= offset so an
+  // implementation stuck re-requesting the same offset cannot pass
+  function stubFetch(pageForOffset) {
+    fetchCalls = []
+    global.fetch = (url) => {
+      const from = Number(new URL(url).searchParams.get('from'))
+      fetchCalls.push(from)
+      return Promise.resolve(pageForOffset(from))
+    }
+  }
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('pages through multi-page search results', async () => {
+    stubFetch((from) => {
+      if (from === 0) return searchPage(searchObjects('multi', 250, 0), 550)
+      if (from === 250) return searchPage(searchObjects('multi', 250, 250), 550)
+      if (from === 500) return searchPage(searchObjects('multi', 50, 500), 550)
+      return searchPage([], 550)
+    })
+    const packages = await findModulesWithKeyword('test-multi-page')
+    chai.expect(packages).to.have.length(550)
+    chai.expect(fetchCalls).to.deep.equal([0, 250, 500])
+  })
+
+  it('resolves with partial results when npm returns an empty page below total', async () => {
+    // npm's total is an estimate: an empty page below the claimed
+    // total must end pagination with the accumulated results
+    stubFetch((from) =>
+      from === 0
+        ? searchPage(searchObjects('short', 250), 300)
+        : searchPage([], 300)
+    )
+    const packages = await findModulesWithKeyword('test-empty-page')
+    chai.expect(packages).to.have.length(250)
+    chai.expect(fetchCalls).to.deep.equal([0, 250])
+  })
+
+  it('stops paging at the page cap when total keeps growing', async () => {
+    stubFetch((from) => searchPage(searchObjects('grow', 1, from), 1000))
+    const packages = await findModulesWithKeyword('test-page-cap')
+    chai.expect(packages).to.have.length(20)
+    chai
+      .expect(fetchCalls)
+      .to.deep.equal(Array.from({ length: 20 }, (_, i) => i))
+  })
+
+  it('coalesces concurrent searches for the same keyword', async () => {
+    stubFetch(() => searchPage(searchObjects('single', 1), 1))
+    const [first, second] = await Promise.all([
+      findModulesWithKeyword('test-coalesce'),
+      findModulesWithKeyword('test-coalesce')
+    ])
+    chai.expect(fetchCalls).to.have.length(1)
+    chai.expect(first).to.equal(second)
+    const third = await findModulesWithKeyword('test-coalesce')
+    chai.expect(third).to.equal(first)
+    chai.expect(fetchCalls).to.have.length(1)
   })
 })
 

--- a/test/modules.js
+++ b/test/modules.js
@@ -4,7 +4,6 @@ const fs = require('fs')
 const path = require('path')
 const {
   modulesWithKeyword,
-  findModulesWithKeyword,
   checkForNewServerVersion,
   getLatestServerVersion,
   importOrRequire,
@@ -67,85 +66,6 @@ describe('modulesWithKeyword', () => {
       (moduleInfo) => moduleInfo.module === updateInstalledModule
     )
     chai.expect(installedModuleInfo.location).to.eql(tempNodeModules)
-  })
-})
-
-describe('findModulesWithKeyword', () => {
-  // each test uses its own keyword because results are cached per
-  // keyword for 60s at module level
-  const originalFetch = global.fetch
-  let fetchCalls
-
-  function searchPage(objects, total) {
-    return { ok: true, json: () => Promise.resolve({ objects, total }) }
-  }
-
-  function searchObjects(prefix, count, start = 0) {
-    return Array.from({ length: count }, (_, i) => ({
-      package: { name: `${prefix}-${start + i}`, version: '1.0.0' }
-    }))
-  }
-
-  // the stub serves pages by the requested from= offset so an
-  // implementation stuck re-requesting the same offset cannot pass
-  function stubFetch(pageForOffset) {
-    fetchCalls = []
-    global.fetch = (url) => {
-      const from = Number(new URL(url).searchParams.get('from'))
-      fetchCalls.push(from)
-      return Promise.resolve(pageForOffset(from))
-    }
-  }
-
-  afterEach(() => {
-    global.fetch = originalFetch
-  })
-
-  it('pages through multi-page search results', async () => {
-    stubFetch((from) => {
-      if (from === 0) return searchPage(searchObjects('multi', 250, 0), 550)
-      if (from === 250) return searchPage(searchObjects('multi', 250, 250), 550)
-      if (from === 500) return searchPage(searchObjects('multi', 50, 500), 550)
-      return searchPage([], 550)
-    })
-    const packages = await findModulesWithKeyword('test-multi-page')
-    chai.expect(packages).to.have.length(550)
-    chai.expect(fetchCalls).to.deep.equal([0, 250, 500])
-  })
-
-  it('resolves with partial results when npm returns an empty page below total', async () => {
-    // npm's total is an estimate: an empty page below the claimed
-    // total must end pagination with the accumulated results
-    stubFetch((from) =>
-      from === 0
-        ? searchPage(searchObjects('short', 250), 300)
-        : searchPage([], 300)
-    )
-    const packages = await findModulesWithKeyword('test-empty-page')
-    chai.expect(packages).to.have.length(250)
-    chai.expect(fetchCalls).to.deep.equal([0, 250])
-  })
-
-  it('stops paging at the page cap when total keeps growing', async () => {
-    stubFetch((from) => searchPage(searchObjects('grow', 1, from), 1000))
-    const packages = await findModulesWithKeyword('test-page-cap')
-    chai.expect(packages).to.have.length(20)
-    chai
-      .expect(fetchCalls)
-      .to.deep.equal(Array.from({ length: 20 }, (_, i) => i))
-  })
-
-  it('coalesces concurrent searches for the same keyword', async () => {
-    stubFetch(() => searchPage(searchObjects('single', 1), 1))
-    const [first, second] = await Promise.all([
-      findModulesWithKeyword('test-coalesce'),
-      findModulesWithKeyword('test-coalesce')
-    ])
-    chai.expect(fetchCalls).to.have.length(1)
-    chai.expect(first).to.equal(second)
-    const third = await findModulesWithKeyword('test-coalesce')
-    chai.expect(third).to.equal(first)
-    chai.expect(fetchCalls).to.have.length(1)
   })
 })
 


### PR DESCRIPTION
Users report the app store hanging indefinitely — nothing loads and the update check never returns until the server is restarted.

The app store search pages through npm's `/-/v1/search` API trusting the reported `total`. That value is an estimate and npm sometimes returns a 200 page with an empty `objects` array while `total` still claims more results. When that happens the pagination loop retries the same offset forever: every request succeeds quickly, so the per-request timeout never fires and `/appstore/available` never responds. The stuck loop also keeps hammering the npm registry, and each admin UI retry started yet another loop because concurrent searches were not shared.

- end pagination on an empty (or malformed) page and cap paging at 20 pages
- coalesce concurrent searches per keyword so parallel app store requests share one npm search
- dedupe results in a Map: a package named e.g. `constructor` would collide with `Object.prototype` keys and throw

Tested: new unit tests for pagination termination (the empty-page case never settles against the previous code), the page cap, and coalescing; full `npm test` at the repo root is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents npm search pagination hangs by:

- Ending pagination when npm returns an empty or malformed page (missing/non-array `objects`) and capping pagination at 20 pages instead of retrying the same offset.
- Coalescing concurrent keyword searches with an in-flight promise cache and caching resolved results for a short TTL.
- Deduplicating results with a `Map` keyed by package name, keeping the highest valid semver version, and filtering out entries with missing/invalid package names or versions.
- Guarding npm debug logging with `.enabled`.

It adds unit tests covering empty-page termination, the page cap, semver filtering, and concurrent search coalescing. Full root-level `npm test` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->