### PR TITLE
Let plugins call other plugins HTTP routes via app.pluginFetch()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ test/plugin-test-config/baseDeltas.json
 test/plugin-test-config/unitpreferences/
 
 test/server-test-config/applicationData/
+# Written by the appstore interface during test runs; the npm metadata it
+# caches carries third-party maintainer emails and machine-local paths.
+test/server-test-config/appstore-cache/
 test/server-test-config/unitpreferences/
 test/server-test-config/ssl-cert.pem
 test/server-test-config/ssl-key.pem

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -340,28 +340,39 @@ export interface ServerAPI
   getDataDirPath(): string
 
   /**
-   * Returns a short-lived readonly token for calling ANOTHER plugin's HTTP
-   * route on this same server over loopback.
+   * Call another plugin's HTTP route on this same server.
    *
    * Plugin routes under `/plugins/` require an authenticated request whenever
    * security is enabled, and a server-side `fetch` carries no session cookie,
-   * so such calls are otherwise rejected with `401`. Pass the token as a
-   * `Bearer` credential. Mint one per request rather than caching it; it
-   * expires in minutes.
+   * so a direct call is otherwise rejected with `401`. This authenticates the
+   * request for you as a readonly principal, and resolves the server's own
+   * address — which moves with `proxy_port`, ssl and socket activation, so it
+   * is not something a plugin should be reconstructing.
    *
-   * Returns `undefined` when security is disabled, in which case no
-   * credential is needed.
+   * The target route must opt in with `router.access('readonly')`. Routes
+   * that declare no permission keep falling through to the admin gate, so
+   * this never widens what a plugin exposes by itself.
+   *
+   * Resolves to the same `Response` a `fetch` would give you, body stream
+   * included, so large exports can be streamed rather than buffered.
+   *
+   * @param pluginId - id of the plugin whose route is being called
+   * @param route - route path relative to that plugin, e.g. `/api/export`
+   * @param init - standard `fetch` options
    *
    * @example
    * ```ts
-   * const token = app.getSelfAuthToken()
-   * const res = await fetch(url, {
-   *   headers: token ? { Authorization: `Bearer ${token}` } : {}
-   * })
+   * const res = await app.pluginFetch('signalk-grafana', '/api/full-export/db')
+   * if (!res.ok) throw new Error(`export failed: ${res.status}`)
+   * await pipeline(res.body, createWriteStream(target))
    * ```
    * @category Configuration
    */
