### PR TITLE
feat(admin-ui): show meta displayName under paths in the Data Browser with inline rename

### DIFF
--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -96,7 +96,7 @@ sudo find / -name "plaka.log"
 
 The _Data_ menu provides tools for viewing, inspecting, and managing your Signal K data:
 
-- **Data Browser** — Browse all Signal K data paths in real time with values, sources, and timestamps.
+- **Data Browser** — Browse all Signal K data paths in real time with values, sources, and timestamps. When a path has a `displayName` set in its metadata, it is shown below the path — handy for telling instanced paths like `tanks.freshWater.2` or `electrical.switches.bank.10.1` apart. Notification rows show the name of the data path they relate to. Administrators can set or edit the name in place via the pencil next to it; it is stored as regular metadata, the same as editing it on the _Meta Data_ page.
 
 - **Meta Data** — View and edit Signal K metadata (units, descriptions, display names, zones) for any path.
 

--- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.tsx
@@ -3,6 +3,7 @@ import Badge from 'react-bootstrap/Badge'
 import { usePathData, useMetaData } from './usePathData'
 import TimestampCell from './TimestampCell'
 import CopyToClipboardWithFade from './CopyToClipboardWithFade'
+import PathDisplayName from './PathDisplayName'
 import SourceLabel from './SourceLabel'
 import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
 import {
@@ -243,6 +244,7 @@ function DataRow({
             {path} <span className="copy-icon" aria-hidden="true" />
           </span>
         </CopyToClipboardWithFade>
+        {path && <PathDisplayName context={realContext} path={path} />}
       </div>
 
       {showContext && (

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
@@ -170,6 +170,90 @@ describe('PathDisplayName', () => {
     )
   })
 
+  it('preserves other metadata fields through successful and rejected saves', async () => {
+    asAdmin()
+    setMeta({
+      [PATH]: { displayName: 'Old', units: 'ratio', description: 'level' }
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200 }))
+    )
+
+    const { getByRole } = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(getByRole('button'))
+    fireEvent.change(getByRole('textbox'), { target: { value: 'New' } })
+    fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' })
+
+    let meta = useStore.getState().signalkMeta['self'][PATH]
+    expect(meta).toMatchObject({
+      displayName: 'New',
+      units: 'ratio',
+      description: 'level'
+    })
+
+    // Rejected save: revert must also merge, not replace.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500 }))
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    fireEvent.click(getByRole('button'))
+    fireEvent.change(getByRole('textbox'), { target: { value: 'Newer' } })
+    fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBe(
+        'New'
+      )
+    )
+    meta = useStore.getState().signalkMeta['self'][PATH]
+    expect(meta).toMatchObject({ units: 'ratio', description: 'level' })
+  })
+
+  it('ignores a stale rejection from a save started before a row remount', async () => {
+    asAdmin()
+    setMeta({})
+    const settlers: Array<(res: { ok: boolean; status: number }) => void> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise((resolve) => {
+            settlers.push(resolve as (typeof settlers)[number])
+          })
+      )
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Mount A: save 'First', then the virtualized row unmounts.
+    const first = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(first.getByRole('button'))
+    fireEvent.change(first.getByRole('textbox'), {
+      target: { value: 'First' }
+    })
+    fireEvent.keyDown(first.getByRole('textbox'), { key: 'Enter' })
+    first.unmount()
+
+    // Mount B: save 'Second'.
+    const second = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(second.getByRole('button'))
+    fireEvent.change(second.getByRole('textbox'), {
+      target: { value: 'Second' }
+    })
+    fireEvent.keyDown(second.getByRole('textbox'), { key: 'Enter' })
+
+    expect(settlers.length).toBe(2)
+    settlers[1]({ ok: true, status: 200 })
+    settlers[0]({ ok: false, status: 500 })
+
+    await waitFor(() =>
+      expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBe(
+        'Second'
+      )
+    )
+  })
+
   it('ignores a stale rejection settling after a newer save', async () => {
     asAdmin()
     setMeta({})

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
@@ -61,6 +61,26 @@ describe('PathDisplayName', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('keeps unnamed rows single-line: inline pencil, no block sub-line', () => {
+    asAdmin()
+    setMeta({})
+    const { container, getByRole } = render(
+      <PathDisplayName context="self" path={PATH} />
+    )
+    expect(container.querySelector('div.path-display-name')).toBeNull()
+    expect(
+      container.querySelector('span.path-display-name')
+    ).toBeInTheDocument()
+    expect(getByRole('button')).toBeInTheDocument()
+  })
+
+  it('renders the block sub-line only when a name is set', () => {
+    asAdmin()
+    setMeta({ [PATH]: { displayName: 'Freshwater STB' } })
+    const { container } = render(<PathDisplayName context="self" path={PATH} />)
+    expect(container.querySelector('div.path-display-name')).toBeInTheDocument()
+  })
+
   it('hides the pencil on non-self contexts', () => {
     setMeta({})
     useStore.setState({

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
@@ -150,6 +150,48 @@ describe('PathDisplayName', () => {
     )
   })
 
+  it('ignores a stale rejection settling after a newer save', async () => {
+    asAdmin()
+    setMeta({})
+    // Manually settled responses so the first save can fail AFTER the
+    // second one succeeded.
+    const settlers: Array<(res: { ok: boolean; status: number }) => void> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise((resolve) => {
+            settlers.push(resolve as (typeof settlers)[number])
+          })
+      )
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { getByRole, queryByText } = render(
+      <PathDisplayName context="self" path={PATH} />
+    )
+    fireEvent.click(getByRole('button'))
+    fireEvent.change(getByRole('textbox'), { target: { value: 'First' } })
+    fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' })
+
+    fireEvent.click(getByRole('button'))
+    fireEvent.change(getByRole('textbox'), { target: { value: 'Second' } })
+    fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' })
+
+    expect(settlers.length).toBe(2)
+    settlers[1]({ ok: true, status: 200 })
+    settlers[0]({ ok: false, status: 500 })
+
+    // The stale rejection must neither revert the newer value nor flag
+    // a failure.
+    await waitFor(() =>
+      expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBe(
+        'Second'
+      )
+    )
+    await waitFor(() => expect(queryByText('Save failed')).toBeNull())
+  })
+
   it('cancels with Escape without saving', () => {
     asAdmin()
     setMeta({ [PATH]: { displayName: 'Freshwater STB' } })

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { useStore } from '../../store'
+import PathDisplayName from './PathDisplayName'
+
+const PATH = 'tanks.freshWater.2.currentLevel'
+
+function setMeta(meta: Record<string, Record<string, unknown>>) {
+  useStore.setState({ signalkMeta: { self: meta } })
+}
+
+function asAdmin() {
+  useStore.setState({
+    loginStatus: {
+      authenticationRequired: true,
+      status: 'loggedIn',
+      userLevel: 'admin'
+    }
+  })
+}
+
+function asReadonlyUser() {
+  useStore.setState({
+    loginStatus: {
+      authenticationRequired: true,
+      status: 'loggedIn',
+      userLevel: 'readonly'
+    }
+  })
+}
+
+describe('PathDisplayName', () => {
+  beforeEach(() => {
+    useStore.setState({ signalkMeta: {}, loginStatus: {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the displayName stored at the exact path', () => {
+    setMeta({ [PATH]: { displayName: 'Freshwater STB' } })
+    const { getByText } = render(<PathDisplayName context="self" path={PATH} />)
+    expect(getByText('Freshwater STB')).toBeInTheDocument()
+  })
+
+  it('shows the mapped data-path name on a notifications row without a pencil', () => {
+    asAdmin()
+    setMeta({ [PATH]: { displayName: 'Freshwater STB' } })
+    const { getByText, queryByRole } = render(
+      <PathDisplayName context="self" path={`notifications.${PATH}`} />
+    )
+    expect(getByText('Freshwater STB')).toBeInTheDocument()
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('renders nothing without a name for a non-editing user', () => {
+    asReadonlyUser()
+    const { container } = render(<PathDisplayName context="self" path={PATH} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('hides the pencil on non-self contexts', () => {
+    setMeta({})
+    useStore.setState({
+      signalkMeta: {
+        'vessels.urn:mrn:imo:mmsi:230099999': {
+          [PATH]: { displayName: 'Other boat tank' }
+        }
+      }
+    })
+    const { getByText, queryByRole } = render(
+      <PathDisplayName
+        context="vessels.urn:mrn:imo:mmsi:230099999"
+        path={PATH}
+      />
+    )
+    expect(getByText('Other boat tank')).toBeInTheDocument()
+    expect(queryByRole('button')).toBeNull()
+  })
+
+  it('saves an edit via PUT and updates the store optimistically', async () => {
+    asAdmin()
+    setMeta({})
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { getByRole } = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(getByRole('button'))
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Freshwater STB' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/signalk/v1/api/vessels/self/tanks/freshWater/2/currentLevel/meta/displayName',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: 'Freshwater STB' })
+      })
+    )
+    expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBe(
+      'Freshwater STB'
+    )
+  })
+
+  it('reverts the optimistic update when the PUT is rejected', async () => {
+    asAdmin()
+    setMeta({ [PATH]: { displayName: 'Old name' } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 401 }))
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { getByRole } = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(getByRole('button'))
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'New name' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBe(
+        'Old name'
+      )
+    )
+    warn.mockRestore()
+  })
+
+  it('cancels with Escape without saving', () => {
+    asAdmin()
+    setMeta({ [PATH]: { displayName: 'Freshwater STB' } })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { getByRole, getByText } = render(
+      <PathDisplayName context="self" path={PATH} />
+    )
+    fireEvent.click(getByRole('button'))
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Changed' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(getByText('Freshwater STB')).toBeInTheDocument()
+  })
+
+  it('clears the name when saving an empty value', () => {
+    asAdmin()
+    setMeta({ [PATH]: { displayName: 'Freshwater STB' } })
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { getByRole } = render(<PathDisplayName context="self" path={PATH} />)
+    fireEvent.click(getByRole('button'))
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify({ value: null }) })
+    )
+    expect(useStore.getState().signalkMeta['self'][PATH].displayName).toBeNull()
+  })
+})

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.test.tsx
@@ -36,6 +36,7 @@ describe('PathDisplayName', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it('shows the displayName stored at the exact path', () => {
@@ -103,16 +104,18 @@ describe('PathDisplayName', () => {
     )
   })
 
-  it('reverts the optimistic update when the PUT is rejected', async () => {
+  it('reverts the optimistic update and shows feedback when the PUT is rejected', async () => {
     asAdmin()
     setMeta({ [PATH]: { displayName: 'Old name' } })
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({ ok: false, status: 401 }))
     )
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const { getByRole } = render(<PathDisplayName context="self" path={PATH} />)
+    const { getByRole, findByText } = render(
+      <PathDisplayName context="self" path={PATH} />
+    )
     fireEvent.click(getByRole('button'))
     const input = getByRole('textbox')
     fireEvent.change(input, { target: { value: 'New name' } })
@@ -123,7 +126,28 @@ describe('PathDisplayName', () => {
         'Old name'
       )
     )
-    warn.mockRestore()
+    expect(await findByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('URL-encodes path segments in the PUT request', () => {
+    asAdmin()
+    setMeta({})
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const oddPath = 'environment.we#ird.1.value'
+
+    const { getByRole } = render(
+      <PathDisplayName context="self" path={oddPath} />
+    )
+    fireEvent.click(getByRole('button'))
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Odd' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/signalk/v1/api/vessels/self/environment/we%23ird/1/value/meta/displayName',
+      expect.objectContaining({ method: 'PUT' })
+    )
   })
 
   it('cancels with Escape without saving', () => {

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
@@ -152,6 +152,65 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
 
   if (!name && !canEdit) return null
 
+  const pencil = canEdit && (
+    <button
+      type="button"
+      onClick={handleStartEdit}
+      title={
+        name
+          ? `Edit displayName (meta.displayName at ${path})`
+          : `Set displayName (meta.displayName at ${path})`
+      }
+      aria-label={
+        name ? `Edit displayName for ${path}` : `Set displayName for ${path}`
+      }
+      className="path-displayname-edit"
+      style={{
+        cursor: 'pointer',
+        opacity: 0.4,
+        fontSize: '0.85em',
+        lineHeight: 1,
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        color: 'inherit'
+      }}
+    >
+      &#9998;
+    </button>
+  )
+
+  const failure = saveFailed && (
+    <span
+      role="alert"
+      style={{ color: 'var(--bs-danger, #d9534f)', fontSize: '0.85em' }}
+      title="The server rejected the displayName change; the previous value was restored."
+    >
+      Save failed
+    </span>
+  )
+
+  // Unnamed rows stay single-line: the pencil flows inline after the
+  // path instead of opening an almost-empty second row, so the table
+  // keeps its density until a name actually needs the space.
+  if (!name) {
+    return (
+      <span
+        className="path-display-name"
+        style={{
+          marginLeft: '4px',
+          whiteSpace: 'nowrap',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '3px'
+        }}
+      >
+        {failure}
+        {pencil}
+      </span>
+    )
+  }
+
   return (
     <div
       className="path-display-name text-muted"
@@ -163,45 +222,9 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
         gap: '3px'
       }}
     >
-      {name && <span style={{ fontStyle: 'italic' }}>{name}</span>}
-      {saveFailed && (
-        <span
-          role="alert"
-          style={{ color: 'var(--bs-danger, #d9534f)' }}
-          title="The server rejected the displayName change; the previous value was restored."
-        >
-          Save failed
-        </span>
-      )}
-      {canEdit && (
-        <button
-          type="button"
-          onClick={handleStartEdit}
-          title={
-            name
-              ? `Edit displayName (meta.displayName at ${path})`
-              : `Set displayName (meta.displayName at ${path})`
-          }
-          aria-label={
-            name
-              ? `Edit displayName for ${path}`
-              : `Set displayName for ${path}`
-          }
-          className="path-displayname-edit"
-          style={{
-            cursor: 'pointer',
-            opacity: 0.4,
-            fontSize: '0.85em',
-            lineHeight: 1,
-            background: 'none',
-            border: 'none',
-            padding: 0,
-            color: 'inherit'
-          }}
-        >
-          &#9998;
-        </button>
-      )}
+      <span style={{ fontStyle: 'italic' }}>{name}</span>
+      {failure}
+      {pencil}
     </div>
   )
 }

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
@@ -23,6 +23,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
   })
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState('')
+  const [saveFailed, setSaveFailed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isCancelRef = useRef(false)
 
@@ -48,6 +49,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
   const handleStartEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     setEditValue(name ?? '')
+    setSaveFailed(false)
     isCancelRef.current = false
     setIsEditing(true)
   }
@@ -60,28 +62,36 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
     const trimmed = editValue.trim()
     if (trimmed !== (name ?? '')) {
       // Editable rows resolve at their own path only, so the previous
-      // value for a revert is simply the currently shown name.
+      // value for a revert is simply the currently shown name. Revert
+      // and failure flag write to the global store / state directly, so
+      // they behave the same even if the virtualized row unmounts while
+      // the request is in flight — deliberately no AbortController,
+      // which would falsely revert a write the server already accepted.
       const previous = name ?? null
       updateMeta(context, path, { displayName: trimmed || null })
-      const revert = () => updateMeta(context, path, { displayName: previous })
-      fetch(
-        `/signalk/v1/api/vessels/self/${path.replaceAll('.', '/')}/meta/displayName`,
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ value: trimmed || null })
-        }
-      )
+      const onFailure = () => {
+        updateMeta(context, path, { displayName: previous })
+        setSaveFailed(true)
+      }
+      // Provider-sourced paths are not guaranteed URL-safe.
+      const encodedPath = path.split('.').map(encodeURIComponent).join('/')
+      fetch(`/signalk/v1/api/vessels/self/${encodedPath}/meta/displayName`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: trimmed || null })
+      })
         .then((res) => {
           if (!res.ok) {
             console.warn('displayName save rejected:', res.status)
-            revert()
+            onFailure()
+          } else {
+            setSaveFailed(false)
           }
         })
         .catch((err) => {
           console.warn('displayName save failed:', err)
-          revert()
+          onFailure()
         })
     }
     // Press-Enter calls this directly and then setIsEditing(false)
