### PR TITLE
fix: Coalesce app store icon-probe cache writes instead of rewriting the whole map per icon

### DIFF
--- a/src/appstore/icon-probe.ts
+++ b/src/appstore/icon-probe.ts
@@ -52,13 +52,22 @@ export interface IconProbeCache {
     declaredPath: string,
     resolved: string | null
   ): void
+  flush(): void
   invalidate(): void
 }
+
+// A probe pass resolves many icons in quick succession, and serializing
+// the whole memo on every result costs O(entries) per probe. Coalesce
+// writes onto a timer so a pass produces one write instead of one per
+// icon; flush() forces the pending write out for callers that need the
+// file on disk immediately.
+const PERSIST_DEBOUNCE_MS = 1_000
 
 export function createIconProbeCache(cacheDir: string): IconProbeCache {
   const file = path.join(cacheDir, 'iconUrls.json')
   let memo: Record<string, ProbedEntry> = {}
   let loaded = false
+  let persistTimer: ReturnType<typeof setTimeout> | undefined
 
   function load() {
     if (loaded) return
@@ -74,6 +83,16 @@ export function createIconProbeCache(cacheDir: string): IconProbeCache {
       debug.enabled && debug('iconUrls cache load failed: %O', err)
       memo = {}
     }
+  }
+
+  function schedulePersist() {
+    if (persistTimer) return
+    persistTimer = setTimeout(() => {
+      persistTimer = undefined
+      persist()
+    }, PERSIST_DEBOUNCE_MS)
+    // Never hold the event loop open just to flush an icon-URL cache.
+    persistTimer.unref?.()
   }
 
   function persist() {
@@ -123,9 +142,21 @@ export function createIconProbeCache(cacheDir: string): IconProbeCache {
         resolved,
         probedAt: Date.now()
       }
+      schedulePersist()
+    },
+    flush() {
+      if (!persistTimer) return
+      clearTimeout(persistTimer)
+      persistTimer = undefined
       persist()
     },
     invalidate() {
+      // Drop any pending write first, or it would rewrite the entries
+      // this call is removing.
+      if (persistTimer) {
+        clearTimeout(persistTimer)
+        persistTimer = undefined
+      }
       memo = {}
       loaded = true
       try {

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -942,6 +942,9 @@ module.exports = function (app) {
     await Promise.all(
       Array.from({ length: ICON_PROBE_CONCURRENCY }, () => worker())
     )
+    // The cache coalesces writes on a timer; force the batch out now that
+    // the pass is done rather than leaving it to an unref'd timeout.
+    iconProbe.flush()
   }
 
   // For non-installed plugins whose npm-search entry lacks signalk.* (because

--- a/test/appstore/icon-probe.test.ts
+++ b/test/appstore/icon-probe.test.ts
@@ -7,6 +7,10 @@ import {
   probeIconUrl
 } from '../../dist/appstore/icon-probe.js'
 
+// Mirrors PERSIST_DEBOUNCE_MS in src/appstore/icon-probe.ts. Kept as a
+// local constant rather than exporting an internal purely for tests.
+const PERSIST_DEBOUNCE_MS = 1_000
+
 const tmpDirs: string[] = []
 function tmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'appstore-iconprobe-'))
@@ -32,8 +36,58 @@ describe('appstore/icon-probe cache', () => {
     const a = createIconProbeCache(dir)
     const url = 'https://unpkg.com/@signalk/foo@1.0.0/public/icon.svg'
     a.set('@signalk/foo', '1.0.0', './icon.svg', url)
+    a.flush()
     const b = createIconProbeCache(dir)
     expect(b.get('@signalk/foo', '1.0.0', './icon.svg')).to.equal(url)
+  })
+
+  it('coalesces writes instead of serializing on every set()', () => {
+    const dir = tmpDir()
+    const cache = createIconProbeCache(dir)
+    const file = path.join(dir, 'iconUrls.json')
+    for (let i = 0; i < 50; i++) {
+      cache.set('pkg', '1.0.0', `./icon-${i}.svg`, `url-${i}`)
+    }
+    expect(fs.existsSync(file)).to.equal(false)
+    cache.flush()
+    const written = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(Object.keys(written)).to.have.lengthOf(50)
+  })
+
+  // Every other persistence case forces the write with flush(), which
+  // bypasses the timer entirely — a broken debounce callback would still
+  // pass those. This one waits the interval out instead.
+  it('persists on the debounce timer without an explicit flush()', async function () {
+    this.timeout(PERSIST_DEBOUNCE_MS * 4)
+    const dir = tmpDir()
+    const cache = createIconProbeCache(dir)
+    const file = path.join(dir, 'iconUrls.json')
+    cache.set('pkg', '1.0.0', './icon.svg', 'url')
+    expect(fs.existsSync(file)).to.equal(false)
+    await new Promise((resolve) => setTimeout(resolve, PERSIST_DEBOUNCE_MS * 2))
+    expect(fs.existsSync(file)).to.equal(true)
+    const written = JSON.parse(fs.readFileSync(file, 'utf8'))
+    expect(Object.keys(written)).to.have.lengthOf(1)
+  })
+
+  it('flush() is a no-op when nothing is pending', () => {
+    const dir = tmpDir()
+    const cache = createIconProbeCache(dir)
+    cache.set('pkg', '1.0.0', './icon.svg', 'url')
+    cache.flush()
+    const first = fs.statSync(path.join(dir, 'iconUrls.json')).mtimeMs
+    cache.flush()
+    expect(fs.statSync(path.join(dir, 'iconUrls.json')).mtimeMs).to.equal(first)
+  })
+
+  it('invalidate() drops a pending write instead of resurrecting entries', () => {
+    const dir = tmpDir()
+    const cache = createIconProbeCache(dir)
+    cache.set('pkg', '1.0.0', './icon.svg', 'url')
+    cache.invalidate()
+    cache.flush()
+    expect(fs.existsSync(path.join(dir, 'iconUrls.json'))).to.equal(false)
+    expect(cache.get('pkg', '1.0.0', './icon.svg')).to.equal(undefined)
   })
 
   it('distinguishes null from undefined (null = probed, 404)', () => {


### PR DESCRIPTION
`createIconProbeCache`'s `set()` serialized the entire memo to disk on every call, so resolving N icons cost N full `JSON.stringify` + write cycles over a map that grows with every package version probed. A probe pass runs six workers concurrently, so those writes also interleave.

Writes are now coalesced onto a short timer, with `flush()` exposed for callers that need the file on disk immediately — the probe runner calls it once its batch completes, and `invalidate()` drops any pending write so it cannot resurrect the entries just cleared.

Behaviour is unchanged: entries still persist across cache instances, and the existing TTL and keying rules are untouched.

Tested
- `test/appstore/icon-probe.test.ts`, extended with coverage for write coalescing, `flush()` being a no-op when nothing is pending, and `invalidate()` dropping a pending write: 10 passing
- `npm test` (full chain) green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR debounces app store icon-probe cache writes by one second and coalesces updates. It adds `flush()` for immediate persistence and calls it after each probe batch. `invalidate()` cancels pending writes before clearing cache data.

## Tests

- Covers deferred, timer-based, and coalesced writes.
- Covers no-op flushing.
- Covers invalidation of pending writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->