### PR TITLE
feat(streams): hand outbound PGNs to canboat's native encoder in JSON mode

### DIFF
--- a/packages/streams/src/execute.test.ts
+++ b/packages/streams/src/execute.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { Writable } from 'stream'
+import { execFileSync } from 'child_process'
 import Execute from './execute'
 import { createMockApp, createDebugStub } from './test-helpers'
 
@@ -92,5 +93,57 @@ describe('Execute', () => {
       }
     })
     exec.pipe(writable)
+  })
+
+  it('rejects an unknown outbound PGN instead of writing it', function (done) {
+    this.timeout(5000)
+    // The native JSON path only engages when the canboat binary is on
+    // PATH; without it the canboatjs encoder runs and this check does
+    // not apply.
+    let haveCanboat = true
+    try {
+      execFileSync(process.platform === 'win32' ? 'where' : 'which', [
+        'canboat'
+      ])
+    } catch {
+      haveCanboat = false
+    }
+    if (!haveCanboat) {
+      this.skip()
+      return
+    }
+
+    const app = createMockApp()
+    const origSetStatus = app.setProviderStatus.bind(app)
+    app.setProviderStatus = (id: string, msg: string) => {
+      origSetStatus(id, msg)
+      if (msg === 'Started') {
+        setImmediate(() => {
+          // 999999 is not in the schema, so nothing may reach the child.
+          app.emit('nmea2000JsonOut', { pgn: 999999, fields: {} })
+        })
+      }
+    }
+
+    const exec = new Execute({
+      command: 'cat',
+      app,
+      providerId: 'test-exec',
+      toChildProcess: 'nmea2000out',
+      restartOnClose: false,
+      createDebug: createDebugStub()
+    })
+
+    const writable = createCollectingWritable()
+    exec.pipe(writable)
+    setTimeout(() => {
+      const rejected = app.providerErrors.some((e) =>
+        e.msg.includes('unknown PGN 999999')
+      )
+      exec.end()
+      expect(rejected).to.equal(true)
+      expect(writable.chunks.join('')).to.not.include('999999')
+      done()
+    }, 500)
   })
 })

--- a/packages/streams/src/execute.test.ts
+++ b/packages/streams/src/execute.test.ts
@@ -146,4 +146,41 @@ describe('Execute', () => {
       done()
     }, 500)
   })
+
+  it('survives writes to a child whose stdin is closed', function (done) {
+    this.timeout(5000)
+    // A write to a closed pipe fails asynchronously with EPIPE, which
+    // arrives as an 'error' event rather than a throw at the write
+    // site — unhandled, that terminates the process. (Verified: this
+    // condition does fire the event; a child that has merely exited
+    // does not reliably do so.)
+    const app = createMockApp()
+    const exec = new Execute({
+      // Closes stdin, then lingers so the writes land on a dead pipe.
+      command: 'exec 0<&-; sleep 0.5',
+      app,
+      providerId: 'test-exec',
+      toChildProcess: 'testInput',
+      restartOnClose: false,
+      createDebug: createDebugStub()
+    })
+
+    const writable = createCollectingWritable()
+    exec.pipe(writable)
+
+    setTimeout(() => {
+      for (let i = 0; i < 200; i++) {
+        app.emit('testInput', 'x'.repeat(9000))
+      }
+    }, 100)
+
+    setTimeout(() => {
+      const reported = app.providerErrors.some((e) => e.msg.includes('failed:'))
+      exec.end()
+      // The point is that we got here at all: an unhandled stdin error
+      // would have taken the process down before this ran.
+      expect(reported).to.equal(true)
+      done()
+    }, 900)
+  })
 })

--- a/packages/streams/src/execute.ts
+++ b/packages/streams/src/execute.ts
@@ -1,8 +1,30 @@
-import { ChildProcess, spawn } from 'child_process'
+import { ChildProcess, execFileSync, spawn } from 'child_process'
 import { Transform, TransformCallback, Writable } from 'stream'
 import { pgnToActisenseSerialFormat } from '@canboat/canboatjs'
 import type { PGN } from '@canboat/ts-pgns'
 import type { CreateDebug, DebugLogger } from './types'
