### PR TITLE
Fix the callback-isolation expectations left stale by the duplicate-delivery fix

### DIFF
--- a/test/subscriptionmanager-callback-isolation.ts
+++ b/test/subscriptionmanager-callback-isolation.ts
@@ -172,12 +172,7 @@ describe('SubscriptionManager callback isolation', () => {
     dispatch(metaDelta(SELF_CONTEXT, STW_PATH))
     dispatch(valueDelta(SELF_CONTEXT, STW_PATH, 3.2))
 
-    expect(pathsOf(received)).to.deep.equal([
-      STW_PATH,
-      STW_PATH,
-      'meta',
-      STW_PATH
-    ])
+    expect(pathsOf(received)).to.deep.equal([STW_PATH, 'meta', STW_PATH])
   })
 
   it('reports callback exceptions through errorCallback', () => {
@@ -186,8 +181,8 @@ describe('SubscriptionManager callback isolation', () => {
 
     dispatch(valueDelta(SELF_CONTEXT, STW_PATH, 3.1))
 
-    // the callback runs for the announcement-time cache bootstrap and for
-    // the live push, so at least one error per delivery must surface
+    // the callback throws on every delivery, so the error must surface
+    // through errorCallback rather than escaping into the dispatch
     expect(errors).to.not.be.empty
     errors.forEach((err) => expect(err).to.be.instanceOf(TypeError))
   })
@@ -203,7 +198,7 @@ describe('SubscriptionManager callback isolation', () => {
     dispatch(valueDelta(SELF_CONTEXT, STW_PATH, 3.1))
     dispatch(valueDelta(SELF_CONTEXT, STW_PATH, 3.2))
 
-    expect(pathsOf(received)).to.deep.equal([STW_PATH, STW_PATH, STW_PATH])
+    expect(pathsOf(received)).to.deep.equal([STW_PATH, STW_PATH])
   })
 
   it('keys announcements keep flowing after repeated callback crashes', () => {


### PR DESCRIPTION
master is currently red: two cases in `test/subscriptionmanager-callback-isolation.ts` fail, in isolation as well as in the full run.

#2905 (callback isolation) and #2906 (deliver a new path's first delta once) touch the same call sites, and #2906's description flagged that whichever merged second would need a rebase. #2905 landed first, so its expectations still encode the duplicate first delivery that #2906 then removed:

- `a callback throwing on live delivery…` expected `[STW, STW, meta, STW]` for three dispatches
- `survives an errorCallback that also throws` expected `[STW, STW, STW]` for two dispatches

Both carried one extra copy of the first `navigation.speedThroughWater` value. The source behaviour is correct; only the expectations were stale. A comment describing the callback running "for the announcement-time cache bootstrap and for the live push" is updated for the same reason.

The isolation guarantees are unchanged. I checked that by mutation: removing the `guardedCallback` wrapper — reintroducing exactly the bug #2905 was written to catch — fails all five cases (0 passing / 5 failing), against 5 passing with it intact. So these expectations still protect the original behaviour, they simply no longer assert the duplicate.

Tested
- `test/subscriptionmanager-callback-isolation.ts`: 5 passing
- `npm test` (full chain): the two failures here are gone; four in `test/appstore-pending-version.ts` remain, which fail on unmodified master too and look like a separate ordering problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates callback-isolation test expectations to remove duplicate `navigation.speedThroughWater` deliveries.
- Updates related comments to reflect the current callback behavior.
- Reduces full test-chain failures from six to four. The remaining failures are unrelated `appstore-pending-version.ts` failures that also occur on `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->