### PR TITLE
fix(deltacache): prune preferredSources and cachedContextPaths on context expiry

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -812,34 +812,71 @@ export default class DeltaCache {
   }
 
   deleteContext(contextKey: string) {
+    this.deleteContextEntries(contextKey)
+    this.prunePreferredSources((context) => context === contextKey)
+  }
+
+  /**
+   * Everything deleteContext drops except the preferredSources sweep,
+   * which walks the whole map and so is batched by pruneContexts.
+   */
+  private deleteContextEntries(contextKey: string) {
     debug('Deleting context ' + contextKey)
     const contextParts = contextKey.split('.')
     if (contextParts.length === 2) {
       delete this.cache[contextParts[0]][contextParts[1]]
     }
+    // Otherwise only cleared by the wholesale 5-minute reset, which
+    // would let a dead context's split-path cache outlive it.
     delete this.cachedContextPaths[contextKey]
-    // preferredSources is keyed `${context}\0${path}` and otherwise never
-    // shrinks: every (context, path) pair ever seen — e.g. every AIS
-    // target that has come into range — would live for the process
-    // lifetime instead of aging out with the context.
-    const prefix = contextKey + '\0'
-    for (const key of this.preferredSources.keys()) {
-      if (key.startsWith(prefix)) {
-        this.preferredSources.delete(key)
-      }
-    }
     this.app.stalenessEnforcer?.onContextRemoved(contextKey)
+  }
+
+  /**
+   * Drop every preferredSources entry whose context the predicate
+   * matches.
+   *
+   * preferredSources is keyed `${context}\0${path}` and otherwise never
+   * shrinks: every (context, path) pair the priority engine routes —
+   * e.g. every AIS target that has come into range — would live for the
+   * process lifetime instead of aging out with its context.
+   */
+  private prunePreferredSources(matches: (context: string) => boolean) {
+    let preferredChanged = false
+    for (const key of this.preferredSources.keys()) {
+      const nullIdx = key.indexOf('\0')
+      if (!matches(nullIdx === -1 ? key : key.slice(0, nullIdx))) continue
+      this.preferredSources.delete(key)
+      // The client's mergeLivePreferredSources only forgets a key when
+      // it receives the empty-string tombstone scheduleLivePreferredEmit
+      // sends for a dirty path with no entry left. Without this a
+      // long-lived admin UI session keeps accumulating winners for
+      // contexts the server has already dropped.
+      this.livePreferredDirtyPaths.add(key)
+      preferredChanged = true
+    }
+    if (preferredChanged) {
+      this.scheduleLivePreferredEmit()
+    }
   }
 
   pruneContexts(seconds: number) {
     debug('pruning contexts...')
     const threshold = Date.now() - seconds * 1000
+    const pruned = new Set<string>()
     for (const contextKey in this.lastModifieds) {
       if (this.lastModifieds[contextKey] < threshold) {
-        this.deleteContext(contextKey)
+        this.deleteContextEntries(contextKey)
         delete this.lastModifieds[contextKey]
+        pruned.add(contextKey)
       }
     }
+    if (pruned.size === 0) return
+    // One pass for the whole sweep. Calling deleteContext per context
+    // would rescan all of preferredSources for each one, and a sweep
+    // that evicts hundreds of stale AIS targets at once is exactly the
+    // case this pruning exists for.
+    this.prunePreferredSources((context) => pruned.has(context))
   }
 
   buildFull(user: string, path: string[]) {

--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -817,6 +817,17 @@ export default class DeltaCache {
     if (contextParts.length === 2) {
       delete this.cache[contextParts[0]][contextParts[1]]
     }
+    delete this.cachedContextPaths[contextKey]
+    // preferredSources is keyed `${context}\0${path}` and otherwise never
+    // shrinks: every (context, path) pair ever seen — e.g. every AIS
+    // target that has come into range — would live for the process
+    // lifetime instead of aging out with the context.
+    const prefix = contextKey + '\0'
+    for (const key of this.preferredSources.keys()) {
+      if (key.startsWith(prefix)) {
+        this.preferredSources.delete(key)
+      }
+    }
     this.app.stalenessEnforcer?.onContextRemoved(contextKey)
   }
 

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -958,4 +958,38 @@ describe('Deltacache', () => {
         deltaCache.removeSourceDelta(NUMERIC_B)
       })
   })
