### PR TITLE
fix(admin-ui): URL-encode path segments in the Meta editor's save URL

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -27,6 +27,7 @@ import type { UnitDefinitions } from '../../utils/unitConversion'
 import Col from 'react-bootstrap/Col'
 import Form from 'react-bootstrap/Form'
 import Row from 'react-bootstrap/Row'
+import { pathToUrlSegments } from './pathUtils'
 
 // Imperative accessor — avoids subscribing Meta to every value change.
 const getSignalkData = () => useStore.getState().signalkData
@@ -594,7 +595,7 @@ const saveMeta = (path: string, meta: MetaData) => {
       : undefined
   }
 
-  fetch(`/signalk/v1/api/vessels/self/${path.replaceAll('.', '/')}/meta`, {
+  fetch(`/signalk/v1/api/vessels/self/${pathToUrlSegments(path)}/meta`, {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { findContextName } from './pathUtils'
+import { findContextName, pathToUrlSegments } from './pathUtils'
 
 describe('findContextName', () => {
   it('resolves the name from a source-suffixed key', () => {
@@ -44,5 +44,25 @@ describe('findContextName', () => {
       'name$AIS.2': { value: 'Black Pearl' }
     }
     expect(findContextName(contextData)).toBe('Black Pearl')
+  })
+})
+
+describe('pathToUrlSegments', () => {
+  it('turns dots into slashes for ordinary paths', () => {
+    expect(pathToUrlSegments('tanks.freshWater.2.currentLevel')).toBe(
+      'tanks/freshWater/2/currentLevel'
+    )
+  })
+
+  it('URL-encodes characters that would change the request target', () => {
+    expect(pathToUrlSegments('environment.we#ird.a?b.100%')).toBe(
+      'environment/we%23ird/a%3Fb/100%25'
+    )
+  })
+
+  it('cannot produce a ".." segment — dots are separators', () => {
+    // Consecutive dots become empty segments, so upward traversal via
+    // a literal '..' segment is structurally impossible.
+    expect(pathToUrlSegments('a...b')).toBe('a///b')
   })
 })

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
@@ -28,3 +28,9 @@ export function findContextName(
   }
   return undefined
 }
+
+// Signal K paths originate from data providers and are not guaranteed
+// URL-safe. Encode each segment before embedding a path into an API URL.
+export function pathToUrlSegments(path: string): string {
+  return path.split('.').map(encodeURIComponent).join('/')
+}


### PR DESCRIPTION
Signal K paths originate from data providers and are not guaranteed URL-safe: a segment containing `#`, `?` or `%` changes the resolved request target of the Meta editor's `PUT .../meta` — a write endpoint. Encode each path segment with `encodeURIComponent` via a small shared `pathUtils` helper, mirroring the encoding the Data Browser already applies elsewhere.

Follow-up to the same hardening applied to the new displayName editor in #2895 during review; this fixes the pre-existing occurrence in the Meta editor's `saveMeta`.

Tested: unit tests for the helper (ordinary paths, reserved characters, consecutive dots); admin-ui suite, repo `build:all` and server test suite all green.