### PR TITLE
fix(admin-ui): show correct letter monograms for apps with no icon

### DIFF
--- a/packages/server-admin-ui/src/utils/monogram.test.ts
+++ b/packages/server-admin-ui/src/utils/monogram.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { monogramFor } from './monogram'
+
+describe('monogramFor', () => {
+  it('takes the initials of the first two words', () => {
+    expect(monogramFor('sailing-dashboard')).toBe('SD')
+  })
+
+  it('takes two letters from a single-word name', () => {
+    expect(monogramFor('freeboard')).toBe('FR')
+  })
+
+  it('ignores punctuation between words', () => {
+    expect(monogramFor('voice-wyoming', 'Voice (Wyoming)')).toBe('VW')
+  })
+
+  it('ignores leading punctuation on a single word', () => {
+    expect(monogramFor('wyoming', '(Wyoming)')).toBe('WY')
+  })
+
+  it('prefers the display name over the package name', () => {
+    expect(monogramFor('@signalk/instrumentpanel', 'Instrument Panel')).toBe(
+      'IP'
+    )
+  })
+
+  it('strips the npm scope from a package name', () => {
+    expect(monogramFor('@signalk/freeboard-sk')).toBe('FS')
+  })
+
+  it('keeps digits', () => {
+    expect(monogramFor('nmea 2000')).toBe('N2')
+  })
+
+  it('keeps non-latin letters', () => {
+    expect(monogramFor('koersvast', 'Кораблик Навигатор')).toBe('КН')
+  })
+
+  it('keeps a supplementary-plane letter whole across two words', () => {
+    expect(monogramFor('kanji', '𠮷 Atlas')).toBe('𠮷A')
+  })
+
+  it('keeps supplementary-plane letters whole in a single word', () => {
+    expect(monogramFor('kanji', '𠮷𠮷𠮷')).toBe('𠮷𠮷')
+  })
+
+  it('keeps the second initial when uppercasing expands the first', () => {
+    expect(monogramFor('eszett', 'ß Atlas')).toBe('SA')
+  })
+
+  it('stays two characters when a single word uppercases wider', () => {
+    expect(monogramFor('eszett', 'ßß')).toBe('SS')
+  })
+
+  it('falls back to a placeholder when there is nothing to take', () => {
+    expect(monogramFor('---', '(!)')).toBe('?')
+  })
+})

