### PR TITLE
feat(server): optionally serve precompressed static assets

### DIFF
--- a/docs/develop/webapps.md
+++ b/docs/develop/webapps.md
@@ -49,6 +49,16 @@ where:
 
 See also [Working Offline](./README.md#offline-use).
 
+### Precompressed Assets
+
+The server serves precompressed sidecar files from the `public` folder: when a file has a `.br` (brotli) or `.gz` (gzip) sibling — for example `bundle.js.br` next to `bundle.js` — the server sends the compressed file directly with the matching `Content-Encoding`, preferring brotli, to browsers that accept it. When no sidecar exists the original file is served, subject to the server's normal response compression, so shipping sidecars is optional — but precompressing at build time saves server CPU on every cold-cache load (Signal K Server often runs on battery-powered Raspberry Pi hardware) and brotli at maximum quality is typically 15–20% smaller than the runtime gzip a client would otherwise receive.
+
+To opt in, generate the sidecar files as part of the webapp's build and include them in the published package. There is no keyword or manifest entry — the presence of the files next to the originals is the whole contract.
+
+Generate **both** `.br` and `.gz` sidecars: browsers only advertise brotli support on secure origins (HTTPS and `localhost`), so on a plain-HTTP connection — the common case for a Signal K server reached by IP address or hostname on the boat network — the browser requests gzip only. A webapp that ships only `.br` files would leave those clients on runtime compression.
+
+Make sure sidecars are always regenerated together with the files they accompany: a stale sidecar takes precedence over a fresh plain file.
+
 ## Application Data: Storing Webapp Data on the Server
 
 Application Data is only supported if security is turned on. It supports two namespaces, one for _global data_ and one for _user specific data_. For example, a client might want to store boat specific gauge configuration globally so that other users have access to it. Otherwise, it could use the user area to store user specific preferences.

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "esm-resolve": "^1.0.11",
     "express": "^4.22.2",
     "express-rate-limit": "^8.5.2",
+    "express-static-gzip": "^3.0.1",
     "file-timestamp-stream": "^2.2.4",
     "geolib": "^3.3.14",
     "get-folder-size": "^5.0.0",

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -49,6 +49,7 @@ import {
 } from '@signalk/server-api'
 import { getLogger } from '@signalk/streams/logging'
 import express, { IRouter, Request, RequestHandler, Response } from 'express'
+import { serveStaticFiles } from '../staticfiles'
 import fs from 'fs'
 import { deprecate } from 'util'
 import _ from 'lodash'
@@ -153,7 +154,7 @@ module.exports = (theApp: any) => {
 
       theApp.use(
         backwardsCompat('/plugins/configure'),
-        express.static(getPluginConfigPublic(theApp))
+        serveStaticFiles(getPluginConfigPublic(theApp))
       )
 
       theApp.get(backwardsCompat('/plugins'), (req: Request, res: Response) => {

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -19,6 +19,7 @@ const debug = createDebug('signalk-server:interfaces:rest')
 const express = require('express')
 const { getMetadata } = require('@signalk/path-metadata')
 const ports = require('../ports')
+const { serveStaticFiles } = require('../staticfiles')
 const {
   resolveDisplayUnits,
   getDefaultCategory
@@ -111,7 +112,7 @@ module.exports = function (app) {
 
   return {
     start: function () {
-      app.use('/', express.static(__dirname + '/../../public'))
+      app.use('/', serveStaticFiles(__dirname + '/../../public'))
 
       function snapshotHandler(snapshotPath, req, res, next) {
         if (!req.query.time) {

--- a/src/interfaces/webapps.ts
+++ b/src/interfaces/webapps.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import express, { Application, Request, Response } from 'express'
+import { Application, Request, Response } from 'express'
+import { serveStaticFiles } from '../staticfiles'
 import fs from 'fs'
 import { uniqBy } from 'lodash'
 import path from 'path'
@@ -87,7 +88,7 @@ function mountWebModules(app: WebappsApp, keyword: string): NpmPackageData[] {
       webappPath += '/public/'
     }
     debug('Mounting web module /' + moduleData.module + ':' + webappPath)
-    app.use('/' + moduleData.module, express.static(webappPath))
+    app.use('/' + moduleData.module, serveStaticFiles(webappPath))
   })
   return modules.map((moduleData) => moduleData.metadata as NpmPackageData)
 }

--- a/src/serverroutes.ts
+++ b/src/serverroutes.ts
@@ -39,6 +39,7 @@ import path from 'path'
 import unzipper from 'unzipper'
 import util from 'util'
 import { mountSwaggerUi } from './api/swagger'
+import { serveStaticFiles } from './staticfiles'
 import {
   ConfigApp,
   readDefaultsFile,
@@ -420,7 +421,7 @@ module.exports = function (
   mountSwaggerUi(app, '/doc/openapi')
 
   // mount server-guide
-  app.use('/documentation', express.static(__dirname + '/../docs/dist'))
+  app.use('/documentation', serveStaticFiles(__dirname + '/../docs/dist'))
 
   // Redirect old documentation URLs to new ones
   let oldpath: keyof typeof redirects
@@ -479,7 +480,7 @@ module.exports = function (
     serveIndexWithAddonScripts(path.join(adminUiPath, 'index.html'), res)
   })
 
-  app.use('/admin', express.static(adminUiPath))
+  app.use('/admin', serveStaticFiles(adminUiPath))
 
   app.get('/', (req: Request, res: Response) => {
     let landingPage = '/admin/'

--- a/src/staticfiles.ts
+++ b/src/staticfiles.ts
@@ -1,0 +1,18 @@
+import { RequestHandler } from 'express'
+import expressStaticGzip from 'express-static-gzip'
+
+/**
+ * Static file serving for bundled assets, webapps and plugin UIs.
+ *
+ * Serves precompressed sidecar files (`asset.js.br` / `asset.js.gz`,
+ * generated at build time) when the client accepts the encoding, falling
+ * back to the plain file. Shipping sidecars is a package's opt-in — no
+ * manifest flag needed. The root directory is scanned once at mount time,
+ * so sidecars added later are picked up on server restart.
+ */
+export function serveStaticFiles(root: string): RequestHandler {
+  return expressStaticGzip(root, {
+    enableBrotli: true,
+    orderPreference: ['br']
+  })
+}

--- a/src/wasm/loader/plugin-registry.ts
+++ b/src/wasm/loader/plugin-registry.ts
@@ -10,7 +10,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
 import Debug from 'debug'
-import express from 'express'
+import { serveStaticFiles } from '../../staticfiles'
 import { WasmPlugin } from './types'
 import { getWasmRuntime, WasmCapabilities } from '../wasm-runtime'
 import {
@@ -123,7 +123,7 @@ function mountWasmWebapp(
 
   // Mount static files
   debug(`Mounting WASM webapp /${packageName}: ${webappPath}`)
-  app.use('/' + packageName, express.static(webappPath))
+  app.use('/' + packageName, serveStaticFiles(webappPath))
 
   // Create webapp metadata for admin UI
   const webappMetadata = {

--- a/test/staticfiles.ts
+++ b/test/staticfiles.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai'
+import express from 'express'
+import fs from 'fs'
+import { AddressInfo } from 'net'
+import os from 'os'
+import path from 'path'
+import zlib from 'zlib'
+import { serveStaticFiles } from '../src/staticfiles'
+
+describe('serveStaticFiles', () => {
+  let fixtureDir: string
+  let baseUrl: string
+  let server: ReturnType<typeof express.application.listen>
+
+  before((done) => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-staticfiles-'))
+    fs.writeFileSync(path.join(fixtureDir, 'app.js'), 'plain content')
+    fs.writeFileSync(
+      path.join(fixtureDir, 'app.js.br'),
+      zlib.brotliCompressSync(Buffer.from('brotli content'))
+    )
+    fs.writeFileSync(
+      path.join(fixtureDir, 'app.js.gz'),
+      zlib.gzipSync(Buffer.from('gzip content'))
+    )
+    fs.writeFileSync(path.join(fixtureDir, 'nosidecar.js'), 'no sidecar')
+    fs.writeFileSync(path.join(fixtureDir, 'index.html'), '<html></html>')
+
+    const app = express()
+    app.use('/webapp', serveStaticFiles(fixtureDir))
+    server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo
+      baseUrl = `http://localhost:${port}/webapp`
+      done()
+    })
+  })
+
+  after((done) => {
+    fs.rmSync(fixtureDir, { recursive: true, force: true })
+    server.close(done)
+  })
+
+  it('serves the brotli sidecar to a client accepting br', async () => {
+    const res = await fetch(`${baseUrl}/app.js`, {
+      headers: { 'accept-encoding': 'gzip, deflate, br' }
+    })
+    expect(res.status).to.equal(200)
+    expect(res.headers.get('content-type')).to.match(/javascript/)
+    expect(res.headers.get('vary')).to.equal('Accept-Encoding')
+    // fetch decodes the body, so content proves which variant was sent
+    expect(await res.text()).to.equal('brotli content')
+  })
+
+  it('serves the gzip sidecar to a gzip-only client', async () => {
+    const res = await fetch(`${baseUrl}/app.js`, {
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    expect(res.status).to.equal(200)
+    expect(await res.text()).to.equal('gzip content')
+  })
+
+  it('serves the plain file to a client accepting no encodings', async () => {
+    const res = await fetch(`${baseUrl}/app.js`, {
+      headers: { 'accept-encoding': 'identity' }
+    })
+    expect(res.status).to.equal(200)
+    expect(res.headers.get('content-encoding')).to.equal(null)
+    expect(await res.text()).to.equal('plain content')
+  })
+
+  it('serves files without sidecars unchanged', async () => {
+    const res = await fetch(`${baseUrl}/nosidecar.js`, {
+      headers: { 'accept-encoding': 'gzip, deflate, br' }
+    })
+    expect(res.status).to.equal(200)
+    expect(res.headers.get('content-encoding')).to.equal(null)
+    expect(await res.text()).to.equal('no sidecar')
+  })
+
+  it('serves index.html for a directory request', async () => {
+    const res = await fetch(`${baseUrl}/`)
+    expect(res.status).to.equal(200)
+    expect(await res.text()).to.equal('<html></html>')
+  })
+
+  it('tolerates a nonexistent root directory', async () => {
+    const app = express()
+    app.use('/missing', serveStaticFiles(path.join(fixtureDir, 'nope')))
+    app.use((_req, res) => res.status(404).end())
+    const missingServer = app.listen(0)
+    await new Promise((resolve) => missingServer.on('listening', resolve))
+    try {
+      const { port } = missingServer.address() as AddressInfo
+      const res = await fetch(`http://localhost:${port}/missing/x.js`)
+      expect(res.status).to.equal(404)
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        missingServer.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  })
+})


### PR DESCRIPTION
Signal K Server typically runs on Pi-class hardware where CPU cycles cost watts. Today every cold-cache request for a webapp bundle is compressed on the fly by the global `compression()` middleware, burning threadpool time per request for identical output — and `.br`/`.gz` files precompressed at build time are ignored entirely.

This replaces `express.static` with [`express-static-gzip`](https://github.com/tkoenig89/express-static-gzip) (via a small shared helper) at all static asset mounts: bundled `public/`, admin UI, documentation, webapps, plugin config UI, and WASM webapps. When a sidecar file (`asset.js.br` / `asset.js.gz`) exists next to the plain file, it is served directly with the matching `Content-Encoding` — zero runtime compression CPU and ~15–20% smaller transfers with brotli. Shipping sidecars is a package's opt-in, documented in `docs/develop/webapps.md`; no manifest flag or plugin API change.

Behavior is unchanged for packages without sidecars: requests fall through to the plain file and the global `compression()` middleware as before. The templated admin `index.html` route is registered ahead of the static mount and keeps serving with `no-cache`.

Follow-up (separate PR): generate sidecars in the admin UI build so every installation benefits out of the box.

## What problem does this solve?

Reduces the need for repeated compression calls (saves CPU) and smaller files for faster file transfer.

## How was this tested?

Tested with unit tests covering encoding negotiation and fallback, plus a manual smoke against a running server (brotli sidecar served and decoded correctly, identity clients get the plain file, admin UI unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds optional support for serving Brotli- and gzip-precompressed static assets.

- Adds the `serveStaticFiles` helper and uses it for public assets, admin UI, documentation, webapps, plugin configuration UIs, and WASM webapps.
- Prefers Brotli or gzip sidecars when the client supports them.
- Falls back to the original file when no suitable sidecar exists.
- Keeps the templated admin `index.html` route ahead of static serving with `no-cache` behavior.
- Documents sidecar generation and publishing requirements for webapps.
- Adds tests for encoding negotiation, fallback behavior, directory indexes, and missing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->