### PR TITLE
perf(admin-ui): generate compressed sidecars at build time

### DIFF
--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -85,6 +85,7 @@
     "simple-line-icons": "^2.5.5",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
+    "vite-plugin-compression2": "^2.5.3",
     "vitest": "^4.1.9"
   },
   "scripts": {

--- a/packages/server-admin-ui/vite.config.ts
+++ b/packages/server-admin-ui/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
+import { compression } from 'vite-plugin-compression2'
 
 import '@signalk/server-admin-ui-dependencies'
 
@@ -86,6 +87,15 @@ export default defineConfig({
     react(),
     babel({
       presets: [reactCompilerPreset()]
+    }),
+    // Emit .br and .gz sidecars next to the originals; the server serves
+    // them directly with matching Content-Encoding, skipping per-request
+    // compression. Both are needed: Chrome only accepts brotli on secure
+    // origins, so plain-HTTP installs fall back to the gzip sidecar.
+    // Files under 1 KB gain nothing from compression.
+    compression({
+      algorithms: ['brotliCompress', 'gzip'],
+      threshold: 1024
     })
   ],
   css: {


### PR DESCRIPTION
Companion to #2883, which taught the server to serve precompressed
sidecar files at its static mounts. This generates those sidecars for
the admin U by adding `vite-plugin-compression2` to the build.

Every emitted text asset over 1 KB gets `.br` (quality 11) and `.gz`
(level 9) sidecars next to the original. Both encodings are needed:
browsers only accept brotli on secure origins, so plain-HTTP installs
(common on LAN Raspberry Pis) fall back to the gzip sidecar — still
smaller than the runtime middleware's level-6 output, at zero server
CPU.

Measured on the current build:

- main CSS: 350 kB → 39 kB brotli / 51 kB gzip
- largest JS chunk (mathjs vendor): 651 kB → 147 kB brotli / 178 kB gzip (brotli ~18% smaller)
- adds ~1.6 MB of sidecars to the published package (originals: ~14 MB)

Independent of #2883 merge order — without it the sidecars are simply
ignored.

## What problem does this solve?

- Slight reduction of CPU load by serving pre-compressed files.
- Very slight reduction of transferred filesize on http, slight reduction of file size on https and localhost

## How was this tested?

Verified end-to-end against a server running #2883: both encodings are
served byte-identical to the on-disk sidecars with correct
`Content-Encoding`, `Vary`, and per-variant ETags; clients without
`Accept-Encoding` get the plain file. The templated admin index is
unaffected — `/admin/` is served by a dedicated route that reads the
plain `index.html`, and at 715 bytes it falls under the 1 KB threshold
anyway.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds `vite-plugin-compression2` to the admin UI build.

- Generates Brotli (`.br`) and gzip (`.gz`) sidecar files for text assets at least 1 KB.
- Uses Brotli quality 11 and gzip level 9.
- Supports precompressed delivery over HTTPS and HTTP.
- Adds approximately 1.6 MB to the published package.
- Preserves the templated admin index and uncompressed responses when clients do not send `Accept-Encoding`.
- Verifies byte-identical delivery and correct `Content-Encoding`, `Vary`, and variant ETags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->