### PR TITLE
feat(streams): native canboat sources for iKonvert, IPG100, SocketCAN, YDWG-02, NavLink2 and W2K-1

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1697,11 +1697,20 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
               iKonvert (canboat)
             </option>
             <option value="navlink2-tcp-canboatjs">NavLink2 (canboatjs)</option>
+            <option value="navlink2" disabled={!hasAnalyzer}>
+              NavLink2 (canboat)
+            </option>
             <option value="canboat-csv-canboatjs">
               canboat-pipeline CSV R/W (canboatjs)
             </option>
             <option value="ydwg02-canboatjs">
               Yacht Devices RAW TCP (canboatjs)
+            </option>
+            <option value="ydwg02" disabled={!hasAnalyzer}>
+              Yacht Devices RAW TCP (canboat)
+            </option>
+            <option value="ydwg02-udp" disabled={!hasAnalyzer}>
+              Yacht Devices RAW UDP (canboat)
             </option>
             <option value="ydwg02-udp-canboatjs">
               Yacht Devices RAW UDP (canboatjs)
@@ -1718,6 +1727,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
             </option>
             <option value="w2k-1-n2k-actisense-canboatjs">
               W2K-1 N2K ACTISENSE (canboatjs)
+            </option>
+            <option value="w2k-1-ascii" disabled={!hasAnalyzer}>
+              W2K-1 N2K ASCII (canboat)
             </option>
             <option value="maretron-ipg-canboatjs">
               Maretron IPG 100 (canboatjs)
@@ -1741,7 +1753,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           <BaudRateInputCanboat value={value.options} onChange={onChange} />
         </div>
       )}
