### PR TITLE
 test(deltaPriority): Make the delta priority timeline test deterministic instead of timing-dependent

### DIFF
--- a/test/deltaPriority.ts
+++ b/test/deltaPriority.ts
@@ -77,38 +77,41 @@ describe('toPreferredDelta logic', () => {
       unknownSourceTimeout: 200
     })
 
-    let totalDelay = 0
+    // The engine decides by comparing the `now` it is handed against the
+    // configured timeouts, so the delays are advanced on a virtual clock
+    // rather than slept through. Real timers put several of the steps
+    // below within a few milliseconds of a 150ms boundary, where a late
+    // callback flips the comparison and drops an emission.
+    let clock = 0
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any[] = []
     const expectedResult: string[] = []
     let n = 0
     function push(sourceRef: string, delay: number, shouldBeEmitted: boolean) {
-      totalDelay += delay
+      clock += delay
       if (shouldBeEmitted) {
         expectedResult.push(sourceRef)
       }
-      setTimeout(() => {
-        result.push(
-          toPreferredDelta(
-            {
-              context: 'self',
-              updates: [
-                {
-                  $source: sourceRef,
-                  values: [
-                    {
-                      path: 'environment.wind.speedApparent',
-                      value: n++
-                    }
-                  ]
-                }
-              ]
-            },
-            new Date(),
-            'self'
-          )
+      result.push(
+        toPreferredDelta(
+          {
+            context: 'self',
+            updates: [
+              {
+                $source: sourceRef,
+                values: [
+                  {
+                    path: 'environment.wind.speedApparent',
+                    value: n++
+                  }
+                ]
+              }
+            ]
+          },
+          new Date(clock),
+          'self'
         )
-      }, totalDelay)
+      )
     }
 
     push('a', 0, true)
@@ -129,19 +132,10 @@ describe('toPreferredDelta logic', () => {
     push('c', 150, true)
     push('d', 205, true)
 
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        try {
-          result
-            .filter((r) => r.updates[0].values.length > 0)
-            .map((r) => r.updates[0].$source)
-            .should.eql(expectedResult)
-          resolve(undefined)
-        } catch (err) {
-          reject(err)
-        }
-      }, totalDelay + 10)
-    })
+    result
+      .filter((r) => r.updates[0].values.length > 0)
+      .map((r) => r.updates[0].$source)
+      .should.eql(expectedResult)
   })
 })
 


### PR DESCRIPTION
The `toPreferredDelta logic > works` case schedules each delta with a real `setTimeout` and asserts once, `totalDelay + 10ms` after the last one.

That makes it load-sensitive, and not only because of the assertion margin. The engine decides with `millis - latest.timestamp > holdTimeout` (`src/deltaPriority.ts`), comparing elapsed wall-clock time against the configured source timeouts of 0, 150 and 200ms. Several steps in the sequence sit within 10ms of the 150ms boundary, so a timer callback that lands late genuinely flips the comparison and the engine drops an emission. The failure then surfaces as a missing `$source` in the expected list:

```
AssertionError: expected [ 'a','b','a','c','b','c', …(2) ] to deeply equal [ …(3) ]
```

`toPreferredDelta(delta, now, selfContext)` already takes `now` as a parameter, so the timeline can be advanced on a virtual clock instead of slept through. The same deltas are pushed with the same cumulative offsets and the same expectations, the assertion becomes synchronous, and nothing in `src/` changes.

This is safe because the engine only ever uses time differences and never reads the clock itself, so starting the virtual timeline at 0 is equivalent to starting it at `Date.now()`.

Side effect: the case drops from about 1s to under 100ms, since it no longer sleeps through its own timeline.

Tested
- `test/deltaPriority.ts`: 58 passing
- mutation check — breaking the `holdTimeout` comparison in `src/deltaPriority.ts` makes the suite fail 14 tests, so the rewritten case still detects regressions rather than merely passing
- `npm test` (full chain) green locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Makes the `deltaPriority` timeline test deterministic with a virtual clock.
- Replaces real `setTimeout` calls with explicit timestamps and synchronous assertions.
- Reduces test runtime from about one second to under 100 ms.
- Makes no production code changes.

## Validation

- 58 tests pass in `test/deltaPriority.ts`.
- Mutation checks pass.
- Full `npm test` passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->