### PR TITLE
fix(eslint): stop reporting two redundant admin UI lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,10 @@ module.exports = defineConfig([
     rules: {
       // React hooks rules
       ...reactHooks.configs.recommended.rules,
+      // Duplicates react-hooks/set-state-in-effect, which is already an error
+      // from the official plugin. Reporting both means every annotated site
+      // needs two disable comments.
+      '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'off',
       // React compiler rules
       'react-compiler/react-compiler': 'warn',
       // React 17+ with new JSX transform doesn't require React in scope
@@ -106,6 +110,16 @@ module.exports = defineConfig([
       'react/prop-types': 'off',
       'react/no-string-refs': 'off',
       'react/no-direct-mutation-state': 'off'
+    }
+  },
+
+  // Admin UI tests. Must follow the React block above so these overrides win.
+  {
+    files: ['packages/server-admin-ui/src/**/*.test.{ts,tsx}'],
+    rules: {
+      // vi.mock factories must re-export hook names verbatim to replace the
+      // real module, so the use-prefix convention cannot apply here.
+      '@eslint-react/hooks-extra/no-unnecessary-use-prefix': 'off'
     }
   },
 


### PR DESCRIPTION
Depends on #2941 — merge that first. Until the admin UI ignore is removed there, these rules are not evaluated and this change has no effect.

Two rules account for 35 of the admin UI's lint warnings without describing anything actionable.

`@eslint-react/hooks-extra/no-direct-set-state-in-use-effect` duplicates `react-hooks/set-state-in-effect` from the official React plugin, which is already an error. Running both means every deliberate, annotated call site needs two disable comments for what is one finding.

`no-unnecessary-use-prefix` fires on `vi.mock` factories in the Vitest suites. Those must re-export hook names verbatim to stand in for the real module, so renaming them would break the mocks and the convention cannot apply.

The admin UI test override has to sit after the React block: under flat config, later entries win.

Combined with #2941 this takes the admin UI from 65 problems to 0 errors and 10 warnings.

## Tested

- `npm run ci-lint` passes on this branch and when stacked on #2941
- 384 admin UI vitest tests pass
- Confirmed both rules stop reporting and no new findings appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates the admin UI ESLint configuration.
- Disables the duplicate `@eslint-react/hooks-extra/no-direct-set-state-in-use-effect` rule.
- Disables `@eslint-react/hooks-extra/no-unnecessary-use-prefix` for Vitest mock factories.
- Places the test override after the React configuration so it takes precedence.
- Reduces lint results to 0 errors and 10 warnings.
- `npm run ci-lint` passes, and 384 admin UI Vitest tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->