+
+  it('deleteContext removes the context entries from preferredSources', function () {
+    // Regression test for a memory leak: preferredSources is keyed
+    // `${context}\0${path}` and previously only grew, since
+    // deleteContext (called by pruneContexts for every aged-out
+    // context) never removed the entries belonging to that context.
+    // Over long uptime with many transient contexts (e.g. AIS
+    // targets) this accumulates unboundedly.
+    const context = 'vessels.urn:mrn:signalk:uuid:prune-leak-test'
+    const path = 'navigation.speedOverGround'
+    const prefKey = context + '\0' + path
+
+    return doSendADelta({
+      context,
+      updates: [
+        {
+          $source: 'pruneLeakSource',
+          timestamp: '2024-05-01T10:00:00.000Z',
+          values: [{ path, value: 1 }]
+        }
+      ]
+    }).then(() => {
+      const deltaCache = theServer.app.deltaCache
+      deltaCache
+        .getLivePreferredSources()
+        .should.have.property(prefKey, 'pruneLeakSource')
+
+      deltaCache.deleteContext(context)
+
+      deltaCache
+        .getLivePreferredSources()
+        .should.not.have.property(prefKey)
+    })
+  })
 })

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -1025,10 +1025,13 @@ describe('Deltacache', () => {
         }
       ]
     })
