### PR TITLE
fix: Serve cached plugin detail instead of rebuilding it on every detail-page view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ test/server-test-config/ssl-cert.pem
 test/server-test-config/ssl-key.pem
 test/server-test-config/plugin-config-data/
 test/server-test-config/sources-cache.json
+test/server-test-config/appstore-cache/
 
 docs/built
 

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -461,6 +461,17 @@ module.exports = function (app) {
       return cached || null
     }
     const pkg = match.package
+    // Serve a cached detail when it was built for the version npm is
+    // currently offering. Rebuilding costs a readme, changelog, metrics
+    // and icon-probe round trip, and the background refresh calls this
+    // once per installed plugin. The version check is what keeps the
+    // short-circuit honest: cache.readPluginDetail() treats an installed
+    // plugin's entry as fresh indefinitely, so without it a newly
+    // published release would never reach the detail page.
+    const cachedDetail = readDetailFromCache(cache, name)
+    if (cachedDetail && cachedDetail.version === pkg.version) {
+      return cachedDetail
+    }
     const isInstalled = !!getPlugin(name) || !!getWebApp(name)
     let pkgForEnrichment = pkg
     // Always try the npm registry first — it has the signalk.* key for
@@ -1389,6 +1400,10 @@ module.exports = function (app) {
     // re-reads from disk and reflects the in-progress version, not the
     // pre-change one. Cleared again on completion below.
     installedMetadataCache.delete(module)
+    // The cached detail carries installed-only fields (local icon and
+    // screenshot URLs) that an install or removal invalidates without
+    // changing the npm version loadPluginDetail matches on.
+    cache.invalidatePluginDetail(module)
     moduleInstalling = {
       name: module,
       output: [],
@@ -1411,6 +1426,7 @@ module.exports = function (app) {
       // Re-evict in case anything cached a stale read between the
       // initial delete and the install completing.
       installedMetadataCache.delete(module)
+      cache.invalidatePluginDetail(module)
       debug.enabled && debug('close: ' + module)
       modulesInstalledSinceStartup[module].code = code
       moduleInstalling = undefined

--- a/test/appstore-detail-cache-e2e.ts
+++ b/test/appstore-detail-cache-e2e.ts
@@ -1,0 +1,160 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import path from 'path'
+import { safeName } from '../src/appstore/safe-name'
+import { serverTestConfigDirectory } from './servertestutilities'
+import { startServer } from './ts-servertestutilities'
+
+// Drives the real /skServer/appstore routes against a running server to
+// cover the detail cache end to end: a repeat detail request is served
+// from cache, and a cached entry for a superseded version is not.
+// Each case drives live npm search plus a detail rebuild, so the default
+// mocha timeout is not enough.
+const APPSTORE_E2E_TIMEOUT_MS = 60000
+
+describe('appstore detail cache', function () {
+  this.timeout(APPSTORE_E2E_TIMEOUT_MS)
+
+  let stop: (() => Promise<unknown>) | undefined
+  let host: string
+
+  before(async function () {
+    const s = await startServer()
+    stop = s.stop
+    host = s.host
+  })
+
+  after(async function () {
+    if (stop) await stop()
+  })
+
+  function detailFileFor(name: string): string {
+    return path.join(
+      serverTestConfigDirectory(),
+      'appstore-cache',
+      'plugins',
+      safeName(name),
+      'detail.json'
+    )
+  }
+
+  // Picks a plugin the live npm search actually returns, so the request
+  // reaches the branch where a match exists rather than the not-found
+  // fallback.
+  async function anAvailablePlugin(
+    ctx: Mocha.Context
+  ): Promise<{ name: string; version: string }> {
+    const res = await fetch(`${host}/skServer/appstore/available`)
+    expect(res.status).to.equal(200)
+    const body = (await res.json()) as {
+      available?: Array<{ name: string; version: string }>
+    }
+    const candidate = (body.available || []).find((p) => p.name && p.version)
+    // No npm reachability in this environment: nothing to assert about a
+    // cache short-circuit that never gets a match to short-circuit on.
+    if (!candidate) ctx.skip()
+    return candidate as { name: string; version: string }
+  }
+
+  it('serves a matched plugin from cache instead of rebuilding it', async function () {
+    const { name, version } = await anAvailablePlugin(this)
+
+    // Seed the cache for the version npm is currently offering, with a
+    // readme no network rebuild could produce. Returning it proves the
+    // short-circuit fired; a rebuild would overwrite it with the real
+    // readme fetched from the CDN.
+    const marker = 'CACHED-README-MARKER'
+    const file = detailFileFor(name)
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        writtenAt: Date.now(),
+        installed: false,
+        payload: {
+          name,
+          version,
+          readme: marker,
+          readmeFormat: 'markdown',
+          screenshots: [],
+          official: false,
+          deprecated: false,
+          fromCache: true
+        }
+      }),
+      'utf8'
+    )
+
+    const res = await fetch(`${host}/skServer/appstore/plugin/${name}`)
+    expect(res.status).to.equal(200)
+    const body = (await res.json()) as { name?: string; readme?: string }
+    expect(body.name).to.equal(name)
+    expect(body.readme).to.equal(marker)
+  })
+
+  it('rebuilds when the cached detail is for a superseded version', async function () {
+    const { name, version } = await anAvailablePlugin(this)
+
+    // Same marker, but stamped with a version npm is not offering. The
+    // version check must reject this entry so a newly published release
+    // still reaches the detail page.
+    const file = detailFileFor(name)
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        writtenAt: Date.now(),
+        installed: false,
+        payload: {
+          name,
+          version: '0.0.0-stale',
+          readme: 'STALE-README-MARKER',
+          readmeFormat: 'markdown',
+          screenshots: [],
+          official: false,
+          deprecated: false,
+          fromCache: true
+        }
+      }),
+      'utf8'
+    )
+
+    const res = await fetch(`${host}/skServer/appstore/plugin/${name}`)
+    expect(res.status).to.equal(200)
+    const body = (await res.json()) as { version?: string; readme?: string }
+    expect(body.version).to.equal(version)
+    expect(body.readme).to.not.equal('STALE-README-MARKER')
+  })
+
+  it('keeps the appstore list responding across repeated requests', async function () {
+    // The list route schedules the background detail refresh and icon
+    // probe, both guarded by an in-flight flag and a cooldown. Repeated
+    // and concurrent requests must still each get a full response.
+    for (let i = 0; i < 3; i++) {
+      const res = await fetch(`${host}/skServer/appstore/available`)
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.be.an('object')
+    }
+
+    const concurrent = await Promise.all(
+      [0, 1, 2, 3].map(() => fetch(`${host}/skServer/appstore/available`))
+    )
+    for (const res of concurrent) {
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.be.an('object')
+    }
+  })
+
+  it('still serves the list after a manual refresh clears the caches', async function () {
+    // A refresh clears every cache mid-flight and reopens the probe
+    // cooldown, so the next list request has to repopulate from cold.
+    const refresh = await fetch(`${host}/skServer/appstore/refresh`, {
+      method: 'POST'
+    })
+    expect(refresh.status).to.equal(200)
+
+    const res = await fetch(`${host}/skServer/appstore/available`)
+    expect(res.status).to.equal(200)
+    expect(await res.json()).to.be.an('object')
+  })
+})


