### PR TITLE
fix(radar-api): keep compound control fields on a control PUT

### DIFF
--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -20,6 +20,31 @@ const RADAR_API_PATH = `/signalk/v2/api/vessels/self/radars`
 export const RADAR_API_VERSION = '3.4.0'
 const TWO_PI = 2 * Math.PI
 
+/**
+ * Unwrap the Signal K `{ value }` PUT envelope from a control payload.
+ *
+ * Signal K PUTs carry their payload as `{ "value": x }`, so a scalar control
+ * arrives wrapped. Radar controls are the one place where that convention
+ * collides with the data: a compound control's payload has its own `value`
+ * field alongside siblings — a guard zone's `value` is its start bearing (see
+ * "Setting a Control Value" in radar_api.md).
+ *
+ * So `value` is only an envelope when it is the *sole* key. Anything else is
+ * the payload itself and must be passed through whole. Unwrapping on the mere
+ * presence of `value` silently discarded every sibling field, which meant a
+ * zone or sector PUT set the bearing and dropped `enabled`, `endValue`,
+ * `startDistance` and `endDistance` — and still answered 200.
+ */
+export function unwrapControlPayload(body: unknown): unknown {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return body
+  }
+  const keys = Object.keys(body)
+  return keys.length === 1 && keys[0] === 'value'
+    ? (body as Record<string, unknown>).value
+    : body
+}
+
 interface RadarApplication
   extends WithSecurityStrategy, SignalKMessageHub, IRouter {}
 
@@ -801,7 +826,7 @@ export class RadarApi {
             })
             return
           }