-  getSelfAuthToken(): string | undefined
+  pluginFetch(
+    pluginId: string,
+    route: string,
+    init?: RequestInit
+  ): Promise<Response>
 
   /**
    * Register a handler to action [`PUT`](http://signalk.org/specification/1.3.0/doc/put.html) requests for a specific path.

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -340,6 +340,30 @@ export interface ServerAPI
   getDataDirPath(): string
 
   /**
+   * Returns a short-lived readonly token for calling ANOTHER plugin's HTTP
+   * route on this same server over loopback.
+   *
+   * Plugin routes under `/plugins/` require an authenticated request whenever
+   * security is enabled, and a server-side `fetch` carries no session cookie,
+   * so such calls are otherwise rejected with `401`. Pass the token as a
+   * `Bearer` credential. Mint one per request rather than caching it; it
+   * expires in minutes.
+   *
+   * Returns `undefined` when security is disabled, in which case no
+   * credential is needed.
+   *
+   * @example
+   * ```ts
+   * const token = app.getSelfAuthToken()
+   * const res = await fetch(url, {
+   *   headers: token ? { Authorization: `Bearer ${token}` } : {}
+   * })
+   * ```
+   * @category Configuration
+   */
+  getSelfAuthToken(): string | undefined
+
+  /**
    * Register a handler to action [`PUT`](http://signalk.org/specification/1.3.0/doc/put.html) requests for a specific path.
    *
    * The action handler can handle the request synchronously or asynchronously.

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -948,6 +948,9 @@ module.exports = (theApp: any) => {
     }
     appCopy.getDataDirPath = () => dirForPluginId(plugin.id)
 
+    appCopy.getSelfAuthToken = () =>
+      app.securityStrategy.getPluginSelfAuthToken?.(plugin.id)
+
     appCopy.registerPutHandler = (context, aPath, callback, source) => {
       appCopy.handleMessage(plugin.id, {
         updates: [

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -140,6 +140,57 @@ function mergeExcludeSelf(
   return merged.size > 0 ? (Array.from(merged) as SourceRef[]) : undefined
 }
 
+/**
+ * Call another plugin's HTTP route on this same server.
+ *
+ * The target route must opt in with `router.access('readonly')`; routes that
+ * declare no permission keep falling through to the admin gate, so this is
+ * never an implicit widening of what a plugin exposes.
+ *
+ * Kept in the server rather than handed to plugins as a raw token: the
+ * credential never leaves this process, its lifetime stops being the caller's
+ * problem, and callers do not have to rebuild the server's own base URL —
+ * which moves with `proxy_port`, ssl, and systemd socket activation.
+ */
+async function pluginFetch(
+  app: {
+    server?: { address(): { port: number; family: string } | string | null }
+    config?: { settings?: { ssl?: boolean } }
+    securityStrategy?: { getPluginSelfAuthToken?: (id: string) => string }
+  },
+  callerPluginId: string,
+  targetPluginId: string,
+  route: string,
+  init: RequestInit = {}
+): Promise<globalThis.Response> {
+  if (!targetPluginId) {
+    throw new Error('pluginFetch requires a target plugin id')
+  }
+  const address = app.server?.address()
+  if (!address || typeof address === 'string') {
+    // A string address means a pipe/unix socket (systemd may hand us one);
+    // there is no loopback URL to build for it.
+    throw new Error(
+      `pluginFetch: ${callerPluginId} cannot reach ${targetPluginId} — the server is not listening on a TCP port`
+    )
+  }
+  // Talk to the loopback interface on the port actually bound, not the
+  // externally advertised one: a reverse proxy in front of us is not
+  // necessarily reachable from here, and may not forward loopback traffic.
+  const host = address.family === 'IPv6' ? '[::1]' : '127.0.0.1'
+  const scheme = app.config?.settings?.ssl ? 'https' : 'http'
+  const path = route.startsWith('/') ? route : `/${route}`
+  const url = `${scheme}://${host}:${address.port}/plugins/${targetPluginId}${path}`
+
+  const token = app.securityStrategy?.getPluginSelfAuthToken?.(callerPluginId)
+  const headers = new Headers(init.headers)
+  // Never overwrite an Authorization the caller set deliberately.
+  if (token && !headers.has('authorization')) {
+    headers.set('authorization', `Bearer ${token}`)
+  }
+  return fetch(url, { ...init, headers })
+}
+
 module.exports = (theApp: any) => {
   const onStopHandlers: any = {}
   const appNodeModules = path.join(theApp.config.appPath, 'node_modules/')
@@ -948,8 +999,17 @@ module.exports = (theApp: any) => {
     }
     appCopy.getDataDirPath = () => dirForPluginId(plugin.id)
 
-    appCopy.getSelfAuthToken = () =>
-      app.securityStrategy.getPluginSelfAuthToken?.(plugin.id)
+    // Plugins run in-process but reach each other's routes over loopback
+    // HTTP, where they carry no session cookie and get a blanket 401 whenever
+    // security is on. Doing the call here keeps both the credential and the
+    // server's own address out of every calling plugin: the token never
+    // leaves this process, and callers stop having to reconstruct a base URL
+    // (proxy_port, ssl and systemd socket activation all move it).
+    appCopy.pluginFetch = (
+      targetPluginId: string,
+      route: string,
+      init?: RequestInit
+    ) => pluginFetch(app, plugin.id, targetPluginId, route, init)
 
     appCopy.registerPutHandler = (context, aPath, callback, source) => {
       appCopy.handleMessage(plugin.id, {

--- a/src/security.ts
+++ b/src/security.ts
@@ -241,6 +241,13 @@ export interface SecurityStrategy {
     permissions: RoutePermission[]
   ) => void
 
+  /**
+   * Mint a short-lived readonly token a plugin can present on loopback HTTP
+   * requests to another plugin's routes in this same server (optional - only
+   * available when token security is active).
+   */
+  getPluginSelfAuthToken?: (pluginId: string) => string
+
   /** Update OIDC config in memory (optional - only available when token security is active) */
   updateOIDCConfig?: (newOidcConfig: PartialOIDCConfig) => void
 

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -96,6 +96,10 @@ const BROWSER_LOGININFO_COOKIE_NAME = 'skLoginInfo'
 const LOGIN_FAILED_MESSAGE = 'Invalid username/password'
 const VALID_PERMISSIONS = new Set(['readonly', 'readwrite', 'admin'])
 
+// Short enough that a leaked plugin self-token is near-useless, long enough to
+// cover a slow export request. Callers mint one per request.
+const PLUGIN_SELF_TOKEN_EXPIRY = '10m'
+
 // Dummy hash for timing attack prevention - pre-generated bcrypt hash
 const DUMMY_HASH = '$2b$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ012'
 
@@ -126,6 +130,7 @@ interface Principal {
 interface JWTPayload {
   id?: string
   device?: string
+  plugin?: string
   exp?: number
   iat?: number
   rememberMe?: boolean
@@ -984,6 +989,22 @@ function tokenSecurityFactory(
     res.type('text/plain').send(token)
   }
 
+  // Plugins run in-process but reach each other's routes over loopback HTTP,
+  // where they have no session cookie. Without this they get a blanket 401
+  // whenever security is on and allow_readonly is false.
+  strategy.getPluginSelfAuthToken = function (pluginId: string): string {
+    // A falsy claim never resolves in getPrincipal, so the token would look
+    // valid but authenticate nothing.
+    if (!pluginId) {
+      throw new Error('getPluginSelfAuthToken requires a plugin id')
+    }
+    const configuration = getConfiguration()
+    const payload: JWTPayload = { plugin: pluginId }
+    return jwt.sign(payload, configuration.secretKey, {
+      expiresIn: PLUGIN_SELF_TOKEN_EXPIRY
+    })
+  }
+
   strategy.allowReadOnly = function (): boolean {
     const configuration = getConfiguration()
     return configuration.allow_readonly
@@ -1663,6 +1684,14 @@ function tokenSecurityFactory(
           identifier: device.clientId,
           permissions: device.permissions
         }
+      }
+    } else if (payload.plugin) {
+      // Minted by getPluginSelfAuthToken for a plugin calling another
+      // plugin's route in this same process. Readonly and short-lived, so it
+      // grants no more than an anonymous request would under allow_readonly.
+      principal = {
+        identifier: `plugin:${payload.plugin}`,
+        permissions: 'readonly'
       }
     }
     return principal

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -89,16 +89,17 @@ module.exports = function(app) {
       router.access('readonly').get('/sensorData/:id', (req, res) => res.json({sensor: req.params.id}))
       // Attempt to downgrade the reserved /config path; the server must ignore this.
       router.access('readonly').get('/config', (req, res) => res.json({data: 'should stay admin only'}))
-      // Calls this plugin's own readonly route over loopback the way one plugin
-      // reaches another's: server-side fetch, no cookie, self-auth token only.
+      // Calls this plugin's own readonly route the way one plugin reaches
+      // another's: through pluginFetch, with no address or credential of its
+      // own. Server-side fetch carries no session cookie, so an unauthenticated
+      // call here would be a 401 whenever security is on.
       router.access('readonly').get('/selfCall', async (req, res) => {
-        const token = app.getSelfAuthToken()
-        const target = `http://127.0.0.1:${req.socket.localPort}/plugins/testplugin/readonlyData`
         try {
-          const upstream = await fetch(target, {
-            headers: token ? { Authorization: `Bearer ${token}` } : {}
-          })
-          res.json({ status: upstream.status, hadToken: Boolean(token) })
+          const upstream = await app.pluginFetch(
+            'testplugin',
+            '/readonlyData'
+          )
+          res.json({ status: upstream.status })
         } catch (err) {
           res.status(500).json({ error: String(err) })
         }

--- a/test/plugin-test-config/node_modules/testplugin/index.js
+++ b/test/plugin-test-config/node_modules/testplugin/index.js
@@ -89,6 +89,20 @@ module.exports = function(app) {
       router.access('readonly').get('/sensorData/:id', (req, res) => res.json({sensor: req.params.id}))
       // Attempt to downgrade the reserved /config path; the server must ignore this.
       router.access('readonly').get('/config', (req, res) => res.json({data: 'should stay admin only'}))
+      // Calls this plugin's own readonly route over loopback the way one plugin
+      // reaches another's: server-side fetch, no cookie, self-auth token only.
+      router.access('readonly').get('/selfCall', async (req, res) => {
+        const token = app.getSelfAuthToken()
+        const target = `http://127.0.0.1:${req.socket.localPort}/plugins/testplugin/readonlyData`
+        try {
+          const upstream = await fetch(target, {
+            headers: token ? { Authorization: `Bearer ${token}` } : {}
+          })
+          res.json({ status: upstream.status, hadToken: Boolean(token) })
+        } catch (err) {
+          res.status(500).json({ error: String(err) })
+        }
+      })
     },
     getOpenApi: () => require('./openApi'),
     app: app

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -40,9 +40,10 @@ describe('Demo plugin ', () => {
     const optionsTest = plugin.app.readPluginOptions()
     assert(optionsTest.configuration.testOption === 'testValue')
 
-    // No security configured, so there is no credential to mint and callers
-    // are expected to send no Authorization header at all.
-    assert.strictEqual(plugin.app.getSelfAuthToken(), undefined)
+    // With no security configured there is no credential to mint; pluginFetch
+    // must still reach the route rather than depending on one existing.
+    const res = await plugin.app.pluginFetch('testplugin', '/readonlyData')
+    assert.strictEqual(res.status, 200)
 
     assert(server.app.signalk.self.some.path.value === 'someValue')
 

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -40,6 +40,10 @@ describe('Demo plugin ', () => {
     const optionsTest = plugin.app.readPluginOptions()
     assert(optionsTest.configuration.testOption === 'testValue')
 
+    // No security configured, so there is no credential to mint and callers
+    // are expected to send no Authorization header at all.
+    assert.strictEqual(plugin.app.getSelfAuthToken(), undefined)
+
     assert(server.app.signalk.self.some.path.value === 'someValue')
 
     const outputValues = []

--- a/test/security.js
+++ b/test/security.js
@@ -1280,26 +1280,24 @@ describe('Plugin route permissions', () => {
     result.status.should.equal(401)
   })
 
-  // The per-plugin app copy, which is what a real plugin holds.
-  function pluginApp() {
-    const plugin = server.app.plugins.find((p) => p.id === 'testplugin')
-    return plugin.app
+  // The token pluginFetch attaches internally. Minted the same way here so the
+  // escalation tests below exercise the real credential, not a stand-in.
+  function selfToken() {
+    return server.app.securityStrategy.getPluginSelfAuthToken('testplugin')
   }
 
-  it('plugin self-auth token authenticates a loopback call to a readonly route', async function () {
+  it('pluginFetch authenticates a call to another plugin readonly route', async function () {
     const result = await fetch(`${url}/plugins/testplugin/selfCall`, {
       headers: { Authorization: `Bearer ${readToken}` }
     })
     result.status.should.equal(200)
     const body = await result.json()
-    body.hadToken.should.equal(true)
-    // Without the token this inner request is the unauthenticated 401 case above.
+    // Unauthenticated, this inner request is the 401 case asserted above.
     body.status.should.equal(200)
   })
 
-  it('plugin self-auth token does not grant admin access', async function () {
-    // Mint through the plugin-facing API, so the appCopy wiring is covered too.
-    const token = pluginApp().getSelfAuthToken()
+  it('the pluginFetch credential does not grant admin access', async function () {
+    const token = selfToken()
     // Guard against a vacuous pass: `Bearer undefined` would 401 regardless.
     token.should.be.a('string').and.not.equal('')
     const result = await fetch(`${url}/plugins/testplugin/config`, {
@@ -1308,8 +1306,8 @@ describe('Plugin route permissions', () => {
     result.status.should.equal(401)
   })
 
-  it('plugin self-auth token does not grant write access', async function () {
-    const token = pluginApp().getSelfAuthToken()
+  it('the pluginFetch credential does not grant write access', async function () {
+    const token = selfToken()
     token.should.be.a('string').and.not.equal('')
     const result = await fetch(`${url}/plugins/testplugin/writeData`, {
       method: 'POST',

--- a/test/security.js
+++ b/test/security.js
@@ -1280,6 +1280,48 @@ describe('Plugin route permissions', () => {
     result.status.should.equal(401)
   })
 
+  // The per-plugin app copy, which is what a real plugin holds.
+  function pluginApp() {
+    const plugin = server.app.plugins.find((p) => p.id === 'testplugin')
+    return plugin.app
+  }
+
+  it('plugin self-auth token authenticates a loopback call to a readonly route', async function () {
+    const result = await fetch(`${url}/plugins/testplugin/selfCall`, {
+      headers: { Authorization: `Bearer ${readToken}` }
+    })
+    result.status.should.equal(200)
+    const body = await result.json()
+    body.hadToken.should.equal(true)
+    // Without the token this inner request is the unauthenticated 401 case above.
+    body.status.should.equal(200)
+  })
+
+  it('plugin self-auth token does not grant admin access', async function () {
+    // Mint through the plugin-facing API, so the appCopy wiring is covered too.
+    const token = pluginApp().getSelfAuthToken()
+    // Guard against a vacuous pass: `Bearer undefined` would 401 regardless.
+    token.should.be.a('string').and.not.equal('')
+    const result = await fetch(`${url}/plugins/testplugin/config`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    result.status.should.equal(401)
+  })
+
+  it('plugin self-auth token does not grant write access', async function () {
+    const token = pluginApp().getSelfAuthToken()
+    token.should.be.a('string').and.not.equal('')
+    const result = await fetch(`${url}/plugins/testplugin/writeData`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ value: 1 })
+    })
+    result.status.should.equal(401)
+  })
+
   it('readonly user can access parameterized route declared as readonly', async function () {
     const result = await fetch(
       `${url}/plugins/testplugin/sensorData/temperature`,


### PR DESCRIPTION
## Summary

A plugin cannot currently call another plugin's HTTP route on the same server. Routes under `/plugins/` require an authenticated request whenever security is enabled, and a server-side `fetch` carries no session cookie, so the call is rejected with `401`. There is no loopback exemption, and no credential a plugin can legitimately present — reading the server's `secretKey` to self-sign a token is not an acceptable workaround.

This adds `app.pluginFetch(pluginId, route, init?)`, which performs the call and authenticates it as a short-lived readonly principal.

The target route must opt in with `router.access('readonly')`. Routes that declare no permission keep falling through to the admin gate, so this never widens what a plugin exposes by itself.

Keeping the call in the server rather than handing plugins a raw token means:

- the credential never leaves the process, and its lifetime stops being the caller's problem;
- callers do not reconstruct the server's own base URL, which moves with `proxy_port` and `ssl`, and does not exist as a TCP port at all under systemd socket activation (`server.address()` returns a pipe string);
- the `Response` is returned untouched, so body streams survive and large exports can be piped to disk rather than buffered.

Superseded an earlier `getSelfAuthToken()` shape after review — see the discussion below.

## Motivating case

signalk-backup snapshots the databases owned by other plugins. It pulls `full-export/db`, `full-export/dashboards` and Parquet exports from signalk-grafana and signalk-questdb over loopback and stages them into its snapshot tree, streaming each response straight to disk. Those exports run on the backup plugin's own timer, so there is no inbound request whose socket it could borrow an address from. Today this only works on servers with security disabled or `allow_readonly: true` (dirkwa/signalk-backup#92).

## Tested

- New security tests: a `pluginFetch` call to a route declared `readonly` succeeds where the same unauthenticated request is rejected, and the credential is rejected on `/config` and on a `readwrite` route — so it cannot be escalated to admin or write access. Both escalation tests assert the token is a non-empty string first, so they cannot pass vacuously on a `Bearer undefined`.
- New plugins test: with no security configured there is no credential to mint, and `pluginFetch` still reaches the route rather than depending on one existing.
- The test plugin exercises the real path — a server-side call with no cookie, no address of its own and no credential of its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `pluginFetch(pluginId, route, init?)` to the server and plugin APIs.
- Authenticates requests with short-lived, readonly plugin tokens when security is enabled.
- Restricts access to routes configured with `router.access('readonly')`.
- Supports proxy, SSL, IPv4/IPv6, and systemd socket activation.
- Preserves the native `fetch` `Response`, including streaming response bodies.
- Works without credentials when security is disabled.
- Adds tests for readonly access, restricted routes, unsecured servers, and plugin API wiring.
- Ignores generated appstore cache metadata from server tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->