### PR TITLE
fix(streams): normalize canboat analyzer camelCase JSON for the N2K pipeline

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -66,6 +66,7 @@
   "homepage": "https://github.com/SignalK/signalk-server-node#readme",
   "dependencies": {
     "@canboat/canboatjs": "^3.20.0",
+    "@canboat/ts-pgns": "^1.11.9",
     "@signalk/client": "^2.4.0",
     "@signalk/n2k-signalk": "^4.6.0",
     "@signalk/nmea0183-signalk": "^3.20.0",

--- a/packages/streams/src/analyzerOutput.test.ts
+++ b/packages/streams/src/analyzerOutput.test.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'events'
+import { unwrapAnalyzerOutput } from './analyzerOutput'
+import { N2kMapper } from '@signalk/n2k-signalk'
+import { FromPgn } from '@canboat/canboatjs'
+
+// Real output of `analyzer -json -si -camel -nv` (canboat v8.0.0-beta1) for
+// the PLAIN line below. The envelope key is the camelCase PGN id; lookup
+// fields arrive as {value, name}.
+const RAW_60928 =
+  '2017-04-15T14:57:58.470Z,6,60928,3,255,8,d3,e5,98,c5,00,82,32,c0'
+const ANALYZER_60928 = {
+  isoAddressClaim: {
+    timestamp: '2017-04-15T14:57:58.470Z',
+    prio: 6,
+    src: 3,
+    dst: 255,
+    pgn: 60928,
+    description: 'ISO Address Claim',
+    fields: {
+      uniqueNumber: 1631699,
+      manufacturerCode: { value: 1580 },
+      deviceInstanceLower: 0,
+      deviceInstanceUpper: 0,
+      deviceFunction: { value: 130, name: 'PC Gateway' },
+      deviceClass: { value: 25, name: 'Internetwork device' },
+      systemInstance: 0,
+      industryGroup: { value: 4, name: 'Marine Industry' },
+      arbitraryAddressCapable: { value: 1, name: 'Yes' }
+    }
+  }
+}
+
+describe('unwrapAnalyzerOutput', () => {
+  it('unwraps the -camel envelope to a flat PGN object', () => {
+    const flat = unwrapAnalyzerOutput(ANALYZER_60928)
+    expect(flat.pgn).to.equal(60928)
+    expect(flat.src).to.equal(3)
+    expect(flat.description).to.equal('ISO Address Claim')
+  })
+
+  it('keeps INDIRECT_LOOKUP fields numeric and resolves plain lookups to names', () => {
+    const flat = unwrapAnalyzerOutput(ANALYZER_60928)
+    const fields = flat.fields as Record<string, unknown>
+    // deviceFunction is an INDIRECT_LOOKUP (meaning depends on deviceClass):
+    // canboatjs leaves it numeric, and the canName derivation re-encodes it,
+    // so a name-string here would change every device's source ref.
+    expect(fields.deviceFunction).to.equal(130)
+    expect(fields.deviceClass).to.equal('Internetwork device')
+    expect(fields.industryGroup).to.equal('Marine Industry')
+    expect(fields.arbitraryAddressCapable).to.equal('Yes')
+    // {value} without a name falls back to the raw value
+    expect(fields.manufacturerCode).to.equal(1580)
+  })
+
+  it('maps bit-lookup arrays to arrays of names', () => {
+    const flat = unwrapAnalyzerOutput({
+      engineParametersDynamic: {
+        pgn: 127489,
+        src: 16,
+        dst: 255,
+        prio: 2,
+        fields: {
+          instance: { value: 0, name: 'Single Engine or Dual Engine Port' },
+          discreteStatus1: [
+            { value: 1, name: 'Check Engine' },
+            { value: 4, name: 'Low Oil Pressure' }
+          ]
+        }
+      }
+    })
+    const fields = flat.fields as Record<string, unknown>
+    expect(fields.instance).to.equal('Single Engine or Dual Engine Port')
+    expect(fields.discreteStatus1).to.deep.equal([
+      'Check Engine',
+      'Low Oil Pressure'
+    ])
+  })
+
+  it('passes already-flat output through unchanged', () => {
+    const flat = {
+      timestamp: '2017-04-15T14:57:58.470Z',
+      pgn: 60928,
+      src: 3,
+      fields: { uniqueNumber: 1631699 }
+    }
+    expect(unwrapAnalyzerOutput(flat)).to.deep.equal(flat)
+  })
+
+  it('derives the same canName as the canboatjs decode path', () => {
+    // The regression that motivated this module: source refs must not change
+    // when a user switches between the canboatjs and analyzer connection
+    // types, or their per-source settings silently detach.
+    const parser = new FromPgn({ format: 1, returnNulls: true, useCamel: true })
+    parser.on('error', () => {})
+    const fromCanboatjs = parser.parseString(RAW_60928)
+    const fromAnalyzer = unwrapAnalyzerOutput(ANALYZER_60928)
+
+    const canNameOf = (pgn: unknown) => {
+      let canName: string | undefined
+      const mapper = new N2kMapper({ useCanName: true }) as N2kMapper &
+        EventEmitter
+      mapper.on(
+        'n2kSourceMetadata',
+        (_n2k: unknown, meta: { canName?: string }) => {
+          canName = meta.canName
+        }
+      )
+      mapper.toDelta(pgn)
+      return canName
+    }
+
+    const jsName = canNameOf(fromCanboatjs)
+    const analyzerName = canNameOf(fromAnalyzer)
+    expect(jsName).to.be.a('string')
+    expect(analyzerName).to.equal(jsName)
+  })
+})

--- a/packages/streams/src/analyzerOutput.test.ts
+++ b/packages/streams/src/analyzerOutput.test.ts
@@ -77,6 +77,22 @@ describe('unwrapAnalyzerOutput', () => {
     ])
   })
 