-          const value = req.body.value !== undefined ? req.body.value : req.body
+          const value = unwrapControlPayload(req.body)
           const result = await provider.setControl(
             req.params.id,
             req.params.controlId,

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -77,6 +77,14 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
   const RADAR = 'radar-0'
   const base = `/signalk/v2/api/vessels/self/radars/${RADAR}/controls`
 
+  // A failed assertion skips any cleanup at the end of a test body, and a
+  // still-listening server keeps the mocha process alive. Close them here
+  // instead, so a failure reports as a failure rather than as a hang.
+  const started: Array<() => Promise<void>> = []
+  afterEach(async () => {
+    while (started.length) await started.pop()!()
+  })
+
   async function startRadarApi(
     onSetControl: (radarId: string, controlId: string, value: unknown) => void
   ) {
@@ -113,20 +121,22 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
     const server = app.listen(0)
     await new Promise((resolve) => server.once('listening', resolve))
     const { port } = server.address() as AddressInfo
+    started.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve()))
+    )
     return {
       put: (path: string, body: unknown) =>
         fetch(`http://127.0.0.1:${port}${path}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
-        }),
-      stop: () => new Promise((resolve) => server.close(resolve))
+        })
     }
   }
 
   it('hands the provider every field of a guard zone body', async () => {
     const seen: Array<[string, string, unknown]> = []
-    const { put, stop } = await startRadarApi((...args) => seen.push(args))
+    const { put } = await startRadarApi((...args) => seen.push(args))
 
     const zone = {
       enabled: true,
@@ -139,17 +149,15 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
 
     expect(res.status).to.equal(200)
     expect(seen).to.deep.equal([[RADAR, 'guardZone1', zone]])
-    await stop()
   })
 
   it('still unwraps a bare envelope for a scalar control', async () => {
     const seen: Array<[string, string, unknown]> = []
-    const { put, stop } = await startRadarApi((...args) => seen.push(args))
+    const { put } = await startRadarApi((...args) => seen.push(args))
 
     const res = await put(`${base}/range`, { value: 1852 })
 
     expect(res.status).to.equal(200)
     expect(seen).to.deep.equal([[RADAR, 'range', 1852]])
-    await stop()
   })
 })

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
 import express from 'express'
+import type { AddressInfo } from 'node:net'
+import type { radar } from '@signalk/server-api'
 import { RadarApi, unwrapControlPayload } from '../../src/api/radar'
 
 // Every shape in the "Setting a Control Value" section of radar_api.md.
@@ -78,11 +80,15 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
   async function startRadarApi(
     onSetControl: (radarId: string, controlId: string, value: unknown) => void
   ) {
-    const app: any = express()
+    const app = express() as unknown as express.Express & {
+      securityStrategy: { shouldAllowPut: () => boolean }
+    }
     app.use(express.json())
     app.securityStrategy = { shouldAllowPut: () => true }
 
-    const api = new RadarApi(app)
+    const api = new RadarApi(
+      app as unknown as ConstructorParameters<typeof RadarApi>[0]
+    )
     await api.start()
     api.register('test-provider', {
       name: 'Test Radar Provider',
@@ -102,11 +108,11 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
           return { success: true }
         }
       }
-    } as any)
+    } as unknown as radar.RadarProvider)
 
     const server = app.listen(0)
     await new Promise((resolve) => server.once('listening', resolve))
-    const { port } = server.address()
+    const { port } = server.address() as AddressInfo
     return {
       put: (path: string, body: unknown) =>
         fetch(`http://127.0.0.1:${port}${path}`, {

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
-import { unwrapControlPayload } from '../../src/api/radar'
+import express from 'express'
+import { RadarApi, unwrapControlPayload } from '../../src/api/radar'
 
 // Every shape in the "Setting a Control Value" section of radar_api.md.
 //
@@ -64,5 +65,85 @@ describe('Radar API: control PUT payload', () => {
     expect(unwrapControlPayload(75)).to.equal(75)
     expect(unwrapControlPayload(null)).to.equal(null)
     expect(unwrapControlPayload(undefined)).to.equal(undefined)
+  })
+})
+
+// Route-level coverage: the unit tests above prove the helper, this proves the
+// PUT handler actually uses it and hands the provider every field.
+
+describe('Radar API: PUT /controls/{controlId} route', () => {
+  const RADAR = 'radar-0'
+  const base = `/signalk/v2/api/vessels/self/radars/${RADAR}/controls`
+
+  async function startRadarApi(
+    onSetControl: (radarId: string, controlId: string, value: unknown) => void
+  ) {
+    const app: any = express()
+    app.use(express.json())
+    app.securityStrategy = { shouldAllowPut: () => true }
+
+    const api = new RadarApi(app)
+    await api.start()
+    api.register('test-provider', {
+      name: 'Test Radar Provider',
+      methods: {
+        getRadars: async () => [RADAR],
+        getRadarInfo: async () => ({
+          name: 'Test',
+          brand: 'Test',
+          radarIpAddress: '10.0.0.1'
+        }),
+        setControl: async (
+          radarId: string,
+          controlId: string,
+          value: unknown
+        ) => {
+          onSetControl(radarId, controlId, value)
+          return { success: true }
+        }
+      }
+    } as any)
+
+    const server = app.listen(0)
+    await new Promise((resolve) => server.once('listening', resolve))
+    const { port } = server.address()
+    return {
+      put: (path: string, body: unknown) =>
+        fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        }),
+      stop: () => new Promise((resolve) => server.close(resolve))
+    }
+  }
+
+  it('hands the provider every field of a guard zone body', async () => {
+    const seen: Array<[string, string, unknown]> = []
+    const { put, stop } = await startRadarApi((...args) => seen.push(args))
+
+    const zone = {
+      enabled: true,
+      value: -0.5585,
+      endValue: 1.7104,
+      startDistance: 100.0,
+      endDistance: 500.0
+    }
+    const res = await put(`${base}/guardZone1`, zone)
+
+    expect(res.status).to.equal(200)
+    expect(seen).to.deep.equal([[RADAR, 'guardZone1', zone]])
+    await stop()
+  })
+
+  it('still unwraps a bare envelope for a scalar control', async () => {
+    const seen: Array<[string, string, unknown]> = []
+    const { put, stop } = await startRadarApi((...args) => seen.push(args))
+
+    const res = await put(`${base}/range`, { value: 1852 })
+
+    expect(res.status).to.equal(200)
+    expect(seen).to.deep.equal([[RADAR, 'range', 1852]])
+    await stop()
   })
 })

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai'
+import { unwrapControlPayload } from '../../src/api/radar'
+
+// Every shape in the "Setting a Control Value" section of radar_api.md.
+//
+// A Signal K PUT carries its payload as `{ "value": x }`, but a compound radar
+// control has its own `value` field alongside siblings — a zone's `value` is
+// its start bearing. Unwrapping whenever `value` is present therefore threw
+// away `enabled`, `endValue`, `startDistance` and `endDistance` on every zone
+// and sector PUT, while still answering 200.
+
+describe('Radar API: control PUT payload', () => {
+  it('unwraps the envelope for a simple numeric control', () => {
+    expect(unwrapControlPayload({ value: 75 })).to.equal(75)
+  })
+
+  it('keeps siblings when a control carries auto alongside value', () => {
+    const body = { auto: false, value: 75 }
+    expect(unwrapControlPayload(body)).to.deep.equal(body)
+  })
+
+  it('passes an auto-only payload through', () => {
+    const body = { auto: true }
+    expect(unwrapControlPayload(body)).to.deep.equal(body)
+  })
+
+  it('passes an auto adjustment payload through', () => {
+    const body = { auto: true, autoValue: -20 }
+    expect(unwrapControlPayload(body)).to.deep.equal(body)
+  })
+
+  it('keeps every field of a sector control', () => {
+    const body = { enabled: true, value: -1.5533, endValue: -1.2217 }
+    expect(unwrapControlPayload(body)).to.deep.equal(body)
+  })
+
+  it('keeps every field of a zone control', () => {
+    const body = {
+      enabled: true,
+      value: -0.5585,
+      endValue: 1.7104,
+      startDistance: 100.0,
+      endDistance: 500.0
+    }
+    expect(unwrapControlPayload(body)).to.deep.equal(body)
+  })
+
+  it('passes an empty button payload through', () => {
+    expect(unwrapControlPayload({})).to.deep.equal({})
+  })
+
+  it('does not unwrap a value that is itself the whole payload', () => {
+    // A single `value` key is the envelope even when its content is an object,
+    // which is how a compound payload may be sent explicitly wrapped.
+    expect(
+      unwrapControlPayload({ value: { auto: true, value: 50 } })
+    ).to.deep.equal({
+      auto: true,
+      value: 50
+    })
+  })
+
+  it('leaves non-object bodies alone', () => {
+    expect(unwrapControlPayload(75)).to.equal(75)
+    expect(unwrapControlPayload(null)).to.equal(null)
+    expect(unwrapControlPayload(undefined)).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
## Summary

`PUT /radars/{id}/controls/{controlId}` unwrapped the Signal K `{ value }` envelope whenever a `value` key was present, discarding every sibling field:

```ts
const value = req.body.value !== undefined ? req.body.value : req.body
```

Radar controls are the one place where that convention collides with the data. A compound control carries its own `value` field alongside siblings — a guard zone’s `value` is its start bearing. So the zone body that `radar_api.md` documents under "Setting a Control Value",

```json
{ "enabled": true, "value": -0.5585, "endValue": 1.7104,
  "startDistance": 100.0, "endDistance": 500.0 }
```

reached the provider as just `-0.5585`. `enabled`, `endValue`, `startDistance` and `endDistance` never left the server, so enabling a guard zone did nothing and no zone was drawn — and the request still answered `200`, so the client had no way to know. Sector controls fail identically, as does any control sending `auto` alongside `value`.

The implementation contradicts its own spec here: of the seven payload shapes documented in that section, three do not survive the round trip.

Treat `value` as an envelope only when it is the **sole** key; anything else is the payload itself. Extracted as `unwrapControlPayload` so it can be unit-tested.

Scope note: the same idiom appears at the bulk `PUT /radars/{id}` and the ARPA settings PUT, but neither is affected — their payloads have no top-level `value`, so the whole body already passes through. Left alone deliberately.

## Tested

- New `test/api/radar-control-put.test.ts`, one case per documented payload shape (simple numeric, auto-only, auto+value, auto+autoValue, sector, zone, empty button) plus non-object bodies. 9 passing. Against the previous logic three of these fail.
- End to end against mayara-server 3.8.1 with a Navico HALO24 dual-range: a zone PUT carrying all five fields previously changed only the bearing and left `enabled`, `endValue`, `startDistance` and `endDistance` at their prior values while returning `{"success":true}`. Writing the same body directly to the provider applied all five, confirming the loss was in this handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes `PUT /radars/{id}/controls/{controlId}` payload handling.
- Preserves compound control fields when `value` appears with other fields.
- Adds `unwrapControlPayload` to unwrap only single-key `{ value }` payloads.
- Adds tests for documented payload shapes and non-object bodies.
- Confirms guard-zone fields reach the provider with Navico HALO24 end-to-end testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->