### PR TITLE
feat(admin-ui): user-selectable Webapps sort order (A-Z, drag & drop, last used)

### DIFF
--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -145,6 +145,20 @@ Click the _Restart_ button at the top right of the screen to restart the server.
 
 After the server has restarted, the installed plugin(s) can be configued by selecting _Server -> Plugin Config_ menu entry.
 
+## The Webapps page
+
+Installed webapps are launched from the _Webapps_ page of the Admin UI.
+
+The sort selector at the top right of the list offers three orders:
+
+- `A-Z` — alphabetical, by display name.
+
+- `Custom order` — arrange the webapps yourself by dragging the grip handle at the top right of each card (works with mouse and touch). Newly installed webapps are appended at the end of your order.
+
+- `Last used` — most recently launched webapps first, followed by the webapps you have not launched yet in alphabetical order.
+
+The last selected order becomes your standard view and is restored on your next visit. It is remembered per browser; on servers with security enabled it is additionally stored per user, so it follows your login across devices.
+
 ## Trouble shooting and the Server Log
 
 If things are not working as expected after installing a plugin or webapp, select _Server -> Server Log_ to view the server's log. If the errors logged there are not providing the information required, you can enable debugging for individual components and plugins by toggling the switch to activate them.

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -83,6 +83,7 @@
     "remark-gfm": "^4.0.1",
     "sass": "^1.101.0",
     "simple-line-icons": "^2.5.5",
+    "typebox": "^1.3.9",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.9"

