### PR TITLE
test: give server-starting hooks a budget that fits a cold start

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,6 +1,11 @@
 module.exports = {
   require: ['ts-node/register'],
   extensions: ['ts', 'tsx', 'js'],
-  timeout: 20000,
+  // Whichever suite runs first pays a one-off cost that dwarfs the work it is
+  // timing: loading dist/ and the first plugin scan take tens of seconds on a
+  // cold cache, while every later server start is a few hundred milliseconds.
+  // Which suite pays it depends on file ordering, so a budget that fits a warm
+  // start makes the first suite fail seemingly at random.
+  timeout: 120000,
   exit: true
 }

--- a/test/externalssl.ts
+++ b/test/externalssl.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
-import { freeport } from './ts-servertestutilities'
+import { freeport, SERVER_START_TIMEOUT } from './ts-servertestutilities'
 import { startServerP } from './servertestutilities'
 
 describe('EXTERNALSSL', function () {
-  this.timeout(10000)
+  this.timeout(SERVER_START_TIMEOUT)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let server: any

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -4,7 +4,7 @@ import {
   startServerP,
   WsPromiser
 } from './servertestutilities'
-import { freeport } from './ts-servertestutilities'
+import { freeport, SERVER_START_TIMEOUT } from './ts-servertestutilities'
 import path from 'path'
 import { rimraf } from 'rimraf'
 import { SERVERSTATEDIRNAME } from '../src/serverstate/store'
@@ -21,7 +21,7 @@ const emptyConfigDirectory = () =>
   )
 
 describe('Metadata end to end', function () {
-  this.timeout(10000)
+  this.timeout(SERVER_START_TIMEOUT)
 
   let port: number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/security.js
+++ b/test/security.js
@@ -1,7 +1,7 @@
 const chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
-const { freeport } = require('./ts-servertestutilities')
+const { freeport, SERVER_START_TIMEOUT } = require('./ts-servertestutilities')
 const path = require('path')
 const WebSocket = require('ws')
 const jwt = require('jsonwebtoken')
@@ -73,7 +73,7 @@ describe('Security', () => {
   let previousHttpRateLimits
 
   before(async function () {
-    this.timeout(20000)
+    this.timeout(SERVER_START_TIMEOUT)
     previousHttpRateLimits = process.env.HTTP_RATE_LIMITS
     process.env.HTTP_RATE_LIMITS = 'api=1000,loginStatus=1000,login=1000'
 
@@ -952,7 +952,7 @@ describe('Access Request Limit', () => {
   let previousHttpRateLimits
 
   before(async function () {
-    this.timeout(20000)
+    this.timeout(SERVER_START_TIMEOUT)
     previousHttpRateLimits = process.env.HTTP_RATE_LIMITS
     process.env.HTTP_RATE_LIMITS = 'api=1000,loginStatus=1000'
 
@@ -1087,7 +1087,7 @@ describe('WS Access Request IP reporting', () => {
   let previousHttpRateLimits
 
   beforeEach(async function () {
-    this.timeout(20000)
+    this.timeout(SERVER_START_TIMEOUT)
     previousHttpRateLimits = process.env.HTTP_RATE_LIMITS
     process.env.HTTP_RATE_LIMITS = 'api=1000,loginStatus=1000'
     port = await freeport()
@@ -1185,7 +1185,7 @@ describe('Plugin route permissions', () => {
   let previousHttpRateLimits
 
   before(async function () {
-    this.timeout(20000)
+    this.timeout(SERVER_START_TIMEOUT)
     previousHttpRateLimits = process.env.HTTP_RATE_LIMITS
     process.env.HTTP_RATE_LIMITS = 'api=1000,loginStatus=1000,login=1000'
 

--- a/test/ssl.ts
+++ b/test/ssl.ts
@@ -1,10 +1,10 @@
 import path from 'path'
 import { unlinkSync, existsSync } from 'fs'
-import { freeport } from './ts-servertestutilities'
+import { freeport, SERVER_START_TIMEOUT } from './ts-servertestutilities'
 import { startServerP, serverTestConfigDirectory } from './servertestutilities'
 
 describe('SSL certificate generation', function () {
-  this.timeout(15000)
+  this.timeout(SERVER_START_TIMEOUT)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let server: any

--- a/test/ts-servertestutilities.ts
+++ b/test/ts-servertestutilities.ts
@@ -13,6 +13,16 @@ import { Delta, hasValues, PathValue, Value } from '@signalk/server-api'
 
 export const DATETIME_REGEX = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)Z?$/
 
+/**
+ * Budget for a hook that starts a server. Whichever suite runs first pays a
+ * one-off cost that dwarfs the start itself - loading dist/ and the first
+ * plugin scan take tens of seconds, while every later start is a few hundred
+ * milliseconds. Which suite pays it depends on file ordering, so every suite
+ * that starts a server needs the larger budget even though it will usually
+ * finish in well under a second.
+ */
+export const SERVER_START_TIMEOUT = 120000
+
 const emptyConfigDirectory = () =>
   Promise.all(
     [SERVERSTATEDIRNAME, 'resources', 'plugin-config-data', 'baseDeltas.json']


### PR DESCRIPTION
## What problem does this solve?

Suites that start a server fail in `before` hooks with `Timeout of Nms exceeded` rather than on an assertion, and they do it inconsistently — the same commit passes on one run and fails on the next.

The cause is a one-off cost that only the first suite in a run pays. Measured on a dev VM:

| step | time |
|---|---|
| `require('../dist')` | 12.3 s |
| first `startServerP` | 20.8 s |
| every later `startServerP` | ~150 ms |

So the first suite needs roughly 33 seconds before its `before` hook returns, and every suite after it needs a fraction of a second. Budgets sized for the warm case — 10 s, 15 s, 20 s — fit every suite except whichever one runs first. Which suite that is depends on file ordering and on which files a given run selects, so the failure moves around and reads as flakiness.

`test/security.js` shows the cost of getting this wrong. Run on its own it reported `14 passing, 2 failing`; the failing `before` aborted the rest of the suite, so 39 further tests never ran. With the hook given room it reports `53 passing`.

## What this changes

- `.mocharc.js` default 20 s → 120 s.
- A shared `SERVER_START_TIMEOUT` in `test/servertestutilities.js` for hooks that start a server, replacing per-file literals in `security.js`, `metadata-e2e.ts`, `ssl.ts` and `externalssl.ts`.

The default alone is not enough — a per-file `this.timeout()` overrides it, which is why `security.js` still failed after only changing the config.

Timeouts that measure an assertion rather than a server start are left alone, including `security.js:980` ("should limit pending access requests to 100"), and the existing 30–90 s values elsewhere.

The numbers are deliberately generous rather than tuned. These hooks normally finish in well under a second; the budget only has to cover the one cold start per run, and a value that merely fits this machine would put CI back in the same position.

## Tested

Each affected suite run on its own, so it pays the cold-start cost — the condition that previously failed:

| suite | before | after |
|---|---|---|
| `security.js` | 14 passing, 2 failing | 53 passing |
| `metadata-e2e.ts` | timed out at 10 s | 5 passing |
| `ssl.ts` | — | 1 passing |
| `externalssl.ts` | — | 5 passing |

Full run: `npm run test-only` 1171 passing, 0 failing. `ci-lint` clean.

## Not addressed here

Reducing the 33 seconds. Making module load or the first plugin scan cheaper would help every run rather than just stopping the failures, but that is a change to server startup rather than to the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR increases test timeouts for server-starting hooks to support cold-start costs.

- Raises Mocha’s default timeout from 20 seconds to 120 seconds.
- Adds the shared `SERVER_START_TIMEOUT` constant.
- Uses the constant in the security, metadata, SSL, and external SSL test suites.
- Keeps assertion-related and existing 30–90 second timeouts unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->