### PR TITLE
fix(ci): skip the demo.signalk.org deploy on beta release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,6 +448,11 @@ jobs:
   deploy_fly:
     runs-on: ubuntu-latest
     needs: copy-to-dockerhub
+    # demo.signalk.org is public and must stay on the release channel, so
+    # prereleases are excluded here the same way they are from the `latest`
+    # npm dist-tag and the floating Docker tags. success() restores the
+    # implicit needs check that an explicit `if` would otherwise drop.
+    if: ${{ success() && !contains(github.ref, 'beta') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
`deploy_fly` was the only job in the release workflow with no condition on it, so pushing a prerelease tag redeployed the public demo at demo.signalk.org with the beta build. Beta tags are already kept off the npm `latest` dist-tag and off the floating Docker tags (`latest`, `v{major}`, `v{major}.{minor}`); the demo should follow the same rule.

Gated the job on the same `!contains(github.ref, 'beta')` predicate used for the Docker tags, so all three prerelease exclusions stay in sync with the "MUST CONTAIN THE STRING beta" convention in `releasing.md`.

The `success() &&` in the condition is deliberate: adding any job-level `if` drops the implicit `success()` that `needs:` otherwise supplies, which would have let a failed `copy-to-dockerhub` fall through to a deploy. The neighbouring `manifest` and `housekeeping` jobs spell out their `needs.*.result` checks for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the `deploy_fly` release job. The job skips deployments to `demo.signalk.org` when `github.ref` contains `beta`.

The condition uses `success() && !contains(github.ref, 'beta')`. This preserves the prerequisite success check and matches existing npm and Docker beta-release exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->