### PR TITLE
fix: Stop app store icon-probe passes stacking on every /appstore/available request

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -26,6 +26,13 @@ const debug = createDebug('signalk-server:interfaces:appstore')
 let installedDetailRefreshInFlight = false
 let installedDetailRefreshLastRunAt = 0
 const INSTALLED_DETAIL_REFRESH_COOLDOWN_MS = 5 * 60 * 1000
+let iconProbeInFlight = false
+let iconProbeLastRunAt = 0
+// Bumped by a manual refresh so a pass that started before the caches
+// were cleared cannot claim the cooldown for the state it no longer
+// reflects.
+let iconProbeGeneration = 0
+const ICON_PROBE_COOLDOWN_MS = 5 * 60 * 1000
 const _ = require('lodash')
 const semver = require('semver')
 const { gt } = semver
@@ -384,6 +391,8 @@ module.exports = function (app) {
         // warmup and the user sees stale icons immediately after asking
         // the server to refresh.
         installedDetailRefreshLastRunAt = 0
+        iconProbeLastRunAt = 0
+        iconProbeGeneration++
         res.json({ ok: true })
       })
 
@@ -990,19 +999,42 @@ module.exports = function (app) {
     )
   }
 
+  // Hydration and probing both capture the full plugin/webapp arrays for
+  // the duration of their network I/O. Without a guard, every
+  // /appstore/available hit starts another pass, so overlapping runs pin
+  // several generations of those arrays alive at once and re-issue probes
+  // the previous pass has not yet cached. Guard with the same in-flight
+  // flag plus cooldown pairing scheduleInstalledDetailRefresh uses.
   function scheduleIconProbe(plugins, webapps) {
+    if (iconProbeInFlight) return
+    if (Date.now() - iconProbeLastRunAt < ICON_PROBE_COOLDOWN_MS) return
+    iconProbeInFlight = true
+    const generation = iconProbeGeneration
     setImmediate(async () => {
       try {
-        await hydrateNonInstalledMetadata(plugins, webapps)
-      } catch (err) {
-        debug.enabled && debug('metadata hydration run failed: %O', err)
+        try {
+          await hydrateNonInstalledMetadata(plugins, webapps)
+        } catch (err) {
+          debug.enabled && debug('metadata hydration run failed: %O', err)
+        }
+        // A refresh landing mid-pass invalidated the module list this
+        // pass was built from, so stop before spending the probe I/O;
+        // the next request rebuilds from the refreshed list.
+        if (generation !== iconProbeGeneration) return
+        const tasks = collectIconProbeTasks(plugins, webapps)
+        if (tasks.length === 0) return
+        debug.enabled && debug('scheduling %d icon probes', tasks.length)
+        await runIconProbeTasks(tasks).catch(
+          (err) => debug.enabled && debug('icon probe run failed: %O', err)
+        )
+      } finally {
+        iconProbeInFlight = false
+        // A refresh during this pass already cleared the caches it was
+        // filling, so leave the cooldown open for the next request.
+        if (generation === iconProbeGeneration) {
+          iconProbeLastRunAt = Date.now()
+        }
       }
-      const tasks = collectIconProbeTasks(plugins, webapps)
-      if (tasks.length === 0) return
-      debug.enabled && debug('scheduling %d icon probes', tasks.length)
-      runIconProbeTasks(tasks).catch(
-        (err) => debug.enabled && debug('icon probe run failed: %O', err)
-      )
     })
   }
 


### PR DESCRIPTION
`scheduleInstalledDetailRefresh` collapses concurrent triggers with an in-flight flag and rate-limits successive passes with a cooldown. `scheduleIconProbe`, directly below it and triggered from the same `/appstore/available` handler, had neither: every list request started another metadata-hydration and icon-probe pass.

Each pass captures the full plugin and webapp arrays for the duration of its network I/O, so overlapping passes pin several generations of those arrays alive at once and re-issue probes an earlier pass has not finished caching.

This gives the icon probe the same in-flight flag and cooldown. A manual refresh still forces an immediate re-probe: it clears the cooldown, and it bumps a generation counter so a pass that started before the caches were cleared neither claims the cooldown for state it no longer reflects nor spends probe I/O against an invalidated module list.

Noticed while investigating #2898. It is not the cause of the heap exhaustion reported there — that path converges rather than growing without bound — but the stacking is real.

Tested
- `npm test` (full chain) green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents overlapping icon-probe passes from repeated `/appstore/available` requests.

- Adds in-flight, cooldown, and generation guards to `scheduleIconProbe`.
- Keeps manual refreshes immediate by clearing cooldown state and incrementing the generation.
- Stops invalidated passes from probing stale module lists or claiming cooldown state.
- Isolates metadata-hydration errors.
- Keeps the change separate from the heap exhaustion issue in `#2898`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->