### PR TITLE
App Store: show the newly installed version instead of the previous one on the Installs & Removes screen

### DIFF
--- a/packages/server-admin-ui/src/store/types.ts
+++ b/packages/server-admin-ui/src/store/types.ts
@@ -40,6 +40,13 @@ export interface AppInfo {
   categories?: string[]
   recent?: boolean
   installedVersion?: string
+  // Target version of an install or update: set while it is queued or
+  // running, and kept afterwards — including on failure. Only once the
+  // operation has settled successfully does it describe what npm actually
+  // put on disk, which is when it is worth showing: installedVersion keeps
+  // reporting the version the running plugin was loaded from until restart.
+  // Never set for removals.
+  pendingVersion?: string
   // Synthetic fields layered on by Apps.tsx when projecting the
   // AppStore state into a single per-row record. Optional because they
   // exist only after that projection runs.
@@ -51,6 +58,7 @@ export interface AppInfo {
 
 export interface InstallingApp {
   name: string
+  pendingVersion?: string
   isWaiting?: boolean
   isInstalling?: boolean
   isRemoving?: boolean

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.test.tsx
@@ -254,3 +254,35 @@ describe('Apps view/search state survives the detail round trip', () => {
     )
   })
 })
+
+describe('Apps projects the pending version onto installing rows', () => {
+  beforeEach(() => {
+    setAppStore(emptyStore)
+    act(() => {
+      useStore.getState().setAppstoreView('All')
+      useStore.getState().setAppstoreSearch('')
+      useStore.getState().setAppstoreCategory('All')
+    })
+  })
+
+  it('shows the just-installed version rather than the running one', () => {
+    setAppStore({
+      ...emptyStore,
+      available: [
+        { name: 'plugin-a', version: '2.0.0', installedVersion: '1.0.0' }
+      ],
+      installed: [
+        { name: 'plugin-a', version: '2.0.0', installedVersion: '1.0.0' }
+      ],
+      installing: [{ name: 'plugin-a', pendingVersion: '2.0.0' }]
+    })
+    render(
+      <MemoryRouter>
+        <Apps />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('v2.0.0 (pending restart)')).toBeInTheDocument()
+    expect(screen.queryByText('Installed v1.0.0')).toBeNull()
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Apps/Apps.tsx
@@ -198,6 +198,7 @@ const Apps: React.FC = () => {
         allApps[app.name] = {
           ...allApps[app.name],
           installing: true,
+          pendingVersion: app.pendingVersion,
           isInstalling: app.isInstalling,
           isWaiting: app.isWaiting,
           isRemoving: app.isRemoving,

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.test.tsx
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { formatBytes } from './ActionCellRenderer'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ActionCellRenderer, {
+  formatBytes,
+  type AppData
+} from './ActionCellRenderer'
 
 describe('formatBytes', () => {
   it('formats bytes', () => {
@@ -23,5 +28,45 @@ describe('formatBytes', () => {
   it('formats gigabytes', () => {
     expect(formatBytes(1073741824)).toBe('1.0 GB')
     expect(formatBytes(2684354560)).toBe('2.5 GB')
+  })
+})
+
+describe('ActionCellRenderer terminal install status', () => {
+  function renderAction(data: Omit<AppData, 'name'>) {
+    return render(
+      <MemoryRouter>
+        <ActionCellRenderer data={{ name: 'signalk-example', ...data }} />
+      </MemoryRouter>
+    )
+  }
+
+  it('names the version an update landed on', () => {
+    renderAction({
+      installing: true,
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0'
+    })
+    expect(screen.getByText('Updated v2.0.0')).toBeDefined()
+  })
+
+  it('names the version a first install landed on', () => {
+    renderAction({ installing: true, pendingVersion: '2.0.0' })
+    expect(screen.getByText('Installed v2.0.0')).toBeDefined()
+  })
+
+  it('falls back to a bare verb when no version is known', () => {
+    renderAction({ installing: true, installedVersion: '1.0.0' })
+    expect(screen.getByText('Updated')).toBeDefined()
+  })
+
+  it('reports a failure rather than a version', () => {
+    renderAction({
+      installing: true,
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installFailed: true
+    })
+    expect(screen.getByText(/Failed/)).toBeDefined()
+    expect(screen.queryByText(/Updated v/)).toBeNull()
   })
 })

--- a/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Grid/cell-renderers/ActionCellRenderer.tsx
@@ -31,10 +31,11 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
-interface AppData {
+export interface AppData {
   name: string
   version?: string
   installedVersion?: string
+  pendingVersion?: string
   newVersion?: string
   installed?: boolean
   installing?: boolean
@@ -207,10 +208,11 @@ export default function ActionCellRenderer({
       status = 'Failed'
     } else if (app.isRemove) {
       status = 'Removed'
-    } else if (app.installedVersion) {
-      status = 'Updated'
     } else {
-      status = 'Installed'
+      // app.installedVersion is the running plugin's version and stays stale
+      // until restart; pendingVersion is what npm just wrote to disk.
+      const verb = app.installedVersion ? 'Updated' : 'Installed'
+      status = app.pendingVersion ? `${verb} v${app.pendingVersion}` : verb
     }
 
     const isTerminalFailure = !progress && app.installFailed

--- a/packages/server-admin-ui/src/views/appstore/components/PluginCard.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginCard.test.tsx
@@ -68,4 +68,62 @@ describe('PluginCard', () => {
     expect(screen.getByText('Weather')).toBeDefined()
     expect(screen.getByText('Utility')).toBeDefined()
   })
+
+  it('shows the just-installed version, not the still-running one', () => {
+    renderCard({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true
+    })
+    expect(screen.getByText('v2.0.0 (pending restart)')).toBeDefined()
+    expect(screen.queryByText('Installed v1.0.0')).toBeNull()
+  })
+
+  it('keeps the busy pill while the install is still running', () => {
+    renderCard({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      isInstalling: true
+    })
+    expect(screen.getByText('Installing')).toBeDefined()
+    expect(screen.queryByText('v2.0.0 (pending restart)')).toBeNull()
+  })
+
+  it('keeps the queued pill while the install is still waiting', () => {
+    renderCard({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      isWaiting: true
+    })
+    expect(screen.getByText('Waiting')).toBeDefined()
+    expect(screen.queryByText(/pending restart/)).toBeNull()
+  })
+
+  it('keeps the failure pill instead of claiming a pending version', () => {
+    renderCard({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      installFailed: true
+    })
+    expect(screen.getByText('Install failed')).toBeDefined()
+    expect(screen.queryByText(/pending restart/)).toBeNull()
+  })
+
+  it('does not claim a pending version after a removal', () => {
+    renderCard({
+      installedVersion: '1.0.0',
+      pendingVersion: '1.0.0',
+      installing: true,
+      isRemove: true
+    })
+    expect(screen.queryByText(/pending restart/)).toBeNull()
+  })
+
+  it('falls back to the installed version when nothing is pending', () => {
+    renderCard({ installedVersion: '1.0.0' })
+    expect(screen.getByText('Installed v1.0.0')).toBeDefined()
+  })
 })

--- a/packages/server-admin-ui/src/views/appstore/components/PluginCard.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginCard.tsx
@@ -8,6 +8,7 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight
 import type { AppInfo } from '../../../store/types'
 import InstallLogModal from './InstallLogModal'
 import PluginIcon from './PluginIcon'
+import { hasPendingInstall } from '../projectAppInfo'
 import RecencyBadge from './RecencyBadge'
 import ScoreRing from './ScoreRing'
 import UpdateAvailableBadge from './UpdateAvailableBadge'
@@ -57,6 +58,16 @@ const StatePill: React.FC<StatePillProps> = ({ app, onFailedClick }) => {
         >
           Install failed
         </button>
+      )
+    }
+    if (hasPendingInstall(app)) {
+      return (
+        <span
+          className="plugin-card__state-pill plugin-card__state-pill--installed"
+          title="Restart the server to activate this version"
+        >
+          v{app.pendingVersion} (pending restart)
+        </span>
       )
     }
   }

--- a/packages/server-admin-ui/src/views/appstore/components/PluginRow.test.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginRow.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PluginRow from './PluginRow'
+import type { AppInfo } from '../../../store/types'
+
+function renderRow(app: Partial<AppInfo>) {
+  const merged: AppInfo = {
+    name: 'signalk-example',
+    version: '1.0.0',
+    description: 'A plugin',
+    ...app
+  }
+  return render(
+    <MemoryRouter>
+      <PluginRow app={merged} />
+    </MemoryRouter>
+  )
+}
+
+describe('PluginRow version label', () => {
+  it('shows the just-installed version while a restart is pending', () => {
+    renderRow({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true
+    })
+    expect(screen.getByText('v2.0.0')).toBeDefined()
+    expect(screen.queryByText('v1.0.0')).toBeNull()
+  })
+
+  it('keeps the running version while the install is still in flight', () => {
+    renderRow({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      isInstalling: true
+    })
+    expect(screen.getByText('v1.0.0')).toBeDefined()
+    expect(screen.queryByText('v2.0.0')).toBeNull()
+  })
+
+  it('keeps the running version while the install is queued', () => {
+    renderRow({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      isWaiting: true
+    })
+    expect(screen.getByText('v1.0.0')).toBeDefined()
+    expect(screen.queryByText('v2.0.0')).toBeNull()
+  })
+
+  it('does not present a failed install as the current version', () => {
+    renderRow({
+      installedVersion: '1.0.0',
+      pendingVersion: '2.0.0',
+      installing: true,
+      installFailed: true
+    })
+    expect(screen.getByText('v1.0.0')).toBeDefined()
+    expect(screen.queryByText('v2.0.0')).toBeNull()
+  })
+
+  it('shows the removed version rather than a pending one', () => {
+    renderRow({
+      installedVersion: '1.0.0',
+      pendingVersion: '1.0.0',
+      installing: true,
+      isRemove: true
+    })
+    expect(screen.getByText('v1.0.0')).toBeDefined()
+  })
+
+  it('shows the upgrade arrow when an update is merely available', () => {
+    renderRow({ installedVersion: '1.0.0', newVersion: '2.0.0' })
+    expect(screen.getByText('v1.0.0 → v2.0.0')).toBeDefined()
+  })
+
+  it('falls back to the available version when nothing is installed', () => {
+    renderRow({})
+    expect(screen.getByText('v1.0.0')).toBeDefined()
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/components/PluginRow.tsx
+++ b/packages/server-admin-ui/src/views/appstore/components/PluginRow.tsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import Badge from 'react-bootstrap/Badge'
 import type { AppInfo } from '../../../store/types'
 import ActionCellRenderer from '../Grid/cell-renderers/ActionCellRenderer'
+import { hasPendingInstall } from '../projectAppInfo'
 import PluginIcon from './PluginIcon'
 import RecencyBadge from './RecencyBadge'
 import UpdateAvailableBadge from './UpdateAvailableBadge'
@@ -13,6 +14,9 @@ interface PluginRowProps {
 }
 
 const formatVersionLabel = (app: AppInfo): string => {
+  if (hasPendingInstall(app)) {
+    return `v${app.pendingVersion}`
+  }
   if (
     app.installedVersion &&
     app.newVersion &&

--- a/packages/server-admin-ui/src/views/appstore/projectAppInfo.test.ts
+++ b/packages/server-admin-ui/src/views/appstore/projectAppInfo.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { hasPendingInstall } from './projectAppInfo'
+import type { AppInfo } from '../../store/types'
+
+const app = (extra: Partial<AppInfo>): AppInfo => ({
+  name: 'plugin-a',
+  ...extra
+})
+
+describe('hasPendingInstall', () => {
+  it('is true once an install has settled successfully', () => {
+    expect(
+      hasPendingInstall(app({ installing: true, pendingVersion: '2.0.0' }))
+    ).toBe(true)
+  })
+
+  it('is false while the install is still running or queued', () => {
+    expect(
+      hasPendingInstall(
+        app({ installing: true, pendingVersion: '2.0.0', isInstalling: true })
+      )
+    ).toBe(false)
+    expect(
+      hasPendingInstall(
+        app({ installing: true, pendingVersion: '2.0.0', isWaiting: true })
+      )
+    ).toBe(false)
+  })
+
+  it('is false when the install failed', () => {
+    expect(
+      hasPendingInstall(
+        app({ installing: true, pendingVersion: '2.0.0', installFailed: true })
+      )
+    ).toBe(false)
+  })
+
+  it('is false for removals', () => {
+    expect(
+      hasPendingInstall(
+        app({ installing: true, pendingVersion: '2.0.0', isRemove: true })
+      )
+    ).toBe(false)
+    expect(
+      hasPendingInstall(
+        app({ installing: true, pendingVersion: '2.0.0', isRemoving: true })
+      )
+    ).toBe(false)
+  })
+
+  it('is false without an install in progress or a pending version', () => {
+    expect(hasPendingInstall(app({ pendingVersion: '2.0.0' }))).toBe(false)
+    expect(hasPendingInstall(app({ installing: true }))).toBe(false)
+  })
+})

--- a/packages/server-admin-ui/src/views/appstore/projectAppInfo.ts
+++ b/packages/server-admin-ui/src/views/appstore/projectAppInfo.ts
@@ -1,5 +1,22 @@
 import type { AppInfo, AppStoreState } from '../../store/types'
 
+// True once an install or update has finished successfully and is only
+// waiting for a server restart. In that window `installedVersion` still
+// reports the version the running plugin was loaded from, so callers should
+// show `pendingVersion` instead. Excludes in-flight, queued, failed and
+// removal states, where nothing new is on disk to advertise.
+export function hasPendingInstall(app: AppInfo): boolean {
+  return !!(
+    app.installing &&
+    app.pendingVersion &&
+    !app.isRemove &&
+    !app.installFailed &&
+    !app.isInstalling &&
+    !app.isWaiting &&
+    !app.isRemoving
+  )
+}
+
 // Build the same synthetic AppInfo shape Apps.tsx projects so consumers
 // (cards, rows, the detail page) see consistent installed / newVersion /
 // installing flags without each rebuilding the merge themselves.
@@ -51,6 +68,7 @@ export function projectAppInfo(
     projected = {
       ...projected,
       installing: true,
+      pendingVersion: installingEntry.pendingVersion,
       isInstalling: installingEntry.isInstalling,
       isWaiting: installingEntry.isWaiting,
       isRemoving: installingEntry.isRemoving,

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -122,6 +122,14 @@ module.exports = function (app) {
             name = req.params.org + '/' + name
           }
 
+          // npm rejects a bad version too, but only after the install has been
+          // recorded as in-flight, which leaks the bogus value to the UI.
+          if (!semver.valid(version)) {
+            res.status(400)
+            res.json({ error: 'version must be valid semver' })
+            return
+          }
+
           findPluginsAndWebapps()
             .then(([plugins, webapps]) => {
               if (
@@ -1295,10 +1303,23 @@ module.exports = function (app) {
         pluginInfo.installedVersion = installedModule.version
       }
 
-      if (moduleInstallQueue.find((p) => p.name === name)) {
+      const queued = moduleInstallQueue.find((p) => p.name === name)
+      if (queued) {
         pluginInfo.isWaiting = true
+        if (!queued.isRemove && typeof queued.version === 'string') {
+          pluginInfo.pendingVersion = queued.version
+        }
         addIfNotDuplicate(result.installing, pluginInfo)
       } else if (modulesInstalledSinceStartup[name]) {
+        // installedVersion comes from the running plugin registration, which
+        // keeps reporting the version loaded at startup until the server is
+        // restarted. Carry the version npm actually put on disk separately so
+        // the UI can show what the user just installed. Removals carry a null
+        // version, so only installs get the field.
+        const operation = modulesInstalledSinceStartup[name]
+        if (!operation.isRemove && typeof operation.version === 'string') {
+          pluginInfo.pendingVersion = operation.version
+        }
         if (moduleInstalling && moduleInstalling.name === name) {
           if (moduleInstalling.isRemove) {
             pluginInfo.isRemoving = true

--- a/test/appstore-pending-version.ts
+++ b/test/appstore-pending-version.ts
@@ -1,0 +1,334 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { startServerP } = require('./servertestutilities')
+
+const PLUGIN_NAME = 'pendingversionplugin'
+const INSTALLED_VERSION = '1.0.0'
+const AVAILABLE_VERSION = '2.0.0'
+
+interface AppInfo {
+  name: string
+  version?: string
+  installedVersion?: string
+  pendingVersion?: string
+  isInstalling?: boolean
+  isWaiting?: boolean
+  isRemove?: boolean
+}
+
+interface AppStoreResponse {
+  installed: AppInfo[]
+  available: AppInfo[]
+  updates: AppInfo[]
+  installing: AppInfo[]
+}
+
+// The install path shells out to `npm`. Putting a stub earlier on PATH keeps
+// the whole server pipeline real — HTTP endpoint, install state machine,
+// APP_STORE_CHANGED refresh — while the "install" itself is just a local
+// package.json rewrite, so the test never touches the network.
+function writeNpmStub(binDir: string, configDir: string) {
+  fs.mkdirSync(binDir, { recursive: true })
+  const stub = path.join(binDir, 'npm')
+  const moduleDir = path.join(configDir, 'node_modules', PLUGIN_NAME)
+  fs.writeFileSync(
+    stub,
+    `#!/bin/sh
+# The server also probes "npm --version" at startup, so only an actual
+# install may touch the plugin on disk.
+for arg in "$@"; do
+  if [ "$arg" = "install" ]; then
+    # While the block file exists the install stays in flight, which lets a
+    # test observe a second install sitting in the queue behind this one.
+    while [ -f ${JSON.stringify(blockFilePath(binDir))} ]; do
+      sleep 0.05
+    done
+    # Emulate "npm --save --ignore-scripts install <name>@<version>" by
+    # bumping the on-disk package.json to the requested version.
+    cat > ${JSON.stringify(path.join(moduleDir, 'package.json'))} <<'EOF'
+${JSON.stringify(pluginPackageJson(AVAILABLE_VERSION), null, 2)}
+EOF
+    echo "added 1 package"
+    exit 0
+  fi
+done
+echo "0.0.0-npm-stub"
+exit 0
+`
+  )
+  fs.chmodSync(stub, 0o755)
+}
+
+function blockFilePath(binDir: string) {
+  return path.join(binDir, 'block-install')
+}
+
+function pluginPackageJson(version: string) {
+  return {
+    name: PLUGIN_NAME,
+    id: PLUGIN_NAME,
+    version,
+    description: 'Plugin used to verify pending-version reporting',
+    keywords: ['signalk-node-server-plugin'],
+    main: 'index.js'
+  }
+}
+
+function seedConfigDir(configDir: string) {
+  const moduleDir = path.join(configDir, 'node_modules', PLUGIN_NAME)
+  fs.mkdirSync(moduleDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(configDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'signalk-server-config',
+        version: '0.0.1',
+        dependencies: { [PLUGIN_NAME]: `^${INSTALLED_VERSION}` }
+      },
+      null,
+      2
+    )
+  )
+  fs.writeFileSync(
+    path.join(moduleDir, 'package.json'),
+    JSON.stringify(pluginPackageJson(INSTALLED_VERSION), null, 2)
+  )
+  fs.writeFileSync(
+    path.join(moduleDir, 'index.js'),
+    `module.exports = function (app) {
+  return {
+    id: '${PLUGIN_NAME}',
+    name: '${PLUGIN_NAME}',
+    start: function () {},
+    stop: function () {},
+    schema: function () { return {} }
+  }
+}
+`
+  )
+}
+
+// npm's search API is the only network dependency in the appstore read path;
+// serve the plugin at the newer version so the server sees an update as
+// available for the locally installed v1.
+function stubNpmSearch() {
+  const realFetch = global.fetch
+  global.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url.startsWith('https://registry.npmjs.org/-/v1/search')) {
+      return Promise.resolve(
+        Response.json({
+          objects: url.includes('signalk-node-server-plugin')
+            ? [
+                {
+                  package: {
+                    name: PLUGIN_NAME,
+                    version: AVAILABLE_VERSION,
+                    description: 'Plugin used to verify pending-version report',
+                    keywords: ['signalk-node-server-plugin'],
+                    date: new Date().toISOString(),
+                    links: {}
+                  }
+                }
+              ]
+            : [],
+          total: url.includes('signalk-node-server-plugin') ? 1 : 0
+        })
+      )
+    }
+    // Everything else the appstore hydrators reach for (dist-tags, registry
+    // metadata, icon probes) is optional enrichment - fail it fast rather
+    // than letting the suite depend on being online.
+    if (url.startsWith('https://registry.npmjs.org')) {
+      return Promise.resolve(new Response('{}', { status: 404 }))
+    }
+    return realFetch(input, init)
+  }) as typeof global.fetch
+  return () => {
+    global.fetch = realFetch
+  }
+}
+
+async function getAppStore(host: string): Promise<AppStoreResponse> {
+  const res = await fetch(`${host}/skServer/appstore/available/`)
+  expect(res.status).to.equal(200)
+  return (await res.json()) as AppStoreResponse
+}
+
+// npm runs in a child process, so the endpoints are polled rather than awaited.
+const POLL_INTERVAL_MS = 100
+const POLL_ATTEMPTS = 100
+const SUITE_TIMEOUT_MS = 60000
+
+// Poll the same endpoint the Admin UI reads until the entry satisfies
+// `settled`, i.e. the operation is no longer in flight.
+async function waitForEntry(
+  host: string,
+  settled: (entry: AppInfo) => boolean,
+  description: string
+): Promise<AppInfo> {
+  for (let i = 0; i < POLL_ATTEMPTS; i++) {
+    const store = await getAppStore(host)
+    const entry = store.installing.find((a) => a.name === PLUGIN_NAME)
+    if (entry && settled(entry)) {
+      return entry
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+  }
+  throw new Error(`${description} did not complete`)
+}
+
+describe('appstore reports the just-installed version (issue #2791)', function () {
+  // Real npm-stub subprocess plus a full server start.
+  this.timeout(SUITE_TIMEOUT_MS)
+
+  let stop: (() => Promise<unknown>) | undefined
+  let restoreFetch: (() => void) | undefined
+  let configDir: string
+  let binDir: string
+  let host: string
+  let originalPath: string | undefined
+
+  before(async function () {
+    if (process.platform === 'win32') {
+      this.skip()
+    }
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-pending-version-'))
+    seedConfigDir(configDir)
+
+    binDir = path.join(configDir, 'bin')
+    writeNpmStub(binDir, configDir)
+    originalPath = process.env.PATH
+    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH}`
+
+    restoreFetch = stubNpmSearch()
+
+    const port = await freeport()
+    host = 'http://localhost:' + port
+    const server = await startServerP(
+      port,
+      false,
+      { settings: { interfaces: { plugins: true } } },
+      undefined,
+      configDir
+    )
+    stop = () => server.stop()
+  })
+
+  after(async function () {
+    if (stop) await stop()
+    if (restoreFetch) restoreFetch()
+    if (originalPath !== undefined) process.env.PATH = originalPath
+    if (configDir) fs.rmSync(configDir, { recursive: true, force: true })
+  })
+
+  it('offers the newer version as an update for the running plugin', async function () {
+    const store = await getAppStore(host)
+    const installed = store.installed.find((a) => a.name === PLUGIN_NAME)
+    expect(installed, 'plugin should be reported as installed').to.exist
+    // `version` is the latest version npm offers; `installedVersion` is what
+    // the running plugin was loaded from.
+    expect(installed!.installedVersion).to.equal(INSTALLED_VERSION)
+    expect(installed!.version).to.equal(AVAILABLE_VERSION)
+
+    const update = store.updates.find((a) => a.name === PLUGIN_NAME)
+    expect(update, 'newer version should be offered as an update').to.exist
+    expect(update!.version).to.equal(AVAILABLE_VERSION)
+  })
+
+  it('rejects an install request carrying a bogus version', async function () {
+    const res = await fetch(
+      `${host}/skServer/appstore/install/${PLUGIN_NAME}/not-a-version`,
+      { method: 'POST' }
+    )
+    expect(res.status).to.equal(400)
+
+    // Nothing may be recorded as in-flight, otherwise the bogus version would
+    // reach the Admin UI as a pending version.
+    const store = await getAppStore(host)
+    expect(store.installing.find((a) => a.name === PLUGIN_NAME)).to.equal(
+      undefined
+    )
+  })
+
+  it('reports the installed version as pending while the old one still runs', async function () {
+    const res = await fetch(
+      `${host}/skServer/appstore/install/${PLUGIN_NAME}/${AVAILABLE_VERSION}`,
+      { method: 'POST' }
+    )
+    expect(res.status).to.equal(200)
+
+    const entry = await waitForEntry(host, (e) => !e.isInstalling, 'install')
+
+    // The regression in #2791: the Installs & Removes screen rendered
+    // installedVersion, which is the version the *running* plugin was loaded
+    // from and stays stale until restart. pendingVersion carries what npm
+    // actually put on disk.
+    expect(entry.pendingVersion).to.equal(AVAILABLE_VERSION)
+    expect(entry.installedVersion).to.equal(INSTALLED_VERSION)
+    expect(entry.isRemove).to.not.equal(true)
+
+    // Sanity-check that the stub really wrote the new version to disk, so the
+    // assertion above cannot pass against an install that never happened.
+    const onDisk = JSON.parse(
+      fs.readFileSync(
+        path.join(configDir, 'node_modules', PLUGIN_NAME, 'package.json'),
+        'utf8'
+      )
+    )
+    expect(onDisk.version).to.equal(AVAILABLE_VERSION)
+  })
+
+  it('reports the target version of an install still sitting in the queue', async function () {
+    // Hold the first install open so the second one has to queue behind it.
+    fs.writeFileSync(blockFilePath(binDir), '')
+    try {
+      const first = await fetch(
+        `${host}/skServer/appstore/install/${PLUGIN_NAME}/${AVAILABLE_VERSION}`,
+        { method: 'POST' }
+      )
+      expect(first.status).to.equal(200)
+      const inFlight = await waitForEntry(
+        host,
+        (e) => !!e.isInstalling,
+        'first install start'
+      )
+      expect(inFlight.pendingVersion).to.equal(AVAILABLE_VERSION)
+
+      const second = await fetch(
+        `${host}/skServer/appstore/install/${PLUGIN_NAME}/${AVAILABLE_VERSION}`,
+        { method: 'POST' }
+      )
+      expect(second.status).to.equal(200)
+
+      const queued = await waitForEntry(host, (e) => !!e.isWaiting, 'queueing')
+      expect(queued.pendingVersion).to.equal(AVAILABLE_VERSION)
+    } finally {
+      fs.rmSync(blockFilePath(binDir), { force: true })
+    }
+
+    await waitForEntry(host, (e) => !e.isInstalling && !e.isWaiting, 'install')
+  })
+
+  it('does not report a pending version for a removal', async function () {
+    const res = await fetch(`${host}/skServer/appstore/remove/${PLUGIN_NAME}`, {
+      method: 'POST'
+    })
+    expect(res.status).to.equal(200)
+
+    const entry = await waitForEntry(
+      host,
+      (e) => !!e.isRemove && !e.isInstalling,
+      'removal'
+    )
+
+    // Removals carry a null version through the install machinery; the field
+    // must stay absent rather than serialize as null.
+    expect(entry.pendingVersion).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
After updating a plugin, the Installs & Removes screen kept showing the version that was installed *before* the update.

The screen rendered `installedVersion`, which comes from the running plugin registration. That value is captured when the plugin is loaded at startup and is never refreshed by an install, so it stays stale until the server restarts.

The server already knows the version it just installed, it simply never sent it to the client. This exposes it as a separate `pendingVersion` field and renders it on the card pill, the list row and the action status while a restart is pending.

`pendingVersion` is only displayed for a settled, successful install: while one is still in flight the target version has not landed on disk yet, a failed install put nothing there, and removals carry no version at all. Each of those keeps the previous display.

The install route also now rejects a non-semver `:version` with a 400. `runNpm` already refused to install one, but only after the operation had been recorded as in-flight, so the bogus value still reached the Admin UI as a pending version.

## Before / after

Updating Meshtastic from v0.1.2 to v0.2.0, screen shown before restarting the server. Rendered from the actual `PluginCard`, `PluginRow` and `ActionCellRenderer` components with the app's stylesheet.

![Before and after comparison of the Installs and Removes screen](https://raw.githubusercontent.com/dirkwa/signalk-server/pr2917-assets/pr2917-before-after.png)

Tested: new end-to-end test starts a real server against a throwaway config dir with a plugin registered at 1.0.0 and a stub npm on PATH, so the HTTP endpoint, install state machine and APP_STORE_CHANGED refresh all run for real without network access. It covers the update, a queued install, a removal and an invalid version, and fails without the fix. Component tests cover the in-flight, queued, failed, removed and settled states on the card, the row and the action cell. Full `npm test` chain passes.

fixes #2791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the App Store Installs & Removes screen to show `pendingVersion` while a server restart is pending.

- Displays the pending version in plugin cards, rows, and action status.
- Keeps the installed version during active, queued, failed, and removal operations.
- Rejects invalid semver versions with HTTP 400 before starting an install.
- Adds component, unit, and end-to-end tests for pending versions, validation, install states, and removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->