+  it('supplies an empty fields object when the analyzer omits it', () => {
+    // All-empty messages (e.g. blank Configuration Information) arrive with
+    // no fields key; n2k-signalk's meta-PGN handlers return n2k.fields
+    // directly and their listeners dereference it.
+    const flat = unwrapAnalyzerOutput({
+      configurationInformation: {
+        pgn: 126998,
+        src: 5,
+        dst: 255,
+        prio: 6,
+        description: 'Configuration Information'
+      }
+    })
+    expect(flat.fields).to.deep.equal({})
+  })
+
   it('passes already-flat output through unchanged', () => {
     const flat = {
       timestamp: '2017-04-15T14:57:58.470Z',

--- a/packages/streams/src/analyzerOutput.test.ts
+++ b/packages/streams/src/analyzerOutput.test.ts
@@ -93,6 +93,50 @@ describe('unwrapAnalyzerOutput', () => {
     expect(flat.fields).to.deep.equal({})
   })
 
+  it('restores omitted SPARE and RESERVED fields as 0', () => {
+    // The analyzer skips all-zero SPARE/RESERVED fields; canboatjs emits
+    // them as 0, and toPgn fills absent fields with all-ones — for 60928
+    // the spare bit sits inside the NAME, so the restoration is what
+    // keeps the re-encoded canName identical to the canboatjs path.
+    const claim = unwrapAnalyzerOutput({
+      isoAddressClaim: {
+        pgn: 60928,
+        src: 3,
+        fields: { uniqueNumber: 1631699 }
+      }
+    })
+    expect((claim.fields as Record<string, unknown>).spare).to.equal(0)
+
+    const engine = unwrapAnalyzerOutput({
+      engineParametersDynamic: {
+        pgn: 127489,
+        src: 16,
+        fields: {
+          instance: { value: 0, name: 'Single Engine or Dual Engine Port' }
+        }
+      }
+    })
+    expect((engine.fields as Record<string, unknown>).reserved).to.equal(0)
+  })
+
+  it('restores omitted BITLOOKUP fields as an empty array', () => {
+    // Bit lookups with no set bits are omitted by the analyzer; canboatjs
+    // emits [], from which n2k-signalk derives "normal" notification
+    // states.
+    const engine = unwrapAnalyzerOutput({
+      engineParametersDynamic: {
+        pgn: 127489,
+        src: 16,
+        fields: {
+          instance: { value: 0, name: 'Single Engine or Dual Engine Port' }
+        }
+      }
+    })
+    const fields = engine.fields as Record<string, unknown>
+    expect(fields.discreteStatus1).to.deep.equal([])
+    expect(fields.discreteStatus2).to.deep.equal([])
+  })
+
   it('passes already-flat output through unchanged', () => {
     const flat = {
       timestamp: '2017-04-15T14:57:58.470Z',
@@ -100,7 +144,10 @@ describe('unwrapAnalyzerOutput', () => {
       src: 3,
       fields: { uniqueNumber: 1631699 }
     }
-    expect(unwrapAnalyzerOutput(flat)).to.deep.equal(flat)
+    // Snapshot before the call: comparing the return value against the
+    // same reference could never fail, even for an in-place mutation.
+    const expected = structuredClone(flat)
+    expect(unwrapAnalyzerOutput(flat)).to.deep.equal(expected)
   })
 
   it('derives the same canName as the canboatjs decode path', () => {

--- a/packages/streams/src/analyzerOutput.ts
+++ b/packages/streams/src/analyzerOutput.ts
@@ -125,20 +125,26 @@ export function unwrapAnalyzerOutput(
   }
   const types = fieldTypesForId(id)
   const result: Record<string, unknown> = { ...inner }
-  if (isPlainObject(inner.fields)) {
-    const fields = normalizeFields(inner.fields, types)
-    for (const [fieldId, fieldType] of Object.entries(types)) {
-      if (isSpareOrReserved(fieldType) && !(fieldId in fields)) {
-        fields[fieldId] = 0
-      }
-      // The analyzer also omits bit lookups with no set bits; canboatjs
-      // emits [], from which n2k-signalk derives "normal" notification
-      // states — restore the empty array so those states are not lost.
-      if (fieldType === 'BITLOOKUP' && !(fieldId in fields)) {
-        fields[fieldId] = []
-      }
+  // A message whose fields are all empty (e.g. a Configuration Information
+  // with blank strings) arrives with no fields object at all — the analyzer
+  // skips empty values wholesale. canboatjs always emits a fields object,
+  // and n2k-signalk's meta-PGN handlers return n2k.fields directly, so a
+  // missing object flows through as undefined metadata and crashes the
+  // n2kSourceMetadata listener. Normalise to {}.
+  const fields = isPlainObject(inner.fields)
+    ? normalizeFields(inner.fields, types)
+    : {}
+  for (const [fieldId, fieldType] of Object.entries(types)) {
+    if (isSpareOrReserved(fieldType) && !(fieldId in fields)) {
+      fields[fieldId] = 0
     }
-    result.fields = fields
+    // The analyzer also omits bit lookups with no set bits; canboatjs
+    // emits [], from which n2k-signalk derives "normal" notification
+    // states — restore the empty array so those states are not lost.
+    if (fieldType === 'BITLOOKUP' && !(fieldId in fields)) {
+      fields[fieldId] = []
+    }
   }
+  result.fields = fields
   return result
 }

--- a/packages/streams/src/analyzerOutput.ts
+++ b/packages/streams/src/analyzerOutput.ts
@@ -1,0 +1,144 @@
+import { getPGNWithId } from '@canboat/ts-pgns'
+
+/*
+ * canboat's analyzer, invoked with -camel (as n2kAnalyzer does), wraps every
+ * JSON message in a single-key envelope keyed by the camelCase PGN id:
+ *
+ *   {"isoAddressClaim": {"prio":6,"src":3,...,"fields":{...}}}
+ *
+ * It has done so since canboat v6.0.0 — the flat form the rest of the
+ * pipeline (n2k-signalk's toDelta) expects only exists in non-camel mode,
+ * whose TitleCase field names n2k-signalk cannot map either. So the envelope
+ * must be unwrapped here.
+ *
+ * Field values need normalising too. canboatjs renders lookup fields as the
+ * enumeration name when known (falling back to the raw number), EXCEPT
+ * indirect lookups (e.g. 60928's deviceFunction, whose meaning depends on
+ * deviceClass), which stay numeric. n2k-signalk relies on that convention:
+ * it derives the device canName by re-encoding PGN 60928 through canboatjs's
+ * toPgn, and a name-string where a number is expected changes the encoded
+ * NAME — every device would get a different source ref on the analyzer path
+ * than on the canboatjs path, silently detaching per-source settings.
+ *
+ * The analyzer cannot be told to follow canboatjs's convention, but with
+ * -nv it emits every such field as {value, name}, which lets us pick the
+ * right representation per field using the PGN schema: the envelope key is
+ * exactly the ts-pgns definition id, and INDIRECT_LOOKUP fields take the
+ * numeric value while everything else prefers the name. Bit lookups arrive
+ * as arrays of {value, name} and map to arrays of names, matching canboatjs.
+ *
+ * One more asymmetry: the analyzer omits SPARE/RESERVED fields whose bits
+ * are all zero (its -json mode skips empty values; -empty does not bring
+ * them back). canboatjs emits them as 0, and toPgn fills fields that are
+ * absent with all-ones ("unavailable") — which would again corrupt the
+ * re-encoded canName (the 60928 spare bit sits inside the NAME). So missing
+ * SPARE/RESERVED fields are restored as 0 from the schema.
+ */
+
+interface NameValue {
+  value: unknown
+  name?: string | null
+}
+
+const isNameValue = (v: unknown): v is NameValue =>
+  typeof v === 'object' && v !== null && !Array.isArray(v) && 'value' in v
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+function fieldTypesForId(id: string): Record<string, string> {
+  const types: Record<string, string> = {}
+  const definition = getPGNWithId(id)
+  if (definition) {
+    for (const field of definition.Fields) {
+      types[field.Id] = field.FieldType as string
+    }
+  }
+  return types
+}
+
+const isSpareOrReserved = (fieldType: string | undefined) =>
+  fieldType === 'SPARE' || fieldType === 'RESERVED'
+
+function normalizeValue(
+  value: unknown,
+  fieldType: string | undefined,
+  types: Record<string, string>
+): unknown {
+  if (Array.isArray(value)) {
+    if (fieldType === 'BITLOOKUP') {
+      // canboatjs renders a bit lookup as the names of the set bits and
+      // yields [] when no named bit is set (incl. the all-ones
+      // "unavailable" pattern); entries whose bit has no enumeration name
+      // are therefore dropped rather than kept as raw numbers.
+      return value
+        .map((entry) => (isNameValue(entry) ? entry.name : entry))
+        .filter((name) => typeof name === 'string')
+    }
+    return value.map((entry) =>
+      isNameValue(entry)
+        ? (entry.name ?? entry.value)
+        : isPlainObject(entry)
+          ? normalizeFields(entry, types)
+          : entry
+    )
+  }
+  if (isNameValue(value)) {
+    return fieldType === 'INDIRECT_LOOKUP'
+      ? value.value
+      : (value.name ?? value.value)
+  }
+  if (isPlainObject(value)) {
+    return normalizeFields(value, types)
+  }
+  return value
+}
+
+function normalizeFields(
+  fields: Record<string, unknown>,
+  types: Record<string, string>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [id, value] of Object.entries(fields)) {
+    result[id] = normalizeValue(value, types[id], types)
+  }
+  return result
+}
+
+/**
+ * Turn one parsed line of `analyzer -json -si -camel -nv` output into the
+ * flat, canboatjs-shaped PGN object the downstream pipeline expects.
+ * Passes through anything that is not a single-key camel envelope (already
+ * flat output from a pre-v6 analyzer, or unrecognised shapes) unchanged.
+ */
+export function unwrapAnalyzerOutput(
+  parsed: Record<string, unknown>
+): Record<string, unknown> {
+  const keys = Object.keys(parsed)
+  const id = keys.length === 1 ? keys[0] : undefined
+  if (id === undefined) {
+    return parsed
+  }
+  const inner = parsed[id]
+  if (!isPlainObject(inner) || typeof inner.pgn !== 'number') {
+    return parsed
+  }
+  const types = fieldTypesForId(id)
+  const result: Record<string, unknown> = { ...inner }
+  if (isPlainObject(inner.fields)) {
+    const fields = normalizeFields(inner.fields, types)
+    for (const [fieldId, fieldType] of Object.entries(types)) {
+      if (isSpareOrReserved(fieldType) && !(fieldId in fields)) {
+        fields[fieldId] = 0
+      }
+      // The analyzer also omits bit lookups with no set bits; canboatjs
+      // emits [], from which n2k-signalk derives "normal" notification
+      // states — restore the empty array so those states are not lost.
+      if (fieldType === 'BITLOOKUP' && !(fieldId in fields)) {
+        fields[fieldId] = []
+      }
+    }
+    result.fields = fields
+  }
+  return result
+}

--- a/packages/streams/src/analyzerOutput.ts
+++ b/packages/streams/src/analyzerOutput.ts
@@ -46,15 +46,38 @@ const isNameValue = (v: unknown): v is NameValue =>
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
 
-function fieldTypesForId(id: string): Record<string, string> {
-  const types: Record<string, string> = {}
-  const definition = getPGNWithId(id)
-  if (definition) {
-    for (const field of definition.Fields) {
-      types[field.Id] = field.FieldType as string
+interface SchemaInfo {
+  types: Record<string, string>
+  /** Fields the analyzer omits but canboatjs always emits, with the
+   * default to restore: 0 for SPARE/RESERVED, [] for BITLOOKUP. */
+  defaults: Array<[string, 0 | []]>
+}
+
+// One schema lookup per PGN id for the lifetime of the process — this
+// runs per message on the hot path, and the schema cannot change.
+const schemaCache = new Map<string, SchemaInfo>()
+
+function schemaForId(id: string): SchemaInfo {
+  let info = schemaCache.get(id)
+  if (info === undefined) {
+    const types: Record<string, string> = {}
+    const defaults: Array<[string, 0 | []]> = []
+    const definition = getPGNWithId(id)
+    if (definition) {
+      for (const field of definition.Fields) {
+        const fieldType = field.FieldType as string
+        types[field.Id] = fieldType
+        if (isSpareOrReserved(fieldType)) {
+          defaults.push([field.Id, 0])
+        } else if (fieldType === 'BITLOOKUP') {
+          defaults.push([field.Id, []])
+        }
+      }
     }
+    info = { types, defaults }
+    schemaCache.set(id, info)
   }
-  return types
+  return info
 }
 
 const isSpareOrReserved = (fieldType: string | undefined) =>
@@ -77,7 +100,11 @@ function normalizeValue(
     }
     return value.map((entry) =>
       isNameValue(entry)
-        ? (entry.name ?? entry.value)
+        ? // Same rule as the scalar branch: indirect lookups stay
+          // numeric — a name string would change re-encoded output.
+          fieldType === 'INDIRECT_LOOKUP'
+          ? entry.value
+          : (entry.name ?? entry.value)
         : isPlainObject(entry)
           ? normalizeFields(entry, types)
           : entry
@@ -123,7 +150,7 @@ export function unwrapAnalyzerOutput(
   if (!isPlainObject(inner) || typeof inner.pgn !== 'number') {
     return parsed
   }
-  const types = fieldTypesForId(id)
+  const { types, defaults } = schemaForId(id)
   const result: Record<string, unknown> = { ...inner }
   // A message whose fields are all empty (e.g. a Configuration Information
   // with blank strings) arrives with no fields object at all — the analyzer
@@ -134,15 +161,15 @@ export function unwrapAnalyzerOutput(
   const fields = isPlainObject(inner.fields)
     ? normalizeFields(inner.fields, types)
     : {}
-  for (const [fieldId, fieldType] of Object.entries(types)) {
-    if (isSpareOrReserved(fieldType) && !(fieldId in fields)) {
-      fields[fieldId] = 0
-    }
-    // The analyzer also omits bit lookups with no set bits; canboatjs
-    // emits [], from which n2k-signalk derives "normal" notification
-    // states — restore the empty array so those states are not lost.
-    if (fieldType === 'BITLOOKUP' && !(fieldId in fields)) {
-      fields[fieldId] = []
+  // The analyzer omits SPARE/RESERVED fields whose bits are all zero and
+  // bit lookups with no set bits; canboatjs emits 0 and [] respectively —
+  // n2k-signalk derives "normal" notification states from the empty
+  // array, and a missing spare corrupts the re-encoded canName.
+  for (const [fieldId, empty] of defaults) {
+    if (!(fieldId in fields)) {
+      // Fresh array per message — the cached entry must never become a
+      // shared mutable instance.
+      fields[fieldId] = empty === 0 ? 0 : []
     }
   }
   result.fields = fields

--- a/packages/streams/src/n2kAnalyzer.ts
+++ b/packages/streams/src/n2kAnalyzer.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from 'child_process'
 import { createInterface } from 'readline'
 import { Transform, TransformCallback, Writable } from 'stream'
+import { unwrapAnalyzerOutput } from './analyzerOutput'
 interface N2kAnalyzerOptions {
   app: {
     emit(event: string, ...args: unknown[]): void
@@ -24,10 +25,15 @@ export default class N2kAnalyzer extends Transform {
 
     this.analyzerOutEvent = options.analyzerOutEvent ?? 'N2KAnalyzerOut'
 
+    // -camel wraps each message in a {"camelPgnId": {...}} envelope (canboat
+    // >= 6.0.0) and -nv emits lookup fields as {value, name} pairs; both are
+    // undone by unwrapAnalyzerOutput below, which needs -nv to rebuild
+    // canboatjs's per-field name-or-number convention.
+    const analyzerCommand = 'analyzer -json -si -camel -nv'
     if (process.platform === 'win32') {
-      this.analyzerProcess = spawn('cmd', ['/c', 'analyzer -json -si -camel'])
+      this.analyzerProcess = spawn('cmd', ['/c', analyzerCommand])
     } else {
-      this.analyzerProcess = spawn('sh', ['-c', 'analyzer -json -si -camel'])
+      this.analyzerProcess = spawn('sh', ['-c', analyzerCommand])
     }
 
     this.analyzerProcess.stderr?.on('data', (data: Buffer) => {
@@ -50,8 +56,9 @@ export default class N2kAnalyzer extends Transform {
           console.log('Connected to analyzer v' + parsed.version)
           return
         }
-        this.push(parsed)
-        options.app.emit(this.analyzerOutEvent, parsed)
+        const flat = unwrapAnalyzerOutput(parsed)
+        this.push(flat)
+        options.app.emit(this.analyzerOutEvent, flat)
       } catch (ex: unknown) {
         console.error(data)
         if (ex instanceof Error) {


### PR DESCRIPTION
Two normalization fixes for records arriving from canboat's analyzer in `-camel` JSON mode, so the N2K pipeline treats them exactly like canboatjs output:

- camelCase analyzer records are rekeyed/unwrapped for n2k-signalk's mapper conventions (lookup shapes, reserved/bitlookup normalization).
- A message whose fields are all empty arrives from the analyzer with no `fields` object at all; canboatjs always emits one, and n2k-signalk's meta-PGN handlers return `n2k.fields` directly — normalize to `{}` so the metadata listener doesn't crash.

Groundwork for connection types backed by the canboat Rust/wasm decoder (companion PRs follow); independent of them — this only touches how analyzer-shaped JSON is normalized.

Tested: unit tests in the streams package cover both normalizations; the pipeline has been running in a staging image against live IPG100/YDWG traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR normalizes canboat analyzer records in `-camel` JSON mode for the N2K pipeline.

- Unwraps camelCase analyzer envelopes into flat PGN objects.
- Normalizes lookup, `INDIRECT_LOOKUP`, reserved/spare, and bitlookup fields to match canboatjs conventions.
- Emits `fields: {}` when analyzer messages contain no populated fields.
- Applies normalization before publishing N2K analyzer data and application events.
- Caches per-PGN schema information during normalization.
- Preserves flat passthrough behavior without in-place mutation.
- Adds unit tests for envelope unwrapping and field normalization.
- Adds `@canboat/ts-pgns` `^1.11.9` as a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->