### PR TITLE
fix(admin-ui): close the mobile sidebar when a menu entry is picked

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, type Location } from 'react-router-dom'
+import Sidebar from './Sidebar'
+
+vi.mock('../../store', () => ({
+  useAppStore: () => ({
+    updates: [],
+    storeAvailable: true,
+    serverUpdate: undefined
+  }),
+  useAccessRequests: () => [],
+  useDevices: () => [],
+  useLoginStatus: () => ({ authenticationRequired: false }),
+  usePlugins: () => [],
+  useMultiSourcePaths: () => ({}),
+  useReconciledGroups: () => [],
+  useSourcePriorities: () => ({ sourcePriorities: [] }),
+  usePriorityOverrides: () => ({ paths: [] }),
+  usePriorityGroups: () => ({ groups: [] }),
+  useActiveConflictCount: () => 0,
+  useUnconfiguredGnssSources: () => [],
+  useHistoryProviderUnavailable: () => false
+}))
+
+const MOBILE_SHOWN = 'sidebar-mobile-show'
+
+function renderSidebar(pathname = '/dashboard') {
+  const location = {
+    pathname,
+    search: '',
+    hash: '',
+    state: null,
+    key: 'test'
+  } as Location
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <Sidebar location={location} />
+    </MemoryRouter>
+  )
+}
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    document.body.classList.add(MOBILE_SHOWN)
+  })
+
+  afterEach(() => {
+    document.body.classList.remove(MOBILE_SHOWN)
+  })
+
+  it('closes the mobile sidebar when a page is picked', () => {
+    // NavLink navigates via pushState, which fires no popstate, so nothing
+    // else takes the overlay down and it covers the page just opened.
+    renderSidebar()
+    fireEvent.click(screen.getByText('Webapps'))
+    expect(document.body.classList.contains(MOBILE_SHOWN)).toBe(false)
+  })
+
+  it('closes the mobile sidebar when a submenu entry is picked', () => {
+    renderSidebar()
+    fireEvent.click(screen.getByText('Data'))
+    fireEvent.click(screen.getByText('Metadata'))
+    expect(document.body.classList.contains(MOBILE_SHOWN)).toBe(false)
+  })
+
+  it('keeps the mobile sidebar open when a dropdown is expanded', () => {
+    // Expanding also navigates (to the group's remembered page), but the
+    // user is about to pick from the children that just appeared.
+    renderSidebar()
+    fireEvent.click(screen.getByText('Data'))
+    expect(document.body.classList.contains(MOBILE_SHOWN)).toBe(true)
+  })
+
+  it('keeps the mobile sidebar open when a dropdown is collapsed', () => {
+    // Rendering under /data/browser auto-opens the group, so a single click
+    // collapses it.
+    renderSidebar('/data/browser')
+    fireEvent.click(screen.getByText('Data'))
+    expect(document.body.classList.contains(MOBILE_SHOWN)).toBe(true)
+  })
+
+  it('closes the mobile sidebar when an external link is picked', () => {
+    // The new tab leaves the current page untouched, but the menu entry was
+    // acted on — leaving the overlay up means finding it on return.
+    renderSidebar()
+    fireEvent.click(screen.getByText('OpenApi'))
+    expect(document.body.classList.contains(MOBILE_SHOWN)).toBe(false)
+  })
+})

--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -476,6 +476,16 @@ export default function Sidebar({ location }: SidebarProps) {
     lastPathnameRef.current = location.pathname
   }, [location.pathname, items])
 
+  // NavLink navigates via pushState, which fires no popstate, so the mobile
+  // sidebar would stay open on top of the page the user just picked. Only
+  // leaf links close it: toggling a dropdown open also navigates (to the
+  // group's remembered page), and closing there would hide the children the
+  // user is about to choose from. Header owns the same class, so both remove
+  // it — the operation is idempotent.
+  const closeMobileSidebar = useCallback(() => {
+    document.body.classList.remove('sidebar-mobile-show')
+  }, [])
+
   const handleClick = useCallback(
     (item: NavItemData) => (e: MouseEvent<HTMLAnchorElement>) => {
       e.preventDefault()
@@ -610,7 +620,12 @@ export default function Sidebar({ location }: SidebarProps) {
     return (
       <Nav.Item as="li" key={key} className={classes.item}>
         {isExternal(url) ? (
-          <Nav.Link href={url} className={classes.link} {...(item.props || {})}>
+          <Nav.Link
+            href={url}
+            className={classes.link}
+            {...(item.props || {})}
+            onClick={closeMobileSidebar}
+          >
             {renderIcon(item.icon)}
             {item.name}
             {renderBadges(item)}
@@ -622,6 +637,7 @@ export default function Sidebar({ location }: SidebarProps) {
               isActive ? `${classes.link} active` : classes.link
             }
             {...(item.props || {})}
+            onClick={closeMobileSidebar}
           >
             {renderIcon(item.icon)}
             {item.name}


### PR DESCRIPTION
On phones the sidebar overlay stayed up after picking a page from it, covering the page just opened and needing a second tap on the toggler to get rid of it. It was only being taken down on `popstate` — the back button fires that, but `NavLink`'s `pushState` does not.

This is a regression of #1579, which added the popstate listener back when hash navigation still fired that event. Moving to React Router v6 turned navigation into `pushState`, and the behaviour went away silently.

Leaf links now close it. Expanding a dropdown deliberately does not: expanding also navigates (to the group's remembered page), and closing there would hide the children the user is about to choose from. That rules out watching `location.pathname`, which cannot tell the two apart.

Verified at phone width against a running server, and covered by unit tests. Desktop is unaffected — the class only exists below the `lg` breakpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates mobile sidebar behavior. The sidebar closes when a user selects a leaf link, submenu item, or external link. Dropdown expansion and collapse keep the sidebar open.

The change adds `closeMobileSidebar` and applies it to internal and external link navigation. Tests cover link selection and dropdown behavior. Desktop behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->