### PR TITLE
style(admin-ui): Webapps card styling

### DIFF
--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -6,6 +6,17 @@ import classNames from 'classnames'
 import { toSafeModuleId } from './dynamicutilities'
 
 const ICON_BOX_SIZE = '72px'
+// Match the Appstore's PluginIcon so a webapp tile and a plugin tile read
+// as the same mark.
+const ICON_BORDER_RADIUS = 8
+const DESCRIPTION_MAX_LINES = 3
+
+const descriptionStyle: React.CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: DESCRIPTION_MAX_LINES,
+  overflow: 'hidden'
+}
 
 interface SignalKInfo {
   displayName?: string
@@ -36,7 +47,7 @@ export default function Webapp({
   onLaunch,
   ...attributes
 }: WebappProps) {
-  const padding = { card: 'p-3', icon: 'p-3', lead: 'mt-2' }
+  const padding = { card: 'p-3', icon: 'p-3' }
 
   const card = {
     style: 'clearfix',
@@ -44,12 +55,7 @@ export default function Webapp({
   }
 
   const lead = { style: 'h5 mb-0', color: card.color, classes: '' }
-  lead.classes = classNames(
-    lead.style,
-    'text-' + card.color,
-    padding.lead,
-    'text-capitalize'
-  )
+  lead.classes = classNames(lead.style, 'text-' + card.color, 'text-capitalize')
   const header = webAppInfo?.signalk?.displayName || webAppInfo.name
   const url = urlToWebapp(webAppInfo)
   const appIcon = webAppInfo?.signalk?.appIcon
@@ -70,7 +76,9 @@ export default function Webapp({
         : 'unset',
       display: 'flex',
       alignItems: 'center',
-      justifyContent: 'center'
+      justifyContent: 'center',
+      borderRadius: ICON_BORDER_RADIUS,
+      overflow: 'hidden'
     }
     if (appIcon) {
       style.width = style.height = ICON_BOX_SIZE
@@ -88,7 +96,9 @@ export default function Webapp({
         <Card.Body className={card.style} {...attributes}>
           {blockIcon()}
           <div className={lead.classes}>{header}</div>
-          <div className="text-muted font-xs">{webAppInfo.description}</div>
+          <div className="text-muted font-xs" style={descriptionStyle}>
+            {webAppInfo.description}
+          </div>
         </Card.Body>
       </Card>
     </a>

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -67,8 +67,12 @@ export default function Webapp({
     color: 'primary'
   }
 
-  const lead = { style: 'h5 mb-0', color: card.color, classes: '' }
-  lead.classes = classNames(lead.style, 'text-' + card.color, 'text-capitalize')
+  const leadStyle = 'h5 mb-0'
+  const lead = {
+    style: leadStyle,
+    color: card.color,
+    classes: classNames(leadStyle, 'text-' + card.color, 'text-capitalize')
+  }
   const header = webAppInfo?.signalk?.displayName || webAppInfo.name
   const url = urlToWebapp(webAppInfo)
   const appIcon = webAppInfo?.signalk?.appIcon

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -9,14 +9,27 @@ const ICON_BOX_SIZE = '72px'
 // Match the Appstore's PluginIcon so a webapp tile and a plugin tile read
 // as the same mark.
 const ICON_BORDER_RADIUS = 8
+const HEADER_MAX_LINES = 1
 const DESCRIPTION_MAX_LINES = 3
+const TEXT_LINE_HEIGHT = 1.4
 
-const descriptionStyle: React.CSSProperties = {
-  display: '-webkit-box',
-  WebkitBoxOrient: 'vertical',
-  WebkitLineClamp: DESCRIPTION_MAX_LINES,
-  overflow: 'hidden'
+// Clamp to a fixed number of lines, ellipsising whatever overflows. The line
+// box is also *reserved*: the height is spelled out rather than left to the
+// content, so a card with a one-line description is exactly as tall as one
+// with an overflowing description.
+function clampToLines(lines: number): React.CSSProperties {
+  return {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: lines,
+    overflow: 'hidden',
+    lineHeight: TEXT_LINE_HEIGHT,
+    height: `${lines * TEXT_LINE_HEIGHT}em`
+  }
 }
+
+const headerStyle = clampToLines(HEADER_MAX_LINES)
+const descriptionStyle = clampToLines(DESCRIPTION_MAX_LINES)
 
 interface SignalKInfo {
   displayName?: string
@@ -95,7 +108,9 @@ export default function Webapp({
       <Card>
         <Card.Body className={card.style} {...attributes}>
           {blockIcon()}
-          <div className={lead.classes}>{header}</div>
+          <div className={lead.classes} style={headerStyle}>
+            {header}
+          </div>
           <div className="text-muted font-xs" style={descriptionStyle}>
             {webAppInfo.description}
           </div>


### PR DESCRIPTION
>This is my first PR, please be gentle!

## What problem does this solve?

Current webapp plugin page does not handle varying plugin name length, plugin description length, and the webapps page end up showing cards with multiple sizes that breaks the grid display.

This PR homogenizes the webapp grid cards with a fixed 1 line name, and maximum 3 lines of description.  It also brings in the icon styling from the appstore for a consistent look across the two systems.

There is also an issue with monogram generation that I'll send in a follow-up PR.

## How was this tested?

Verified visually in Chrome (desktop and mobile)

## Before Screenshot

<img width="1455" height="819" alt="before" src="https://github.com/user-attachments/assets/9769757a-97e1-427a-ab4b-ffb6dfd250a6" />

## After Screenshot

<img width="1455" height="819" alt="webapps-styling" src="https://github.com/user-attachments/assets/4c944706-c88e-46ba-bd1c-db6d80b02320" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR standardizes webapp cards by:

- Clamping app names to one line and descriptions to three lines.
- Applying fixed heights to maintain consistent card sizing.
- Adding rounded corners and hidden overflow to icon containers.
- Simplifying lead styling by removing the separate lead padding class.
- Applying clamp styles to card headers and descriptions.

Visual testing covers Chrome on desktop and mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->