### PR TITLE
chore: Bundle Skip instead of KIP as the default instrument webapp

### DIFF
--- a/docker/Dockerfile_rel
+++ b/docker/Dockerfile_rel
@@ -38,8 +38,9 @@ RUN printf 'allow-scripts[]=@canboat/canboatjs\n' > /home/node/signalk/.npmrc
 # Install locally (not globally) to avoid permission issues, then relocate
 # nested packages to where webapp/plugin discovery expects them. The @signalk
 # packages are required in both editions, so that relocation always runs. The
-# @mxtommy/kip relocation is guarded on presence, so it is skipped automatically
-# in core, where kip is not installed.
+# @halos-org relocation moves the whole scope, since Skip's own dependencies
+# hoist alongside it, and is guarded on presence so it is skipped
+# automatically in core, where Skip is not installed.
 RUN case "$EDITION" in \
       full) npm_flags="" ;; \
       core) npm_flags="--omit=optional" ;; \
@@ -54,10 +55,10 @@ RUN case "$EDITION" in \
   && mkdir -p node_modules/signalk-server/node_modules/@signalk/ \
   && cp -rf node_modules/@signalk/* node_modules/signalk-server/node_modules/@signalk/ \
   && rm -rf node_modules/@signalk/ \
-  && if [ -d node_modules/@mxtommy/kip ]; then \
-       mkdir -p node_modules/signalk-server/node_modules/@mxtommy/ \
-       && cp -rf node_modules/@mxtommy/kip node_modules/signalk-server/node_modules/@mxtommy/ \
-       && rm -rf node_modules/@mxtommy/; \
+  && if [ -d node_modules/@halos-org ]; then \
+       mkdir -p node_modules/signalk-server/node_modules/@halos-org/ \
+       && cp -rf node_modules/@halos-org/* node_modules/signalk-server/node_modules/@halos-org/ \
+       && rm -rf node_modules/@halos-org/; \
      fi \
   && can_socket=$(find node_modules -path '*/@canboat/canboatjs/build/Release/canSocket.node' -print -quit) \
   && if [ -z "$can_socket" ]; then \

--- a/docker/README.md
+++ b/docker/README.md
@@ -116,7 +116,7 @@ The core `-core` suffix is appended after the full variant's tag, so core mirror
 
 The core image omits these packages — all declared in `package.json` `optionalDependencies` and discovered at runtime from `/home/node/.signalk`, so they can be reinstalled on demand (see below):
 
-- Webapps: `@signalk/freeboard-sk`, `@signalk/instrumentpanel`, `@mxtommy/kip`, `@signalk/app-dock`
+- Webapps: `@signalk/freeboard-sk`, `@signalk/instrumentpanel`, `@halos-org/skip`, `@signalk/app-dock`
 - Plugins and bridges: `@signalk/set-system-time`, `@signalk/signalk-to-nmea0183`, `@signalk/udp-nmea-plugin`, `signalk-n2kais-to-nmea0183`, `signalk-to-nmea2000`
 
 What the core image ships: the Signal K server, the admin UI (`@signalk/server-admin-ui`) and its app store, serial-port support (`serialport`), `@signalk/server-api`, `@signalk/streams`, `@signalk/signalk-schema`, `@signalk/course-provider`, `@signalk/resources-provider`, and the NMEA0183 / NMEA2000 parser libraries (`@signalk/nmea0183-signalk`, `@signalk/n2k-signalk`).

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "ws": "^8.17.0"
   },
   "optionalDependencies": {
-    "@mxtommy/kip": "^4.8.0",
+    "@halos-org/skip": "^1.3.0",
     "@signalk/app-dock": "^1.1.0",
     "@signalk/freeboard-sk": "^2.24.0",
     "@signalk/instrumentpanel": "0.x",

--- a/test/modules.js
+++ b/test/modules.js
@@ -19,7 +19,7 @@ describe('modulesWithKeyword', () => {
       '@signalk/instrumentpanel',
       '@signalk/freeboard-sk',
       '@signalk/server-admin-ui',
-      '@mxtommy/kip'
+      '@halos-org/skip'
     ]
     const updateInstalledModule = '@signalk/instrumentpanel'
 


### PR DESCRIPTION
## Motivation

KIP (`@mxtommy/kip`) is no longer actively maintained. Its successor is Skip (`@halos-org/skip`), published by Hat Labs — a continuation of the same project, with KIP's author among its contributors and the same description and feature scope.

New installations and full Docker images should ship the maintained webapp.

## Approach

Swap `@mxtommy/kip` for `@halos-org/skip` in `optionalDependencies`, and update the Docker core-image documentation and the bundled-webapp test fixture to match.

`Dockerfile_rel` relocates scoped packages into `node_modules/signalk-server/node_modules/` so webapp discovery finds them. The `@halos-org` relocation moves the **whole scope** rather than just the Skip directory: Skip depends on `@halos-org/skip-freeboard-panel`, which npm hoists alongside it, so copying only `skip` and then `rm -rf`-ing the scope would delete the sibling package. This mirrors how the `@signalk` scope is already handled.

`src/categories.ts` intentionally gets no entry for Skip. `DEFAULT_MODULE_CAT_KEYWORDS` is consulted only as a fallback for packages that declare no recognised category keywords; Skip declares `signalk-category-instruments`, `-notifications` and `-ais`, so `getCategories()` already resolves to Instruments / Notifications / AIS and an entry would be unreachable.

KIP keeps its existing `categories.ts` entry so it stays categorised, findable and reinstallable from the app store for users who already run it. Existing installations are unaffected — this changes only what ships by default.

## Tested

- `npm run build` — clean
- `npm run ci-lint` (eslint + prettier) — clean
- `test/modules.js` — 28 passing, including the `modulesWithKeyword` fixture that now expects Skip
- `test/appstore/**` — 131 passing
- Verified `@halos-org/skip@1.3.0` installs and carries the `signalk-webapp` keyword required for discovery
- Verified `getCategories()` on the installed Skip package returns `['Instruments', 'Notifications', 'AIS']` without a `categories.ts` entry
- Shell syntax of the modified `RUN` block checked with `bash -n`; the scope relocation simulated against a fixture containing both `skip` and `skip-freeboard-panel` to confirm the sibling survives

The Docker images themselves were not built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR replaces the bundled KIP webapp with Skip.

- Replaces `@mxtommy/kip` with `@halos-org/skip`.
- Updates Docker documentation and test fixtures.
- Relocates the `@halos-org` scope in `Dockerfile_rel` to preserve Skip dependencies.
- Keeps KIP’s category entry for existing installations.
- Omits a separate Skip category because Skip declares its own keywords.
- Passes build, lint, module, app-store, installation, and category discovery checks.
- Does not build Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->