### PR TITLE
refactor(admin-ui): escape literal apostrophes in JSX text

### DIFF
--- a/packages/server-admin-ui/src/views/DataBrowser/SourceDiscovery.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/SourceDiscovery.tsx
@@ -464,13 +464,13 @@ const SourceDiscovery: React.FC = () => {
           variant="warning"
           style={{ fontSize: '0.9rem', marginBottom: '16px' }}
         >
-          <FontAwesomeIcon icon={faInfoCircle} /> The server can't currently
-          send ISO Requests on the N2K bus. <strong>Discover Devices</strong>,
-          instance edits and the automatic identity refresh are unavailable.
-          This usually means the N2K connection hasn't completed address claim
-          yet (give it ~5 s after boot) — or, for Yacht Devices YDEN / YDWG
-          gateways over TCP, that <em>Act as N2K device</em> is off on the
-          connection.{' '}
+          <FontAwesomeIcon icon={faInfoCircle} /> The server can&apos;t
+          currently send ISO Requests on the N2K bus.{' '}
+          <strong>Discover Devices</strong>, instance edits and the automatic
+          identity refresh are unavailable. This usually means the N2K
+          connection hasn&apos;t completed address claim yet (give it ~5 s after
+          boot) — or, for Yacht Devices YDEN / YDWG gateways over TCP, that{' '}
+          <em>Act as N2K device</em> is off on the connection.{' '}
           <a href="./#/data/connections/-" className="text-decoration-none">
             Open Connections
           </a>{' '}

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.tsx
@@ -1555,8 +1555,8 @@ function DeviceInstanceInput({
       </Col>
       <Col xs="7" md="6" className="form-text text-muted small">
         {MIN_DEVICE_INSTANCE}–{MAX_DEVICE_INSTANCE}. Identifies this
-        signalk-server among multiple N2K nodes (split into PGN 60928's lower 3
-        bits and upper 5 bits). Defaults to 0.
+        signalk-server among multiple N2K nodes (split into PGN 60928&apos;s
+        lower 3 bits and upper 5 bits). Defaults to 0.
       </Col>
     </Form.Group>
   )
@@ -1748,9 +1748,9 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           <div className="text-muted small mt-1 mb-2">
             UDP is receive-only — N2K device discovery and PGN 126208 instance
             edits are not available. Frames may also occasionally be attributed
-            to the gateway's own N2K address rather than the originating device,
-            producing ghost sources in Source Discovery and priority groups. Use
-            TCP if either matters for your setup.
+            to the gateway&apos;s own N2K address rather than the originating
+            device, producing ghost sources in Source Discovery and priority
+            groups. Use TCP if either matters for your setup.
           </div>
         </div>
       )}
@@ -1847,8 +1847,8 @@ function NMEA2000({ value, onChange, hasAnalyzer }: TypeComponentProps) {
           <ActAsCanDeviceInput value={value.options} onChange={onChange} />
           <div className="text-muted small mt-1 mb-2">
             Generic source for IP-based N2K gateways that stream raw CAN frames
-            over TCP in one of canboatjs's supported text formats. Default port
-            2599, default format candump3.
+            over TCP in one of canboatjs&apos;s supported text formats. Default
+            port 2599, default format candump3.
           </div>
         </div>
       )}

--- a/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
@@ -160,7 +160,7 @@ const PluginCiMatrix: React.FC<PluginCiMatrixProps> = ({ data }) => {
     <div className="plugin-detail__plugin-ci">
       <h5 className="mt-4">plugin-ci matrix</h5>
       <div className="text-muted small mb-2">
-        Tested against the published version's commit{' '}
+        Tested against the published version&apos;s commit{' '}
         <a
           href={data.commit_url}
           target="_blank"


### PR DESCRIPTION
Six literal apostrophes in rendered prose across `SourceDiscovery`,
`BasicProvider` and `PluginCiMatrix` are replaced with `&apos;`.

Prettier reflowed the surrounding JSX and inserted the `{' '}` separators
needed to keep spacing around the inline `<strong>` / `<em>` elements
identical, so the rendered text is unchanged.

## Tested

- `npm run build:all` — clean
- `npm run ci-lint` — clean
- `npm run test:admin-ui` — 380 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replace literal apostrophes in rendered JSX prose with `&apos;` in `SourceDiscovery`, `BasicProvider`, and `PluginCiMatrix`.
- Preserve the rendered text and component interfaces.
- Confirm validation with successful build and lint checks and 380 passing admin UI tests.
- Record six CI failures that also occur on `master` and relate to separate changes.

## Testing

- `npm run build:all`
- `npm run ci-lint`
- `npm run test:admin-ui` — 380 passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->