### PR TITLE
perf(server): drop lodash from getCachedDeltas

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -1493,22 +1493,23 @@ export default class DeltaCache {
     key?: string,
     sourcePolicy?: 'preferred' | 'all'
   ) {
-    const contexts: Context[] = []
-    _.keys(this.cache).forEach((type) => {
-      _.keys(this.cache[type]).forEach((id) => {
+    // Split the dotted path once per call — lodash _.get would re-parse
+    // it per context, and its 500-entry stringToPath memoize cache is
+    // cleared wholesale on overflow, so a server with more distinct
+    // subscribed paths re-parses continuously.
+    const keyParts: string[] = key ? key.split('.') : []
+
+    const deltas: NormalizedDelta[] = []
+    for (const type in this.cache) {
+      const contextsOfType: StringKeyed = this.cache[type]
+      for (const id in contextsOfType) {
         const context = `${type}.${id}` as Context
-        if (contextFilter({ context })) {
-          contexts.push(this.cache[type][id])
+        if (!contextFilter({ context })) {
+          continue
         }
-      })
-    })
-
-    const deltas = contexts.reduce(
-      (acc: NormalizedDelta[], context: Context) => {
-        let deltasToProcess
-
+        const contextNode: StringKeyed = contextsOfType[id]
         if (key === undefined) {
-          deltasToProcess = findDeltas(context)
+          findDeltas(contextNode, deltas)
         } else if (key === '') {
           // An empty-path subscription targets values stored at the
           // context root (e.g. mmsi, name), which live intermixed with
@@ -1516,25 +1517,22 @@ export default class DeltaCache {
           // only those whose own path is empty. Testing `if (key)` here
           // would treat '' as "no key" and leak every path into the
           // bootstrap snapshot.
-          deltasToProcess = findDeltas(context).filter(
-            (delta: NormalizedDelta) => delta.path === ''
-          )
+          findDeltas(contextNode, deltas, hasEmptyPath)
         } else {
-          deltasToProcess = _.get(context, key)
+          let node: StringKeyed | undefined = contextNode
+          for (let i = 0; i < keyParts.length; i++) {
+            node = node?.[keyParts[i]]
+          }
+          if (node) {
+            for (const akey in node) {
+              if (akey !== 'meta') {
+                deltas.push(node[akey])
+              }
+            }
+          }
         }
-        if (deltasToProcess) {
-          acc = acc.concat(
-            _.values(
-              _.pickBy(deltasToProcess, (val, akey) => {
-                return akey !== 'meta'
-              })
-            )
-          )
-        }
-        return acc
-      },
-      []
-    )
+      }
+    }
 
     const preferred =
       sourcePolicy === 'all' ? deltas : this.filterDeltasToPreferred(deltas)
@@ -1563,20 +1561,49 @@ function pathToProcessForFull(pathArray: any[]) {
   return pathArray
 }
 
-function pickDeltasFromBranch(acc: any[], obj: any) {
-  if (typeof obj === 'object') {
-    if (isUndefined(obj.path) || isUndefined(obj.value)) {
-      // not a delta, so process possible children
-      _.values(obj).reduce(pickDeltasFromBranch, acc)
-    } else {
-      acc.push(obj)
+const hasEmptyPath = (delta: NormalizedDelta) => delta.path === ''
+
+// A cache leaf carries the delta's own path and value; branch nodes
+// only carry children keyed by path segment or source ref.
+const isCachedDelta = (node: object): node is NormalizedDelta =>
+  'path' in node &&
+  node.path !== undefined &&
+  'value' in node &&
+  node.value !== undefined
+
+function pickDeltasFromBranch(
+  acc: NormalizedDelta[],
+  node: unknown,
+  predicate?: (delta: NormalizedDelta) => boolean
+) {
+  if (typeof node !== 'object' || node === null) {
+    return acc
+  }
+  if (isCachedDelta(node)) {
+    if (predicate === undefined || predicate(node)) {
+      acc.push(node)
+    }
+  } else {
+    // for...in over StringKeyed rather than Object.values(): this
+    // recursion visits the whole cache on connect scans and must not
+    // allocate per branch.
+    const branch: StringKeyed = node
+    for (const key in branch) {
+      pickDeltasFromBranch(acc, branch[key], predicate)
     }
   }
   return acc
 }
 
-function findDeltas(branchOrLeaf: any) {
-  return _.values(branchOrLeaf).reduce(pickDeltasFromBranch, [])
+function findDeltas(
+  branchOrLeaf: StringKeyed,
+  acc: NormalizedDelta[] = [],
+  predicate?: (delta: NormalizedDelta) => boolean
+) {
+  for (const key in branchOrLeaf) {
+    pickDeltasFromBranch(acc, branchOrLeaf[key], predicate)
+  }
+  return acc
 }
 
 function ensureHasDollarSource(normalizedDelta: NormalizedDelta): SourceRef {

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -1445,22 +1445,23 @@ export default class DeltaCache {
     key?: string,
     sourcePolicy?: 'preferred' | 'all'
   ) {
-    const contexts: Context[] = []
-    _.keys(this.cache).forEach((type) => {
-      _.keys(this.cache[type]).forEach((id) => {
+    // Split the dotted path once per call — lodash _.get would re-parse
+    // it per context, and its 500-entry stringToPath memoize cache is
+    // cleared wholesale on overflow, so a server with more distinct
+    // subscribed paths re-parses continuously.
+    const keyParts: string[] = key ? key.split('.') : []
+
+    const deltas: NormalizedDelta[] = []
+    for (const type in this.cache) {
+      const contextsOfType: StringKeyed = this.cache[type]
+      for (const id in contextsOfType) {
         const context = `${type}.${id}` as Context
-        if (contextFilter({ context })) {
-          contexts.push(this.cache[type][id])
+        if (!contextFilter({ context })) {
+          continue
         }
-      })
-    })
-
-    const deltas = contexts.reduce(
-      (acc: NormalizedDelta[], context: Context) => {
-        let deltasToProcess
-
+        const contextNode: StringKeyed = contextsOfType[id]
         if (key === undefined) {
-          deltasToProcess = findDeltas(context)
+          findDeltas(contextNode, deltas)
         } else if (key === '') {
           // An empty-path subscription targets values stored at the
           // context root (e.g. mmsi, name), which live intermixed with
@@ -1468,25 +1469,22 @@ export default class DeltaCache {
           // only those whose own path is empty. Testing `if (key)` here
           // would treat '' as "no key" and leak every path into the
           // bootstrap snapshot.
-          deltasToProcess = findDeltas(context).filter(
-            (delta: NormalizedDelta) => delta.path === ''
-          )
+          findDeltas(contextNode, deltas, hasEmptyPath)
         } else {
-          deltasToProcess = _.get(context, key)
+          let node: StringKeyed | undefined = contextNode
+          for (let i = 0; i < keyParts.length; i++) {
+            node = node?.[keyParts[i]]
+          }
+          if (node) {
+            for (const akey in node) {
+              if (akey !== 'meta') {
+                deltas.push(node[akey])
+              }
+            }
+          }
         }
-        if (deltasToProcess) {
-          acc = acc.concat(
-            _.values(
-              _.pickBy(deltasToProcess, (val, akey) => {
-                return akey !== 'meta'
-              })
-            )
-          )
-        }
-        return acc
-      },
-      []
-    )
+      }
+    }
 
     const preferred =
       sourcePolicy === 'all' ? deltas : this.filterDeltasToPreferred(deltas)
@@ -1515,20 +1513,49 @@ function pathToProcessForFull(pathArray: any[]) {
   return pathArray
 }
 
-function pickDeltasFromBranch(acc: any[], obj: any) {
-  if (typeof obj === 'object') {
-    if (isUndefined(obj.path) || isUndefined(obj.value)) {
-      // not a delta, so process possible children
-      _.values(obj).reduce(pickDeltasFromBranch, acc)
-    } else {
-      acc.push(obj)
+const hasEmptyPath = (delta: NormalizedDelta) => delta.path === ''
+
+// A cache leaf carries the delta's own path and value; branch nodes
+// only carry children keyed by path segment or source ref.
+const isCachedDelta = (node: object): node is NormalizedDelta =>
+  'path' in node &&
+  node.path !== undefined &&
+  'value' in node &&
+  node.value !== undefined
+
+function pickDeltasFromBranch(
+  acc: NormalizedDelta[],
+  node: unknown,
+  predicate?: (delta: NormalizedDelta) => boolean
+) {
+  if (typeof node !== 'object' || node === null) {
+    return acc
+  }
+  if (isCachedDelta(node)) {
+    if (predicate === undefined || predicate(node)) {
+      acc.push(node)
+    }
+  } else {
+    // for...in over StringKeyed rather than Object.values(): this
+    // recursion visits the whole cache on connect scans and must not
+    // allocate per branch.
+    const branch: StringKeyed = node
+    for (const key in branch) {
+      pickDeltasFromBranch(acc, branch[key], predicate)
     }
   }
   return acc
 }
 
-function findDeltas(branchOrLeaf: any) {
-  return _.values(branchOrLeaf).reduce(pickDeltasFromBranch, [])
+function findDeltas(
+  branchOrLeaf: StringKeyed,
+  acc: NormalizedDelta[] = [],
+  predicate?: (delta: NormalizedDelta) => boolean
+) {
+  for (const key in branchOrLeaf) {
+    pickDeltasFromBranch(acc, branchOrLeaf[key], predicate)
+  }
+  return acc
 }
 
 function ensureHasDollarSource(normalizedDelta: NormalizedDelta): SourceRef {


### PR DESCRIPTION
## Why

`getCachedDeltas` runs on the subscription bootstrap path:

- once per WebSocket connect (`sendLatestDeltas` — full cache scan),
- once per subscribe row per matching path bus (`handleSubscribeRow`) — a
  wildcard subscription sweeps **every** known path,
- and again for every *new* path that appears × every active subscription.

In the live-server profile from #2874 it accounted for 27.6% of wall clock. The
lodash calls inside it are what burn that time:

- `_.keys(...).forEach` allocates a fresh id array for every context on every call
- `_.get(context, key)` re-parses the dotted path (`castPath` → `stringToPath`)
  **per context per call** — and lodash's `memoizeCapped` path cache holds only
  500 entries and clears itself *wholesale* on overflow, so a server with more
  than 500 distinct paths in play re-parses continuously
- `_.values(_.pickBy(...))` + `acc.concat(...)` allocate two intermediate
  objects and a new array per context, just to drop a single `meta` key

## How

Plain JS, no behavior change:

- `for...in` over the cache instead of `_.keys().forEach` — no intermediate arrays
- split the dotted path **once per call** and walk it with an index loop instead
  of `_.get` per context
- push matches straight into one shared accumulator instead of
  `_.pickBy` → `_.values` → `concat`, including in `findDeltas` /
  `pickDeltasFromBranch` (only used by `getCachedDeltas`)

Output is **byte-identical**: a snapshot of full results (connect scan, self-only
scan, empty-path key, 50 subscribe keys, `sourcePolicy: 'all'`) diffs clean
between old and new code.

## Benchmark

Attached micro-benchmark instantiates the real compiled `DeltaCache`, populates
it like the server does (101 contexts = self + 100 AIS vessels, 600 distinct
paths — enough to overflow lodash's 500-entry path cache), and times the two
real call shapes. Median of 3 runs, Node 22, rockchip64:

| Scenario (per operation) | Before | After | Change |
|---|---:|---:|---:|
| Wildcard-subscribe bootstrap sweep (600 keys × 101 contexts) | 47.1 ms | 21.9 ms | **−53% (2.2×)** |
| Connect scan, all contexts (`sendLatestDeltas`, subscribe=all) | 9.5 ms | 5.4 ms | **−43% (1.8×)** |
| Connect scan, self only (subscribe=self) | 0.78 ms | 0.56 ms | **−28% (1.4×)** |

Lodash self-time in a `--cpu-prof` capture of the benchmark, before → after:

| Frame | Before | After |
|---|---:|---:|
| `castPath` | 7.6% | — |
| `isKey` + its `^\w*$` regex | 8.3% | — |
| `baseKeys` | 3.6% | — |
| `baseGet` | 3.2% | — |
| `stringToPath` regex | 2.3% | — |
| `memoized`, `values`, misc lodash | 5.2% | — |
| **Total lodash** | **~30%** | **0%** |

`castPath` appearing at all confirms the memoize-cache thrash: with fewer than
500 distinct paths it would be parsed once and never again.

To reproduce: `npm run build`, then from the repo root
`node getcacheddeltas-bench.js` (timing) and
`node getcacheddeltas-bench.js --snapshot out.json` (parity diff) on each of the
two builds.

fixes #2876

[getcacheddeltas-bench.js.txt](https://github.com/user-attachments/files/30581435/getcacheddeltas-bench.js.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes lodash from the `getCachedDeltas` hot path.

- Uses native loops for key enumeration and dotted-path traversal.
- Accumulates results directly while excluding `meta`.
- Updates `findDeltas` and `pickDeltasFromBranch` to share an accumulator.
- Preserves byte-identical output.
- Improves benchmark performance by 28–53%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->