--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -19,6 +19,10 @@ import {
   type GnssPositionSlice
 } from './slices/gnssPositionSlice'
 import {
+  createWebappSortSlice,
+  type WebappSortSlice
+} from './slices/webappSortSlice'
+import {
   conflictKey,
   detectInstanceConflicts,
   extractN2kDevices
@@ -34,13 +38,15 @@ export type { DataSlice, PathData, MetaData } from './slices/dataSlice'
 export type { PrioritiesSlice } from './slices/prioritiesSlice'
 export type { UnitPreferencesSlice } from './slices/unitPreferencesSlice'
 export type { GnssPositionSlice } from './slices/gnssPositionSlice'
+export type { WebappSortSlice } from './slices/webappSortSlice'
 
 export type SignalKStore = AppSlice &
   WsSlice &
   DataSlice &
   PrioritiesSlice &
   UnitPreferencesSlice &
-  GnssPositionSlice
+  GnssPositionSlice &
+  WebappSortSlice
 
 export const useStore = create<SignalKStore>()(
   subscribeWithSelector((...args) => ({
@@ -49,7 +55,8 @@ export const useStore = create<SignalKStore>()(
     ...createDataSlice(...args),
     ...createPrioritiesSlice(...args),
     ...createUnitPreferencesSlice(...args),
-    ...createGnssPositionSlice(...args)
+    ...createGnssPositionSlice(...args),
+    ...createWebappSortSlice(...args)
   }))
 )
 
@@ -184,6 +191,18 @@ export function useWebapps() {
 
 export function useAddons() {
   return useStore((s) => s.addons)
+}
+
+export function useWebappSortMode() {
+  return useStore((s) => s.webappSortMode)
+}
+
+export function useWebappCustomOrder() {
+  return useStore((s) => s.webappCustomOrder)
+}
+
+export function useWebappLastUsed() {
+  return useStore((s) => s.webappLastUsed)
 }
 
 export function usePlugins() {

--- a/packages/server-admin-ui/src/store/slices/webappSortSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/webappSortSlice.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useStore } from '../index'
+import {
+  WEBAPP_SORT_MODE_KEY,
+  WEBAPP_CUSTOM_ORDER_KEY,
+  WEBAPP_LAST_USED_KEY
+} from './webappSortSlice'
+
+interface FetchCall {
+  url: string
+  init?: RequestInit
+}
+
+function mockFetch(status: number, body?: unknown): FetchCall[] {
+  const calls: FetchCall[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init })
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body
+      }
+    })
+  )
+  return calls
+}
+
+const postCalls = (calls: FetchCall[]) =>
+  calls.filter((c) => c.init?.method === 'POST')
+
+describe('webappSortSlice', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    useStore.setState({
+      webappSortMode: 'name',
+      webappCustomOrder: [],
+      webappLastUsed: {},
+      webappSortSynced: false
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initWebappSort', () => {
+    it('defaults to name mode on a fresh install (nothing persisted, security off)', async () => {
+      mockFetch(405)
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('name')
+      expect(s.webappCustomOrder).toEqual([])
+      expect(s.webappLastUsed).toEqual({})
+      expect(s.webappSortSynced).toBe(false)
+    })
+
+    it('restores the last chosen mode from localStorage', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'lastUsed')
+      mockFetch(405)
+
+      await useStore.getState().initWebappSort()
+
+      expect(useStore.getState().webappSortMode).toBe('lastUsed')
+    })
+
+    it('falls back to defaults for invalid stored values', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'frecency')
+      window.localStorage.setItem(WEBAPP_CUSTOM_ORDER_KEY, '{not json')
+      // Valid JSON, wrong shape:
+      window.localStorage.setItem(WEBAPP_LAST_USED_KEY, '["a"]')
+      mockFetch(405)
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('name')
+      expect(s.webappCustomOrder).toEqual([])
+      expect(s.webappLastUsed).toEqual({})
+    })
+
+    it('lets the server copy win for mode and order and max-merges lastUsed', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'name')
+      window.localStorage.setItem(
+        WEBAPP_LAST_USED_KEY,
+        JSON.stringify({ local: 100, both: 900 })
+      )
+      const calls = mockFetch(200, {
+        sortMode: 'custom',
+        customOrder: ['server-app'],
+        lastUsed: { server: 50, both: 200 }
+      })
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('custom')
+      expect(s.webappCustomOrder).toEqual(['server-app'])
+      expect(s.webappLastUsed).toEqual({ local: 100, both: 900, server: 50 })
+      expect(s.webappSortSynced).toBe(true)
+      // Local launches were unknown to the server → merged doc pushed up.
+      expect(postCalls(calls).length).toBe(1)
+      // The merged state is also written back to localStorage.
+      expect(window.localStorage.getItem(WEBAPP_SORT_MODE_KEY)).toBe('custom')
+    })
+
+    it('treats a 200 with {} as available-but-empty and pushes local state up', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'custom')
+      window.localStorage.setItem(
+        WEBAPP_CUSTOM_ORDER_KEY,
+        JSON.stringify(['a'])
+      )
+      const calls = mockFetch(200, {})
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('custom')
+      expect(s.webappCustomOrder).toEqual(['a'])
+      expect(s.webappSortSynced).toBe(true)
+      expect(postCalls(calls).length).toBe(1)
+    })
+
+    it('treats a 404 (security off, routes not mounted) as unavailable', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'custom')
+      mockFetch(404)
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('custom')
+      expect(s.webappSortSynced).toBe(false)
+    })
+
+    it('ignores a malformed server document', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'lastUsed')
+      mockFetch(200, { sortMode: 'frecency', bogus: true })
+
+      await useStore.getState().initWebappSort()
+
+      const s = useStore.getState()
+      expect(s.webappSortMode).toBe('lastUsed')
+      expect(s.webappSortSynced).toBe(true)
+    })
+
+    it('keeps a user edit made while the GET is in flight over the server copy', async () => {
+      window.localStorage.setItem(WEBAPP_SORT_MODE_KEY, 'name')
+      let releaseGet = () => {}
+      const gate = new Promise<void>((resolve) => {
+        releaseGet = resolve
+      })
+      const calls: FetchCall[] = []
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string, init?: RequestInit) => {
+          calls.push({ url, init })
+          if (!init?.method) await gate
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              sortMode: 'lastUsed',
+              customOrder: [],
+              lastUsed: {}
+            })
+          }
+        })
+      )
+
+      const init = useStore.getState().initWebappSort()
+      useStore.getState().setWebappSortMode('custom')
+      releaseGet()
+      await init
+
+      expect(useStore.getState().webappSortMode).toBe('custom')
+    })
+
+    it('stays localStorage-only on network errors', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          throw new Error('offline')
+        })
+      )
+
+      await useStore.getState().initWebappSort()
+
+      expect(useStore.getState().webappSortSynced).toBe(false)
+    })
+  })
+
+  describe('setWebappSortMode / setWebappCustomOrder', () => {
+    it('persists to localStorage', () => {
+      const calls = mockFetch(405)
+
+      useStore.getState().setWebappSortMode('custom')
+      useStore.getState().setWebappCustomOrder(['b', 'a'])
+
+      expect(window.localStorage.getItem(WEBAPP_SORT_MODE_KEY)).toBe('custom')
+      expect(window.localStorage.getItem(WEBAPP_CUSTOM_ORDER_KEY)).toBe(
+        JSON.stringify(['b', 'a'])
+      )
+      expect(useStore.getState().webappSortMode).toBe('custom')
+      expect(useStore.getState().webappCustomOrder).toEqual(['b', 'a'])
+      // Not synced → no server traffic.
+      expect(postCalls(calls).length).toBe(0)
+    })
+
+    it('POSTs the full document when synced', () => {
+      const calls = mockFetch(200, {})
+      useStore.setState({ webappSortSynced: true, webappLastUsed: { a: 1 } })
+
+      useStore.getState().setWebappSortMode('lastUsed')
+
+      expect(postCalls(calls).length).toBe(1)
+      expect(JSON.parse(String(postCalls(calls)[0].init?.body))).toEqual({
+        sortMode: 'lastUsed',
+        customOrder: [],
+        lastUsed: { a: 1 }
+      })
+    })
+  })
+
+  describe('recordWebappLaunch', () => {
+    it('writes the timestamp to localStorage synchronously and never POSTs', () => {
+      const calls = mockFetch(200, {})
+      useStore.setState({ webappSortSynced: true })
+
+      useStore.getState().recordWebappLaunch('@signalk/freeboard-sk')
+
+      const stored = JSON.parse(
+        window.localStorage.getItem(WEBAPP_LAST_USED_KEY) ?? '{}'
+      )
+      expect(typeof stored['@signalk/freeboard-sk']).toBe('number')
+      expect(stored['@signalk/freeboard-sk']).toBeGreaterThan(0)
+      expect(useStore.getState().webappLastUsed['@signalk/freeboard-sk']).toBe(
+        stored['@signalk/freeboard-sk']
+      )
+      expect(postCalls(calls).length).toBe(0)
+    })
+  })
+})