@@ -146,6 +156,15 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
       }}
     >
       {name && <span style={{ fontStyle: 'italic' }}>{name}</span>}
+      {saveFailed && (
+        <span
+          role="alert"
+          style={{ color: 'var(--bs-danger, #d9534f)' }}
+          title="The server rejected the displayName change; the previous value was restored."
+        >
+          Save failed
+        </span>
+      )}
       {canEdit && (
         <button
           type="button"

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
@@ -26,6 +26,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
   const [saveFailed, setSaveFailed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isCancelRef = useRef(false)
+  const saveSeqRef = useRef(0)
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -68,8 +69,15 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
       // the request is in flight — deliberately no AbortController,
       // which would falsely revert a write the server already accepted.
       const previous = name ?? null
+      // Rapid consecutive saves can settle out of order; only the
+      // latest request may revert the store or toggle the failure flag,
+      // otherwise a stale rejection would clobber the newer optimistic
+      // value with its older `previous` snapshot.
+      const seq = ++saveSeqRef.current
+      const isCurrent = () => saveSeqRef.current === seq
       updateMeta(context, path, { displayName: trimmed || null })
       const onFailure = () => {
+        if (!isCurrent()) return
         updateMeta(context, path, { displayName: previous })
         setSaveFailed(true)
       }
@@ -85,7 +93,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
           if (!res.ok) {
             console.warn('displayName save rejected:', res.status)
             onFailure()
-          } else {
+          } else if (isCurrent()) {
             setSaveFailed(false)
           }
         })

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { useStore, useLoginStatus } from '../../store'
+import { notificationDataPath, resolveDisplayName } from './displayNameUtils'
+
+interface PathDisplayNameProps {
+  context: string
+  path: string
+}
+
+// Muted second line under the path showing meta.displayName, with the
+// same inline pencil editing pattern as SourceLabel. The name shown is
+// exactly the one stored at the row's own path (notifications rows
+// mirror their data path read-only), and edits write plain
+// meta.displayName at that path — nothing is stored anywhere else.
+const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
+  const loginStatus = useLoginStatus()
+  const updateMeta = useStore((s) => s.updateMeta)
+  // Primitive selector result so a row only re-renders when its resolved
+  // name actually changes, not on every meta delta in the context.
+  const resolvedKey = useStore((s) => {
+    const resolved = resolveDisplayName(s.signalkMeta[context], path)
+    return resolved ? `${resolved.metaPath}\0${resolved.name}` : null
+  })
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const isCancelRef = useRef(false)
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const name = resolvedKey
+    ? resolvedKey.slice(resolvedKey.indexOf('\0') + 1)
+    : undefined
+
+  // The PUT endpoint writes vessels.self only, and notifications rows
+  // just mirror their data path — the pencil lives on the data row.
+  const canEdit =
+    context === 'self' &&
+    notificationDataPath(path) === undefined &&
+    (!loginStatus.authenticationRequired ||
+      (loginStatus.status === 'loggedIn' && loginStatus.userLevel === 'admin'))
+
+  const handleStartEdit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    setEditValue(name ?? '')
+    isCancelRef.current = false
+    setIsEditing(true)
+  }
+
+  const handleSave = () => {
+    if (isCancelRef.current) {
+      isCancelRef.current = false
+      return
+    }
+    const trimmed = editValue.trim()
+    if (trimmed !== (name ?? '')) {
+      // Editable rows resolve at their own path only, so the previous
+      // value for a revert is simply the currently shown name.
+      const previous = name ?? null
+      updateMeta(context, path, { displayName: trimmed || null })
+      const revert = () => updateMeta(context, path, { displayName: previous })
+      fetch(
+        `/signalk/v1/api/vessels/self/${path.replaceAll('.', '/')}/meta/displayName`,
+        {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: trimmed || null })
+        }
+      )
+        .then((res) => {
+          if (!res.ok) {
+            console.warn('displayName save rejected:', res.status)
+            revert()
+          }
+        })
+        .catch((err) => {
+          console.warn('displayName save failed:', err)
+          revert()
+        })
+    }
+    // Press-Enter calls this directly and then setIsEditing(false)
+    // unmounts the input, which fires onBlur and re-enters handleSave.
+    // Re-using the cancel ref short-circuits that second pass.
+    isCancelRef.current = true
+    setIsEditing(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.stopPropagation()
+      handleSave()
+    } else if (e.key === 'Escape') {
+      e.stopPropagation()
+      isCancelRef.current = true
+      setIsEditing(false)
+    }
+  }
+
+  if (isEditing) {
+    return (
+      <div
+        className="path-display-name"
+        style={{ fontSize: '0.85em', marginTop: '2px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={handleKeyDown}
+          placeholder="displayName"
+          aria-label={`displayName for ${path}`}
+          style={{
+            fontSize: 'inherit',
+            padding: '1px 4px',
+            border: '1px solid var(--bs-primary, #20a8d8)',
+            borderRadius: '3px',
+            width: '220px',
+            outline: 'none'
+          }}
+        />
+      </div>
+    )
+  }
+
+  if (!name && !canEdit) return null
+
+  return (
+    <div
+      className="path-display-name text-muted"
+      style={{
+        fontSize: '0.85em',
+        marginTop: '2px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '3px'
+      }}
+    >
+      {name && <span style={{ fontStyle: 'italic' }}>{name}</span>}
+      {canEdit && (
+        <button
+          type="button"
+          onClick={handleStartEdit}
+          title={
+            name
+              ? `Edit displayName (meta.displayName at ${path})`
+              : `Set displayName (meta.displayName at ${path})`
+          }
+          aria-label={
+            name
+              ? `Edit displayName for ${path}`
+              : `Set displayName for ${path}`
+          }
+          className="path-displayname-edit"
+          style={{
+            cursor: 'pointer',
+            opacity: 0.4,
+            fontSize: '0.85em',
+            lineHeight: 1,
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            color: 'inherit'
+          }}
+        >
+          &#9998;
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default PathDisplayName

--- a/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/PathDisplayName.tsx
@@ -7,6 +7,18 @@ interface PathDisplayNameProps {
   path: string
 }
 
+const SUB_LINE_FONT_SIZE = '0.85em'
+const SUB_LINE_TOP_MARGIN = '2px'
+const EDIT_INPUT_WIDTH = '220px'
+const PENCIL_OPACITY = 0.4
+const ITEM_GAP = '3px'
+const INLINE_PENCIL_LEFT_MARGIN = '4px'
+
+// Latest save revision per row, module-level so a virtualized
+// unmount/remount continues the same sequence — a stale settlement from
+// a request started in a previous mount must not touch the store.
+const saveRevisions = new Map<string, number>()
+
 // Muted second line under the path showing meta.displayName, with the
 // same inline pencil editing pattern as SourceLabel. The name shown is
 // exactly the one stored at the row's own path (notifications rows
@@ -26,7 +38,6 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
   const [saveFailed, setSaveFailed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const isCancelRef = useRef(false)
-  const saveSeqRef = useRef(0)
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -72,9 +83,12 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
       // Rapid consecutive saves can settle out of order; only the
       // latest request may revert the store or toggle the failure flag,
       // otherwise a stale rejection would clobber the newer optimistic
-      // value with its older `previous` snapshot.
-      const seq = ++saveSeqRef.current
-      const isCurrent = () => saveSeqRef.current === seq
+      // value with its older `previous` snapshot. Revisions are keyed
+      // per row (context + path), not per component instance.
+      const revisionKey = `${context}\0${path}`
+      const seq = (saveRevisions.get(revisionKey) ?? 0) + 1
+      saveRevisions.set(revisionKey, seq)
+      const isCurrent = () => saveRevisions.get(revisionKey) === seq
       updateMeta(context, path, { displayName: trimmed || null })
       const onFailure = () => {
         if (!isCurrent()) return
@@ -125,7 +139,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
     return (
       <div
         className="path-display-name"
-        style={{ fontSize: '0.85em', marginTop: '2px' }}
+        style={{ fontSize: SUB_LINE_FONT_SIZE, marginTop: SUB_LINE_TOP_MARGIN }}
         onClick={(e) => e.stopPropagation()}
       >
         <input
@@ -142,7 +156,7 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
             padding: '1px 4px',
             border: '1px solid var(--bs-primary, #20a8d8)',
             borderRadius: '3px',
-            width: '220px',
+            width: EDIT_INPUT_WIDTH,
             outline: 'none'
           }}
         />
@@ -167,8 +181,8 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
       className="path-displayname-edit"
       style={{
         cursor: 'pointer',
-        opacity: 0.4,
-        fontSize: '0.85em',
+        opacity: PENCIL_OPACITY,
+        fontSize: SUB_LINE_FONT_SIZE,
         lineHeight: 1,
         background: 'none',
         border: 'none',
@@ -183,7 +197,10 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
   const failure = saveFailed && (
     <span
       role="alert"
-      style={{ color: 'var(--bs-danger, #d9534f)', fontSize: '0.85em' }}
+      style={{
+        color: 'var(--bs-danger, #d9534f)',
+        fontSize: SUB_LINE_FONT_SIZE
+      }}
       title="The server rejected the displayName change; the previous value was restored."
     >
       Save failed
@@ -198,11 +215,11 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
       <span
         className="path-display-name"
         style={{
-          marginLeft: '4px',
+          marginLeft: INLINE_PENCIL_LEFT_MARGIN,
           whiteSpace: 'nowrap',
           display: 'inline-flex',
           alignItems: 'center',
-          gap: '3px'
+          gap: ITEM_GAP
         }}
       >
         {failure}
@@ -215,11 +232,11 @@ const PathDisplayName: React.FC<PathDisplayNameProps> = ({ context, path }) => {
     <div
       className="path-display-name text-muted"
       style={{
-        fontSize: '0.85em',
-        marginTop: '2px',
+        fontSize: SUB_LINE_FONT_SIZE,
+        marginTop: SUB_LINE_TOP_MARGIN,
         display: 'flex',
         alignItems: 'center',
-        gap: '3px'
+        gap: ITEM_GAP
       }}
     >
       <span style={{ fontStyle: 'italic' }}>{name}</span>

--- a/packages/server-admin-ui/src/views/DataBrowser/displayNameUtils.test.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/displayNameUtils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { notificationDataPath, resolveDisplayName } from './displayNameUtils'
+
+describe('notificationDataPath', () => {
+  it('maps a notification path to its data path', () => {
+    expect(
+      notificationDataPath('notifications.tanks.freshWater.2.currentLevel')
+    ).toBe('tanks.freshWater.2.currentLevel')
+  })
+
+  it('returns undefined for data paths and the bare notifications root', () => {
+    expect(
+      notificationDataPath('tanks.freshWater.2.currentLevel')
+    ).toBeUndefined()
+    expect(notificationDataPath('notifications')).toBeUndefined()
+  })
+})
+
+describe('resolveDisplayName', () => {
+  const meta = {
+    'tanks.freshWater.2.currentLevel': { displayName: 'Freshwater STB' },
+    'tanks.freshWater.2': { displayName: 'Tank object name' },
+    'electrical.switches.bank.10.1.state': { displayName: 'Anchor light' },
+    'notifications.special': { displayName: 'Direct notification name' },
+    'tanks.freshWater.9.currentLevel': { units: 'ratio' }
+  }
+
+  it('returns the displayName stored at the exact path', () => {
+    expect(
+      resolveDisplayName(meta, 'electrical.switches.bank.10.1.state')
+    ).toEqual({
+      name: 'Anchor light',
+      metaPath: 'electrical.switches.bank.10.1.state'
+    })
+  })
+
+  it('does NOT inherit from ancestor paths', () => {
+    // tanks.freshWater.2 has a name; capacity must not pick it up.
+    expect(resolveDisplayName(meta, 'tanks.freshWater.2.capacity')).toBeNull()
+  })
+
+  it('maps a notifications row to the data path it mirrors', () => {
+    expect(
+      resolveDisplayName(meta, 'notifications.tanks.freshWater.2.currentLevel')
+    ).toEqual({
+      name: 'Freshwater STB',
+      metaPath: 'tanks.freshWater.2.currentLevel'
+    })
+  })
+
+  it('prefers a name stored directly at the notification path', () => {
+    expect(resolveDisplayName(meta, 'notifications.special')).toEqual({
+      name: 'Direct notification name',
+      metaPath: 'notifications.special'
+    })
+  })
+
+  it('returns null for meta without displayName, missing meta and empty input', () => {
+    expect(
+      resolveDisplayName(meta, 'tanks.freshWater.9.currentLevel')
+    ).toBeNull()
+    expect(resolveDisplayName(meta, 'navigation.position')).toBeNull()
+    expect(
+      resolveDisplayName(undefined, 'tanks.freshWater.2.currentLevel')
+    ).toBeNull()
+    expect(resolveDisplayName(meta, '')).toBeNull()
+  })
+
+  it('treats a non-string or empty displayName as unset', () => {
+    expect(resolveDisplayName({ p: { displayName: 42 } }, 'p')).toBeNull()
+    expect(resolveDisplayName({ p: { displayName: '' } }, 'p')).toBeNull()
+    expect(resolveDisplayName({ p: { displayName: null } }, 'p')).toBeNull()
+  })
+})

--- a/packages/server-admin-ui/src/views/DataBrowser/displayNameUtils.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/displayNameUtils.ts
@@ -1,0 +1,38 @@
+import type { MetaData } from '../../store'
+
+const NOTIFICATIONS_PREFIX = 'notifications.'
+
+// notifications.tanks.freshWater.2.currentLevel -> tanks.freshWater.2.currentLevel
+export function notificationDataPath(path: string): string | undefined {
+  return path.startsWith(NOTIFICATIONS_PREFIX)
+    ? path.slice(NOTIFICATIONS_PREFIX.length)
+    : undefined
+}
+
+export interface ResolvedDisplayName {
+  name: string
+  metaPath: string
+}
+
+// A row shows exactly the displayName stored at its own path — no
+// ancestor inheritance, so what is displayed is always literally what is
+// in the metadata. The single mapping rule: a notifications.<dataPath>
+// row mirrors the name of the data path it notifies about.
+export function resolveDisplayName(
+  contextMeta: Record<string, MetaData> | undefined,
+  path: string
+): ResolvedDisplayName | null {
+  if (!contextMeta || !path) return null
+  const own = contextMeta[path]?.displayName
+  if (typeof own === 'string' && own) {
+    return { name: own, metaPath: path }
+  }
+  const dataPath = notificationDataPath(path)
+  if (dataPath) {
+    const mapped = contextMeta[dataPath]?.displayName
+    if (typeof mapped === 'string' && mapped) {
+      return { name: mapped, metaPath: dataPath }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
With dozens of instanced paths (`tanks.freshWater.2.*`, `electrical.switches.bank.10.1.*`, battery banks, …) the instance numbers are technically correct but easy to mix up. The human-readable name already exists in `meta.displayName` but is only visible on the Meta Data page.

This shows the path's `meta.displayName` as a muted line under the path in Data Browser rows (flat and by-source views). Display is strictly the name stored at the row's own path — no inheritance — so the UI always reflects exactly what is in the metadata. The single mapping rule: `notifications.<dataPath>` rows show the name of the data path they relate to, read-only.

Administrators can set or edit the name in place via a pencil, following the source-alias editing pattern. Edits go through the existing single-property meta endpoint (`PUT .../<path>/meta/displayName`), so they persist in baseDeltas and stay fully consistent with the Meta Data page — no parallel storage. Unset rows show only the faint pencil (nothing for non-admins).

No websocket overhead: meta is already streamed to the admin UI once per connection (`sendMeta=all`); rendering is a client-side lookup and an edit is one REST call (optimistic update, reverted if the server rejects).

Tested: vitest units for the resolution rules and the editor (16 new; suite green); repo `build:all` and server test suite; headless-chromium e2e against a live secured server — pencil on unnamed rows, edit round-trip with PUT observed, notification-row mirroring, no inheritance on sibling paths, persistence across reload and server restart, REST meta round-trip consistent with the Meta Data page.

Docs: short addition to the Data Browser section in `docs/setup/configuration.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds `meta.displayName` display and inline editing to the admin Data Browser.

- Displays each row’s display name beneath its path.
- Displays related data path names for notification rows.
- Keeps notification display names read-only.
- Lets administrators create, edit, and clear names inline.
- Keeps unnamed rows on one line with an inline edit control.
- Persists changes through the existing single-property metadata endpoint and `baseDeltas`.
- Handles concurrent saves and virtualization remounts safely.
- Shows `Save failed` when the latest save is rejected.
- Uses streamed metadata without additional websocket traffic.
- Adds unit tests, end-to-end coverage, validation, and documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->