-      {value.options.type === 'ydwg02-canboatjs' && (
+      {(value.options.type === 'ydwg02-canboatjs' ||
+        value.options.type === 'ydwg02' ||
+        value.options.type === 'navlink2') && (
         <div>
           <HostInput value={value.options} onChange={onChange} />
           <PortInput value={value.options} onChange={onChange} />
@@ -1751,7 +1765,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           />
         </div>
       )}
-      {value.options.type === 'ydwg02-udp-canboatjs' && (
+      {(value.options.type === 'ydwg02-udp-canboatjs' ||
+        value.options.type === 'ydwg02-udp') && (
         <div>
           <HostInput value={value.options} onChange={onChange} />
           <PortInput value={value.options} onChange={onChange} />
@@ -1817,7 +1832,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
         <CollectNetworkStatsInput value={value.options} onChange={onChange} />
       )}
       {(value.options.type === 'w2k-1-n2k-ascii-canboatjs' ||
-        value.options.type === 'w2k-1-n2k-actisense-canboatjs') && (
+        value.options.type === 'w2k-1-n2k-actisense-canboatjs' ||
+        value.options.type === 'w2k-1-ascii') && (
         <div>
           <HostInput value={value.options} onChange={onChange} />
           <PortInput value={value.options} onChange={onChange} />

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -971,7 +971,10 @@ function BaudRateInputCanboat({
   onChange: OnChangeHandler
 }) {
   // Default baud rate based on device type - controlled with fallback
-  const defaultBaudrate = value.type === 'ikonvert-canboatjs' ? 230400 : 115200
+  const defaultBaudrate =
+    value.type === 'ikonvert-canboatjs' || value.type === 'ikonvert'
+      ? 230400
+      : 115200
   const displayBaudrate = value.baudrate ?? defaultBaudrate
 
   return (
@@ -1690,6 +1693,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
               Actisense NGT-1 (canboat)
             </option>
             <option value="ikonvert-canboatjs">iKonvert (canboatjs)</option>
+            <option value="ikonvert" disabled={!hasAnalyzer}>
+              iKonvert (canboat)
+            </option>
             <option value="navlink2-tcp-canboatjs">NavLink2 (canboatjs)</option>
             <option value="canboat-csv-canboatjs">
               canboat-pipeline CSV R/W (canboatjs)
@@ -1716,6 +1722,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
             <option value="maretron-ipg-canboatjs">
               Maretron IPG 100 (canboatjs)
             </option>
+            <option value="maretron-ipg" disabled={!hasAnalyzer}>
+              Maretron IPG 100 (canboat)
+            </option>
             <option value="canbus" disabled={!hasAnalyzer}>
               Canbus (canboat)
             </option>
@@ -1725,7 +1734,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
       {(value.options.type === 'ngt-1' ||
         value.options.type === 'ngt-1-canboatjs' ||
         value.options.type === 'ydwg02-usb-canboatjs' ||
-        value.options.type === 'ikonvert-canboatjs') && (
+        value.options.type === 'ikonvert-canboatjs' ||
+        value.options.type === 'ikonvert') && (
         <div>
           <DeviceInput value={value.options} onChange={onChange} />
           <BaudRateInputCanboat value={value.options} onChange={onChange} />
@@ -1852,7 +1862,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           </div>
         </div>
       )}
-      {value.options.type === 'maretron-ipg-canboatjs' && (
+      {(value.options.type === 'maretron-ipg-canboatjs' ||
+        value.options.type === 'maretron-ipg') && (
         <div>
           <HostInput value={value.options} onChange={onChange} />
           <PortInput value={value.options} onChange={onChange} />

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1750,7 +1750,13 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
         value.options.type === 'ikonvert') && (
         <div>
           <DeviceInput value={value.options} onChange={onChange} />
-          <BaudRateInputCanboat value={value.options} onChange={onChange} />
+          {/* The canboatjs iKonvert and YDWG-02 USB elements pin their
+              protocol's baud rate, so offering the control there would
+              save a value the server ignores. */}
+          {value.options.type !== 'ikonvert-canboatjs' &&
+            value.options.type !== 'ydwg02-usb-canboatjs' && (
+              <BaudRateInputCanboat value={value.options} onChange={onChange} />
+            )}
         </div>
       )}
       {(value.options.type === 'ydwg02-canboatjs' ||
@@ -1768,7 +1774,11 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
       {(value.options.type === 'ydwg02-udp-canboatjs' ||
         value.options.type === 'ydwg02-udp') && (
         <div>
-          <HostInput value={value.options} onChange={onChange} />
+          {/* The native bridge listens on a UDP port and never dials a
+              host, so a Host value there would be saved and ignored. */}
+          {value.options.type !== 'ydwg02-udp' && (
+            <HostInput value={value.options} onChange={onChange} />
+          )}
           <PortInput value={value.options} onChange={onChange} />
           <div className="text-muted small mt-1 mb-2">
             UDP is receive-only — N2K device discovery and PGN 126208 instance
@@ -1903,7 +1913,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           </Form.Group>
           <div className="text-muted small mt-1 mb-2">
             Maretron IPG 100 Ethernet gateway. Default TCP port 6543. Uses
-            Maretron&apos;s 0xA5-framed binary protocol (handled by canboatjs).
+            Maretron&apos;s 0xA5-framed binary protocol. The password is sent in
+            the clear during the gateway&apos;s own connection handshake — the
+            protocol offers no encrypted alternative.
           </div>
         </div>
       )}

--- a/packages/streams/src/execute.ts
+++ b/packages/streams/src/execute.ts
@@ -14,7 +14,7 @@ interface ExecuteOptions {
     setProviderError(id: string, msg: string): void
   }
   providerId: string
-  toChildProcess?: string
+  toChildProcess?: string | false
   restartOnClose?: boolean
   restartThrottleTime?: number
   createDebug?: CreateDebug
@@ -49,6 +49,15 @@ export default class Execute extends Transform {
   pipe<T extends NodeJS.WritableStream>(pipeTo: T): T {
     this.pipeTo = pipeTo as unknown as Writable
     this.startProcess(this.options.command)
+
+    // `false` disables stdin wiring entirely, for gateways that cannot
+    // transmit (the YDWG-02's receive-only UDP mode). Leaving the
+    // option undefined subscribes to the default event instead, so
+    // absence alone would still write to the child's stdin.
+    if (this.options.toChildProcess === false) {
+      this.debug('Receive-only provider: not wiring the child process stdin')
+      return super.pipe(pipeTo)
+    }
 
     const stdOutEvent = this.options.toChildProcess ?? 'toChildProcess'
     this.debug(

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -423,7 +423,7 @@ function nmea2000input(
       return n
     }
     let command: string
-    let toChildProcess: string | undefined
+    let toChildProcess: string | false | undefined
     if (subOptions.type === 'ngt-1') {
       command = `actisense-serial -s ${safeNum(subOptions.baudrate ?? 115200, 'baud rate')} ${safeArg(subOptions.device, 'device')}`
       toChildProcess = 'nmea2000out'
@@ -433,12 +433,15 @@ function nmea2000input(
       // accepts outbound PGNs on stdin, which the candump pipeline cannot.
       // -u/-m mirror the uniqueNumber/mfgCode settings the canboatjs
       // SocketCAN option honors.
+      // Absence, not falsiness: 0 is a valid manufacturer code (the
+      // form offers it as "Internal") and a valid unique number.
+      const hasValue = (v: unknown) => v !== undefined && v !== null && v !== ''
       command =
         `socketcan-serial` +
-        (subOptions.uniqueNumber
+        (hasValue(subOptions.uniqueNumber)
           ? ` -u ${safeNum(subOptions.uniqueNumber, 'unique number')}`
           : '') +
-        (subOptions.mfgCode
+        (hasValue(subOptions.mfgCode)
           ? ` -m ${safeNum(subOptions.mfgCode, 'manufacturer code')}`
           : '') +
         ` ${safeArg(subOptions.interface, 'interface')}`
@@ -457,9 +460,11 @@ function nmea2000input(
       command = `canboat interface --kind ydwg tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 1457, 'port')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'ydwg02-udp') {
-      // The YDWG-02's UDP mode is receive-only — no stdin wiring, so
-      // the admin UI never reports transmit activity for it.
+      // The YDWG-02's UDP mode is receive-only: `false` disables the
+      // child's stdin wiring outright, so no plugin's outbound PGN can
+      // reach a gateway that cannot transmit.
       command = `canboat interface --kind ydwg udp://${safeNum(subOptions.port ?? 1457, 'port')}`
+      toChildProcess = false
     } else if (subOptions.type === 'navlink2') {
       command = `canboat interface --kind ikonvert tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 6001, 'port')}`
       toChildProcess = 'nmea2000out'

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -430,6 +430,20 @@ function nmea2000input(
         (password ? ` --password=${shellescape(password)}` : '') +
         ` tcp://${subOptions.host}:${subOptions.port ?? 6543}`
       toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'ydwg02') {
+      command = `canboat interface --kind ydwg tcp://${subOptions.host}:${subOptions.port ?? 1457}`
+      toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'ydwg02-udp') {
+      // The YDWG-02's UDP mode is receive-only; the bridge drops
+      // outbound frames with a warning.
+      command = `canboat interface --kind ydwg udp://${subOptions.port ?? 1457}`
+      toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'navlink2') {
+      command = `canboat interface --kind ikonvert tcp://${subOptions.host}:${subOptions.port ?? 6001}`
+      toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'w2k-1-ascii') {
+      command = `canboat interface --kind w2k-ascii tcp://${subOptions.host}:${subOptions.port ?? 60002}`
+      toChildProcess = 'nmea2000out'
     } else {
       throw new Error(`unknown NMEA2000 type ${subOptions.type}`)
     }

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -401,10 +401,31 @@ function nmea2000input(
     // PLAIN/FAST CSV on stdout, which the downstream N2kAnalyzer decodes.
     // Where toChildProcess is set, the same CSV format is accepted on stdin
     // for outbound PGNs (encoded by canboatjs in execute.ts).
+    //
+    // Execute runs the command through a shell, so every provider-config
+    // value is validated before interpolation: hosts/devices/interfaces
+    // against the character set their legitimate values need, numbers as
+    // finite. Anything else fails the provider loudly.
+    const safeArg = (value: unknown, what: string): string => {
+      const s = String(value ?? '')
+      if (!/^[A-Za-z0-9_.:/-]+$/.test(s)) {
+        throw new Error(`invalid ${what} for NMEA 2000 connection: '${s}'`)
+      }
+      return s
+    }
+    const safeNum = (value: unknown, what: string): number => {
+      const n = Number(value)
+      if (!Number.isFinite(n)) {
+        throw new Error(
+          `invalid ${what} for NMEA 2000 connection: '${String(value)}'`
+        )
+      }
+      return n
+    }
     let command: string
     let toChildProcess: string | undefined
     if (subOptions.type === 'ngt-1') {
-      command = `actisense-serial -s ${subOptions.baudrate ?? 115200} ${subOptions.device}`
+      command = `actisense-serial -s ${safeNum(subOptions.baudrate ?? 115200, 'baud rate')} ${safeArg(subOptions.device, 'device')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'canbus') {
       // canboat's socketcan-serial rather than candump|candump2analyzer:
@@ -415,34 +436,35 @@ function nmea2000input(
       command =
         `socketcan-serial` +
         (subOptions.uniqueNumber
-          ? ` -u ${Number(subOptions.uniqueNumber)}`
+          ? ` -u ${safeNum(subOptions.uniqueNumber, 'unique number')}`
           : '') +
-        (subOptions.mfgCode ? ` -m ${Number(subOptions.mfgCode)}` : '') +
-        ` ${subOptions.interface}`
+        (subOptions.mfgCode
+          ? ` -m ${safeNum(subOptions.mfgCode, 'manufacturer code')}`
+          : '') +
+        ` ${safeArg(subOptions.interface, 'interface')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'ikonvert') {
-      command = `ikonvert-serial -s ${subOptions.baudrate ?? 230400} ${subOptions.device}`
+      command = `ikonvert-serial -s ${safeNum(subOptions.baudrate ?? 230400, 'baud rate')} ${safeArg(subOptions.device, 'device')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'maretron-ipg') {
       const password = (subOptions as { password?: string }).password
       command =
         `maretron-ipg` +
         (password ? ` --password=${shellescape(password)}` : '') +
-        ` tcp://${subOptions.host}:${subOptions.port ?? 6543}`
+        ` tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 6543, 'port')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'ydwg02') {
-      command = `canboat interface --kind ydwg tcp://${subOptions.host}:${subOptions.port ?? 1457}`
+      command = `canboat interface --kind ydwg tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 1457, 'port')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'ydwg02-udp') {
-      // The YDWG-02's UDP mode is receive-only; the bridge drops
-      // outbound frames with a warning.
-      command = `canboat interface --kind ydwg udp://${subOptions.port ?? 1457}`
-      toChildProcess = 'nmea2000out'
+      // The YDWG-02's UDP mode is receive-only — no stdin wiring, so
+      // the admin UI never reports transmit activity for it.
+      command = `canboat interface --kind ydwg udp://${safeNum(subOptions.port ?? 1457, 'port')}`
     } else if (subOptions.type === 'navlink2') {
-      command = `canboat interface --kind ikonvert tcp://${subOptions.host}:${subOptions.port ?? 6001}`
+      command = `canboat interface --kind ikonvert tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 6001, 'port')}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'w2k-1-ascii') {
-      command = `canboat interface --kind w2k-ascii tcp://${subOptions.host}:${subOptions.port ?? 60002}`
+      command = `canboat interface --kind w2k-ascii tcp://${safeArg(subOptions.host, 'host')}:${safeNum(subOptions.port ?? 60002, 'port')}`
       toChildProcess = 'nmea2000out'
     } else {
       throw new Error(`unknown NMEA2000 type ${subOptions.type}`)

--- a/packages/streams/src/simple.ts
+++ b/packages/streams/src/simple.ts
@@ -1,4 +1,5 @@
 import { Transform, TransformCallback } from 'stream'
+import shellescape from 'any-shell-escape'
 import N2kAnalyzer from './n2kAnalyzer'
 import FromJson from './from_json'
 import MultiplexedLog from './multiplexedlog'
@@ -396,14 +397,39 @@ function nmea2000input(
       })
     ]
   } else {
+    // Native (canboat) sources: each command bridges the gateway to canboat
+    // PLAIN/FAST CSV on stdout, which the downstream N2kAnalyzer decodes.
+    // Where toChildProcess is set, the same CSV format is accepted on stdin
+    // for outbound PGNs (encoded by canboatjs in execute.ts).
     let command: string
     let toChildProcess: string | undefined
     if (subOptions.type === 'ngt-1') {
       command = `actisense-serial -s ${subOptions.baudrate ?? 115200} ${subOptions.device}`
       toChildProcess = 'nmea2000out'
     } else if (subOptions.type === 'canbus') {
-      command = `candump ${subOptions.interface} | candump2analyzer`
-      toChildProcess = undefined
+      // canboat's socketcan-serial rather than candump|candump2analyzer:
+      // same decode path, but bidirectional — it claims an address and
+      // accepts outbound PGNs on stdin, which the candump pipeline cannot.
+      // -u/-m mirror the uniqueNumber/mfgCode settings the canboatjs
+      // SocketCAN option honors.
+      command =
+        `socketcan-serial` +
+        (subOptions.uniqueNumber
+          ? ` -u ${Number(subOptions.uniqueNumber)}`
+          : '') +
+        (subOptions.mfgCode ? ` -m ${Number(subOptions.mfgCode)}` : '') +
+        ` ${subOptions.interface}`
+      toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'ikonvert') {
+      command = `ikonvert-serial -s ${subOptions.baudrate ?? 230400} ${subOptions.device}`
+      toChildProcess = 'nmea2000out'
+    } else if (subOptions.type === 'maretron-ipg') {
+      const password = (subOptions as { password?: string }).password
+      command =
+        `maretron-ipg` +
+        (password ? ` --password=${shellescape(password)}` : '') +
+        ` tcp://${subOptions.host}:${subOptions.port ?? 6543}`
+      toChildProcess = 'nmea2000out'
     } else {
       throw new Error(`unknown NMEA2000 type ${subOptions.type}`)
     }


### PR DESCRIPTION
Extends the existing native-canboat connection pattern (`ngt-1`/`canbus` via the `analyzer` toolchain) to the remaining common gateways: Digital Yacht iKonvert, Maretron IPG100 (including its session password), bidirectional SocketCAN via canboat's `socketcan-serial` (address claim + outbound PGNs, which a candump pipeline cannot do), Yacht Devices YDWG-02 (TCP and receive-only UDP), NavLink2, and Actisense W2K-1 N2K ASCII. All hasAnalyzer-gated in the admin UI, exactly like the existing native options — nothing changes for installations without the canboat tools.

The last commit hardens the whole native block (pre-existing pattern included): every provider-config value interpolated into the shell command is validated first — character-set checks for hosts/devices/interfaces, finite-number checks for ports, baud rates and NAME fields — and the receive-only ydwg02-udp bridge no longer wires stdin, so the UI stops reporting transmit activity it cannot have.

Companion of #2908 (analyzer camelCase normalization); independent to review and merge.

Tested: streams typecheck and unit tests; every gateway type has been running in a staging image — IPG100 verified against live hardware on a real N2K network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds native NMEA 2000 analyzer sources for iKonvert, Maretron IPG100, bidirectional SocketCAN, YDWG-02, NavLink2, and Actisense W2K-1 ASCII.

- Supports serial, TCP, UDP, and SocketCAN connections.
- Adds IPG100 session passwords and SocketCAN address claiming with outbound PGNs.
- Keeps YDWG-02 UDP receive-only and prevents stdin wiring.
- Validates provider values before interpolation into native shell commands.
- Gates analyzer options in the admin UI with `hasAnalyzer`.
- Adds iKonvert baud-rate handling with a 230400 default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->