--- a/packages/server-admin-ui/src/store/slices/webappSortSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/webappSortSlice.ts
@@ -1,0 +1,196 @@
+import type { StateCreator } from 'zustand'
+import { Check } from 'typebox/value'
+import {
+  mergeLastUsed,
+  WEBAPP_SORT_MODES,
+  WebappCustomOrderSchema,
+  WebappLastUsedSchema,
+  WebappSortDocSchema,
+  type WebappSortDoc,
+  type WebappSortMode
+} from '../../utils/webappSort'
+import {
+  readJson,
+  readString,
+  writeJson,
+  writeString
+} from '../../utils/safeLocalStorage'
+
+export const WEBAPP_SORT_MODE_KEY = 'signalk.webapps.sortMode'
+export const WEBAPP_CUSTOM_ORDER_KEY = 'signalk.webapps.customOrder'
+export const WEBAPP_LAST_USED_KEY = 'signalk.webapps.lastUsed'
+
+const APPLICATION_DATA_URL =
+  '/signalk/v1/applicationData/user/webapp-sort/1.0.0'
+
+export interface WebappSortSliceState {
+  webappSortMode: WebappSortMode
+  webappCustomOrder: string[]
+  webappLastUsed: Record<string, number>
+  // applicationData reachable this session (security enabled and the GET
+  // in initWebappSort answered) — gates the fire-and-forget POSTs.
+  webappSortSynced: boolean
+}
+
+export interface WebappSortSliceActions {
+  initWebappSort: () => Promise<void>
+  setWebappSortMode: (mode: WebappSortMode) => void
+  setWebappCustomOrder: (order: string[]) => void
+  recordWebappLaunch: (name: string) => void
+}
+
+export type WebappSortSlice = WebappSortSliceState & WebappSortSliceActions
+
+// localStorage survives server restarts (it lives in the browser) and is
+// the always-available store; applicationData adds cross-device sync per
+// user but is disabled entirely on servers without security.
+function readLocalDoc(): WebappSortDoc {
+  const rawOrder = readJson(WEBAPP_CUSTOM_ORDER_KEY)
+  const rawLastUsed = readJson(WEBAPP_LAST_USED_KEY)
+  return {
+    sortMode: readString(WEBAPP_SORT_MODE_KEY, WEBAPP_SORT_MODES, 'name'),
+    customOrder: Check(WebappCustomOrderSchema, rawOrder) ? rawOrder : [],
+    lastUsed: Check(WebappLastUsedSchema, rawLastUsed) ? rawLastUsed : {}
+  }
+}
+
+function writeLocalDoc(doc: WebappSortDoc): void {
+  writeString(WEBAPP_SORT_MODE_KEY, doc.sortMode)
+  writeJson(WEBAPP_CUSTOM_ORDER_KEY, doc.customOrder)
+  writeJson(WEBAPP_LAST_USED_KEY, doc.lastUsed)
+}
+
+interface ServerDocResult {
+  // false when applicationData is not usable this session, so POSTs are
+  // pointless: with security off the routes are not even mounted (GET
+  // falls through to a 404), without a login the GET is a 401.
+  available: boolean
+  doc?: WebappSortDoc
+}
+
+async function fetchServerDoc(): Promise<ServerDocResult> {
+  try {
+    const res = await fetch(APPLICATION_DATA_URL, { credentials: 'include' })
+    if (!res.ok) {
+      return { available: false }
+    }
+    const data: unknown = await res.json()
+    // A whole-doc GET answers 200 with {} when nothing is stored yet; a
+    // malformed or partial doc (e.g. written by a future version) is
+    // treated the same — absent rather than trusted.
+    return {
+      available: true,
+      doc: Check(WebappSortDocSchema, data) ? data : undefined
+    }
+  } catch {
+    return { available: false }
+  }
+}
+
+function postServerDoc(doc: WebappSortDoc): void {
+  fetch(APPLICATION_DATA_URL, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(doc)
+  })
+    .then((res) => {
+      if (!res.ok) {
+        console.debug('webapp-sort sync rejected:', res.status)
+      }
+    })
+    .catch((err) => console.debug('webapp-sort sync failed:', err))
+}
+
+export const createWebappSortSlice: StateCreator<
+  WebappSortSlice,
+  [],
+  [],
+  WebappSortSlice
+> = (set, get) => {
+  const initial = readLocalDoc()
+  return {
+    webappSortMode: initial.sortMode,
+    webappCustomOrder: initial.customOrder,
+    webappLastUsed: initial.lastUsed,
+    webappSortSynced: false,
+
+    initWebappSort: async () => {
+      const local = readLocalDoc()
+      set({
+        webappSortMode: local.sortMode,
+        webappCustomOrder: local.customOrder,
+        webappLastUsed: local.lastUsed
+      })
+
+      const server = await fetchServerDoc()
+      if (!server.available) return
+
+      // The user may have changed mode/order or launched a webapp while
+      // the GET was in flight — those newer edits win over the server copy.
+      const current = get()
+      const merged: WebappSortDoc = {
+        sortMode:
+          current.webappSortMode !== local.sortMode
+            ? current.webappSortMode
+            : (server.doc?.sortMode ?? local.sortMode),
+        customOrder:
+          current.webappCustomOrder !== local.customOrder
+            ? current.webappCustomOrder
+            : (server.doc?.customOrder ?? local.customOrder),
+        lastUsed: mergeLastUsed(
+          mergeLastUsed(local.lastUsed, current.webappLastUsed),
+          server.doc?.lastUsed ?? {}
+        )
+      }
+
+      set({
+        webappSortMode: merged.sortMode,
+        webappCustomOrder: merged.customOrder,
+        webappLastUsed: merged.lastUsed,
+        webappSortSynced: true
+      })
+      writeLocalDoc(merged)
+      // Push local knowledge (e.g. launches recorded while the server
+      // copy was elsewhere) up to the server. Key-order differences can
+      // cause a redundant POST; the write is idempotent so that is
+      // harmless.
+      if (JSON.stringify(server.doc) !== JSON.stringify(merged)) {
+        postServerDoc(merged)
+      }
+    },
+
+    setWebappSortMode: (mode) => {
+      set({ webappSortMode: mode })
+      const { webappCustomOrder, webappLastUsed, webappSortSynced } = get()
+      const doc: WebappSortDoc = {
+        sortMode: mode,
+        customOrder: webappCustomOrder,
+        lastUsed: webappLastUsed
+      }
+      writeLocalDoc(doc)
+      if (webappSortSynced) postServerDoc(doc)
+    },
+
+    setWebappCustomOrder: (order) => {
+      set({ webappCustomOrder: order })
+      const { webappSortMode, webappLastUsed, webappSortSynced } = get()
+      const doc: WebappSortDoc = {
+        sortMode: webappSortMode,
+        customOrder: order,
+        lastUsed: webappLastUsed
+      }
+      writeLocalDoc(doc)
+      if (webappSortSynced) postServerDoc(doc)
+    },
+
+    // localStorage only: the click navigates away immediately, so the
+    // synchronous write is all that reliably completes. The server copy
+    // catches up via the merge in initWebappSort on the next visit.
+    recordWebappLaunch: (name) => {
+      const lastUsed = { ...get().webappLastUsed, [name]: Date.now() }
+      set({ webappLastUsed: lastUsed })
+      writeJson(WEBAPP_LAST_USED_KEY, lastUsed)
+    }
+  }
+}

