### PR TITLE
fix(admin-ui): keep the App Store category filter across plugin detail navigation

### DIFF
--- a/packages/server-admin-ui/src/store/index.ts
+++ b/packages/server-admin-ui/src/store/index.ts
@@ -132,8 +132,10 @@ export function useAppstoreFilter() {
     useShallow((s) => ({
       view: s.appstoreView,
       search: s.appstoreSearch,
+      category: s.appstoreCategory,
       setView: s.setAppstoreView,
-      setSearch: s.setAppstoreSearch
+      setSearch: s.setAppstoreSearch,
+      setCategory: s.setAppstoreCategory
     }))
   )
 }

--- a/packages/server-admin-ui/src/store/slices/appSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.test.ts
@@ -24,7 +24,21 @@ describe('appSlice', () => {
       vesselInfo: {},
       backpressureWarning: null,
       serverStatistics: null,
-      providerStatus: []
+      providerStatus: [],
+      appstoreCategory: 'All'
+    })
+  })
+
+  describe('appstore filter state', () => {
+    it('persists the selected category across component lifecycles', () => {
+      // The Apps view unmounts when a plugin detail page opens; the
+      // category must live in the store (like view and search) so
+      // "Back to Store" restores it.
+      expect(useStore.getState().appstoreCategory).toBe('All')
+
+      useStore.getState().setAppstoreCategory('Weather')
+
+      expect(useStore.getState().appstoreCategory).toBe('Weather')
     })
   })
 

--- a/packages/server-admin-ui/src/store/slices/appSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/appSlice.ts
@@ -116,6 +116,7 @@ export interface AppSliceState {
    */
   appstoreView: AppstoreView
   appstoreSearch: string
+  appstoreCategory: string
 }
 
 export interface AppSliceActions {
@@ -189,6 +190,7 @@ export interface AppSliceActions {
   ) => void
   setAppstoreView: (view: AppstoreView) => void
   setAppstoreSearch: (search: string) => void
+  setAppstoreCategory: (category: string) => void
 }
 
 export type AppSlice = AppSliceState & AppSliceActions
@@ -239,7 +241,8 @@ const initialAppState: AppSliceState = {
   sourceStatus: {},
   sourceStatusLoaded: false,
   appstoreView: 'All',
-  appstoreSearch: ''
+  appstoreSearch: '',
+  appstoreCategory: 'All'
 }
 
 export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
@@ -504,5 +507,9 @@ export const createAppSlice: StateCreator<AppSlice, [], [], AppSlice> = (
 
   setAppstoreSearch: (appstoreSearch) => {
     set({ appstoreSearch })
+  },
+
+  setAppstoreCategory: (appstoreCategory) => {
+    set({ appstoreCategory })
   }
 })

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -170,6 +170,7 @@ describe('Apps view/search state survives the detail round trip', () => {
     act(() => {
       useStore.getState().setAppstoreView('All')
       useStore.getState().setAppstoreSearch('')
+      useStore.getState().setAppstoreCategory('All')
     })
   })
 
