### PR TITLE
fix(admin-ui): keep freshly added path overrides from vanishing on save

### DIFF
--- a/packages/server-admin-ui/src/store/slices/prioritiesSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/prioritiesSlice.test.ts
@@ -11,6 +11,13 @@ describe('prioritiesSlice', () => {
           dirty: false,
           timeoutsOk: true
         }
+      },
+      priorityOverridesData: {
+        paths: [],
+        saveState: {
+          dirty: false,
+          timeoutsOk: true
+        }
       }
     })
   })
@@ -102,6 +109,55 @@ describe('prioritiesSlice', () => {
 
       expect(useStore.getState().sourcePrioritiesData.saveState.dirty).toBe(
         true
+      )
+    })
+
+    it('should register the path as a priority override', () => {
+      // The save payload only carries paths present in
+      // priorityOverridesData: without this, a freshly added ungrouped
+      // override is dropped from the PUT and vanishes on save.
+      useStore.getState().changePath(0, 'navigation.headingTrue')
+
+      expect(useStore.getState().priorityOverridesData.paths).toContain(
+        'navigation.headingTrue'
+      )
+      expect(useStore.getState().priorityOverridesData.saveState.dirty).toBe(
+        true
+      )
+    })
+
+    it('should not duplicate an already-registered override path', () => {
+      useStore
+        .getState()
+        .setPriorityOverridesFromServer(['navigation.headingTrue'])
+      useStore.getState().changePath(0, 'navigation.headingTrue')
+
+      expect(useStore.getState().priorityOverridesData.paths).toEqual([
+        'navigation.headingTrue'
+      ])
+      expect(useStore.getState().priorityOverridesData.saveState.dirty).toBe(
+        false
+      )
+    })
+
+    it('should keep registered override paths sorted', () => {
+      useStore
+        .getState()
+        .setPriorityOverridesFromServer(['navigation.position'])
+      useStore.getState().changePath(0, 'navigation.headingTrue')
+
+      expect(useStore.getState().priorityOverridesData.paths).toEqual([
+        'navigation.headingTrue',
+        'navigation.position'
+      ])
+    })
+
+    it('should not register an empty path as an override', () => {
+      useStore.getState().changePath(0, '')
+
+      expect(useStore.getState().priorityOverridesData.paths).toEqual([])
+      expect(useStore.getState().priorityOverridesData.saveState.dirty).toBe(
+        false
       )
     })
   })

--- a/packages/server-admin-ui/src/store/slices/prioritiesSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/prioritiesSlice.ts
@@ -158,12 +158,29 @@ export const createPrioritiesSlice: StateCreator<
         sourcePriorities.push({ path: '', priorities: [] })
       }
       sourcePriorities[index] = { ...sourcePriorities[index], path }
+      // Giving a row a path is an explicit user override, so the path
+      // must enter priorityOverridesData too: the save payload only
+      // carries paths present there, and without this a freshly added
+      // ungrouped override is silently dropped from the PUT and
+      // vanishes on save.
+      const priorityOverridesData =
+        !path || state.priorityOverridesData.paths.includes(path)
+          ? state.priorityOverridesData
+          : {
+              ...state.priorityOverridesData,
+              paths: [...state.priorityOverridesData.paths, path].sort(),
+              saveState: {
+                ...state.priorityOverridesData.saveState,
+                dirty: true
+              }
+            }
       return {
         sourcePrioritiesData: {
           ...state.sourcePrioritiesData,
           sourcePriorities,
           saveState: { ...state.sourcePrioritiesData.saveState, dirty: true }
-        }
+        },
+        priorityOverridesData
       }
     })
   },


### PR DESCRIPTION
Reported on Discord: adding an ungrouped path override on the Source Priorities page (e.g. `navigation.headingTrue` ranked between a device plugin and derived-data) and clicking Save makes the override disappear with no error, so the priority is never applied.

The save payload only carries paths present in `priorityOverridesData`, but `changePath` never registered its path there — the only writer was the group fan-out checkbox. A freshly added ungrouped override (or one created via the Data Browser deep link, which uses the same action) was silently dropped from the PUT: the request succeeded, the server persisted an override-less map, and the websocket echo removed the row from the UI. Registering the path inside `changePath` covers both entry points while leaving the fan-out uncheck flow (which relies on the payload gate to drop removed overrides) untouched.

Tested: new vitest cases for the slice (fresh path registered + dirty, no duplicate registration, sorted insertion, empty-path guard); full repo test chain green; end-to-end against a live server with two plugin sources publishing `navigation.headingTrue` — driving the real admin UI with Playwright (add override, assign both sources, Save, reload). On the unfixed build the e2e reproduces the report exactly (server persists `{}`, row vanishes after reload); with the fix the override persists as `[{preferred, 0}, {fallback, 15000}]` and survives reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes admin UI path overrides disappearing after save by registering newly added paths in `priorityOverridesData` from `changePath`. This supports Source Priorities additions and Data Browser deep links while preserving fan-out uncheck behavior.

Adds Vitest coverage for path registration, dirty state, duplicate prevention, sorted insertion, and empty-path handling. End-to-end testing confirms overrides persist across reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->