### PR TITLE
Reset the npm module caches between test servers so stubbed registry suites are not poisoned

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -399,9 +399,33 @@ const modulesByKeyword: Record<
 // paging through the registry on their own.
 const searchInFlight: Map<string, Promise<NpmModuleData[]>> = new Map()
 
+// Bumped by resetModuleCaches so a request that was already in flight
+// cannot commit its result into the caches the reset emptied.
+let cacheGeneration = 0
+
+// Both caches above are module scope with a 60s TTL, which is what a running
+// server wants. A test process runs many servers in sequence, so a suite that
+// stubs the npm registry still reads whatever an earlier suite cached —
+// stubbing replaces the transport, not the cached result. Reset between test
+// servers, the same way requestResponse.resetRequests() is.
+export function resetModuleCaches() {
+  // A search or dist-tag fetch started before this call still resolves
+  // afterwards — the appstore's background refresh is fire-and-forget and
+  // outlives the server that scheduled it — and would write its result
+  // into the caches this reset just emptied. Bump the generation so those
+  // late writes are discarded instead.
+  cacheGeneration++
+  for (const keyword of Object.keys(modulesByKeyword)) {
+    delete modulesByKeyword[keyword]
+  }
+  searchInFlight.clear()
+  distTagsCache = { time: 0, data: {} }
+}
+
 async function findModulesWithKeyword(
   keyword: string
 ): Promise<NpmModuleData[]> {
+  const generation = cacheGeneration
   if (
     modulesByKeyword[keyword] &&
     Date.now() - modulesByKeyword[keyword].time < 60 * 1000
@@ -439,14 +463,20 @@ async function findModulesWithKeyword(
     )
 
     const packages = [...result.values()]
-    modulesByKeyword[keyword] = { time: Date.now(), packages }
+    if (generation === cacheGeneration) {
+      modulesByKeyword[keyword] = { time: Date.now(), packages }
+    }
     return packages
   })()
   searchInFlight.set(keyword, search)
   try {
     return await search
   } finally {
-    searchInFlight.delete(keyword)
+    // Only drop our own entry: a reset may have cleared the map and a
+    // newer search may already have registered under this keyword.
+    if (searchInFlight.get(keyword) === search) {
+      searchInFlight.delete(keyword)
+    }
   }
 }
 
@@ -508,6 +538,7 @@ let distTagsCache: { time: number; data: Record<string, NpmDistTags> } = {
 async function fetchDistTagsForPackages(
   packageNames: string[]
 ): Promise<Record<string, NpmDistTags>> {
+  const generation = cacheGeneration
   if (Date.now() - distTagsCache.time < 60 * 1000) {
     return distTagsCache.data
   }
@@ -537,7 +568,9 @@ async function fetchDistTagsForPackages(
     i += CONCURRENCY
   }
 
-  distTagsCache = { time: Date.now(), data: result }
+  if (generation === cacheGeneration) {
+    distTagsCache = { time: Date.now(), data: result }
+  }
   return result
 }
 
@@ -662,5 +695,6 @@ module.exports = {
   restoreModules,
   importOrRequire,
   runNpm,
-  getPluginDataSize
+  getPluginDataSize,
+  resetModuleCaches
 }

--- a/test/servertestutilities.js
+++ b/test/servertestutilities.js
@@ -138,6 +138,12 @@ module.exports = {
     } catch (_e) {
       // ignore - not critical for non-test usage
     }
+    // The npm keyword/dist-tag caches are module scope with a 60s TTL, so a
+    // suite that stubs the registry would otherwise serve the previous
+    // suite's live search results. Deliberately unguarded: a failure here
+    // means test isolation is broken, which must surface as a setup error
+    // rather than as confusing cross-suite failures later.
+    require('../dist/modules').resetModuleCaches()
     const props = {
       config: JSON.parse(JSON.stringify(defaultConfig))
     }


### PR DESCRIPTION
Fixes #2921 — four cases in `test/appstore-pending-version.ts` fail in the full run on master while passing in isolation.

The keyword-search and dist-tag caches in `src/modules.ts` are module scope with a 60-second TTL, which is right for a running server. A test process runs many servers in sequence, so a suite that stubs the npm registry still reads whatever an earlier suite cached: stubbing `fetch` replaces the transport, not the already-cached result.

`appstore-pending-version.ts` stubs the search so it can offer its own fixture plugin. Any earlier suite that hit `/appstore/available` left the real registry results cached, so the fixture was absent and `store.installed` came back without it.

The reset runs alongside the existing `requestResponse.resetRequests()` in `startServerP`, so every test server starts from a clean cache rather than only fixing the one suite that noticed.

Narrowing, for the record: bisecting the suites that load earlier showed exactly one trigger, and it was not that file's contents — a single `GET /skServer/appstore/available` from any earlier suite reproduces it. Inserting a 65-second wait after that request also makes the failures disappear, which is what pointed at the 60-second TTL.

Tested
- `test/appstore-detail-cache-e2e.ts` + `test/appstore-pending-version.ts` together: 9 passing, was 4 failing
- the three suites involved in the current master breakage, run together three times: 14 passing each time
- `npm test` (full chain) with this and #2920 applied: 1135 + 47 + 97 + 16 passing, 0 failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `resetModuleCaches()` to clear npm keyword-search, in-flight search, and dist-tag caches.
- Prevents in-flight requests from repopulating caches after a reset.
- Calls `resetModuleCaches()` from `startServerP` after resetting request state.
- Prevents cached registry results from affecting later test suites.
- Fixes cross-suite failures in `test/appstore-pending-version.ts`.
- Targeted suites and the full test chain pass with zero failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->