### PR TITLE
fix(radar-api): route the shortcut control endpoints through setControl

### DIFF
--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -434,7 +434,7 @@ export class RadarApi {
             })
             return
           }
-          const { success } = await applyControl(
+          const { success, error } = await applyControl(
             provider,
             req.params.id,
             'power',
@@ -448,7 +448,7 @@ export class RadarApi {
             res.status(400).json({
               statusCode: 400,
               state: 'FAILED',
-              message: 'Failed to set radar power state'
+              message: error ?? 'Failed to set radar power state'
             })
           }
         } catch (err: any) {
@@ -493,7 +493,7 @@ export class RadarApi {
             })
             return
           }
-          const { success } = await applyControl(
+          const { success, error } = await applyControl(
             provider,
             req.params.id,
             'range',
@@ -507,7 +507,7 @@ export class RadarApi {
             res.status(400).json({
               statusCode: 400,
               state: 'FAILED',
-              message: 'Failed to set radar range'
+              message: error ?? 'Failed to set radar range'
             })
           }
         } catch (err: any) {
@@ -553,7 +553,7 @@ export class RadarApi {
             })
             return
           }
-          const { success } = await applyControl(
+          const { success, error } = await applyControl(
             provider,
             req.params.id,
             'gain',
@@ -566,7 +566,7 @@ export class RadarApi {
             res.status(400).json({
               statusCode: 400,
               state: 'FAILED',
-              message: 'Failed to set radar gain'
+              message: error ?? 'Failed to set radar gain'
             })
           }
         } catch (err: any) {
@@ -612,7 +612,7 @@ export class RadarApi {
             })
             return
           }
-          const { success } = await applyControl(
+          const { success, error } = await applyControl(
             provider,
             req.params.id,
             'sea',
@@ -625,7 +625,7 @@ export class RadarApi {
             res.status(400).json({
               statusCode: 400,
               state: 'FAILED',
-              message: 'Failed to set radar sea clutter'
+              message: error ?? 'Failed to set radar sea clutter'
             })
           }
         } catch (err: any) {
@@ -671,7 +671,7 @@ export class RadarApi {
             })
             return
           }
