### PR TITLE
Announce each new path on the internal keys bus only once

### DIFF
--- a/src/streambundle.ts
+++ b/src/streambundle.ts
@@ -148,7 +148,14 @@ export class StreamBundle implements IStreamBundle {
       let result = this.buses[path]
       if (!result) {
         result = this.buses[path] = new Bacon.Bus()
-        this.keys.push(path)
+        // Don't double-emit on `keys` if getUnfilteredBus(path) already
+        // announced it. Value deltas reach the unfiltered bus first, so
+        // without this guard every value path is announced twice and
+        // subscriptionmanager's keys listener builds two delivery chains
+        // for it, delivering each delta to the client twice.
+        if (!this.unfilteredBuses[path]) {
+          this.keys.push(path)
+        }
       }
       return result
     } else {

--- a/test/streambundle.ts
+++ b/test/streambundle.ts
@@ -1,0 +1,124 @@
+import {
+  Context,
+  Delta,
+  MetaValue,
+  Path,
+  SourceRef,
+  Timestamp,
+  Value
+} from '@signalk/server-api'
+import { expect } from 'chai'
+import { StreamBundle } from '../src/streambundle'
+
+const SELF_ID = 'self-uuid'
+const SELF_CONTEXT = `vessels.${SELF_ID}` as Context
+const TIMESTAMP = '2026-01-01T00:00:00.000Z' as Timestamp
+const SOURCE_REF = 'test.1' as SourceRef
+
+const SOG_PATH = 'navigation.speedOverGround' as Path
+const HEADING_PATH = 'navigation.headingTrue' as Path
+const WATER_TEMP_PATH = 'environment.water.temperature' as Path
+
+const SOG_FIRST = 3.4
+const SOG_SECOND = 3.5
+const SOG_THIRD = 3.6
+const HEADING = 1.2
+const WATER_TEMP = 285.4
+
+const WATER_TEMP_META: MetaValue = { units: 'K' }
+
+function valueDelta(path: Path, value: Value): Delta {
+  return {
+    context: SELF_CONTEXT,
+    updates: [
+      { $source: SOURCE_REF, timestamp: TIMESTAMP, values: [{ path, value }] }
+    ]
+  }
+}
+
+function metaDelta(path: Path, value: MetaValue): Delta {
+  return {
+    context: SELF_CONTEXT,
+    updates: [
+      { $source: SOURCE_REF, timestamp: TIMESTAMP, meta: [{ path, value }] }
+    ]
+  }
+}
+
+// index.ts emits `unfilteredDelta` before `delta`, and registers
+// pushUnfilteredDelta / pushDelta as permanent listeners on both, so every
+// delta reaches the unfiltered bus first. Replicate that order here.
+function dispatch(bundle: StreamBundle, delta: Delta) {
+  bundle.pushUnfilteredDelta(delta)
+  bundle.pushDelta(delta)
+}
+
+describe('StreamBundle path announcements', () => {
+  let bundle: StreamBundle
+  let announced: Path[]
+
+  beforeEach(() => {
+    bundle = new StreamBundle(SELF_ID)
+    announced = []
+    bundle.keys.onValue((path) => {
+      announced.push(path)
+    })
+  })
+
+  it('announces a new value path exactly once', () => {
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_FIRST))
+
+    expect(announced).to.deep.equal([SOG_PATH])
+  })
+
+  it('announces a path only once across repeated deltas', () => {
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_SECOND))
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_THIRD))
+
+    expect(announced).to.deep.equal([SOG_PATH])
+  })
+
+  // pushUnfilteredDelta skips updates carrying no `values`, so a path whose
+  // first appearance is meta-only gets its bus from pushDelta instead. It
+  // still has to be announced, and still only once when a value follows.
+  it('announces a meta-first path once, including when a value follows', () => {
+    dispatch(bundle, metaDelta(WATER_TEMP_PATH, WATER_TEMP_META))
+    expect(announced).to.deep.equal([WATER_TEMP_PATH])
+
+    dispatch(bundle, valueDelta(WATER_TEMP_PATH, WATER_TEMP))
+    expect(announced).to.deep.equal([WATER_TEMP_PATH])
+  })
+
+  it('announces each distinct path once', () => {
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(HEADING_PATH, HEADING))
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_SECOND))
+
+    expect(announced).to.deep.equal([SOG_PATH, HEADING_PATH])
+  })
+
+  // A single announcement must still leave both buses usable: the delta cache
+  // subscribes via getBus(), live subscriptions with sourcePolicy 'all' via
+  // getUnfilteredBus(). Neither may lose values.
+  it('delivers values on both the filtered and unfiltered bus for an announced path', () => {
+    const filtered: unknown[] = []
+    const unfiltered: unknown[] = []
+
+    bundle.keys.onValue((announcedPath) => {
+      bundle.getBus(announcedPath).onValue((d) => filtered.push(d.value))
+      bundle
+        .getUnfilteredBus(announcedPath)
+        .onValue((d) => unfiltered.push(d.value))
+    })
+
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(SOG_PATH, SOG_SECOND))
+
+    // Only the unfiltered bus announces the path, and it does so before
+    // receiving the delta that created it. The listener attaches to both buses
+    // at that point, so each delivers every value exactly once.
+    expect(filtered).to.deep.equal([SOG_FIRST, SOG_SECOND])
+    expect(unfiltered).to.deep.equal([SOG_FIRST, SOG_SECOND])
+  })
+})


### PR DESCRIPTION
`StreamBundle.getUnfilteredBus` guards its `keys.push` with `if (!this.buses[path])`, but `getBus` pushed unconditionally. Value deltas reach the unfiltered bus first (`index.ts` emits `unfilteredDelta` before `delta`, and both listeners are registered permanently), so for a value-first path `unfilteredBuses[path]` is always created before `buses[path]` and the existing guard can never fire. Every value path was announced twice.

That matters because `subscriptionmanager.ts` builds a delivery chain per announcement. A path that appears after a client has subscribed cost two retained Bacon chains instead of one, and the client received every delta on that path twice.

Measured against the real `StreamBundle`, driving deltas in the order `index.ts` dispatches them:

| | before | after |
|---|---|---|
| announcements for a new value path | 2 | 1 |
| chains built by a `keys` consumer | 2 | 1 |
| deliveries per delta on that path | 2 | 1 |

Paths first seen as meta-only are unaffected either way: `pushUnfilteredDelta` skips updates without `values`, so `buses[path]` is created first and the existing guard already handled that case. The added test covers both orderings so a later attempt to collapse the two guards into one cannot silently drop the meta-first announcement.

Found while looking at #2882, where the duplicate chains show up as per-connection memory growth. This is independent of the rest of that issue and of #2874 / #2875 / #2885.

## Test plan

- [x] New `test/streambundle.ts`: value-first path announced once, repeated deltas do not re-announce, meta-first path announced once and still announced when a value follows, distinct paths each announced once, and both the filtered and unfiltered bus still deliver every value for an announced path.
- [x] Verified before/after against the real `StreamBundle` with the numbers in the table above.
- [x] `prettier --check` and `eslint` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents duplicate path announcements on the internal keys bus in `StreamBundle`.
- Guards `getBus` before announcing value-first paths.
- Preserves existing meta-only path behavior.
- Adds tests for value-first, meta-first, repeated, and distinct paths.
- Verifies delivery through filtered and unfiltered buses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->