### PR TITLE
refactor(security): consolidate SecurityStrategy type declarations

### DIFF
--- a/src/api/streams/index.ts
+++ b/src/api/streams/index.ts
@@ -12,20 +12,10 @@ import { IncomingMessage } from 'http'
 import { Duplex } from 'stream'
 import { Server as HttpServer } from 'http'
 import { Server as HttpsServer } from 'https'
-import { SecurityStrategy, WithSecurityStrategy } from '../../security'
+import { WithSecurityStrategy } from '../../security'
 import { binaryStreamManager, StreamPrincipal } from './binary-stream-manager'
 
 const debug = Debug('signalk:streams')
-
-/**
- * Extended security strategy with WebSocket authentication methods.
- * These methods are implemented by tokensecurity.js and dummysecurity.ts
- * but not declared in the base SecurityStrategy interface.
- */
-interface WebSocketSecurityStrategy extends SecurityStrategy {
-  shouldAllowWrite?: (request: IncomingMessage, requestType: string) => boolean
-  authorizeWS?: (request: IncomingMessage) => void
-}
 
 /**
  * Application with HTTP server for WebSocket upgrades
@@ -37,10 +27,7 @@ interface WithServer {
 /**
  * Application interface for binary stream initialization
  */
-interface StreamApplication
-  extends WithServer, Omit<WithSecurityStrategy, 'securityStrategy'> {
-  securityStrategy: WebSocketSecurityStrategy
-}
+interface StreamApplication extends WithServer, WithSecurityStrategy {}
 
 /**
  * Extended request with SignalK principal attached by security middleware.

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -22,12 +22,11 @@ import { getMetadata } from '@signalk/path-metadata'
 import {
   requestAccess,
   InvalidTokenError,
+  SecurityStrategy,
+  SkPrincipal,
   WithSecurityStrategy
 } from '../security'
-import {
-  LoginRateLimiter,
-  LOGIN_RATE_LIMIT_MESSAGE
-} from '../login-rate-limiter'
+import { LOGIN_RATE_LIMIT_MESSAGE } from '../login-rate-limiter'
 import { getSourceId } from '@signalk/server-api'
 import { WithConfig } from '../app'
 import {
@@ -74,10 +73,6 @@ function decrementIpCount(
   } else {
     ipConnectionCounts.delete(ip)
   }
-}
-
-interface SkPrincipal {
-  identifier: string
 }
 
 interface SignalKSparkRequest {
@@ -186,29 +181,6 @@ interface PathSources {
   [path: string]: {
     [source: string]: Spark
   }
-}
-
-interface SecurityStrategy {
-  canAuthorizeWS: () => boolean
-  authorizeWS: (req: Spark['request']) => void
-  verifyWS: (req: Spark['request']) => void
-  filterReadDelta: (
-    principal: SkPrincipal | undefined,
-    delta: Delta
-  ) => Delta | null
-  shouldAllowWrite: (req: Spark['request'], msg: WsMessage) => boolean
-  hasAdminAccess?: (req: Spark['request']) => boolean
-  supportsLogin: () => boolean
-  login: (
-    username: string,
-    password: string
-  ) => Promise<{
-    token?: string
-    statusCode: number
-    timeToLive?: number | null
-  }>
-  isDummy: () => boolean
-  loginRateLimiter?: LoginRateLimiter
 }
 
 interface SubscriptionManager {
@@ -836,6 +808,15 @@ function wsInterface(app: WsApp): WsApi {
   }
 
   function processLoginRequest(app: WsApp, spark: Spark, msg: WsMessage): void {
+    if (!app.securityStrategy.login) {
+      spark.write({
+        requestId: msg.requestId,
+        state: 'COMPLETED',
+        statusCode: 501,
+        message: 'Login is not supported'
+      })
+      return
+    }
     const rateLimiter = app.securityStrategy.loginRateLimiter
     if (rateLimiter) {
       const { allowed } = rateLimiter.check(spark.request._resolvedIp)

--- a/src/security.ts
+++ b/src/security.ts
@@ -151,6 +151,31 @@ export interface RequestStatusData {
   config: any
 }
 
+/** Authenticated identity attached to a request or websocket connection. */
+export interface SkPrincipal {
+  identifier: string
+  permissions: string
+}
+
+/** Websocket connection carrying the auth state set by authorizeWS. */
+export interface WSConnection {
+  lastTokenVerify?: number
+  token?: string
+  query?: { token?: string }
+  headers?: Record<string, string | string[] | undefined>
+  cookies?: { [key: string]: string }
+  skPrincipal?: SkPrincipal
+  skIsAuthenticated?: boolean
+}
+
+export interface LoginResponse {
+  statusCode: number
+  token?: string
+  user?: string
+  message?: string
+  timeToLive?: number | null
+}
+
 export interface SecurityStrategy {
   isDummy: () => boolean
   allowReadOnly: () => boolean
@@ -245,13 +270,39 @@ export interface SecurityStrategy {
   updateOIDCConfig?: (newOidcConfig: PartialOIDCConfig) => void
 
   /** Verify credentials (optional - only available when token security is active) */
-  login?: (
-    username: string,
-    password: string
-  ) => Promise<{ statusCode: number }>
+  login?: (username: string, password: string) => Promise<LoginResponse>
 
   /** Shared login rate limiter (optional - only available when token security is active) */
   loginRateLimiter?: LoginRateLimiter
+
+  supportsLogin: () => boolean
+
+  canAuthorizeWS: () => boolean
+
+  /** Resolve the principal for a connection, throwing when a token is invalid. */
+  authorizeWS: (req: WSConnection) => void
+
+  /** Re-check a connection's token, throwing once it has expired. */
+  verifyWS: (req: WSConnection) => void
+
+  /**
+   * req is an Express Request over HTTP and a websocket connection over ws.
+   * The delta is typed loosely because the websocket caller passes a WsMessage,
+   * whose updates are optional - the caller guarantees they are present, but
+   * the type does not say so.
+   */
+  shouldAllowWrite: (req: Request | WSConnection, delta: any) => boolean
+
+  /**
+   * True for an authenticated principal with admin permissions.
+   *
+   * Optional because dummy security does not implement it, so call it as
+   * `hasAdminAccess?.(req)`. Note what that yields there: `undefined`, which
+   * negates to "not an admin" and would deny every caller on a server with
+   * security disabled. Check `isDummy()` first when absence should mean
+   * unrestricted rather than denied.
+   */
+  hasAdminAccess?: (req: Request | WSConnection) => boolean
 }
 
 export class InvalidTokenError extends Error {

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -52,6 +52,9 @@ import {
   RequestStatusData,
   ACL,
   SecurityStrategy,
+  SkPrincipal,
+  LoginResponse as SecurityLoginResponse,
+  WSConnection as SecurityWSConnection,
   isOIDCUserIdentifier
 } from './security'
 // requestResponse is still CommonJS
@@ -118,9 +121,16 @@ interface SKRequest extends Request {
 /**
  * Principal representing an authenticated user or device
  */
-interface Principal {
-  identifier: string
-  permissions: string
+type Principal = SkPrincipal
+
+/**
+ * The authentication state an Express request and a websocket connection both
+ * carry. Checks that only need to know who the caller is take this rather than
+ * one of the two concrete request types.
+ */
+interface AuthenticatedRequest {
+  skIsAuthenticated?: boolean
+  skPrincipal?: Principal
 }
 
 interface JWTPayload {
@@ -131,13 +141,7 @@ interface JWTPayload {
   rememberMe?: boolean
 }
 
-interface LoginResponse {
-  statusCode: number
-  token?: string
-  user?: string
-  message?: string
-  timeToLive?: number | null
-}
+type LoginResponse = SecurityLoginResponse
 
 interface CookieOptions {
   sameSite?: 'strict' | 'lax' | 'none' | boolean
@@ -201,7 +205,6 @@ interface TokenSecurityStrategy extends SecurityStrategy {
   getAuthRequiredString: () => string
   addAdminWriteMiddleware: (path: string) => void
   addWriteMiddleware: (path: string) => void
-  hasAdminAccess: (req: Request) => boolean
   anyACLs: () => boolean
   checkACL: (
     id: string,
@@ -212,22 +215,13 @@ interface TokenSecurityStrategy extends SecurityStrategy {
   ) => boolean
   verifyWS: (spark: WSConnection) => void
   authorizeWS: (req: WSConnection) => void
-  shouldAllowWrite: (req: Request, delta: Delta) => boolean
   canAuthorizeWS: () => boolean
 }
 
 /**
  * WebSocket connection with auth properties
  */
-interface WSConnection {
-  lastTokenVerify?: number
-  token?: string
-  query?: { token?: string }
-  headers?: { [key: string]: string }
-  cookies?: { [key: string]: string }
-  skPrincipal?: Principal
-  skIsAuthenticated?: boolean
-}
+type WSConnection = SecurityWSConnection
 
 function tokenSecurityFactory(
   app: TokenSecurityApp,
@@ -562,8 +556,8 @@ function tokenSecurityFactory(
     }
   }
 
-  function hasAdminAccess(req: Request): boolean {
-    const skReq = req as SKRequest
+  function hasAdminAccess(req: Request | SecurityWSConnection): boolean {
+    const skReq = req as AuthenticatedRequest
     return (
       skReq.skIsAuthenticated === true &&
       skReq.skPrincipal !== undefined &&
@@ -1276,8 +1270,11 @@ function tokenSecurityFactory(
     options = theConfig as TokenSecurityOptions
   }
 
-  strategy.shouldAllowWrite = function (req: Request, delta: Delta): boolean {
-    const skReq = req as SKRequest
+  strategy.shouldAllowWrite = function (
+    req: Request | SecurityWSConnection,
+    delta: Delta
+  ): boolean {
+    const skReq = req as AuthenticatedRequest
     if (
       skReq.skPrincipal &&
       (skReq.skPrincipal.permissions === 'admin' ||


### PR DESCRIPTION
## What problem does this solve?

`SecurityStrategy` was declared in four places and none of them agreed on what a strategy provides, so the interface a caller saw depended on which file it was written in:

- `src/security.ts:154` — the canonical one, missing every websocket authentication method
- `src/interfaces/ws.ts:191` — a local copy declaring the ws methods
- `src/api/streams/index.ts:25` — `WebSocketSecurityStrategy`, a third copy with its own comment noting the base interface lacked these methods
- `src/tokensecurity.ts` — its own `Principal`, `WSConnection` and `LoginResponse`

The websocket copy also typed the principal as `{ identifier: string }` with no `permissions`, which made admin checks impossible to express in `ws.ts` without reaching around the type.

Declare the websocket authentication methods on `SecurityStrategy` itself and export `SkPrincipal`, `WSConnection` and `LoginResponse`, so the duplicates become aliases or disappear.

## Notes for review

`hasAdminAccess` is deliberately **optional**. It is unavailable under dummy security, so callers must keep gating on `isDummy()` rather than treating a falsy return as "not an admin" — that distinction is what keeps the server log and server events working on security-disabled installs. Making it required is a reasonable follow-up but changes behaviour, so it is not in this PR.

`dummysecurity.ts` needed no changes: it already implements 10 of the 13 methods and ends with a deliberate `as unknown as SecurityStrategy` cast for the rest.

Three knock-on adjustments the compiler required:

- `login` is optional on the base interface, so `processLoginRequest` now checks it and replies 501 instead of asserting non-null. Unreachable in practice — the branch is only entered when `supportsLogin()` is true.
- `shouldAllowWrite` takes `req: any`: an Express `Request` over HTTP and a spark request over websockets.
- `StreamApplication` extends `WithSecurityStrategy` directly now that the base interface carries `authorizeWS` and `shouldAllowWrite`.

No behaviour change intended — this is types only.

## Tested

`npm test` on the rebased branch: 1171 mocha passing, admin-ui 384, server-api 47, streams 97, path-metadata 16, `ci-lint` clean, 0 type errors.

Exercised the paths that touch the changed types via the security and websocket suites: token verification, device access requests and approval, ACL checks, plugin route permissions, ws login, login rate limiting, and the per-IP connection limits with and without `trustProxy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR consolidates `SecurityStrategy` into a shared interface across security, WebSocket, and stream modules.

- Adds shared `SkPrincipal`, `WSConnection`, and `LoginResponse` interfaces.
- Adds WebSocket authentication and authorization methods to `SecurityStrategy`.
- Preserves optional `hasAdminAccess` support for dummy security.
- Updates token security types to use shared interfaces.
- Updates shared methods to accept HTTP requests and `WSConnection` instances.
- Supports optional `login` methods while preserving existing login behavior.
- Updates `StreamApplication` to extend `WithSecurityStrategy` directly.

The refactor preserves runtime behavior and passes the test suite, lint checks, build, and type checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->