-          const { success } = await applyControl(
+          const { success, error } = await applyControl(
             provider,
             req.params.id,
             'rain',
@@ -684,7 +684,7 @@ export class RadarApi {
             res.status(400).json({
               statusCode: 400,
               state: 'FAILED',
-              message: 'Failed to set radar rain clutter'
+              message: error ?? 'Failed to set radar rain clutter'
             })
           }
         } catch (err: any) {

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -45,6 +45,42 @@ export function unwrapControlPayload(body: unknown): unknown {
     : body
 }
 
+/**
+ * Apply one control, preferring the generic `setControl` path.
+ *
+ * The `/power`, `/range`, `/gain`, `/sea` and `/rain` routes predate
+ * `/controls/{controlId}` and each called its own typed provider method.
+ * Those methods bypass the control abstraction the rest of the API is built
+ * on, so a provider has to implement the same control twice and the two
+ * paths drift: against mayara-server, `/range` and `/power` worked (their
+ * payload is a scalar and survives the detour) while `/gain`, `/sea` and
+ * `/rain` returned 400, because the typed methods reshape `{ auto, value }`
+ * into something the provider's own control endpoint does not accept.
+ *
+ * Routing them through `setControl` with the control id makes the shortcut
+ * routes exactly equivalent to the documented generic route. `setControl` is
+ * optional, so the typed method stays as a fallback for providers that only
+ * implement it.
+ */
+export async function applyControl(
+  provider: radar.RadarProviderMethods,
+  radarId: string,
+  controlId: string,
+  payload: unknown,
+  legacy?: () => Promise<boolean>
+): Promise<{ success: boolean; error?: string }> {
+  if (provider.setControl) {
+    return provider.setControl(radarId, controlId, payload)
+  }
+  if (legacy) {
+    return { success: await legacy() }
+  }
+  return {
+    success: false,
+    error: `Provider supports neither setControl nor a ${controlId} method`
+  }
+}
+
 interface RadarApplication
   extends WithSecurityStrategy, SignalKMessageHub, IRouter {}
 
@@ -380,7 +416,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
             return
           }
-          if (!provider.setPower) {
+          if (!provider.setControl && !provider.setPower) {
             res.status(501).json({
               statusCode: 501,
               state: 'FAILED',
@@ -398,7 +434,14 @@ export class RadarApi {
             })
             return
           }
-          const success = await provider.setPower(req.params.id, state)
+          const { success } = await applyControl(
+            provider,
+            req.params.id,
+            'power',
+            state,
+            provider.setPower &&
+              (() => provider.setPower!(req.params.id, state))
+          )
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
@@ -433,7 +476,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
             return
           }
-          if (!provider.setRange) {
+          if (!provider.setControl && !provider.setRange) {
             res.status(501).json({
               statusCode: 501,
               state: 'FAILED',
@@ -450,7 +493,14 @@ export class RadarApi {
             })
             return
           }
-          const success = await provider.setRange(req.params.id, range)
+          const { success } = await applyControl(
+            provider,
+            req.params.id,
+            'range',
+            range,
+            provider.setRange &&
+              (() => provider.setRange!(req.params.id, range))
+          )
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
@@ -485,7 +535,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
             return
           }
-          if (!provider.setGain) {
+          if (!provider.setControl && !provider.setGain) {
             res.status(501).json({
               statusCode: 501,
               state: 'FAILED',
@@ -503,7 +553,13 @@ export class RadarApi {
             })
             return
           }
-          const success = await provider.setGain(req.params.id, gain)
+          const { success } = await applyControl(
+            provider,
+            req.params.id,
+            'gain',
+            gain,
+            provider.setGain && (() => provider.setGain!(req.params.id, gain))
+          )
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
@@ -538,7 +594,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
             return
           }
-          if (!provider.setSea) {
+          if (!provider.setControl && !provider.setSea) {
             res.status(501).json({
               statusCode: 501,
               state: 'FAILED',
@@ -556,7 +612,13 @@ export class RadarApi {
             })
             return
           }
-          const success = await provider.setSea(req.params.id, sea)
+          const { success } = await applyControl(
+            provider,
+            req.params.id,
+            'sea',
+            sea,
+            provider.setSea && (() => provider.setSea!(req.params.id, sea))
+          )
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
@@ -591,7 +653,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
             return
           }
-          if (!provider.setRain) {
+          if (!provider.setControl && !provider.setRain) {
             res.status(501).json({
               statusCode: 501,
               state: 'FAILED',
@@ -609,7 +671,13 @@ export class RadarApi {
             })
             return
           }
-          const success = await provider.setRain(req.params.id, rain)
+          const { success } = await applyControl(
+            provider,
+            req.params.id,
+            'rain',
+            rain,
+            provider.setRain && (() => provider.setRain!(req.params.id, rain))
+          )
           if (success) {
             res.status(200).json(Responses.ok)
           } else {

--- a/test/api/radar-shortcut-routes.test.ts
+++ b/test/api/radar-shortcut-routes.test.ts
@@ -11,14 +11,28 @@ import type { radar } from '@signalk/server-api'
 // /power worked, purely because a scalar survives the detour and { auto, value }
 // does not. These routes now go through setControl with the control id.
 
+const RADAR_ID = 'radar-0'
+
+/**
+ * A RadarProviderMethods carrying only the two members the interface requires,
+ * plus whatever the test under discussion needs. Object.assign rather than a
+ * spread so the required members stay non-optional and no cast is needed.
+ */
 function methods(
-  overrides: Partial<radar.RadarProviderMethods>
+  overrides: Partial<radar.RadarProviderMethods> = {}
 ): radar.RadarProviderMethods {
-  return {
-    getRadars: async () => ['radar-0'],
-    getRadarInfo: async () => null,
-    ...overrides
-  } as radar.RadarProviderMethods
+  const base: radar.RadarProviderMethods = {
+    getRadars: async () => [RADAR_ID],
+    getRadarInfo: async () => null
+  }
+  return Object.assign(base, overrides)
+}
+
+/** The provider wrapper, built from a real RadarProviderMethods. */
+function provider(
+  overrides: Partial<radar.RadarProviderMethods> = {}
+): radar.RadarProvider {
+  return { name: 'Test Radar Provider', methods: methods(overrides) }
 }
 
 /** One nautical mile in metres — a range every marine radar supports. */
@@ -35,10 +49,10 @@ describe('Radar API: shortcut control routes', () => {
     })
 
     const payload = { auto: false, value: 75 }
-    const result = await applyControl(provider, 'radar-0', 'gain', payload)
+    const result = await applyControl(provider, RADAR_ID, 'gain', payload)
 
     expect(result.success).to.equal(true)
-    expect(seen).to.deep.equal([['radar-0', 'gain', payload]])
+    expect(seen).to.deep.equal([[RADAR_ID, 'gain', payload]])
   })
 
   it('passes a compound payload through untouched', async () => {
@@ -119,7 +133,7 @@ describe('Radar API: shortcut control routes', () => {
   })
 
   it('fails clearly when the provider supports neither path', async () => {
-    const result = await applyControl(methods({}), 'radar-0', 'gain', {
+    const result = await applyControl(methods({}), RADAR_ID, 'gain', {
       auto: true
     })
     expect(result.success).to.equal(false)
@@ -132,8 +146,7 @@ describe('Radar API: shortcut control routes', () => {
 // the response contract are exercised too.
 
 describe('Radar API: shortcut routes over HTTP', () => {
-  const RADAR = 'radar-0'
-  const root = `/signalk/v2/api/vessels/self/radars/${RADAR}`
+  const root = `/signalk/v2/api/vessels/self/radars/${RADAR_ID}`
 
   // A failed assertion skips any cleanup at the end of a test body, and a
   // still-listening server keeps the mocha process alive. Close them here
@@ -144,28 +157,30 @@ describe('Radar API: shortcut routes over HTTP', () => {
   })
 
   async function startRadarApi(overrides: Partial<radar.RadarProviderMethods>) {
-    const app = express() as unknown as express.Express & {
-      securityStrategy: { shouldAllowPut: () => boolean }
-    }
+    const app = Object.assign(express(), {
+      securityStrategy: { shouldAllowPut: () => true }
+    })
     app.use(express.json())
-    app.securityStrategy = { shouldAllowPut: () => true }
 
+    // The one unavoidable seam: RadarApi's application type also extends
+    // SignalKMessageHub, which express cannot satisfy and which the radar
+    // routes never touch — they use only the router methods and
+    // securityStrategy, both of which `app` really does provide.
     const api = new RadarApi(
       app as unknown as ConstructorParameters<typeof RadarApi>[0]
     )
     await api.start()
-    api.register('test-provider', {
-      name: 'Test Radar Provider',
-      methods: {
-        getRadars: async () => [RADAR],
+    api.register(
+      'test-provider',
+      provider({
         getRadarInfo: async () => ({
           name: 'Test',
           brand: 'Test',
           radarIpAddress: '10.0.0.1'
         }),
         ...overrides
-      }
-    } as unknown as radar.RadarProvider)
+      })
+    )
 
     const server = app.listen(0)
     await new Promise((resolve) => server.once('listening', resolve))

--- a/test/api/radar-shortcut-routes.test.ts
+++ b/test/api/radar-shortcut-routes.test.ts
@@ -21,6 +21,9 @@ function methods(
   } as radar.RadarProviderMethods
 }
 
+/** One nautical mile in metres — a range every marine radar supports. */
+const ONE_NM_METRES = 1852
+
 describe('Radar API: shortcut control routes', () => {
   it('routes through setControl with the control id and payload', async () => {
     const seen: Array<[string, string, unknown]> = []
@@ -56,10 +59,16 @@ describe('Radar API: shortcut control routes', () => {
     let usedLegacy = false
     const provider = methods({ setControl: async () => ({ success: true }) })
 
-    await applyControl(provider, 'radar-0', 'range', 1852, async () => {
-      usedLegacy = true
-      return true
-    })
+    await applyControl(
+      provider,
+      'radar-0',
+      'range',
+      ONE_NM_METRES,
+      async () => {
+        usedLegacy = true
+        return true
+      }
+    )
     expect(usedLegacy).to.equal(false)
   })
 
@@ -71,7 +80,7 @@ describe('Radar API: shortcut control routes', () => {
       provider,
       'radar-0',
       'range',
-      1852,
+      ONE_NM_METRES,
       async () => {
         usedLegacy = true
         return true
@@ -87,7 +96,7 @@ describe('Radar API: shortcut control routes', () => {
       provider,
       'radar-0',
       'range',
-      1852,
+      ONE_NM_METRES,
       async () => false
     )
     expect(result.success).to.equal(false)
@@ -97,7 +106,12 @@ describe('Radar API: shortcut control routes', () => {
     const provider = methods({
       setControl: async () => ({ success: false, error: 'range not settable' })
     })
-    const result = await applyControl(provider, 'radar-0', 'range', 1852)
+    const result = await applyControl(
+      provider,
+      'radar-0',
+      'range',
+      ONE_NM_METRES
+    )
     expect(result).to.deep.equal({
       success: false,
       error: 'range not settable'
@@ -120,6 +134,14 @@ describe('Radar API: shortcut control routes', () => {
 describe('Radar API: shortcut routes over HTTP', () => {
   const RADAR = 'radar-0'
   const root = `/signalk/v2/api/vessels/self/radars/${RADAR}`
+
+  // A failed assertion skips any cleanup at the end of a test body, and a
+  // still-listening server keeps the mocha process alive. Close them here
+  // instead, so a failure reports as a failure rather than as a hang.
+  const started: Array<() => Promise<void>> = []
+  afterEach(async () => {
+    while (started.length) await started.pop()!()
+  })
 
   async function startRadarApi(overrides: Partial<radar.RadarProviderMethods>) {
     const app = express() as unknown as express.Express & {
@@ -148,20 +170,22 @@ describe('Radar API: shortcut routes over HTTP', () => {
     const server = app.listen(0)
     await new Promise((resolve) => server.once('listening', resolve))
     const { port } = server.address() as AddressInfo
+    started.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve()))
+    )
     return {
       put: (path: string, body: unknown) =>
         fetch(`http://127.0.0.1:${port}${path}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
-        }),
-      stop: () => new Promise((resolve) => server.close(resolve))
+        })
     }
   }
 
   it('forwards each shortcut to setControl with its control id', async () => {
     const seen: Array<[string, unknown]> = []
-    const { put, stop } = await startRadarApi({
+    const { put } = await startRadarApi({
       setControl: async (_id, controlId, value) => {
         seen.push([controlId, value])
         return { success: true }
@@ -171,7 +195,9 @@ describe('Radar API: shortcut routes over HTTP', () => {
     expect((await put(`${root}/power`, { value: 'transmit' })).status).to.equal(
       200
     )
-    expect((await put(`${root}/range`, { value: 1852 })).status).to.equal(200)
+    expect(
+      (await put(`${root}/range`, { value: ONE_NM_METRES })).status
+    ).to.equal(200)
     expect(
       (await put(`${root}/gain`, { auto: false, value: 75 })).status
     ).to.equal(200)
@@ -184,17 +210,16 @@ describe('Radar API: shortcut routes over HTTP', () => {
 
     expect(seen).to.deep.equal([
       ['power', 'transmit'],
-      ['range', 1852],
+      ['range', ONE_NM_METRES],
       ['gain', { auto: false, value: 75 }],
       ['sea', { auto: true, autoValue: -20 }],
       ['rain', { auto: false, value: 30 }]
     ])
-    await stop()
   })
 
   it('works for a provider that implements only the typed methods', async () => {
     let gain: unknown
-    const { put, stop } = await startRadarApi({
+    const { put } = await startRadarApi({
       setGain: async (_id, value) => {
         gain = value
         return true
@@ -204,18 +229,16 @@ describe('Radar API: shortcut routes over HTTP', () => {
     const res = await put(`${root}/gain`, { auto: false, value: 75 })
     expect(res.status).to.equal(200)
     expect(gain).to.deep.equal({ auto: false, value: 75 })
-    await stop()
   })
 
   it('returns 501 when the provider supports neither path', async () => {
-    const { put, stop } = await startRadarApi({})
+    const { put } = await startRadarApi({})
     const res = await put(`${root}/gain`, { auto: false, value: 75 })
     expect(res.status).to.equal(501)
-    await stop()
   })
 
   it("reports the provider's own error rather than a generic message", async () => {
-    const { put, stop } = await startRadarApi({
+    const { put } = await startRadarApi({
       setControl: async () => ({
         success: false,
         error: 'gain is read-only in auto mode'
@@ -227,12 +250,11 @@ describe('Radar API: shortcut routes over HTTP', () => {
     expect((await res.json()).message).to.equal(
       'gain is read-only in auto mode'
     )
-    await stop()
   })
 
   it('still validates before reaching the provider', async () => {
     let called = false
-    const { put, stop } = await startRadarApi({
+    const { put } = await startRadarApi({
       setControl: async () => {
         called = true
         return { success: true }
@@ -244,6 +266,5 @@ describe('Radar API: shortcut routes over HTTP', () => {
     )
     expect((await put(`${root}/range`, { value: -1 })).status).to.equal(400)
     expect(called).to.equal(false)
-    await stop()
   })
 })

--- a/test/api/radar-shortcut-routes.test.ts
+++ b/test/api/radar-shortcut-routes.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
-import { applyControl } from '../../src/api/radar'
+import express from 'express'
+import type { AddressInfo } from 'node:net'
+import { applyControl, RadarApi } from '../../src/api/radar'
 import type { radar } from '@signalk/server-api'
 
 // The /power, /range, /gain, /sea and /rain routes predate
@@ -108,5 +110,140 @@ describe('Radar API: shortcut control routes', () => {
     })
     expect(result.success).to.equal(false)
     expect(result.error).to.match(/neither setControl nor a gain method/)
+  })
+})
+
+// Route-level coverage. The unit tests above prove the dispatch rule; these
+// drive the five shortcut endpoints themselves, so the capability guards and
+// the response contract are exercised too.
+
+describe('Radar API: shortcut routes over HTTP', () => {
+  const RADAR = 'radar-0'
+  const root = `/signalk/v2/api/vessels/self/radars/${RADAR}`
+
+  async function startRadarApi(overrides: Partial<radar.RadarProviderMethods>) {
+    const app = express() as unknown as express.Express & {
+      securityStrategy: { shouldAllowPut: () => boolean }
+    }
+    app.use(express.json())
+    app.securityStrategy = { shouldAllowPut: () => true }
+
+    const api = new RadarApi(
+      app as unknown as ConstructorParameters<typeof RadarApi>[0]
+    )
+    await api.start()
+    api.register('test-provider', {
+      name: 'Test Radar Provider',
+      methods: {
+        getRadars: async () => [RADAR],
+        getRadarInfo: async () => ({
+          name: 'Test',
+          brand: 'Test',
+          radarIpAddress: '10.0.0.1'
+        }),
+        ...overrides
+      }
+    } as unknown as radar.RadarProvider)
+
+    const server = app.listen(0)
+    await new Promise((resolve) => server.once('listening', resolve))
+    const { port } = server.address() as AddressInfo
+    return {
+      put: (path: string, body: unknown) =>
+        fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        }),
+      stop: () => new Promise((resolve) => server.close(resolve))
+    }
+  }
+
+  it('forwards each shortcut to setControl with its control id', async () => {
+    const seen: Array<[string, unknown]> = []
+    const { put, stop } = await startRadarApi({
+      setControl: async (_id, controlId, value) => {
+        seen.push([controlId, value])
+        return { success: true }
+      }
+    })
+
+    expect((await put(`${root}/power`, { value: 'transmit' })).status).to.equal(
+      200
+    )
+    expect((await put(`${root}/range`, { value: 1852 })).status).to.equal(200)
+    expect(
+      (await put(`${root}/gain`, { auto: false, value: 75 })).status
+    ).to.equal(200)
+    expect(
+      (await put(`${root}/sea`, { auto: true, autoValue: -20 })).status
+    ).to.equal(200)
+    expect(
+      (await put(`${root}/rain`, { auto: false, value: 30 })).status
+    ).to.equal(200)
+
+    expect(seen).to.deep.equal([
+      ['power', 'transmit'],
+      ['range', 1852],
+      ['gain', { auto: false, value: 75 }],
+      ['sea', { auto: true, autoValue: -20 }],
+      ['rain', { auto: false, value: 30 }]
+    ])
+    await stop()
+  })
+
+  it('works for a provider that implements only the typed methods', async () => {
+    let gain: unknown
+    const { put, stop } = await startRadarApi({
+      setGain: async (_id, value) => {
+        gain = value
+        return true
+      }
+    })
+
+    const res = await put(`${root}/gain`, { auto: false, value: 75 })
+    expect(res.status).to.equal(200)
+    expect(gain).to.deep.equal({ auto: false, value: 75 })
+    await stop()
+  })
+
+  it('returns 501 when the provider supports neither path', async () => {
+    const { put, stop } = await startRadarApi({})
+    const res = await put(`${root}/gain`, { auto: false, value: 75 })
+    expect(res.status).to.equal(501)
+    await stop()
+  })
+
+  it("reports the provider's own error rather than a generic message", async () => {
+    const { put, stop } = await startRadarApi({
+      setControl: async () => ({
+        success: false,
+        error: 'gain is read-only in auto mode'
+      })
+    })
+
+    const res = await put(`${root}/gain`, { auto: false, value: 75 })
+    expect(res.status).to.equal(400)
+    expect((await res.json()).message).to.equal(
+      'gain is read-only in auto mode'
+    )
+    await stop()
+  })
+
+  it('still validates before reaching the provider', async () => {
+    let called = false
+    const { put, stop } = await startRadarApi({
+      setControl: async () => {
+        called = true
+        return { success: true }
+      }
+    })
+
+    expect((await put(`${root}/power`, { value: 'nonsense' })).status).to.equal(
+      400
+    )
+    expect((await put(`${root}/range`, { value: -1 })).status).to.equal(400)
+    expect(called).to.equal(false)
+    await stop()
   })
 })

--- a/test/api/radar-shortcut-routes.test.ts
+++ b/test/api/radar-shortcut-routes.test.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai'
+import { applyControl } from '../../src/api/radar'
+import type { radar } from '@signalk/server-api'
+
+// The /power, /range, /gain, /sea and /rain routes predate
+// /controls/{controlId} and each called its own typed provider method, which
+// bypasses the control abstraction the rest of the API uses. Against
+// mayara-server that made /gain, /sea and /rain fail with 400 while /range and
+// /power worked, purely because a scalar survives the detour and { auto, value }
+// does not. These routes now go through setControl with the control id.
+
+function methods(
+  overrides: Partial<radar.RadarProviderMethods>
+): radar.RadarProviderMethods {
+  return {
+    getRadars: async () => ['radar-0'],
+    getRadarInfo: async () => null,
+    ...overrides
+  } as radar.RadarProviderMethods
+}
+
+describe('Radar API: shortcut control routes', () => {
+  it('routes through setControl with the control id and payload', async () => {
+    const seen: Array<[string, string, unknown]> = []
+    const provider = methods({
+      setControl: async (id, controlId, value) => {
+        seen.push([id, controlId, value])
+        return { success: true }
+      }
+    })
+
+    const payload = { auto: false, value: 75 }
+    const result = await applyControl(provider, 'radar-0', 'gain', payload)
+
+    expect(result.success).to.equal(true)
+    expect(seen).to.deep.equal([['radar-0', 'gain', payload]])
+  })
+
+  it('passes a compound payload through untouched', async () => {
+    let captured: unknown
+    const provider = methods({
+      setControl: async (_id, _controlId, value) => {
+        captured = value
+        return { success: true }
+      }
+    })
+
+    const sea = { auto: true, autoValue: -20 }
+    await applyControl(provider, 'radar-0', 'sea', sea)
+    expect(captured).to.deep.equal(sea)
+  })
+
+  it('prefers setControl over the typed method when both exist', async () => {
+    let usedLegacy = false
+    const provider = methods({ setControl: async () => ({ success: true }) })
+
+    await applyControl(provider, 'radar-0', 'range', 1852, async () => {
+      usedLegacy = true
+      return true
+    })
+    expect(usedLegacy).to.equal(false)
+  })
+
+  it('falls back to the typed method when setControl is absent', async () => {
+    let usedLegacy = false
+    const provider = methods({})
+
+    const result = await applyControl(
+      provider,
+      'radar-0',
+      'range',
+      1852,
+      async () => {
+        usedLegacy = true
+        return true
+      }
+    )
+    expect(usedLegacy).to.equal(true)
+    expect(result.success).to.equal(true)
+  })
+
+  it('reports a provider failure from the typed fallback', async () => {
+    const provider = methods({})
+    const result = await applyControl(
+      provider,
+      'radar-0',
+      'range',
+      1852,
+      async () => false
+    )
+    expect(result.success).to.equal(false)
+  })
+
+  it('surfaces the error a provider returns from setControl', async () => {
+    const provider = methods({
+      setControl: async () => ({ success: false, error: 'range not settable' })
+    })
+    const result = await applyControl(provider, 'radar-0', 'range', 1852)
+    expect(result).to.deep.equal({
+      success: false,
+      error: 'range not settable'
+    })
+  })
+
+  it('fails clearly when the provider supports neither path', async () => {
+    const result = await applyControl(methods({}), 'radar-0', 'gain', {
+      auto: true
+    })
+    expect(result.success).to.equal(false)
+    expect(result.error).to.match(/neither setControl nor a gain method/)
+  })
+})


### PR DESCRIPTION
## Summary

`/radars/{id}/power`, `/range`, `/gain`, `/sea` and `/rain` predate the generic `/controls/{controlId}` route, and each calls its own typed provider method (`setPower`, `setRange`, `setGain`, `setSea`, `setRain`). Those sit outside the control abstraction the rest of the API is built on, so a provider implements the same control twice and the two paths drift.

They have drifted. Measured against mayara-server 3.8.1 with a Navico HALO24:

| route | result |
|---|---|
| `PUT /range` | `200` — applied |
| `PUT /power` | `200` — applied |
| `PUT /gain` | `400` Failed to set radar gain |
| `PUT /sea`  | `400` Failed to set radar sea clutter |
| `PUT /rain` | same shape as gain/sea |

The split is not arbitrary: `range` and `power` take a **scalar**, which survives the detour through the typed method. `gain`/`sea`/`rain` take `{ auto, value }`, and the typed methods reshape it into something the provider’s own control endpoint rejects. Setting the identical control through `/controls/gain` works.

None of these five paths appear in `openApi.ts` or in `radar_api.md` — the docs only describe `/controls/{control_id}` — which is presumably why three of them being dead went unnoticed.

Route all five through `setControl` with the control id, making them exactly equivalent to the documented generic route. `setControl` is optional in the provider interface, so the typed method is kept as a fallback and a provider that implements only the typed methods is unaffected; the 501 guards now accept either.

Extracted as `applyControl` so the dispatch is unit-testable.

## Tested

- New `test/api/radar-shortcut-routes.test.ts`: dispatch to `setControl` with the right control id and payload, compound payload passed through untouched, `setControl` preferred when both exist, fallback to the typed method when it is absent, provider failure and provider error surfaced, and a clear failure when neither is implemented. 7 passing.
- `tsc --noEmit`, eslint and prettier clean.
- Behaviour on the working routes is unchanged: `/range` and `/power` already forwarded a scalar to `setControl` inside the reference provider, so they take the same path as before.

Note for reviewers: `/gain`, `/sea` and `/rain` only complete end to end against mayara once MarineYachtRadar/mayara-server-signalk-plugin#105 lands — that provider re-wraps a compound payload in a second `{ value }` envelope. This change is what lets a correct payload reach it at all. Related: #2935 fixes the same class of loss on `/controls/{controlId}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Routes `/power`, `/range`, `/gain`, `/sea`, and `/rain` through the generic `setControl` abstraction.
- Preserves the existing control IDs and payloads.
- Falls back to typed provider methods when `setControl` is unavailable.
- Adds the exported `applyControl` helper for dispatch and unit testing.
- Updates unsupported-operation checks to accept either implementation.
- Adds tests for dispatch, payload preservation, method preference, fallback behavior, provider failures, missing implementations, and HTTP responses.
- TypeScript, ESLint, and Prettier checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->