### PR TITLE
fix(appstore): re-download a plugin icon when its version changes

### DIFF
--- a/src/appstore/icon-bytes.ts
+++ b/src/appstore/icon-bytes.ts
@@ -40,6 +40,8 @@ export interface StoredIcon {
   contentType: string
   size: number
   writtenAt: number
+  /** Version this icon was downloaded for, taken from the filename. */
+  version: string
 }
 
 export interface IconBytesCache {
@@ -126,6 +128,12 @@ export function createIconBytesCache(cacheDir: string): IconBytesCache {
     const full = path.join(root, best.entry)
     const ext = best.entry.split('.').pop() || ''
     const contentType = guessContentTypeFromExt(ext)
+    // Filenames are `${safeName(pkg)}@${version}.${ext}`, so the version is
+    // whatever sits between the prefix and the extension.
+    const version = best.entry.slice(
+      prefix.length,
+      best.entry.length - (ext.length + 1)
+    )
     // Re-stat for the size: a concurrent purgeOldVersions or a manual
     // /appstore/refresh between the loop and here could have removed
     // the file. Treat that as "not stored" rather than throwing.
@@ -140,7 +148,8 @@ export function createIconBytesCache(cacheDir: string): IconBytesCache {
       path: full,
       contentType,
       size,
-      writtenAt: best.mtime
+      writtenAt: best.mtime,
+      version
     }
   }
 
@@ -211,7 +220,8 @@ export function createIconBytesCache(cacheDir: string): IconBytesCache {
         path: full,
         contentType: contentType.split(';')[0].trim(),
         size: bytes.byteLength,
-        writtenAt: Date.now()
+        writtenAt: Date.now(),
+        version
       }
     } catch (err) {
       debug.enabled && debug('write %s failed: %O', full, err)

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -537,12 +537,14 @@ module.exports = function (app) {
                     t.declaredPath,
                     iconProbe
                   )
-                  if (
-                    resolved &&
-                    t.kind === 'icon' &&
-                    !iconBytes.read(pkg.name)
-                  ) {
-                    await iconBytes.download(pkg.name, pkg.version, resolved)
+                  if (resolved && t.kind === 'icon') {
+                    // Icons are cached per version, so check the version and
+                    // not just presence — otherwise a plugin that changes its
+                    // icon keeps serving the one cached for an older release.
+                    const stored = iconBytes.read(pkg.name)
+                    if (!stored || stored.version !== pkg.version) {
+                      await iconBytes.download(pkg.name, pkg.version, resolved)
+                    }
                   }
                 } catch (err) {
                   debug.enabled &&
@@ -573,7 +575,7 @@ module.exports = function (app) {
           name: pkg.name,
           version: pkg.version,
           displayName: ext.displayName,
-          appIcon: appIconUrlFor(pkg.name, ext.appIcon),
+          appIcon: appIconUrlFor(pkg.name, ext.appIcon, pkg.version),
           screenshots: ext.screenshots || [],
           official: ext.official,
           deprecated: ext.deprecated,
@@ -778,10 +780,14 @@ module.exports = function (app) {
   // route so the browser never has to reach unpkg. This makes the grid
   // render instantly on a boat with no internet after a one-time warmup.
   // When bytes aren't cached yet, pass the CDN URL through unchanged.
-  function appIconUrlFor(pkgName, cdnUrl) {
+  // The icon route is versionless and sets a one-hour max-age, so the version
+  // goes in the query string: without it a browser holds the old icon for up
+  // to an hour after the bytes are replaced. Bytes cached for some other
+  // version fall through to the CDN rather than render the wrong icon.
+  function appIconUrlFor(pkgName, cdnUrl, version) {
     if (!pkgName) return cdnUrl
-    if (iconBytes.read(pkgName)) {
-      return `${SERVERROUTESPREFIX}/appstore/icon/${pkgName}`
+    if (iconBytes.read(pkgName)?.version === version) {
+      return `${SERVERROUTESPREFIX}/appstore/icon/${pkgName}?v=${version}`
     }
     return cdnUrl
   }
@@ -825,7 +831,7 @@ module.exports = function (app) {
       const ext = enrichEntry(pkg, { iconUrlLookup })
       return {
         displayName: ext.displayName,
-        appIcon: appIconUrlFor(name, ext.appIcon),
+        appIcon: appIconUrlFor(name, ext.appIcon, pkg.version),
         installed
       }
     }
@@ -892,11 +898,20 @@ module.exports = function (app) {
         for (const entry of entries) {
           const key = `${pkg.name}@${pkg.version}@${entry.declaredPath}`
           if (queuedKey.has(key)) continue
-          if (
-            iconProbe.get(pkg.name, pkg.version, entry.declaredPath) !==
-            undefined
+          const probed = iconProbe.get(
+            pkg.name,
+            pkg.version,
+            entry.declaredPath
           )
-            continue
+          // A cached probe result usually means there is nothing left to do,
+          // but the byte download that follows it can fail on its own. Keep
+          // the task when this version's bytes are still missing, so the
+          // worker retries the download against the URL already probed.
+          const bytesMissing =
+            entry.kind === 'icon' &&
+            typeof probed === 'string' &&
+            iconBytes.read(pkg.name)?.version !== pkg.version
+          if (probed !== undefined && !bytesMissing) continue
           queuedKey.add(key)
           tasks.push({
             name: pkg.name,
@@ -930,7 +945,7 @@ module.exports = function (app) {
           // Screenshots stay remote (larger + only viewed on detail).
           if (resolved && t.kind === 'icon') {
             const existing = iconBytes.read(t.name)
-            if (!existing) {
+            if (!existing || existing.version !== t.version) {
               await iconBytes.download(t.name, t.version, resolved)
             }
           }
@@ -1226,7 +1241,7 @@ module.exports = function (app) {
           (v) => v === 'signalk-embeddable-webapp'
         ),
         displayName: ext.displayName,
-        appIcon: appIconUrlFor(name, ext.appIcon),
+        appIcon: appIconUrlFor(name, ext.appIcon, plugin.package.version),
         installedIconUrl: localIcons?.appIcon,
         screenshots: ext.screenshots,
         // Only advertise installedScreenshotUrls when the installed version

--- a/test/appstore/icon-bytes.test.ts
+++ b/test/appstore/icon-bytes.test.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import http from 'http'
+import os from 'os'
+import path from 'path'
+import { createIconBytesCache } from '../../dist/appstore/icon-bytes.js'
+
+const tmpDirs: string[] = []
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'appstore-iconbytes-'))
+  tmpDirs.push(dir)
+  return dir
+}
+
+function writeIcon(root: string, filename: string) {
+  fs.mkdirSync(path.join(root, 'icon-bytes'), { recursive: true })
+  fs.writeFileSync(path.join(root, 'icon-bytes', filename), 'x')
+}
+
+describe('appstore/icon-bytes cache', () => {
+  afterEach(() => {
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop()
+      if (dir) fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns undefined when nothing is stored', () => {
+    expect(createIconBytesCache(tmpDir()).read('signalk-foo')).to.equal(
+      undefined
+    )
+  })
+
+  it('reports the version the stored icon was downloaded for', () => {
+    const dir = tmpDir()
+    writeIcon(dir, 'signalk-foo@0.10.1.svg')
+    const stored = createIconBytesCache(dir).read('signalk-foo')
+    expect(stored?.version).to.equal('0.10.1')
+    expect(stored?.contentType).to.equal('image/svg+xml')
+  })
+
+  it('reports the version for scoped packages', () => {
+    const dir = tmpDir()
+    writeIcon(dir, '@scope__signalk-foo@1.2.3.png')
+    const stored = createIconBytesCache(dir).read('@scope/signalk-foo')
+    expect(stored?.version).to.equal('1.2.3')
+  })
+
+  it('reports a prerelease version containing dots and dashes', () => {
+    const dir = tmpDir()
+    writeIcon(dir, 'signalk-foo@1.0.0-beta.2.svg')
+    expect(createIconBytesCache(dir).read('signalk-foo')?.version).to.equal(
+      '1.0.0-beta.2'
+    )
+  })
+
+  it('does not match a different package sharing a name prefix', () => {
+    const dir = tmpDir()
+    writeIcon(dir, 'signalk-foo-extra@1.0.0.svg')
+    expect(createIconBytesCache(dir).read('signalk-foo')).to.equal(undefined)
+  })
+
+  describe('download', () => {
+    let server: http.Server
+    let origin: string
+
+    beforeEach(async () => {
+      server = http.createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'image/svg+xml' })
+        res.end(`<svg id="${req.url}" />`)
+      })
+      await new Promise<void>((resolve) => server.listen(0, resolve))
+      const addr = server.address() as { port: number }
+      origin = `http://127.0.0.1:${addr.port}`
+    })
+
+    afterEach(async () => {
+      await new Promise((resolve) => server.close(resolve))
+    })
+
+    it('replaces the previous version rather than accumulating icons', async () => {
+      const dir = tmpDir()
+      const cache = createIconBytesCache(dir)
+
+      await cache.download('signalk-foo', '1.0.0', `${origin}/v1.svg`)
+      expect(cache.read('signalk-foo')?.version).to.equal('1.0.0')
+
+      await cache.download('signalk-foo', '2.0.0', `${origin}/v2.svg`)
+      const stored = cache.read('signalk-foo')
+      expect(stored?.version).to.equal('2.0.0')
+      expect(fs.readFileSync(stored!.path, 'utf8')).to.contain('/v2.svg')
+      expect(fs.readdirSync(path.join(dir, 'icon-bytes'))).to.deep.equal([
+        'signalk-foo@2.0.0.svg'
+      ])
+    })
+  })
+})


### PR DESCRIPTION
A plugin that changes its icon in a new release never gets the new icon shown in the app store.

## What happens

`icon-bytes` stores icons per version, as `name@version.ext`. Both places that decide whether to download only check whether an icon exists for the package *name*:

```js
if (resolved && t.kind === 'icon' && !iconBytes.read(pkg.name)) {
  await iconBytes.download(pkg.name, pkg.version, resolved)
}
```

`read()` resolves by name and returns the newest file matching that prefix, whatever version it belongs to. So after the first successful download the guard is false forever and no later version is ever fetched. `purgeOldVersions()` would clear the old file, but it only runs inside `download()`, which by then never runs.

The serving route (`/appstore/icon/:name`) has no version in it either, so the stale file is what the card and detail view render.

The only way out today is `POST /appstore/refresh`, which calls `iconBytes.invalidate()` and drops the cache for every package, then re-probes all of them.

I hit this locally: my `appstore-cache/icon-bytes` had `signalk-noaa-space-weather@0.10.1.svg` sitting there while the registry was offering 0.11.3 with a different icon. It had been stale for weeks and nothing short of deleting the file by hand shifted it.

## The change

`StoredIcon` gains a `version`, read back out of the filename in `findStored()`. Both call sites re-download when the stored version doesn't match the version they're about to render. `purgeOldVersions()` then removes the old file on the way through, as it was already written to do.

No change to the cache layout or the route, so existing caches keep working; the first probe after upgrading a plugin replaces the file.

## Tests

New `test/appstore/icon-bytes.test.ts` covers the version parse: scoped names (`@scope__pkg@1.2.3.png`), prereleases with dots and dashes (`1.0.0-beta.2`), and that `signalk-foo` doesn't match a stored `signalk-foo-extra@1.0.0.svg`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes app store icon caching version-aware. Cached icons are re-downloaded when the plugin version changes.

- `StoredIcon` includes the parsed icon version.
- Cache lookups extract versions from icon filenames.
- Download checks compare cached and requested versions at both call sites.
- Older icons are removed during replacement.
- Tests cover scoped packages, prerelease versions, package-prefix mismatches, SVG content types, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->