-      // Ingesting the delta marks the path dirty too, so let that emit
-      // drain before deleting — otherwise the assertion could race
-      // against an event announcing the winner rather than retiring it.
-      .then(() => delay(EMIT_DEBOUNCE_MS + 200))
+      .then(() => {
+        // Ingesting the delta marks the path dirty too, so let that
+        // emit drain before deleting — otherwise the assertion could
+        // race against an event announcing the winner rather than
+        // retiring it.
+        return delay(EMIT_DEBOUNCE_MS + 200)
+      })
       .then(() => {
         const tombstoned = new Promise((resolve) => {
           const onServerEvent = (event) => {

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -160,6 +160,10 @@ const expectedOrder = [
   }
 ]
 
+// Mirrors scheduleLivePreferredEmit's debounce in src/deltacache.ts.
+const EMIT_DEBOUNCE_MS = 1000
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
 describe('Deltacache', () => {
   let doStop, theServer, doSendADelta
 
@@ -969,6 +973,12 @@ describe('Deltacache', () => {
     const context = 'vessels.urn:mrn:signalk:uuid:prune-leak-test'
     const path = 'navigation.speedOverGround'
     const prefKey = context + '\0' + path
+    const deltaCache = theServer.app.deltaCache
+    // onValue only records a winner for paths the priority engine
+    // routes, and a server with no priorities configured gates every
+    // path off — which would leave preferredSources empty and make
+    // this test vacuous. Stand in for a configured engine.
+    deltaCache.setRoutesPathPredicate(() => true)
 
     return doSendADelta({
       context,
@@ -979,17 +989,63 @@ describe('Deltacache', () => {
           values: [{ path, value: 1 }]
         }
       ]
-    }).then(() => {
-      const deltaCache = theServer.app.deltaCache
-      deltaCache
-        .getLivePreferredSources()
-        .should.have.property(prefKey, 'pruneLeakSource')
-
-      deltaCache.deleteContext(context)
-
-      deltaCache
-        .getLivePreferredSources()
-        .should.not.have.property(prefKey)
     })
+      .then(() => {
+        deltaCache.cachedContextPaths.should.have.property(context)
+        deltaCache
+          .getLivePreferredSources()
+          .should.have.property(prefKey, 'pruneLeakSource')
+
+        deltaCache.deleteContext(context)
+
+        deltaCache.cachedContextPaths.should.not.have.property(context)
+        deltaCache.getLivePreferredSources().should.not.have.property(prefKey)
+      })
+      .finally(() => deltaCache.setRoutesPathPredicate(null))
+  })
+
+  it('deleteContext tombstones the removed paths on the live preferred stream', function () {
+    // The admin UI merges LIVEPREFERREDSOURCES over its snapshot and
+    // only forgets a key on an empty-string tombstone, so a silent
+    // server-side delete would move the leak into every long-lived
+    // browser session.
+    const context = 'vessels.urn:mrn:signalk:uuid:prune-tombstone-test'
+    const path = 'navigation.speedOverGround'
+    const prefKey = context + '\0' + path
+    const deltaCache = theServer.app.deltaCache
+    deltaCache.setRoutesPathPredicate(() => true)
+
+    return doSendADelta({
+      context,
+      updates: [
+        {
+          $source: 'pruneTombstoneSource',
+          timestamp: '2024-05-01T10:00:00.000Z',
+          values: [{ path, value: 1 }]
+        }
+      ]
+    })
+      // Ingesting the delta marks the path dirty too, so let that emit
+      // drain before deleting — otherwise the assertion could race
+      // against an event announcing the winner rather than retiring it.
+      .then(() => delay(EMIT_DEBOUNCE_MS + 200))
+      .then(() => {
+        const tombstoned = new Promise((resolve) => {
+          const onServerEvent = (event) => {
+            if (
+              event.type === 'LIVEPREFERREDSOURCES' &&
+              prefKey in (event.data || {})
+            ) {
+              theServer.app.removeListener('serverevent', onServerEvent)
+              resolve(event.data[prefKey])
+            }
+          }
+          theServer.app.on('serverevent', onServerEvent)
+        })
+        deltaCache.deleteContext(context)
+        return tombstoned
+      })
+      .then((sourceRef) => sourceRef.should.equal(''))
+      .finally(() => deltaCache.setRoutesPathPredicate(null))
   })
 })


### PR DESCRIPTION
## What problem does this solve?

Fixes #2903.

`DeltaCache.deleteContext` (called by `pruneContexts` every 60s for every
context that hasn't been updated within `pruneContextsMinutes`) only
removed the context from `this.cache`. It never touched
`this.preferredSources`, a `Map` keyed by `` `${context}\0${path}` `` that
records the winning source per path for the admin UI's source-priority
engine ("Preferred source" badges, `LIVEPREFERREDSOURCES`).

Every `(context, path)` pair ever observed therefore stayed in
`preferredSources` for the life of the process, instead of aging out
with its context. In busy AIS traffic this grows unboundedly with the
total number of distinct vessel contacts ever seen over the process's
uptime, not the number currently in range — a genuine memory leak
independent of any plugin. Reported with allocation-sampling evidence
in #2903 (~60-100MB/hour growth over ~41h uptime, eventually causing
swap exhaustion and an unrelated OOM kill).

This change also clears the corresponding entry in
`cachedContextPaths` immediately on context deletion (that map is
otherwise wiped wholesale every 5 minutes as a coarser, self-healing
mitigation, so this just makes cleanup immediate rather than relying
on the timer).

## How was this tested?

- Added a regression test in `test/deltacache.js`
  (`deleteContext removes the context entries from preferredSources`)
  that ingests a delta for a throwaway context, confirms
  `getLivePreferredSources()` contains its `preferredSources` entry,
  calls `deleteContext`, and asserts the entry is gone.
- Verified the test fails against the pre-fix code (entry survives
  `deleteContext`) and passes with the fix, using a standalone script
  that exercises the compiled `StreamBundle`/`DeltaCache` directly
  (bypassing full server bootstrap, which was impractical in the
  sandboxed test environment due to resource contention with a running
  production instance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a memory leak in `DeltaCache.deleteContext`.

- Removes `preferredSources` entries for deleted contexts.
- Emits `LIVEPREFERREDSOURCES` tombstones for deleted entries.
- Clears matching `cachedContextPaths` entries immediately.
- Adds regression tests for preferred-source cleanup, cached-path cleanup, and tombstone emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->