@@ -200,6 +201,24 @@ describe('Apps view/search state survives the detail round trip', () => {
 
     expect(tabIsActive(/^Installed$/)).toBe(true)
     expect(tabIsActive(/^All$/)).toBe(false)
+  })
+
+  it('restores the selected category after an unmount/remount', async () => {
+    const user = userEvent.setup()
+    setAppStore({
+      ...emptyStore,
+      categories: ['All', 'Weather', 'Utility']
+    })
+    const { unmount } = renderApps()
+
+    await user.click(screen.getByRole('button', { name: /^Weather$/ }))
+    expect(tabIsActive(/^Weather$/)).toBe(true)
+
+    unmount()
+    renderApps()
+
+    expect(tabIsActive(/^Weather$/)).toBe(true)
+    expect(tabIsActive(/^Utility$/)).toBe(false)
   })
 
   it('restores the search term after an unmount/remount', async () => {

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -207,18 +207,36 @@ describe('Apps view/search state survives the detail round trip', () => {
     const user = userEvent.setup()
     setAppStore({
       ...emptyStore,
-      categories: ['All', 'Weather', 'Utility']
+      categories: ['All', 'Weather', 'Utility'],
+      available: [
+        {
+          name: 'weather-plugin',
+          version: '1.0.0',
+          description: 'forecasts',
+          categories: ['Weather']
+        },
+        {
+          name: 'util-plugin',
+          version: '1.0.0',
+          description: 'tools',
+          categories: ['Utility']
+        }
+      ]
     })
     const { unmount } = renderApps()
 
     await user.click(screen.getByRole('button', { name: /^Weather$/ }))
-    expect(tabIsActive(/^Weather$/)).toBe(true)
+    // The category filters the visible results…
+    expect(screen.getByText('weather-plugin')).toBeInTheDocument()
+    expect(screen.queryByText('util-plugin')).toBeNull()
 
     unmount()
     renderApps()
 
+    // …and keeps filtering them after the detail round trip.
+    expect(screen.getByText('weather-plugin')).toBeInTheDocument()
+    expect(screen.queryByText('util-plugin')).toBeNull()
     expect(tabIsActive(/^Weather$/)).toBe(true)
-    expect(tabIsActive(/^Utility$/)).toBe(false)
   })
 
   it('restores the search term after an unmount/remount', async () => {

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -226,14 +226,12 @@ describe('Apps view/search state survives the detail round trip', () => {
     const { unmount } = renderApps()
 
     await user.click(screen.getByRole('button', { name: /^Weather$/ }))
-    // The category filters the visible results…
     expect(screen.getByText('weather-plugin')).toBeInTheDocument()
     expect(screen.queryByText('util-plugin')).toBeNull()
 
     unmount()
     renderApps()
 
-    // …and keeps filtering them after the detail round trip.
     expect(screen.getByText('weather-plugin')).toBeInTheDocument()
     expect(screen.queryByText('util-plugin')).toBeNull()
     expect(tabIsActive(/^Weather$/)).toBe(true)

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -110,15 +110,17 @@ function writeString(key: string, value: string) {
 const Apps: React.FC = () => {
   const appStore = useAppStore() as AppStoreState
   const [searchParams, setSearchParams] = useSearchParams()
-  // View and search live in the store so they survive the unmount/remount
-  // when the user opens a plugin detail page and returns via "Back to Store".
+  // View, search and category live in the store so they survive the
+  // unmount/remount when the user opens a plugin detail page and returns
+  // via "Back to Store".
   const {
     view,
     search,
+    category,
     setView: setSelectedView,
-    setSearch
+    setSearch,
+    setCategory: setSelectedCategory
   } = useAppstoreFilter()
-  const [category, setSelectedCategory] = useState('All')
 
   // An explicit ?q= in the URL (author link from a card/detail page, or a
   // reloaded/bookmarked search) wins over the remembered store value. Runs


### PR DESCRIPTION
Selecting a category in the App Store (e.g. Weather), opening a plugin's detail page and returning via "Back to Store" silently reset the filter to All. Opening the detail page unmounts the store view; view and search already live in the zustand store precisely to survive that round trip, but the category filter was still component-local state.

Move the category into the store next to view and search and expose it through the existing `useAppstoreFilter` hook.

Tested: reproduced the reset in a real browser before the change and verified the category survives the detail round trip after it; added an unmount/remount component test alongside the existing view/search round-trip tests plus a store-slice test; admin-ui suite, repo `build:all` and server test suite all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR moves the App Store category filter into the Zustand store. The existing `useAppstoreFilter` hook exposes the category and its setter. The selected category persists when the Apps view unmounts and remounts.

## Tests

- Adds store coverage for updating `appstoreCategory`.
- Adds Apps view coverage for category persistence.
- Resets `appstoreCategory` to `All` in test setup.
- The admin-ui suite, `build:all`, and server test suite pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->