### PR TITLE
fix: deliver a new path's first delta once, not twice

### DIFF
--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -150,10 +150,16 @@ class SubscriptionManager implements ISubscriptionManager {
         user,
         sourcePolicy,
         perSubEngine,
-        this.selfContext
+        this.selfContext,
+        true
       )
       // listen to new keys and then use the same logic to check if we
-      // want to subscribe, passing in a map with just that single bus
+      // want to subscribe, passing in a map with just that single bus.
+      // No cache bootstrap here: a keys announcement is triggered by the
+      // delta that is mid-dispatch, already ingested into the delta cache
+      // (index.ts ingests before it emits), and its live push follows the
+      // attach within the same dispatch — a cache replay would deliver
+      // that first delta twice.
       unsubscribes.push(
         this.streambundle.keys.onValue((path) => {
           const newBuses: BusesMap = {}
@@ -171,7 +177,8 @@ class SubscriptionManager implements ISubscriptionManager {
             user,
             sourcePolicy,
             perSubEngine,
-            this.selfContext
+            this.selfContext,
+            false
           )
         })
       )
@@ -286,7 +293,8 @@ function handleSubscribeRows(
   user?: string,
   sourcePolicy?: 'preferred' | 'all',
   perSubEngine?: ToPreferredDelta | null,
-  selfContext?: string
+  selfContext?: string,
+  bootstrapFromCache?: boolean
 ) {
   rows.reduce((acc, subscribeRow) => {
     if (subscribeRow.path !== undefined) {
@@ -301,7 +309,8 @@ function handleSubscribeRows(
         user,
         sourcePolicy,
         perSubEngine,
-        selfContext
+        selfContext,
+        bootstrapFromCache
       )
     }
     return acc
@@ -323,7 +332,8 @@ function handleSubscribeRow(
   user?: string,
   sourcePolicy?: 'preferred' | 'all',
   perSubEngine?: ToPreferredDelta | null,
-  selfContext?: string
+  selfContext?: string,
+  bootstrapFromCache?: boolean
 ) {
   const matcher = pathMatcher(subscribeRow.path)
   // iterate over all the buses, checking if we want to subscribe to its values
@@ -447,37 +457,39 @@ function handleSubscribeRow(
         )
       }
 
-      // Bootstrap snapshot: fetch every source's last cached value
-      // (sourcePolicy='all') when a per-subscription engine owns this
-      // subscription, then replay through the engine so the snapshot
-      // honours the exclude mask. Without the override the snapshot
-      // would carry the global preferred winner — which may BE the
-      // excluded source — and the subscriber would see it once on
+      // Bootstrap snapshot at subscribe time only: fetch every source's
+      // last cached value (sourcePolicy='all') when a per-subscription
+      // engine owns this subscription, then replay through the engine so
+      // the snapshot honours the exclude mask. Without the override the
+      // snapshot would carry the global preferred winner — which may BE
+      // the excluded source — and the subscriber would see it once on
       // startup.
-      const cached = app.deltaCache.getCachedDeltas(
-        filter,
-        user,
-        key,
-        perSubEngine ? 'all' : sourcePolicy
-      )
-      const latest =
-        flattenRootValues && cached
-          ? flattenCachedRootDeltas(cached, matcher)
-          : cached
-      if (latest) {
-        if (perSubEngine) {
-          const now = new Date()
-          for (const delta of latest) {
-            const filtered = runPerSubEngine(
-              perSubEngine,
-              delta,
-              now,
-              selfContext ?? ''
-            )
-            if (filtered) callback(filtered)
+      if (bootstrapFromCache) {
+        const cached = app.deltaCache.getCachedDeltas(
+          filter,
+          user,
+          key,
+          perSubEngine ? 'all' : sourcePolicy
+        )
+        const latest =
+          flattenRootValues && cached
+            ? flattenCachedRootDeltas(cached, matcher)
+            : cached
+        if (latest) {
+          if (perSubEngine) {
+            const now = new Date()
+            for (const delta of latest) {
+              const filtered = runPerSubEngine(
+                perSubEngine,
+                delta,
+                now,
+                selfContext ?? ''
+              )
+              if (filtered) callback(filtered)
+            }
+          } else {
+            latest.forEach(callback)
           }
-        } else {
-          latest.forEach(callback)
         }
       }
     }

--- a/test/subscriptionmanager-bootstrap.ts
+++ b/test/subscriptionmanager-bootstrap.ts
@@ -1,0 +1,134 @@
+import {
+  Context,
+  Delta,
+  Path,
+  SourceRef,
+  SubscriptionOptions,
+  Timestamp
+} from '@signalk/server-api'
+import { expect } from 'chai'
+import { StreamBundle } from '../src/streambundle'
+import SubscriptionManager from '../src/subscriptionmanager'
+
+const SELF_ID = 'self-uuid'
+const SELF_CONTEXT = `vessels.${SELF_ID}` as Context
+const TIMESTAMP = '2026-01-01T00:00:00.000Z' as Timestamp
+const SOURCE_REF = 'test.1' as SourceRef
+
+const SOG_PATH = 'navigation.speedOverGround' as Path
+
+const SOG_FIRST = 3.4
+const SOG_SECOND = 3.5
+
+function valueDelta(context: Context, path: Path, value: number): Delta {
+  return {
+    context,
+    updates: [
+      { $source: SOURCE_REF, timestamp: TIMESTAMP, values: [{ path, value }] }
+    ]
+  }
+}
+
+function valuesOf(deltas: Delta[]): unknown[] {
+  return deltas.map((d) => {
+    const update = d.updates[0]
+    return 'values' in update ? update.values[0].value : undefined
+  })
+}
+
+// The cache bootstrap in handleSubscribeRow serves two callers with
+// different needs. At subscribe time it delivers the last known value of
+// paths that are already flowing — the subscriber's snapshot. In the keys
+// listener the announcement is triggered by the delta that is mid-dispatch
+// (index.ts ingests into the delta cache before emitting), so the live push
+// follows the attach within the same dispatch and a cache replay would
+// deliver that first delta twice.
+describe('SubscriptionManager cache bootstrap', () => {
+  let bundle: StreamBundle
+  let cache: Map<string, Delta>
+  let received: Delta[]
+  let unsubscribes: Array<() => void>
+
+  // index.ts dispatchDelta order: deltaCache.ingestDelta, then the
+  // unfilteredDelta emit, then the delta emit
+  const dispatch = (delta: Delta) => {
+    const update = delta.updates[0]
+    if ('values' in update) {
+      cache.set(update.values[0].path, delta)
+    }
+    bundle.pushUnfilteredDelta(delta)
+    bundle.pushDelta(delta)
+  }
+
+  const subscribe = (
+    rows: SubscriptionOptions[],
+    sourcePolicy?: 'preferred' | 'all'
+  ) => {
+    const manager = new SubscriptionManager({
+      streambundle: bundle,
+      selfContext: SELF_CONTEXT,
+      deltaCache: {
+        getCachedDeltas: (_filter: unknown, _user: unknown, key?: string) => {
+          if (key !== undefined) {
+            const hit = cache.get(key)
+            return hit ? [hit] : []
+          }
+          return [...cache.values()]
+        }
+      },
+      signalk: { root: {} }
+    })
+    manager.subscribe(
+      { context: '*' as Context, subscribe: rows },
+      unsubscribes,
+      () => undefined,
+      (delta: Delta) => received.push(delta),
+      undefined,
+      sourcePolicy
+    )
+  }
+
+  beforeEach(() => {
+    bundle = new StreamBundle(SELF_ID)
+    cache = new Map()
+    received = []
+    unsubscribes = []
+    // DeltaCache's constructor registers a keys listener that touches the
+    // per-path bus inside the announcement dispatch
+    bundle.keys.onValue((key) => {
+      bundle.getBus(key).onValue(() => undefined)
+    })
+  })
+
+  afterEach(() => {
+    unsubscribes.forEach((f) => f())
+  })
+
+  it('delivers the first delta of a path appearing after subscribe exactly once', () => {
+    subscribe([{ path: SOG_PATH }])
+
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(valuesOf(received)).to.deep.equal([SOG_FIRST, SOG_SECOND])
+  })
+
+  it("delivers a sourcePolicy 'all' subscriber the first delta exactly once", () => {
+    subscribe([{ path: SOG_PATH }], 'all')
+
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+
+    expect(valuesOf(received)).to.deep.equal([SOG_FIRST, SOG_SECOND])
+  })
+
+  it('still replays the cached value at subscribe time for known paths', () => {
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+
+    subscribe([{ path: SOG_PATH }])
+    expect(valuesOf(received)).to.deep.equal([SOG_FIRST])
+
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
+    expect(valuesOf(received)).to.deep.equal([SOG_FIRST, SOG_SECOND])
+  })
+})


### PR DESCRIPTION
A subscription made before a path exists attaches to the per-path bus via the streambundle `keys` announcement. That announcement is triggered by the delta that is mid-dispatch, which `dispatchDelta` has already ingested into the delta cache, so the cache bootstrap in `handleSubscribeRow` replayed the very delta whose live push follows the attach within the same dispatch. Every subscriber that subscribed ahead of its data — plugins at server startup, granular WebSocket clients — therefore received the first value of each path twice, double-triggering whatever computation or re-emission hangs off it.

The fix bootstraps from the delta cache only on the initial subscribe pass, where it delivers the snapshot of already-flowing paths; the keys-listener attach relies on the live push that caused the announcement. Surfaced while writing the regression tests for #2905; the two PRs touch the same call sites, so whichever merges second needs a trivial rebase (I'll take care of it).

Tested
- new regression tests in test/subscriptionmanager-bootstrap.ts: the two dedup tests fail without the src change, all three pass with it
- npm test (full chain) green locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Limits delta-cache bootstrap to the initial subscription pass.
- Prevents duplicate delivery when new path announcements trigger subscriptions.
- Preserves cache replay for subscriptions to known paths.
- Adds regression tests for normal and `sourcePolicy: 'all'` subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->