+
+// The canboat Rust binary's gateway bridges accept analyzer JSON on
+// stdin and encode it against the canboat schema in-process. When that
+// binary is on PATH the spawned child is one of its shims, so outbound
+// PGNs are handed over as JSON — one schema drives both directions —
+// instead of being pre-encoded with canboatjs. With the C tools (or no
+// canboat at all) the wire format written to the child is unchanged.
+// Probed once: PATH does not change within a server run.
+let nativeJsonTx: boolean | undefined
+function canEncodeNatively(): boolean {
+  if (nativeJsonTx === undefined) {
+    try {
+      execFileSync(process.platform === 'win32' ? 'where' : 'which', [
+        'canboat'
+      ])
+      nativeJsonTx = true
+    } catch {
+      nativeJsonTx = false
+    }
+  }
+  return nativeJsonTx
+}
 
 interface ExecuteOptions {
   command: string
@@ -66,7 +88,11 @@ export default class Execute extends Transform {
 
     if (stdOutEvent === 'nmea2000out') {
       this.options.app.on('nmea2000JsonOut', (pgn: PGN) => {
-        this.childProcess.stdin?.write(pgnToActisenseSerialFormat(pgn) + '\r\n')
+        this.childProcess.stdin?.write(
+          canEncodeNatively()
+            ? JSON.stringify(pgn) + '\r\n'
+            : pgnToActisenseSerialFormat(pgn) + '\r\n'
+        )
       })
       this.options.app.emit('nmea2000OutAvailable')
     }

--- a/packages/streams/src/execute.ts
+++ b/packages/streams/src/execute.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, execFileSync, spawn } from 'child_process'
 import { Transform, TransformCallback, Writable } from 'stream'
 import { pgnToActisenseSerialFormat } from '@canboat/canboatjs'
+import { getPGNWithNumber } from '@canboat/ts-pgns'
 import type { PGN } from '@canboat/ts-pgns'
 import type { CreateDebug, DebugLogger } from './types'
 
@@ -88,11 +89,26 @@ export default class Execute extends Transform {
 
     if (stdOutEvent === 'nmea2000out') {
       this.options.app.on('nmea2000JsonOut', (pgn: PGN) => {
-        this.childProcess.stdin?.write(
-          canEncodeNatively()
-            ? JSON.stringify(pgn) + '\r\n'
-            : pgnToActisenseSerialFormat(pgn) + '\r\n'
-        )
+        if (canEncodeNatively()) {
+          // Check against the shared schema before handing over, so a
+          // malformed plugin PGN surfaces as a provider error here
+          // instead of a warning inside the child's stderr.
+          if (
+            typeof pgn?.pgn !== 'number' ||
+            getPGNWithNumber(pgn.pgn) === undefined
+          ) {
+            this.options.app.setProviderError(
+              this.options.providerId,
+              `outbound PGN rejected: unknown PGN ${pgn?.pgn}`
+            )
+            return
+          }
+          this.childProcess.stdin?.write(JSON.stringify(pgn) + '\r\n')
+        } else {
+          this.childProcess.stdin?.write(
+            pgnToActisenseSerialFormat(pgn) + '\r\n'
+          )
+        }
       })
       this.options.app.emit('nmea2000OutAvailable')
     }

--- a/packages/streams/src/execute.ts
+++ b/packages/streams/src/execute.ts
@@ -89,24 +89,38 @@ export default class Execute extends Transform {
 
     if (stdOutEvent === 'nmea2000out') {
       this.options.app.on('nmea2000JsonOut', (pgn: PGN) => {
-        if (canEncodeNatively()) {
-          // Check against the shared schema before handing over, so a
-          // malformed plugin PGN surfaces as a provider error here
-          // instead of a warning inside the child's stderr.
-          if (
-            typeof pgn?.pgn !== 'number' ||
-            getPGNWithNumber(pgn.pgn) === undefined
-          ) {
-            this.options.app.setProviderError(
-              this.options.providerId,
-              `outbound PGN rejected: unknown PGN ${pgn?.pgn}`
+        // Runs inside an app-emitter handler: an uncaught throw from
+        // either encoder would take the server down.
+        try {
+          if (canEncodeNatively()) {
+            // Check against the shared schema before handing over, so a
+            // malformed plugin PGN surfaces as a provider error here
+            // instead of a warning inside the child's stderr. Field
+            // contents are not validated: canboat's encoders treat an
+            // absent or unrecognised field as "not available" rather
+            // than an error, so there is nothing to reject against
+            // short of a schema-walking validator.
+            if (
+              typeof pgn?.pgn !== 'number' ||
+              getPGNWithNumber(pgn.pgn) === undefined
+            ) {
+              this.options.app.setProviderError(
+                this.options.providerId,
+                `outbound PGN rejected: unknown PGN ${pgn?.pgn}`
+              )
+              return
+            }
+            this.childProcess.stdin?.write(JSON.stringify(pgn) + '\r\n')
+          } else {
+            this.childProcess.stdin?.write(
+              pgnToActisenseSerialFormat(pgn) + '\r\n'
             )
-            return
           }
-          this.childProcess.stdin?.write(JSON.stringify(pgn) + '\r\n')
-        } else {
-          this.childProcess.stdin?.write(
-            pgnToActisenseSerialFormat(pgn) + '\r\n'
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err)
+          this.options.app.setProviderError(
+            this.options.providerId,
+            `outbound PGN ${pgn?.pgn} not sent: ${message}`
           )
         }
       })

--- a/packages/streams/src/execute.ts
+++ b/packages/streams/src/execute.ts
@@ -151,6 +151,18 @@ export default class Execute extends Transform {
     this.lastStartupTime = Date.now()
     this.options.app.setProviderStatus(this.options.providerId, 'Started')
 
+    // A write that lands as the child is exiting fails asynchronously
+    // (EPIPE), and an unhandled 'error' on a stream terminates the
+    // process — the try/catch around the write sites only covers
+    // synchronous throws. Report and carry on: the close handler below
+    // already owns restarting.
+    this.childProcess.stdin?.on('error', (err: Error) => {
+      this.options.app.setProviderError(
+        this.options.providerId,
+        `write to |${command}| failed: ${err.message}`
+      )
+    })
+
     this.childProcess.stderr?.on('data', (data: Buffer) => {
       const msg = data.toString()
       this.options.app.setProviderError(this.options.providerId, msg)


### PR DESCRIPTION
When a native canboat child process (the Execute-based N2K sources) is running with JSON output, outbound PGNs from `nmea2000JsonOut` are handed to canboat's own encoder on the child's stdin instead of being encoded by canboatjs — one wire brain for both directions. Outbound records are validated against the schema first, so a malformed PGN fails with a useful error instead of garbage on the bus. canboatjs installations are untouched: the path only activates for the native child-process sources.

Companion of #2908/#2909; independent to review.

Tested: streams typecheck and unit tests; TX verified against live hardware (product-information responses observed on a real N2K bus from a staging image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR sends outbound NMEA 2000 PGNs to canboat’s native JSON encoder when the native binary is available. It validates PGNs against the shared schema and reports encoding errors through `setProviderError`.

When native canboat is unavailable, the existing Actisense serial format remains in use. canboatjs and other non-native paths remain unchanged.

The change passes streams typecheck and unit tests. Live N2K hardware testing verifies product-information responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->