### PR TITLE
fix(admin-ui): make truncated plugin list evident

### DIFF
--- a/packages/server-admin-ui/scss/_custom.scss
+++ b/packages/server-admin-ui/scss/_custom.scss
@@ -276,8 +276,14 @@ form.rjsf {
 }
 
 // Plugin config: scrollable list and connected panels on desktop
+$plugin-list-min-height: 20rem;
+
 @media (min-width: 1200px) {
   .plugin-list-container {
+    // max-height is viewport-relative but this block is gated on width, so a
+    // wide, short window would otherwise collapse the list to a row or two.
+    // Floor the pane and let the page scroll instead.
+    min-height: $plugin-list-min-height;
     max-height: calc(100vh - 280px);
     overflow-y: auto;
   }

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.test.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { useStore } from '../../store'
+
+// HistoryProviderSettings fetches on mount and is unrelated to the plugin
+// list; stub it so this suite only exercises Configuration itself.
+vi.mock('../ServerConfig/HistoryProviderSettings', () => ({
+  default: () => null
+}))
+
+import Configuration from './Configuration'
+
+function samplePlugin(id: string) {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    packageName: id,
+    description: 'A plugin',
+    schema: {},
+    data: { enabled: true, configuration: {} }
+  }
+}
+
+function mockFetch(plugins: unknown[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(
+            String(url).endsWith('/plugins')
+              ? plugins
+              : { interfaces: { wasm: true } }
+          )
+      } as Response)
+    )
+  )
+}
+
+function renderConfiguration() {
+  ;(window as unknown as { serverRoutesPrefix: string }).serverRoutesPrefix =
+    '/skServer'
+  return render(
+    <MemoryRouter initialEntries={['/apps/configuration/-']}>
+      <Routes>
+        <Route
+          path="/apps/configuration/:pluginid"
+          element={<Configuration />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+let originalServerRoutesPrefix: string | undefined
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  localStorage.clear()
+  originalServerRoutesPrefix = (
+    window as unknown as { serverRoutesPrefix?: string }
+  ).serverRoutesPrefix
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  // The store is a module singleton -- reset it so plugin state cannot leak
+  // into unrelated suites sharing the worker.
+  act(() => {
+    useStore.getState().setPlugins([])
+  })
+  ;(window as unknown as { serverRoutesPrefix?: string }).serverRoutesPrefix =
+    originalServerRoutesPrefix
+})
+
+describe('Configuration plugin list', () => {
+  it('clears the list and count when the last plugin is removed', async () => {
+    mockFetch([samplePlugin('signalk-example')])
+    renderConfiguration()
+
+    expect(await screen.findByText('1 plugin')).toBeDefined()
+    expect(screen.getByText('Plugin signalk-example')).toBeDefined()
+
+    // A PLUGINS_CHANGED update after uninstalling the only plugin.
+    act(() => {
+      useStore.getState().setPlugins([])
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('No plugins installed')).toBeDefined()
+    })
+    expect(screen.queryByText('Plugin signalk-example')).toBeNull()
+  })
+
+  it('does not claim an empty install before the initial load resolves', () => {
+    mockFetch([samplePlugin('signalk-example')])
+    renderConfiguration()
+
+    expect(screen.queryByText('No plugins installed')).toBeNull()
+  })
+})

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.tsx
@@ -27,6 +27,7 @@ import { faCircleInfo } from '@fortawesome/free-solid-svg-icons/faCircleInfo'
 import EmbeddedPluginConfigurationForm from './EmbeddedPluginConfigurationForm'
 import HistoryProviderSettings from '../ServerConfig/HistoryProviderSettings'
 import { useStore } from '../../store'
+import { pluginCountLabel } from './pluginCountLabel'
 
 interface PluginSchema {
   properties?: Record<string, unknown>
@@ -67,6 +68,9 @@ export default function PluginConfigurationList() {
   const params = useParams<{ pluginid?: string }>()
 
   const [plugins, setPlugins] = useState<Plugin[]>([])
+  // An empty list means "no plugins installed" only once a load has succeeded;
+  // before that it is indistinguishable from a pending or failed request.
+  const [pluginsLoaded, setPluginsLoaded] = useState(false)
   const [search, setSearch] = useState(
     () => localStorage.getItem(searchStorageKey) || ''
   )
@@ -310,6 +314,7 @@ export default function PluginConfigurationList() {
         }
 
         setPlugins(fetchedPlugins)
+        setPluginsLoaded(true)
         useStore.getState().setPlugins(fetchedPlugins)
         setSelectedPlugin(initialSelectedPlugin)
         setWasmEnabled(wasmInterfaceEnabled)
@@ -333,19 +338,22 @@ export default function PluginConfigurationList() {
     const unsubscribe = useStore.subscribe(
       (state) => state.plugins,
       (storePlugins) => {
-        if (storePlugins.length > 0) {
-          setPlugins(storePlugins as Plugin[])
-          setSelectedPlugin((prev) => {
-            if (!prev) return null
-            return (
-              (storePlugins.find((p) => p.id === prev.id) as Plugin) || null
-            )
-          })
+        // Before the initial load an empty store just means "not loaded yet".
+        // Afterwards it means the last plugin was removed, which must clear
+        // the list rather than leave the removed plugin on screen.
+        if (storePlugins.length === 0 && !pluginsLoaded) {
+          return
         }
+        setPlugins(storePlugins as Plugin[])
+        setPluginsLoaded(true)
+        setSelectedPlugin((prev) => {
+          if (!prev) return null
+          return (storePlugins.find((p) => p.id === prev.id) as Plugin) || null
+        })
       }
     )
     return unsubscribe
-  }, [])
+  }, [pluginsLoaded])
 
   const pluginList = getFilteredPlugins()
   const selectedPluginId = selectedPlugin ? selectedPlugin.id : null
