### PR TITLE
refactor(admin-ui): drop unused store subscriptions and a superseded PrefsEditor prop

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
@@ -38,7 +38,6 @@ import {
   useConfiguredPriorityPaths,
   usePreferredSourceByPath,
   useLivePreferredSources,
-  useSourcePrioritiesLoaded,
   useDiscoveredAddresses
 } from '../../store'
 
@@ -160,7 +159,6 @@ const DataBrowser: React.FC = () => {
   const configuredPriorityPaths = useConfiguredPriorityPaths()
   const preferredSourceByPath = usePreferredSourceByPath()
   const livePreferredSourcesRaw = useLivePreferredSources()
-  const sourcePrioritiesLoaded = useSourcePrioritiesLoaded()
   const discoveredAddresses = useDiscoveredAddresses()
 
   // Paths the user has flagged for fan-out (sentinel '*' override).

--- a/packages/server-admin-ui/src/views/ServerConfig/PrefsEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PrefsEditor.tsx
@@ -25,7 +25,6 @@ interface SelectOption {
 interface PrefsEditorProps {
   path: string
   priorities: Priority[]
-  pathIndex: number
   isSaving: boolean
   sourcesData: SourcesData | null
   multiSourcePaths: Record<string, string[]>
@@ -85,7 +84,6 @@ const wrappingSelectStyles: StylesConfig<SelectOption, false> = {
 export const PrefsEditor: React.FC<PrefsEditorProps> = ({
   path,
   priorities,
-  pathIndex,
   isSaving,
   sourcesData,
   multiSourcePaths,
@@ -96,20 +94,19 @@ export const PrefsEditor: React.FC<PrefsEditorProps> = ({
   const movePriority = useStore((s) => s.movePriority)
   const setPathPriorities = useStore((s) => s.setPathPriorities)
 
-  // pathIndex is render-local; in grouped overrides multiple editors
-  // can render with the same index, which would collide on the
-  // pg-fanout-* DOM id and let one card's label toggle another's
-  // checkbox. useId gives us a process-stable unique prefix per
-  // editor instance.
+  // In grouped overrides multiple editors can render at the same
+  // position, which would collide on the pg-fanout-* DOM id and let one
+  // card's label toggle another's checkbox. useId gives us a
+  // process-stable unique prefix per editor instance.
   const fanOutId = useId()
 
-  // pathIndex passed in via props is the index in sourcePriorities[] at
-  // render time. It goes stale the moment another override is deleted
-  // — the next click on this card would otherwise reach into the wrong
-  // row. Resolve the current index from path at click time so the slice
-  // action always operates on the right entry. Returns null when the
-  // path has been removed (concurrent delete in another tab) so callers
-  // can no-op rather than mutate an unrelated row.
+  // A render-time index into sourcePriorities[] goes stale the moment
+  // another override is deleted — the next click on this card would
+  // otherwise reach into the wrong row. Resolve the current index from
+  // path at click time so the slice action always operates on the right
+  // entry. Returns null when the path has been removed (concurrent
+  // delete in another tab) so callers can no-op rather than mutate an
+  // unrelated row.
   const resolvePathIndex = (): number | null => {
     const arr = useStore.getState().sourcePrioritiesData.sourcePriorities
     const i = arr.findIndex((p) => p.path === path)

--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -367,25 +367,6 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
     [group.newcomerSources]
   )
 
-  // Lookup from path → configured priorities, for paths within this group.
-  // Prefer entries with a populated rank-1 sourceRef when duplicates exist.
-  const pathPrioritiesByPath = useMemo(() => {
-    const map = new Map<
-      string,
-      (typeof sourcePriorities)[number]['priorities']
-    >()
-    for (const pp of sourcePriorities) {
-      if (!groupPathSet.has(pp.path)) continue
-      const existing = map.get(pp.path)
-      const existingHasRankOne = !!existing?.[0]?.sourceRef
-      const incomingHasRankOne = !!pp.priorities?.[0]?.sourceRef
-      if (!existing || (!existingHasRankOne && incomingHasRankOne)) {
-        map.set(pp.path, pp.priorities)
-      }
-    }
-    return map
-  }, [sourcePriorities, groupPathSet])
-
   // Short descriptor per path (PGNs / 0183 sentences).
   const pathKinds: PathKinds = useMemo(() => {
     const map = new Map<string, string[]>()
@@ -969,7 +950,7 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                 </div>
               ) : (
                 <div className="pg-overrides-list">
-                  {overrideRows.map(({ pp, index }) => {
+                  {overrideRows.map(({ pp }) => {
                     const kinds = pathKinds.get(pp.path) ?? []
                     const isFanOut =
                       pp.priorities.length === 1 &&
@@ -1067,7 +1048,6 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
                         <PrefsEditor
                           path={pp.path}
                           priorities={pp.priorities}
-                          pathIndex={index}
                           isSaving={isSaving}
                           sourcesData={sourcesData}
                           multiSourcePaths={multiSourcePaths}

--- a/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/SourcePriorities.tsx
@@ -17,9 +17,7 @@ import {
   useReconciledGroups,
   usePriorityGroups,
   usePriorityDefaults,
-  usePriorityOverrides,
-  useSourceStatus,
-  useSourceStatusLoaded
+  usePriorityOverrides
 } from '../../store'
 import type { SourcesData } from '../../utils/sourceLabels'
 import type { SourcePriority } from '../../store/types'
@@ -327,8 +325,6 @@ const SourcePriorities: React.FC = () => {
   const priorityOverridesData = usePriorityOverrides()
   const multiSourcePaths = useMultiSourcePaths()
   const reconciled = useReconciledGroups()
-  const sourceStatus = useSourceStatus()
-  const sourceStatusLoaded = useSourceStatusLoaded()
 
   const setSaving = useStore((s) => s.setSaving)
   const setSaved = useStore((s) => s.setSaved)
@@ -946,7 +942,6 @@ const SourcePriorities: React.FC = () => {
                     <PrefsEditor
                       path={pp.path}
                       priorities={pp.priorities}
-                      pathIndex={index}
                       isSaving={isSaving}
                       sourcesData={sourcesData}
                       multiSourcePaths={multiSourcePaths}


### PR DESCRIPTION
Five values in the admin UI were computed and never read.

Three of them (`useSourceStatus`, `useSourceStatusLoaded`,
`useSourcePrioritiesLoaded`) each opened a zustand subscription, so removing
them also drops re-renders that could not affect what is displayed. The
fourth was a dead `useMemo` in `PriorityGroupCard`.

The fifth is `PrefsEditor`'s `pathIndex` prop. It was superseded by
`resolvePathIndex()`, which re-derives the index from `path` at click time
because a render-time index goes stale as soon as another override is
deleted. Nothing read the prop any more, so it is removed from the interface
and both call sites, and the two comments that still described it are
reworded.

No behavior change.

## Tested

- `npm run build:all` — clean
- `npm run ci-lint` — clean
- `npm run test:admin-ui` — 380 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes five unused computed values from the admin UI:

- Removes three unused Zustand store subscriptions.
- Removes the unused `useMemo` in `PriorityGroupCard`.
- Removes the obsolete `PrefsEditor` `pathIndex` prop and its call sites.
- Retains `resolvePathIndex()` for click-time index resolution.
- Updates related comments.

The changes do not alter behavior. Builds, linting, and admin UI tests pass, with 380 tests passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->