### PR TITLE
Cut subscription memory by building Bacon stages only for rows that need them

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -338,14 +338,20 @@ function handleSubscribeRow(
     const flattenRootValues = key === '' && !matcher(key)
     if (matcher(key) || flattenRootValues) {
       debug.enabled && debug('Subscribing to key ' + key)
-      let filteredBus: Bacon.EventStream<NormalizedDelta> = bus.filter(filter)
+      // Build Bacon stages only for rows that need them. A plain row (no
+      // rate limiting, no root flattening, no per-subscription engine) is
+      // delivered by a single inline sink further down instead, which
+      // retains about a quarter of what filter().map().onValue() does.
+      let filteredBus: Bacon.EventStream<NormalizedDelta> | null = null
       if (flattenRootValues) {
-        filteredBus = filteredBus.flatMap(
-          (normalizedDelta: NormalizedDelta) =>
-            Bacon.fromArray(
-              flattenRootDelta(normalizedDelta, matcher)
-            ) as Bacon.EventStream<NormalizedDelta>
-        )
+        filteredBus = bus
+          .filter(filter)
+          .flatMap(
+            (normalizedDelta: NormalizedDelta) =>
+              Bacon.fromArray(
+                flattenRootDelta(normalizedDelta, matcher)
+              ) as Bacon.EventStream<NormalizedDelta>
+          )
       }
       if (subscribeRow.minPeriod) {
         if (subscribeRow.policy && subscribeRow.policy !== 'instant') {
@@ -366,7 +372,9 @@ function handleSubscribeRow(
           // path delivered first. Root identity data also arrives on AIS
           // static-report cadence, far slower than any practical period.
           debug('debouncing')
-          filteredBus = filteredBus.debounceImmediate(minPeriodValue)
+          filteredBus = (filteredBus ?? bus.filter(filter)).debounceImmediate(
+            minPeriodValue
+          )
         }
       } else if (
         subscribeRow.period ||
@@ -379,7 +387,7 @@ function handleSubscribeRow(
         } else if (key !== '') {
           // we can not apply period for empty path subscriptions
           const interval = Number(subscribeRow.period) || 1000
-          filteredBus = filteredBus
+          filteredBus = (filteredBus ?? bus.filter(filter))
             .bufferWithTime(interval)
             .flatMapLatest((bufferedValues: any) => {
               const uniqueValues = _(bufferedValues)
@@ -413,7 +421,7 @@ function handleSubscribeRow(
       // plugin's own (or otherwise excluded) sources removed from the
       // candidate set.
       if (perSubEngine) {
-        const engineStream = filteredBus
+        const engineStream = (filteredBus ?? bus.filter(filter))
           .map(toDelta)
           .flatMap((delta: Delta) => {
             const filtered = runPerSubEngine(
@@ -425,8 +433,18 @@ function handleSubscribeRow(
             return filtered ? Bacon.once(filtered) : Bacon.never()
           }) as Bacon.EventStream<Delta>
         unsubscribes.push(engineStream.onValue(callback))
-      } else {
+      } else if (filteredBus) {
         unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
+      } else {
+        // Plain row: no stages needed. Returning the callback's result keeps
+        // Bacon.noMore working the same as through a filter/map chain.
+        unsubscribes.push(
+          bus.onValue((normalizedDelta: NormalizedDelta) => {
+            if (filter(normalizedDelta)) {
+              return callback(toDelta(normalizedDelta))
+            }
+          })
+        )
       }
 
       // Bootstrap snapshot: fetch every source's last cached value

--- a/test/subscriptionmanager-delivery.ts
+++ b/test/subscriptionmanager-delivery.ts
@@ -1,0 +1,203 @@
+import {
+  Context,
+  Delta,
+  Path,
+  SourceRef,
+  SubscriptionOptions,
+  Timestamp
+} from '@signalk/server-api'
+import * as Bacon from 'baconjs'
+import { expect } from 'chai'
+import { StreamBundle } from '../src/streambundle'
+import SubscriptionManager from '../src/subscriptionmanager'
+
+const SELF_ID = 'self-uuid'
+const SELF_CONTEXT = `vessels.${SELF_ID}` as Context
+const AIS_CONTEXT = 'vessels.urn:mrn:imo:mmsi:999' as Context
+const TIMESTAMP = '2026-01-01T00:00:00.000Z' as Timestamp
+const SOURCE_REF = 'test.1' as SourceRef
+
+const ALL_CONTEXTS = '*' as Context
+const ALL_PATHS = '*' as Path
+const SOG_PATH = 'navigation.speedOverGround' as Path
+const HEADING_PATH = 'navigation.headingTrue' as Path
+
+const SOG_FIRST = 3.4
+const SOG_SECOND = 3.5
+const HEADING = 1.2
+const AIS_SOG = 9.9
+
+function valueDelta(context: Context, path: Path, value: number): Delta {
+  return {
+    context,
+    updates: [
+      { $source: SOURCE_REF, timestamp: TIMESTAMP, values: [{ path, value }] }
+    ]
+  }
+}
+
+// index.ts emits `unfilteredDelta` before `delta`, and registers
+// pushUnfilteredDelta / pushDelta as permanent listeners on both.
+function dispatch(bundle: StreamBundle, delta: Delta) {
+  bundle.pushUnfilteredDelta(delta)
+  bundle.pushDelta(delta)
+}
+
+function pathsOf(deltas: Delta[]): string[] {
+  return deltas.map((d) => {
+    const update = d.updates[0]
+    return 'values' in update ? update.values[0].path : 'meta'
+  })
+}
+
+function mockApp(bundle: StreamBundle, cached: Delta[] = []) {
+  return {
+    streambundle: bundle,
+    selfContext: SELF_CONTEXT,
+    deltaCache: { getCachedDeltas: () => cached },
+    securityStrategy: {
+      filterReadDelta: (_user: unknown, delta: Delta) => delta,
+      shouldFilterDeltas: () => false
+    },
+    signalk: { root: {} }
+  }
+}
+
+// Rows carrying no rate limiting, no root flattening and no source excludes
+// are delivered by a single inline sink rather than a filter/map/onValue Bacon
+// chain. These pin the delivery contract that shortcut has to honour.
+describe('SubscriptionManager delivery', () => {
+  let bundle: StreamBundle
+  let received: Delta[]
+  let manager: SubscriptionManager
+  let unsubscribes: Array<() => void>
+
+  const subscribe = (
+    rows: SubscriptionOptions[],
+    callback?: (delta: Delta) => unknown,
+    cached: Delta[] = []
+  ) => {
+    manager = new SubscriptionManager(mockApp(bundle, cached))
+    manager.subscribe(
+      { context: ALL_CONTEXTS, subscribe: rows },
+      unsubscribes,
+      () => undefined,
+      callback ?? ((delta: Delta) => received.push(delta)),
+      undefined,
+      'preferred',
+      undefined
+    )
+  }
+
+  beforeEach(() => {
+    bundle = new StreamBundle(SELF_ID)
+    received = []
+    unsubscribes = []
+    // seed the paths so the initial pass over the bus map sees them
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, HEADING_PATH, HEADING))
+  })
+
+  it('delivers every matching delta once for a wildcard row', () => {
+    subscribe([{ path: ALL_PATHS }])
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, HEADING_PATH, HEADING))
+    dispatch(bundle, valueDelta(AIS_CONTEXT, SOG_PATH, AIS_SOG))
+
+    expect(pathsOf(received)).to.deep.equal([SOG_PATH, HEADING_PATH, SOG_PATH])
+  })
+
+  it('delivers only the subscribed path for an explicit row', () => {
+    subscribe([{ path: SOG_PATH }])
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, HEADING_PATH, HEADING))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(pathsOf(received)).to.deep.equal([SOG_PATH])
+    expect(received[0].updates[0]).to.have.property('$source', SOURCE_REF)
+  })
+
+  it('applies the context filter', () => {
+    manager = new SubscriptionManager(mockApp(bundle))
+    manager.subscribe(
+      { context: SELF_CONTEXT, subscribe: [{ path: ALL_PATHS }] },
+      unsubscribes,
+      () => undefined,
+      (delta: Delta) => received.push(delta),
+      undefined,
+      'preferred',
+      undefined
+    )
+
+    dispatch(bundle, valueDelta(AIS_CONTEXT, SOG_PATH, AIS_SOG))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(received.map((d) => d.context)).to.deep.equal([SELF_CONTEXT])
+  })
+
+  // Returning Bacon.noMore from a subscriber ends the subscription. That works
+  // through a filter/map chain and has to keep working through the inline sink,
+  // which means the sink must return the callback's result.
+  it('honours Bacon.noMore returned by the callback', () => {
+    subscribe([{ path: SOG_PATH }], (delta: Delta) => {
+      received.push(delta)
+      return Bacon.noMore
+    })
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+
+    expect(received).to.have.lengthOf(1)
+  })
+
+  it('replays cached deltas at subscribe time before live ones', () => {
+    const cachedValue = 1.11
+    subscribe([{ path: SOG_PATH }], undefined, [
+      valueDelta(SELF_CONTEXT, SOG_PATH, cachedValue)
+    ])
+
+    const replayed = received.length
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(replayed).to.equal(1)
+    expect(pathsOf(received)).to.deep.equal([SOG_PATH, SOG_PATH])
+  })
+
+  it('stops delivering after the subscription is torn down', () => {
+    subscribe([{ path: ALL_PATHS }])
+    unsubscribes.forEach((unsubscribe) => unsubscribe())
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(received).to.be.empty
+  })
+
+  // minPeriod and period rows still need real Bacon stages, so they must not
+  // take the inline path.
+  it('still debounces a row carrying minPeriod', (done) => {
+    subscribe([{ path: SOG_PATH, minPeriod: 200 }])
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    setTimeout(() => {
+      expect(received).to.have.lengthOf(1)
+      done()
+    }, 50)
+  })
+
+  it('still buffers a row carrying period', (done) => {
+    subscribe([{ path: SOG_PATH, period: 100 }])
+
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(bundle, valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    // nothing is emitted synchronously; the buffer flushes on the interval
+    expect(received).to.be.empty
+    setTimeout(() => {
+      expect(received).to.have.lengthOf(1)
+      done()
+    }, 200)
+  })
+})


### PR DESCRIPTION
`handleSubscribeRow` builds `bus.filter(f).map(toDelta).onValue(cb)` for every matching bus: three Bacon stages per (row x matching bus), even for a plain row with no rate limiting. Each chain retains about 3.4 KB, and one subscribe message carrying a `*` row against 2000 known paths builds 2000 of them.

This materialises `filteredBus` lazily. Rows that need real stages keep exactly the topology they have today. A plain row is delivered by a single inline sink applying the context filter and `toDelta` directly.

Measured over 100 subscribe messages against 2000 known paths, `heapUsed` after forced GC, driving the real `SubscriptionManager` and `StreamBundle`:

| rows per message | before | after |
|---|---|---|
| one `{"path":"*"}` row | **592.3 MB** | **102.4 MB** |
| 20 explicit paths | 6.9 MB | 4.9 MB |
| 20 explicit paths, 500 known paths | 6.3 MB | 2.5 MB |
| 5 explicit paths | 1.8 MB | 1.3 MB |

## Behaviour is unchanged

Still on the existing Bacon path, untouched: `minPeriod`, `period` / `policy: 'fixed'`, root-value flattening for leaf rows (#2858), and `excludeSources` / per-subscription priority engine rows.

The inline sink returns the callback's result, so `Bacon.noMore` still unsubscribes exactly as it does through a `filter`/`map` chain.

A harness capturing the exact sequence of deltas delivered to the subscriber across 15 scenarios produces **byte-identical output before and after**: wildcard, explicit, duplicate and prefix-wildcard rows, root flattening and explicit `''` rows, `vessels.self` context filtering, both source policies, cached bootstrap replay, `minPeriod`, `period`, an invalid policy, `Bacon.noMore`, and synchronous re-entrancy ordering where the subscriber dispatches another delta from inside its own callback.

## What this does not do

It does not close #2882. Growth is still unbounded in (messages x matching paths): there is still no dedup, the per-message `keys.onValue` listener still accumulates one per subscribe message, and granular unsubscribe still throws. This makes each unit roughly 4x cheaper, it does not make the total bounded. The per-subscribe cache replay cost is also untouched, which is #2874 / #2875 / #2885 territory.

## Test plan

- [x] New `test/subscriptionmanager-delivery.ts`, 8 cases pinning the delivery contract: wildcard and explicit row delivery, context filtering, `Bacon.noMore`, cached replay ordering, teardown, and that `minPeriod` still debounces and `period` still buffers.
- [x] Those tests pass against **both** this branch and unpatched master, which is the point: the change is behaviour-preserving, so they are a guard against future regressions rather than a demonstration of a fix.
- [x] Byte-identical delivered-sequence comparison across the 15 scenarios above.
- [x] `prettier --check` and `eslint` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Lazily builds Bacon processing stages only for subscriptions that need rate limiting, root-value flattening, or per-subscription priority processing.
- Uses a direct bus sink for plain subscriptions. The sink applies context filtering and `toDelta` inline.
- Preserves `Bacon.noMore` unsubscribe behavior and delivery behavior.
- Adds tests for path matching, filtering, replay ordering, teardown, `minPeriod`, and `period`.
- Reduces memory use from 592.3 MB to 102.4 MB for 100 wildcard subscriptions across 2,000 known paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->