@@ -395,6 +403,16 @@ export default function PluginConfigurationList() {
                   </Form.Select>
                 </Form.Group>
               </Form>
+
+              <div
+                className="text-body-secondary small mb-1"
+                id="pluginCount"
+                role="status"
+              >
+                {pluginsLoaded
+                  ? pluginCountLabel(pluginList.length, plugins.length)
+                  : ''}
+              </div>
 
               <div
                 ref={tableContainerRef}

--- a/packages/server-admin-ui/src/views/Configuration/pluginCountLabel.test.ts
+++ b/packages/server-admin-ui/src/views/Configuration/pluginCountLabel.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { pluginCountLabel } from './pluginCountLabel'
+
+describe('pluginCountLabel', () => {
+  it('reports the total when nothing is filtered out', () => {
+    expect(pluginCountLabel(77, 77)).toBe('77 plugins')
+  })
+
+  it('reports both counts when a filter hides some plugins', () => {
+    expect(pluginCountLabel(3, 77)).toBe('Showing 3 of 77 plugins')
+  })
+
+  it('reports both counts when a filter matches nothing', () => {
+    expect(pluginCountLabel(0, 77)).toBe('Showing 0 of 77 plugins')
+  })
+
+  it('singularises a single installed plugin', () => {
+    expect(pluginCountLabel(1, 1)).toBe('1 plugin')
+  })
+
+  it('singularises a single installed plugin hidden by a filter', () => {
+    expect(pluginCountLabel(0, 1)).toBe('Showing 0 of 1 plugin')
+  })
+
+  it('describes an empty install without counts', () => {
+    expect(pluginCountLabel(0, 0)).toBe('No plugins installed')
+  })
+})

--- a/packages/server-admin-ui/src/views/Configuration/pluginCountLabel.ts
+++ b/packages/server-admin-ui/src/views/Configuration/pluginCountLabel.ts
@@ -1,0 +1,15 @@
+/**
+ * The plugin list is a scroll pane with a sticky header, so a filtered or
+ * clipped view is easy to mistake for the complete list. Stating both counts
+ * makes a partial view self-evident.
+ */
+export function pluginCountLabel(shown: number, total: number): string {
+  if (total === 0) {
+    return 'No plugins installed'
+  }
+  const noun = `plugin${total === 1 ? '' : 's'}`
+  if (shown === total) {
+    return `${total} ${noun}`
+  }
+  return `Showing ${shown} of ${total} ${noun}`
+}


### PR DESCRIPTION
Fixes #2933.

## Motivation

`.plugin-list-container` takes `max-height: calc(100vh - 280px)` inside a `@media (min-width: 1200px)` block. The constraint is on **height** but gated on **width**, and there is no floor. On a viewport that is wide enough to trigger the rule but short, the pane collapses toward zero while the sticky header and hairline scrollbar still read as a complete table.

With 77 plugins installed at 1366×430 the pane renders three rows, search empty and filter on "All Plugins". It looks like the server has lost its plugins — `GET /skServer/plugins` returns all 77 correctly the whole time.

Measured rows visible without scrolling, width 1366, height varied:

| viewport height | before | after |
|---|---|---|
| 1000 | 22 | 22 |
| 768 | 15 | 15 |
| 620 | 10 | 10 |
| 500 | 6 | 10 |
| 430 | 3 | 10 |

## Approach

Two changes, both aimed at the same failure — a partial view that does not announce itself.

1. **Floor the pane.** `min-height: 20rem` via a named variable. `min-height` wins over `max-height` per spec, so on a short viewport the pane settles at 20rem and the page scrolls instead of the list vanishing. Verified in Chromium: `clientHeight` is 320px rather than 148px at 1366×430.

2. **State the counts.** A line above the list reads `77 plugins` when nothing is hidden and `Showing 3 of 77 plugins` when the viewport or a filter hides some. This covers the search and status filters too, which have the same "did my plugins disappear?" failure mode because both persist in `localStorage` across reloads.

The label is a pure helper (`pluginCountLabel`) so it can be tested without mounting the view.

## Checks

- `npx prettier --check` on the touched paths — clean
- `npm test` in `packages/server-admin-ui` — 385 passed (32 files), including 5 new tests for `pluginCountLabel`
- `npm run build` — succeeds; compiled CSS confirms `min-height:20rem`
- `npx eslint` on the touched files — 0 errors

No version numbers changed.

Happy to split this into two PRs if you would rather take the CSS floor and the count separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR:

- Prevents the plugin list from collapsing by adding a `20rem` minimum height.
- Displays plugin counts for total and filtered results.
- Hides counts until plugin loading succeeds.
- Marks the count as a status region for assistive technology.
- Clears the list and count when all plugins are removed.
- Adds unit and view tests for count labels and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->