--- a/packages/server-admin-ui/src/utils/safeLocalStorage.ts
+++ b/packages/server-admin-ui/src/utils/safeLocalStorage.ts
@@ -1,0 +1,46 @@
+// localStorage access can throw in restricted-storage contexts (Safari
+// private mode, browsers with site data blocked), so every read and
+// write is wrapped and degrades to the caller's fallback.
+
+export function readString<T extends string>(
+  key: string,
+  allowed: readonly T[],
+  fallback: T
+): T {
+  if (typeof window === 'undefined') return fallback
+  try {
+    const raw = window.localStorage?.getItem(key)
+    if (raw && (allowed as readonly string[]).includes(raw)) return raw as T
+    return fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function writeString(key: string, value: string): void {
+  try {
+    window.localStorage?.setItem(key, value)
+  } catch {
+    // localStorage unavailable (private mode); silently ignore.
+  }
+}
+
+// Returns undefined for missing keys, invalid JSON, and unavailable
+// storage alike — callers validate the shape before trusting the value.
+export function readJson(key: string): unknown {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const raw = window.localStorage?.getItem(key)
+    return raw ? JSON.parse(raw) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function writeJson(key: string, value: unknown): void {
+  try {
+    window.localStorage?.setItem(key, JSON.stringify(value))
+  } catch {
+    // localStorage unavailable (private mode); silently ignore.
+  }
+}

--- a/packages/server-admin-ui/src/utils/webappSort.test.ts
+++ b/packages/server-admin-ui/src/utils/webappSort.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest'
+import { Check } from 'typebox/value'
+import {
+  applyWebappSort,
+  mergeLastUsed,
+  WebappSortDocSchema,
+  type SortableWebapp
+} from './webappSort'
+
+const app = (name: string, displayName?: string): SortableWebapp =>
+  displayName ? { name, signalk: { displayName } } : { name }
+
+const names = (webapps: SortableWebapp[]) => webapps.map((w) => w.name)
+
+describe('applyWebappSort', () => {
+  describe('name mode', () => {
+    it('sorts alphabetically, case-insensitive', () => {
+      const result = applyWebappSort(
+        [app('zulu'), app('Alpha'), app('mike')],
+        'name',
+        [],
+        {}
+      )
+      expect(names(result)).toEqual(['Alpha', 'mike', 'zulu'])
+    })
+
+    it('sorts by displayName when present, package name otherwise', () => {
+      const result = applyWebappSort(
+        [app('a-package', 'Zebra App'), app('z-package', 'Anchor App')],
+        'name',
+        [],
+        {}
+      )
+      expect(names(result)).toEqual(['z-package', 'a-package'])
+    })
+  })
+
+  describe('custom mode', () => {
+    it('orders by the stored order', () => {
+      const result = applyWebappSort(
+        [app('a'), app('b'), app('c')],
+        'custom',
+        ['c', 'a', 'b'],
+        {}
+      )
+      expect(names(result)).toEqual(['c', 'a', 'b'])
+    })
+
+    it('appends webapps missing from the stored order as an alphabetical tail', () => {
+      const result = applyWebappSort(
+        [app('new-b'), app('ranked'), app('new-a')],
+        'custom',
+        ['ranked'],
+        {}
+      )
+      expect(names(result)).toEqual(['ranked', 'new-a', 'new-b'])
+    })
+
+    it('tolerates stored names that are not installed (slot kept, no crash)', () => {
+      const result = applyWebappSort(
+        [app('b'), app('a')],
+        'custom',
+        ['gone', 'b', 'a'],
+        {}
+      )
+      expect(names(result)).toEqual(['b', 'a'])
+    })
+  })
+
+  describe('lastUsed mode', () => {
+    it('sorts by most recent launch first', () => {
+      const result = applyWebappSort(
+        [app('old'), app('newest'), app('mid')],
+        'lastUsed',
+        [],
+        { old: 100, newest: 300, mid: 200 }
+      )
+      expect(names(result)).toEqual(['newest', 'mid', 'old'])
+    })
+
+    it('puts never-launched webapps in an alphabetical tail', () => {
+      const result = applyWebappSort(
+        [app('n-zulu'), app('used'), app('n-alpha')],
+        'lastUsed',
+        [],
+        { used: 100 }
+      )
+      expect(names(result)).toEqual(['used', 'n-alpha', 'n-zulu'])
+    })
+
+    it('is not confused by webapps named like Object.prototype members', () => {
+      const result = applyWebappSort(
+        [app('constructor'), app('used')],
+        'lastUsed',
+        [],
+        { used: 100 }
+      )
+      expect(names(result)).toEqual(['used', 'constructor'])
+    })
+  })
+
+  it('does not mutate its input', () => {
+    const input = [app('b'), app('a')]
+    applyWebappSort(input, 'name', [], {})
+    expect(names(input)).toEqual(['b', 'a'])
+  })
+})
+
+describe('mergeLastUsed', () => {
+  it('takes the per-webapp maximum and unions both maps', () => {
+    expect(mergeLastUsed({ a: 100, b: 500 }, { b: 200, c: 300 })).toEqual({
+      a: 100,
+      b: 500,
+      c: 300
+    })
+  })
+
+  it('handles empty maps', () => {
+    expect(mergeLastUsed({}, { a: 1 })).toEqual({ a: 1 })
+    expect(mergeLastUsed({ a: 1 }, {})).toEqual({ a: 1 })
+    expect(mergeLastUsed({}, {})).toEqual({})
+  })
+})
+
+describe('WebappSortDocSchema', () => {
+  const valid = {
+    sortMode: 'custom',
+    customOrder: ['a', 'b'],
+    lastUsed: { a: 123 }
+  }
+
+  it('accepts a valid document', () => {
+    expect(Check(WebappSortDocSchema, valid)).toBe(true)
+  })
+
+  it('rejects an unknown sort mode', () => {
+    expect(Check(WebappSortDocSchema, { ...valid, sortMode: 'frecency' })).toBe(
+      false
+    )
+  })
+
+  it('rejects non-string custom order entries', () => {
+    expect(Check(WebappSortDocSchema, { ...valid, customOrder: [1, 2] })).toBe(
+      false
+    )
+  })
+
+  it('rejects non-numeric lastUsed timestamps', () => {
+    expect(
+      Check(WebappSortDocSchema, { ...valid, lastUsed: { a: '123' } })
+    ).toBe(false)
+  })
+
+  it('rejects missing fields and non-objects', () => {
+    expect(Check(WebappSortDocSchema, { sortMode: 'name' })).toBe(false)
+    expect(Check(WebappSortDocSchema, null)).toBe(false)
+    expect(Check(WebappSortDocSchema, 'name')).toBe(false)
+  })
+})

--- a/packages/server-admin-ui/src/utils/webappSort.ts
+++ b/packages/server-admin-ui/src/utils/webappSort.ts
@@ -1,0 +1,98 @@
+import Type, { type Static } from 'typebox'
+
+export const WebappSortModeSchema = Type.Union([
+  Type.Literal('name'),
+  Type.Literal('custom'),
+  Type.Literal('lastUsed')
+])
+
+export type WebappSortMode = Static<typeof WebappSortModeSchema>
+
+// Runtime list derived from the schema so the localStorage validation
+// (readString allow-list) and the document validation cannot drift.
+export const WEBAPP_SORT_MODES: readonly WebappSortMode[] =
+  WebappSortModeSchema.anyOf.map((literal) => literal.const as WebappSortMode)
+
+export const WebappCustomOrderSchema = Type.Array(Type.String())
+
+export const WebappLastUsedSchema = Type.Record(Type.String(), Type.Number())
+
+// The document synced to /signalk/v1/applicationData/user/webapp-sort —
+// also the shape persisted (field by field) in localStorage. Everything
+// read from either source is validated against these schemas before use.
+export const WebappSortDocSchema = Type.Object({
+  sortMode: WebappSortModeSchema,
+  customOrder: WebappCustomOrderSchema,
+  lastUsed: WebappLastUsedSchema
+})
+
+export type WebappSortDoc = Static<typeof WebappSortDocSchema>
+
+export interface SortableWebapp {
+  name: string
+  signalk?: {
+    displayName?: string
+  }
+}
+
+const sortName = (webapp: SortableWebapp) =>
+  webapp.signalk?.displayName || webapp.name
+
+const byName = (a: SortableWebapp, b: SortableWebapp) =>
+  sortName(a).localeCompare(sortName(b), undefined, { sensitivity: 'base' })
+
+export function applyWebappSort<T extends SortableWebapp>(
+  webapps: T[],
+  mode: WebappSortMode,
+  customOrder: string[],
+  lastUsed: Record<string, number>
+): T[] {
+  const sorted = [...webapps]
+  if (mode === 'custom') {
+    // Ranked names keep their stored position; webapps not in the stored
+    // order (newly installed) form an alphabetical tail.
+    const rank = new Map(customOrder.map((name, index) => [name, index]))
+    sorted.sort((a, b) => {
+      const rankA = rank.get(a.name)
+      const rankB = rank.get(b.name)
+      if (rankA !== undefined && rankB !== undefined) return rankA - rankB
+      if (rankA !== undefined) return -1
+      if (rankB !== undefined) return 1
+      return byName(a, b)
+    })
+  } else if (mode === 'lastUsed') {
+    // Most recently launched first; never-launched webapps form an
+    // alphabetical tail. Map lookup instead of property access so a
+    // webapp named like an Object.prototype member cannot resolve to
+    // an inherited value.
+    const launched = new Map(Object.entries(lastUsed))
+    sorted.sort((a, b) => {
+      const launchedA = launched.get(a.name)
+      const launchedB = launched.get(b.name)
+      if (launchedA !== undefined && launchedB !== undefined)
+        return launchedB - launchedA
+      if (launchedA !== undefined) return -1
+      if (launchedB !== undefined) return 1
+      return byName(a, b)
+    })
+  } else {
+    sorted.sort(byName)
+  }
+  return sorted
+}
+
+// Per-webapp maximum of both timestamp maps, so partial histories from
+// two devices combine instead of one overwriting the other.
+export function mergeLastUsed(
+  a: Record<string, number>,
+  b: Record<string, number>
+): Record<string, number> {
+  const merged = new Map(Object.entries(a))
+  for (const [name, timestamp] of Object.entries(b)) {
+    const existing = merged.get(name)
+    if (existing === undefined || timestamp > existing) {
+      merged.set(name, timestamp)
+    }
+  }
+  return Object.fromEntries(merged)
+}

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
 import Webapp from './Webapp'
 
 describe('Webapp', () => {
@@ -43,6 +43,20 @@ describe('Webapp', () => {
       expect(
         container.querySelector('[data-icon="table-cells"]')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('launch', () => {
+    it('fires onLaunch when the card link is clicked', () => {
+      const onLaunch = vi.fn()
+      const { container } = render(
+        <Webapp webAppInfo={{ name: 'test-app' }} onLaunch={onLaunch} />
+      )
+
+      const link = container.querySelector('a') as HTMLAnchorElement
+      fireEvent.click(link)
+
+      expect(onLaunch).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -21,6 +21,7 @@ interface WebAppInfo {
 
 interface WebappProps {
   webAppInfo: WebAppInfo
+  onLaunch?: () => void
   children?: ReactNode
 }
 
@@ -30,7 +31,11 @@ export function urlToWebapp(webAppInfo: WebAppInfo): string {
     : `/${webAppInfo.name}/`
 }
 
-export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
+export default function Webapp({
+  webAppInfo,
+  onLaunch,
+  ...attributes
+}: WebappProps) {
   const padding = { card: 'p-3', icon: 'p-3', lead: 'mt-2' }
 
   const card = {
@@ -78,7 +83,7 @@ export default function Webapp({ webAppInfo, ...attributes }: WebappProps) {
   }
 
   return (
-    <a href={url}>
+    <a href={url} onClick={onLaunch}>
       <Card>
         <Card.Body className={card.style} {...attributes}>
           {blockIcon()}

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
@@ -203,7 +203,8 @@ export default function Webapps() {
     // hidden (e.g. a disabled plugin's webapp) keep a slot by being
     // re-appended, so they come back ranked instead of vanishing from
     // the stored order.
-    const hidden = customOrder.filter((name) => !displayedNames.includes(name))
+    const displayedSet = new Set(displayedNames)
+    const hidden = customOrder.filter((name) => !displayedSet.has(name))
     setWebappCustomOrder([...next, ...hidden])
   }
 

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.tsx
@@ -3,14 +3,51 @@ import {
   useMemo,
   Suspense,
   createElement,
-  ComponentType
+  ComponentType,
+  CSSProperties
 } from 'react'
-import { useWebapps, useAddons } from '../../store'
+import {
+  useWebapps,
+  useAddons,
+  useStore,
+  useWebappSortMode,
+  useWebappCustomOrder,
+  useWebappLastUsed
+} from '../../store'
 import { fetchWebapps } from '../../actions'
 import Card from 'react-bootstrap/Card'
 import Col from 'react-bootstrap/Col'
+import Form from 'react-bootstrap/Form'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faGripVertical } from '@fortawesome/free-solid-svg-icons/faGripVertical'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { ADDON_PANEL, toLazyDynamicComponent } from './dynamicutilities'
 import Webapp from './Webapp'
+import { applyWebappSort, type WebappSortMode } from '../../utils/webappSort'
+
+const DRAG_ACTIVATION_DISTANCE_PX = 4
+const TOUCH_ACTIVATION_DELAY_MS = 150
+const TOUCH_ACTIVATION_TOLERANCE_PX = 5
+const DRAGGING_OPACITY = 0.6
+const DRAGGING_Z_INDEX = 2
+const HANDLE_Z_INDEX = 3
+const HANDLE_COLOR = '#8a93a2'
 
 interface WebAppInfo {
   name: string
@@ -31,13 +68,144 @@ interface AddonPanelProps {
   addons: AddonModule[]
 }
 
+interface SortableWebappColProps {
+  webAppInfo: WebAppInfo
+  onLaunch: () => void
+}
+
+// In custom mode each grid cell becomes sortable. The card itself stays a
+// plain link — dragging happens only via the grip handle, so a drag can
+// never be misread as a navigation (and vice versa).
+function SortableWebappCol({ webAppInfo, onLaunch }: SortableWebappColProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id: webAppInfo.name })
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? DRAGGING_OPACITY : 1,
+    zIndex: isDragging ? DRAGGING_Z_INDEX : undefined,
+    position: 'relative'
+  }
+
+  const handleStyle: CSSProperties = {
+    // Without touch-action: none, iOS Safari treats a vertical drag on
+    // the handle as page scroll and DnD never starts.
+    touchAction: 'none',
+    position: 'absolute',
+    top: '0.5rem',
+    right: '1.25rem',
+    zIndex: HANDLE_Z_INDEX,
+    border: 'none',
+    background: 'transparent',
+    color: HANDLE_COLOR,
+    cursor: 'grab',
+    padding: '0.25rem 0.5rem'
+  }
+
+  return (
+    <Col xs="12" md="12" lg="6" xl="4" ref={setNodeRef} style={style}>
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        style={handleStyle}
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag ${webAppInfo.signalk?.displayName || webAppInfo.name}`}
+      >
+        <FontAwesomeIcon icon={faGripVertical} />
+      </button>
+      <Webapp webAppInfo={webAppInfo} onLaunch={onLaunch} />
+    </Col>
+  )
+}
+
 export default function Webapps() {
   const webapps = useWebapps() as WebAppInfo[]
   const addons = useAddons() as AddonModule[]
+  const sortMode = useWebappSortMode()
+  const customOrder = useWebappCustomOrder()
+  const lastUsed = useWebappLastUsed()
+  const initWebappSort = useStore((s) => s.initWebappSort)
+  const setWebappSortMode = useStore((s) => s.setWebappSortMode)
+  const setWebappCustomOrder = useStore((s) => s.setWebappCustomOrder)
+  const recordWebappLaunch = useStore((s) => s.recordWebappLaunch)
 
   useEffect(() => {
     fetchWebapps()
-  }, [])
+    void initWebappSort()
+  }, [initWebappSort])
+
+  const visibleWebapps = useMemo(
+    () =>
+      webapps.filter(
+        (webAppInfo) => webAppInfo.name !== '@signalk/server-admin-ui'
+      ),
+    [webapps]
+  )
+
+  const sortedWebapps = useMemo(
+    () => applyWebappSort(visibleWebapps, sortMode, customOrder, lastUsed),
+    [visibleWebapps, sortMode, customOrder, lastUsed]
+  )
+
+  const displayedNames = useMemo(
+    () => sortedWebapps.map((webAppInfo) => webAppInfo.name),
+    [sortedWebapps]
+  )
+
+  const handleModeChange = (mode: WebappSortMode) => {
+    if (mode === 'custom' && customOrder.length === 0) {
+      // First entry into custom mode: seed with the order currently on
+      // screen so dragging starts from what the user sees.
+      setWebappCustomOrder(displayedNames)
+    }
+    setWebappSortMode(mode)
+  }
+
+  // PointerSensor handles mouse + most pen/pointer-aware browsers, but
+  // iOS Safari maps touch into pointer events tied to scroll gestures
+  // and the drag never starts. A separate TouchSensor with a hold delay
+  // makes touch DnD reliable and keeps a tap from being misread as a
+  // drag.
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE_PX }
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: TOUCH_ACTIVATION_DELAY_MS,
+        tolerance: TOUCH_ACTIVATION_TOLERANCE_PX
+      }
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const from = displayedNames.indexOf(String(active.id))
+    const to = displayedNames.indexOf(String(over.id))
+    if (from === -1 || to === -1) return
+    const next = [...displayedNames]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    // Persist the full on-screen order. Stored names that are currently
+    // hidden (e.g. a disabled plugin's webapp) keep a slot by being
+    // re-appended, so they come back ranked instead of vanishing from
+    // the stored order.
+    const hidden = customOrder.filter((name) => !displayedNames.includes(name))
+    setWebappCustomOrder([...next, ...hidden])
+  }
 
   const addonComponents = useMemo(
     () =>
@@ -51,24 +219,61 @@ export default function Webapps() {
     [addons]
   )
 
+  const grid = (
+    <div className="row">
+      {sortedWebapps.map((webAppInfo) =>
+        sortMode === 'custom' ? (
+          <SortableWebappCol
+            key={webAppInfo.name}
+            webAppInfo={webAppInfo}
+            onLaunch={() => recordWebappLaunch(webAppInfo.name)}
+          />
+        ) : (
+          <Col xs="12" md="12" lg="6" xl="4" key={webAppInfo.name}>
+            <Webapp
+              webAppInfo={webAppInfo}
+              onLaunch={() => recordWebappLaunch(webAppInfo.name)}
+            />
+          </Col>
+        )
+      )}
+    </div>
+  )
+
   return (
     <div className="animated fadeIn">
       <Card>
-        <Card.Header>Webapps</Card.Header>
+        <Card.Header className="d-flex justify-content-between align-items-center">
+          <span>Webapps</span>
+          <Form.Select
+            size="sm"
+            style={{ width: 'auto' }}
+            value={sortMode}
+            onChange={(e) => handleModeChange(e.target.value as WebappSortMode)}
+            aria-label="Sort order"
+          >
+            <option value="name">A-Z</option>
+            <option value="custom">Custom order</option>
+            <option value="lastUsed">Last used</option>
+          </Form.Select>
+        </Card.Header>
         <Card.Body>
-          <div className="row">
-            {webapps
-              .filter(
-                (webAppInfo) => webAppInfo.name !== '@signalk/server-admin-ui'
-              )
-              .map((webAppInfo) => {
-                return (
-                  <Col xs="12" md="12" lg="6" xl="4" key={webAppInfo.name}>
-                    <Webapp key={webAppInfo.name} webAppInfo={webAppInfo} />
-                  </Col>
-                )
-              })}
-          </div>
+          {sortMode === 'custom' ? (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={displayedNames}
+                strategy={rectSortingStrategy}
+              >
+                {grid}
+              </SortableContext>
+            </DndContext>
+          ) : (
+            grid
+          )}
         </Card.Body>
       </Card>
 


### PR DESCRIPTION
The Webapps page renders the list in the order the server returns it: regular webapps followed by embeddable ones, each group alphabetical with `@signalk`-scoped packages hoisted first. To users this looks random, and there is no way to influence it.

This adds a sort selector to the Webapps page with three modes:

- **A-Z** (default on first visit) — by display name
- **Custom order** — arrange the cards by dragging a grip handle (mouse, touch and keyboard, via the dnd-kit setup already used by Source Priorities)
- **Last used** — most recently launched first, never-launched webapps as an alphabetical tail

The last chosen mode becomes the user's standard view and is restored on the next visit. Preferences live in localStorage, so the feature works on servers without security and survives restarts. With security enabled they additionally sync per user via `applicationData` (appid `webapp-sort`), so the arrangement follows the login across devices; sync degrades silently to localStorage-only when applicationData is unavailable. Everything read from localStorage or the network is validated against typebox schemas, and state lives in a new zustand slice following the unitpreferences pattern.

typebox 1.x is added as a devDependency of the admin UI only (bundled by vite, nothing new installed at runtime). It is a separate npm package from the server's `@sinclair/typebox` 0.34, so the two coexist without conflict.

Includes a user-facing docs section in `docs/setup/configuration.md`.

Tested: vitest units for the sort/merge logic and the slice (localStorage persistence, server-copy-wins merge, in-flight-edit race, malformed-input rejection); full admin-ui suite plus repo `build:all` and server test suite; headless-chromium e2e against a live server covering security-off (localStorage only, no sync traffic) and secured setups (per-user sync, cross-device pickup in a second browser profile, persistence across a server restart).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds selectable Webapps sorting in the admin UI:

- **A-Z** sorts by display name and is the default.
- **Custom order** supports mouse, touch, and keyboard drag-and-drop.
- **Last used** sorts by launch time and places never-launched apps in alphabetical order.

The selected mode, custom order, and launch timestamps persist in `localStorage`. When security is enabled, preferences synchronize per user through `applicationData` with app ID `webapp-sort`. The UI falls back silently to local storage when synchronization is unavailable.

TypeBox schemas validate local and remote data. The PR adds Zustand state management, sorting utilities, safe local-storage helpers, documentation, unit tests, admin UI and server test coverage, build validation, and secured and unsecured headless Chromium tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->