### PR TITLE
test: fix type errors surfaced by mocha 11.8.0

### DIFF
--- a/test/appstore/enrich.test.ts
+++ b/test/appstore/enrich.test.ts
@@ -46,7 +46,6 @@ describe('appstore/enrich', () => {
     const r = enrichEntry({
       ...basePkg,
       signalk: {
-        // @ts-expect-error — intentionally invalid input to test guard
         screenshots: ['./ok.png', null, 42, './also.png']
       }
     })

--- a/test/history-duration.ts
+++ b/test/history-duration.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai'
+import { Duration } from '@signalk/server-api/history'
 import { parseTimeRangeParams } from '../dist/api/history/index.js'
+
+const totalSeconds = (d: Duration | undefined) =>
+  typeof d === 'number' ? d : d?.total({ unit: 'seconds' })
 
 const callParse = (query: Record<string, unknown>) => {
   try {
@@ -20,18 +24,13 @@ describe('parseTimeRangeParams duration handling', () => {
   it('parses an integer number of seconds passed as a string', () => {
     const result = callParse({ duration: '900' })
     if (result instanceof Error) throw result
-    const total = result.timeRangeParams.duration?.total({
-      unit: 'seconds'
-    })
-    expect(total).to.equal(900)
+    expect(totalSeconds(result.timeRangeParams.duration)).to.equal(900)
   })
 
   it('parses zero seconds as a valid duration', () => {
     const result = callParse({ duration: '0', from: '2025-01-01T00:00:00Z' })
     if (result instanceof Error) throw result
-    expect(
-      result.timeRangeParams.duration?.total({ unit: 'seconds' })
-    ).to.equal(0)
+    expect(totalSeconds(result.timeRangeParams.duration)).to.equal(0)
   })
 
   it('rejects fractional duration strings', () => {
@@ -79,8 +78,8 @@ describe('parseTimeRangeParams duration handling', () => {
     const seconds = callParse({ duration: '900' })
     if (iso instanceof Error) throw iso
     if (seconds instanceof Error) throw seconds
-    const isoSec = iso.timeRangeParams.duration?.total({ unit: 'seconds' })
-    const intSec = seconds.timeRangeParams.duration?.total({ unit: 'seconds' })
+    const isoSec = totalSeconds(iso.timeRangeParams.duration)
+    const intSec = totalSeconds(seconds.timeRangeParams.duration)
     expect(isoSec).to.equal(intSec)
   })
 


### PR DESCRIPTION
Master CI is currently red: mocha 11.8.0 (resolved on fresh installs since there is no lockfile) propagates ts-node type-check errors when loading test files, where 11.7.6 silently swallowed them. f595264a removed two of the three defunct `@ts-expect-error` directives in `test/appstore/enrich.test.ts` but its CI run was cancelled, so the remaining one at line 49 still fails every build.

Fixing that surfaces a second latent error in `test/history-duration.ts`, previously hidden because mocha aborts at the first failing file: `TimeRangeParams` types `duration` as `Temporal.Duration | number`, so calling `.total()` without narrowing is a type error. I added a small `totalSeconds` helper that narrows before calling `total()`.

Tested: full `npm test` with mocha 11.8.0 installed locally — the suite compiles and runs; both touched files pass (33 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removes the obsolete `@ts-expect-error` directive from the invalid screenshot-entry test.
- Adds `totalSeconds` to narrow numeric and `Temporal.Duration` values before calling `.total()`.
- Updates duration tests to use the helper.
- Both modified files pass under Mocha 11.8.0, covering 33 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->