### PR TITLE
fix: restore req.url after static middleware fallthrough

### DIFF
--- a/src/staticfiles.ts
+++ b/src/staticfiles.ts
@@ -11,8 +11,21 @@ import expressStaticGzip from 'express-static-gzip'
  * so sidecars added later are picked up on server restart.
  */
 export function serveStaticFiles(root: string): RequestHandler {
-  return expressStaticGzip(root, {
+  const middleware = expressStaticGzip(root, {
     enableBrotli: true,
     orderPreference: ['br']
   })
+  // express-static-gzip rewrites req.url in place (directory requests get
+  // index.html appended, compressed hits get the sidecar extension) and
+  // does not undo this when no file matches, so downstream routes would
+  // see the mangled url — e.g. /signalk/v1/api/ arriving at the REST
+  // interface as /signalk/v1/api/index.html. Restore the url whenever the
+  // request falls through.
+  return (req, res, next) => {
+    const originalUrl = req.url
+    middleware(req, res, (err?: unknown) => {
+      req.url = originalUrl
+      next(err)
+    })
+  }
 }

--- a/test/staticfiles.ts
+++ b/test/staticfiles.ts
@@ -83,6 +83,24 @@ describe('serveStaticFiles', () => {
     expect(await res.text()).to.equal('<html></html>')
   })
 
+  it('leaves req.url intact for downstream routes on fallthrough', async () => {
+    const app = express()
+    app.use('/', serveStaticFiles(fixtureDir))
+    app.get('/api/*', (req, res) => res.json({ url: req.url }))
+    const routeServer = app.listen(0)
+    await new Promise((resolve) => routeServer.on('listening', resolve))
+    try {
+      const { port } = routeServer.address() as AddressInfo
+      const res = await fetch(`http://localhost:${port}/api/`)
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.deep.equal({ url: '/api/' })
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        routeServer.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  })
+
   it('tolerates a nonexistent root directory', async () => {
     const app = express()
     app.use('/missing', serveStaticFiles(path.join(fixtureDir, 'nope')))


### PR DESCRIPTION
Fixes the two "Server" test failures visible on master now that #2901 lets CI compile again — and a real API regression behind them.

express-static-gzip rewrites `req.url` in place (directory requests get `index.html` appended, compressed hits get the sidecar extension) and does not undo it when no file matches. Mounted at `/`, this made every trailing-slash request fall through to downstream routes with a mangled url: `GET /signalk/v1/api/` arrived at the REST interface as `/signalk/v1/api/index.html`, fell off the data tree, and 404ed with an HTML error page. Any spec-legal trailing-slash API URL was affected, not just the tests.

I wrapped the middleware in `serveStaticFiles` to save `req.url` and restore it in the fallthrough callback. Serving is unchanged: compressed sidecars and directory index resolution still work because the rewrite is only undone when the request leaves the static handler unserved. Added a regression test asserting a downstream route sees the original url.

Tested: full `npm test` at repo root (1112 passing, 0 failing — including the two previously failing `multiple-values` cases) and the new `test/staticfiles.ts` case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restores the original `req.url` when `express-static-gzip` falls through without serving a file.
- Preserves compressed-file and directory-index serving behavior.
- Adds a regression test that verifies downstream routes receive the original URL for trailing-slash requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->