### PR DESCRIPTION
`loadPluginDetail` writes a detail payload to the cache on every success but only ever reads it back when the plugin is absent from npm search. Every detail-page view therefore rebuilt the payload from scratch — npm metadata, readme, changelog or GitHub releases, raw metrics and icon probes — even with a valid cached copy on disk. The background refresh does the same once per installed plugin.

A cached entry is now reused when it was built for the version npm currently offers. The version check is what keeps this honest: `readPluginDetail` treats an installed plugin's entry as fresh indefinitely, so without it a newly published release would never reach the detail page.

The cached payload also carries installed-only fields (the local icon and screenshot URLs), which an install or removal changes without changing the npm version, so both now invalidate that plugin's cached detail.

Measured against a running server, a repeat detail request for the same version drops from about 1.4s to a few milliseconds.

Tested
- new `test/appstore-detail-cache-e2e.ts` driving the real routes against a running server: cache hit, rebuild on a superseded version, repeated and concurrent list requests, and a list request after a manual refresh — 4 passing, and the cache-hit case fails without the source change
- `npm test` (full chain) green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes plugin detail-page caching.

- Reuses cached details when the cached version matches the npm version.
- Rebuilds cached details when npm offers a newer version.
- Invalidates cached details before and after plugin installation or removal.
- Applies cache validation to background refreshes.
- Adds end-to-end tests for cache hits, version changes, repeated and concurrent requests, and manual refreshes.
- Improves repeated request time from about 1.4 seconds to a few milliseconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->