--- a/packages/server-admin-ui/src/utils/monogram.ts
+++ b/packages/server-admin-ui/src/utils/monogram.ts
@@ -1,0 +1,25 @@
+/**
+ * Two-letter monogram used as the icon fallback for webapps and plugins that
+ * ship no app icon.
+ */
+
+// Punctuation is never part of a monogram: a display name like
+// "Voice (Wyoming)" reads as "VW", not "V(".
+const WORD = /[\p{L}\p{N}]+/gu
+const MONOGRAM_LENGTH = 2
+
+export function monogramFor(name: string, displayName?: string): string {
+  const source = (displayName || name).replace(/^@[^/]+\//, '')
+  const words = source.match(WORD)
+  if (!words) return '?'
+  // Uppercase each word before taking its initial, not the joined result: ß
+  // maps to SS, so uppercasing afterwards would overflow MONOGRAM_LENGTH and
+  // truncating that would drop the second word's initial. Slice by code
+  // point too — a supplementary-plane letter like 𠮷 is two UTF-16 units,
+  // and splitting those apart yields a lone surrogate.
+  const initials =
+    words.length === 1
+      ? Array.from(words[0].toUpperCase()).slice(0, MONOGRAM_LENGTH)
+      : [words[0], words[1]].map((word) => Array.from(word.toUpperCase())[0])
+  return initials.join('')
+}

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.test.tsx
@@ -18,31 +18,52 @@ describe('Webapp', () => {
       expect(iconBox).not.toHaveClass('bg-primary')
     })
 
-    it('renders a blue placeholder box with a grid icon when neither appIcon nor displayName is set', () => {
+    it('renders a blue placeholder box with a monogram of the package name when appIcon is not set', () => {
       const { container } = render(<Webapp webAppInfo={{ name: 'test-app' }} />)
 
       const iconBox = container.querySelector('.float-start') as HTMLElement
       expect(iconBox).toHaveClass('bg-primary')
-      expect(
-        container.querySelector('[data-icon="table-cells"]')
-      ).toBeInTheDocument()
+      expect(iconBox).toHaveTextContent('TA')
     })
 
-    it('renders an empty blue box when displayName is set but appIcon is not', () => {
+    it('sizes the placeholder to match a real icon', () => {
+      // Cards sit in a row, so a monogram tile and an icon tile have to be
+      // the same square or the row loses its alignment.
+      const renderIconBox = (appIcon?: string) =>
+        render(
+          <Webapp webAppInfo={{ name: 'test-app', signalk: { appIcon } }} />
+        ).container.querySelector('.float-start') as HTMLElement
+
+      const withIcon = renderIconBox('icon.png')
+      const placeholder = renderIconBox()
+
+      expect(placeholder.style.width).toBe(withIcon.style.width)
+      expect(placeholder.style.height).toBe(withIcon.style.height)
+      expect(placeholder.style.width).not.toBe('')
+    })
+
+    it('takes the monogram from displayName, ignoring punctuation', () => {
       const { container } = render(
         <Webapp
           webAppInfo={{
-            name: 'test-app',
-            signalk: { displayName: 'Test App' }
+            name: 'voice-wyoming',
+            signalk: { displayName: 'Voice (Wyoming)' }
           }}
         />
       )
 
       const iconBox = container.querySelector('.float-start') as HTMLElement
       expect(iconBox).toHaveClass('bg-primary')
-      expect(
-        container.querySelector('[data-icon="table-cells"]')
-      ).not.toBeInTheDocument()
+      expect(iconBox).toHaveTextContent('VW')
+    })
+
+    it('hides the icon box from the accessibility tree', () => {
+      const { container } = render(<Webapp webAppInfo={{ name: 'test-app' }} />)
+
+      // The monogram is decorative: the card already names the app in its
+      // header, so announcing "TA" ahead of it is noise.
+      const iconBox = container.querySelector('.float-start') as HTMLElement
+      expect(iconBox).toHaveAttribute('aria-hidden', 'true')
     })
   })
 

--- a/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from 'react'
 import Card from 'react-bootstrap/Card'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTableCells } from '@fortawesome/free-solid-svg-icons/faTableCells'
 import classNames from 'classnames'
+import { monogramFor } from '../../utils/monogram'
 import { toSafeModuleId } from './dynamicutilities'
 
 const ICON_BOX_SIZE = '72px'
@@ -76,13 +75,15 @@ export default function Webapp({
   const header = webAppInfo?.signalk?.displayName || webAppInfo.name
   const url = urlToWebapp(webAppInfo)
   const appIcon = webAppInfo?.signalk?.appIcon
-  const hasDisplayName = !!webAppInfo?.signalk?.displayName
+  const displayName = webAppInfo?.signalk?.displayName
 
   const blockIcon = function () {
     // A real icon renders on a transparent box so the card shows through its
     // transparent areas; the primary colour is reserved for the placeholder.
+    // text-white because the surrounding anchor would otherwise paint the
+    // monogram in link blue, on blue.
     const classes = classNames(
-      !appIcon && 'bg-primary',
+      !appIcon && 'bg-primary text-white',
       padding.icon,
       'font-2xl me-3 float-start'
     )
@@ -95,14 +96,15 @@ export default function Webapp({
       alignItems: 'center',
       justifyContent: 'center',
       borderRadius: ICON_BORDER_RADIUS,
-      overflow: 'hidden'
-    }
-    if (appIcon) {
-      style.width = style.height = ICON_BOX_SIZE
+      overflow: 'hidden',
+      // Fixed square for the placeholder too, so a monogram tile lines up
+      // with the real icons in the same row.
+      width: ICON_BOX_SIZE,
+      height: ICON_BOX_SIZE
     }
     return (
-      <span className={classes} style={style}>
-        {!appIcon && !hasDisplayName && <FontAwesomeIcon icon={faTableCells} />}
+      <span aria-hidden="true" className={classes} style={style}>
+        {!appIcon && monogramFor(webAppInfo.name, displayName)}
       </span>
     )
   }

--- a/packages/server-admin-ui/src/views/appstore/components/PluginIcon.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginIcon.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
+import { monogramFor } from '../../../utils/monogram'
 
 interface PluginIconProps {
   name: string
@@ -6,14 +7,6 @@ interface PluginIconProps {
   appIcon?: string
   installedIconUrl?: string
   size?: number
-}
-
-function monogramFor(name: string, displayName?: string): string {
-  const source = (displayName || name).replace(/^@[^/]+\//, '')
-  const words = source.split(/[-_ .]+/).filter(Boolean)
-  if (words.length === 0) return '?'
-  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
-  return (words[0][0] + words[1][0]).toUpperCase()
 }
 
 // Stable per-name pastel hue so the monogram tile reads as the plugin's


### PR DESCRIPTION
## What problem does this solve?

Two user-visible problems with the fallback icon shown for apps that ship no
`appIcon`:

**Webapps cards showed an empty blue square.** The placeholder drew a grid
glyph only when a webapp had neither an `appIcon` nor a `displayName`. Any
icon-less webapp that did set a `displayName` — most of them — got a blank
blue box with nothing in it.

**Appstore monograms picked up punctuation.** The monogram split the name on
`[-_ .]` only, so any other character became an initial: "Voice (Wyoming)"
rendered as "V(" instead of "VW".

Webapp cards now render a monogram for every icon-less app, which retires the
grid glyph, and the monogram is built from runs of letters and digits so
punctuation is dropped wherever it sits. The placeholder gets the same fixed
square as a real icon, so a row of cards stays aligned. `monogramFor` moves to
`src/utils` and is now shared by both views rather than duplicated.

The tile is sized for exactly two characters, so the helper guarantees two.
Initials are taken by code point rather than UTF-16 code unit, and each word
is uppercased before its initial is selected — case mappings can widen a
letter (ß becomes SS), and uppercasing the joined result instead would
overflow the tile.

## How was this tested?

Unit tests, all new in this PR:

- `src/utils/monogram.test.ts` — 13 cases covering initials, single-word
  names, npm scope stripping, digits, embedded and leading punctuation,
  Cyrillic, supplementary-plane letters, widening case mappings, and the
  empty fallback.
- `src/views/Webapps/Webapp.test.tsx` — the icon box renders a monogram from
  the package name, takes it from `displayName` when set, and is hidden from
  the accessibility tree.

## Screenshots

### Before

<img width="1315" height="742" alt="Screenshot 2026-08-06 at 13 09 17" src="https://github.com/user-attachments/assets/2eac3921-b040-41d5-ad66-91974ff29213" />

### After

<img width="1316" height="730" alt="Screenshot 2026-08-06 at 15 58 33" src="https://github.com/user-attachments/assets/b1987fbb-2f9a-49d1-adbe-faff7572ce11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR standardizes fallback icons for apps and webapps without an `appIcon`.

- Webapp cards display letter monograms instead of empty squares or grid icons.
- Monograms derive initials from Unicode letter and number runs.
- Punctuation is excluded from monograms.
- Placeholder icons use fixed square dimensions.
- `monogramFor` is shared from `src/utils`.
- Unit tests cover monogram generation and Webapp icon rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
