### PR TITLE
fix(gnss): make antenna fromCenter positive to starboard

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
@@ -58,14 +58,14 @@ const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
   const svgRef = useRef<SVGSVGElement>(null)
   const [dragging, setDragging] = useState<number | null>(null)
 
-  // SK spec: positive fromCenter is port, negative is starboard, but SVG
-  // x grows rightward (starboard) — flip the sign when mapping into SVG.
+  // SK spec: positive fromCenter is starboard, which is also the direction
+  // SVG x grows in, so the mapping is direct.
   const toSvgCoords = useCallback(
     (fromBow: number | null, fromCenter: number | null) => {
       const bow = fromBow ?? 0
       const center = fromCenter ?? 0
       const y = HULL_TOP + (bow / vesselLength) * HULL_H
-      const x = HULL_CX - (center / (vesselBeam / 2)) * (HULL_W / 2)
+      const x = HULL_CX + (center / (vesselBeam / 2)) * (HULL_W / 2)
       return {
         x: Math.max(HULL_LEFT, Math.min(HULL_RIGHT, x)),
         y: Math.max(HULL_TOP, Math.min(HULL_BOTTOM, y))
@@ -82,7 +82,7 @@ const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
         Math.round(((clampedY - HULL_TOP) / HULL_H) * vesselLength * 10) / 10
       const fromCenter =
         Math.round(
-          -((clampedX - HULL_CX) / (HULL_W / 2)) * (vesselBeam / 2) * 10
+          ((clampedX - HULL_CX) / (HULL_W / 2)) * (vesselBeam / 2) * 10
         ) / 10
       return { fromBow, fromCenter }
     },

--- a/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BoatSchematicEditor.tsx
@@ -58,8 +58,8 @@ const BoatSchematicEditor: React.FC<BoatSchematicEditorProps> = ({
   const svgRef = useRef<SVGSVGElement>(null)
   const [dragging, setDragging] = useState<number | null>(null)
 
-  // SK spec: positive fromCenter is starboard, which is also the direction
-  // SVG x grows in, so the mapping is direct.
+  // SK spec: positive fromCenter is starboard, and SVG x increases to the
+  // right, so the mapping is direct.
   const toSvgCoords = useCallback(
     (fromBow: number | null, fromCenter: number | null) => {
       const bow = fromBow ?? 0

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -382,7 +382,7 @@ const GnssPositionSettings: React.FC = () => {
           Accurate antenna positions improve position data by accounting for the
           offset between GNSS receiver and vessel reference point (CCRP:
           Consistent Common Reference Point). Positive &quot;From Center&quot;
-          values indicate port, negative indicate starboard (per Signal K
+          values indicate starboard, negative indicate port (per Signal K
           specification). Configure a detected source by editing one of its
           fields.
         </Alert>

--- a/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/GnssPositionSettings.tsx
@@ -382,7 +382,7 @@ const GnssPositionSettings: React.FC = () => {
           Accurate antenna positions improve position data by accounting for the
           offset between GNSS receiver and vessel reference point (CCRP:
           Consistent Common Reference Point). Positive &quot;From Center&quot;
-          values indicate starboard, negative indicate port (per Signal K
+          values indicate starboard, negative values indicate port (per Signal K
           specification). Configure a detected source by editing one of its
           fields.
         </Alert>

--- a/src/api/gnssOffsetCorrector/leverArm.ts
+++ b/src/api/gnssOffsetCorrector/leverArm.ts
@@ -7,12 +7,17 @@
  * AIS industry convention for the vessel reference point.
  *
  * Body-frame convention (origin at the bow on the centerline):
- *   +x toward bow  -> points OUT through the bow; hull lies at negative x
- *   +y to port     (matches sensors.json "+ve to port, -ve to starboard")
+ *   +x toward bow   -> points OUT through the bow; hull lies at negative x
+ *   +y to starboard (matches sensors.json "+ve to starboard, -ve to port")
+ *
+ * This is a right-handed frame with the same handedness as
+ * navigation.attitude.yaw and navigation.rateOfTurn, both of which are
+ * positive to starboard, so an offset and a heading combine without a
+ * sign correction.
  *
  * Body-frame positions:
  *   Antenna:  x = -fromBow         (fromBow metres aft of the bow)
- *             y = +fromCenter      (fromCenter metres to port of centerline)
+ *             y = +fromCenter      (fromCenter metres to starboard of centerline)
  *   CCRP:     x = -lengthOverall/2 (midships, aft of the bow)
  *             y = 0
  *
@@ -21,22 +26,17 @@
  *               (negative when antenna is forward of midships -> CCRP is aft;
  *                positive when antenna is aft of midships -> CCRP is forward)
  *   body_y = 0 - fromCenter = -fromCenter
- *               (negative when antenna is to port -> CCRP is to starboard;
- *                positive when antenna is to starboard -> CCRP is to port)
+ *               (negative when antenna is to starboard -> CCRP is to port;
+ *                positive when antenna is to port -> CCRP is to starboard)
  *
  * Body→earth rotation for heading θ (true, clockwise from north, bow
- * points along +x body):
- *   At θ=0:  +x body = +north earth, +y body = -east earth (port = west).
- *   The +y body axis lies 90° counterclockwise from +x body in the
- *   horizontal earth plane, i.e. azimuth (θ - 90°).
- *     +x body in earth N/E: ( cos θ,  sin θ)
- *     +y body in earth N/E: ( sin θ, -cos θ)
+ * points along +x body) is the standard NED rotation:
+ *   At θ=0:  +x body = +north earth, +y body = +east earth (starboard = east).
+ *     +x body in earth N/E: ( cos θ, sin θ)
+ *     +y body in earth N/E: (-sin θ, cos θ)
  *   Therefore:
- *     north = body_x * cos θ + body_y * sin θ
- *     east  = body_x * sin θ - body_y * cos θ
- *
- * (Note: this differs from the standard NED rotation matrix because
- * +y body is port here, not starboard.)
+ *     north = body_x * cos θ - body_y * sin θ
+ *     east  = body_x * sin θ + body_y * cos θ
  */
 
 export interface AntennaOffset {
@@ -64,8 +64,8 @@ export function correctPosition(
   const bodyY = -offset.fromCenter
   const cosH = Math.cos(headingTrueRad)
   const sinH = Math.sin(headingTrueRad)
-  const north = bodyX * cosH + bodyY * sinH
-  const east = bodyX * sinH - bodyY * cosH
+  const north = bodyX * cosH - bodyY * sinH
+  const east = bodyX * sinH + bodyY * cosH
   const latRad = antenna.latitude * DEG_TO_RAD
   const dLat = (north / EARTH_RADIUS_M) * RAD_TO_DEG
   const dLon = (east / (EARTH_RADIUS_M * Math.cos(latRad))) * RAD_TO_DEG

--- a/src/api/sensors/openApi.ts
+++ b/src/api/sensors/openApi.ts
@@ -70,8 +70,8 @@ export const sensorsApiDoc: any = {
             type: 'number',
             nullable: true,
             description:
-              'Metres to port (positive) or starboard (negative) of the centerline.',
-            example: -0.5
+              'Metres to starboard (positive) or port (negative) of the centerline.',
+            example: 0.5
           }
         }
       },

--- a/test/api/gnssOffsetCorrector.test.ts
+++ b/test/api/gnssOffsetCorrector.test.ts
@@ -152,14 +152,14 @@ describe('leverArm.correctPosition', function () {
   })
 
   it('port-side antenna at midships, vessel pointing north: CCRP is to the east', function () {
-    // antenna at midships (fromBow = length/2 = 10) with fromCenter=2
+    // antenna at midships (fromBow = length/2 = 10) with fromCenter=-2
     // (2m to port of centerline). Physically: heading north -> port
     // is west, so the antenna sits 2m west of the centerline; the
     // CCRP is on the centerline (2m east of antenna). Longitude
     // increases by 2/(R cos lat).
     const out = correctPosition(
       { latitude: 60, longitude: 24 },
-      { fromBow: 10, fromCenter: 2 },
+      { fromBow: 10, fromCenter: -2 },
       20,
       0
     )
@@ -170,16 +170,38 @@ describe('leverArm.correctPosition', function () {
   })
 
   it('starboard-side antenna at midships, vessel pointing north: CCRP is to the west', function () {
-    // Mirror of the previous case: fromCenter=-2 (starboard) ->
+    // Mirror of the previous case: fromCenter=2 (starboard) ->
     // antenna 2m east of centerline at heading north -> CCRP 2m west.
     const out = correctPosition(
       { latitude: 60, longitude: 24 },
-      { fromBow: 10, fromCenter: -2 },
+      { fromBow: 10, fromCenter: 2 },
       20,
       0
     )
     const latRad = (60 * Math.PI) / 180
     const expectedDLon = ((-2 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.longitude).to.be.closeTo(24 + expectedDLon, 1e-9)
+  })
+
+  it('starboard antenna forward of midships, vessel pointing east', function () {
+    // Both body components non-zero and the heading off-axis, so a sign
+    // error in either term of the rotation shows up. fromBow=5 on a 20m
+    // vessel -> body_x = 5-10 = -5 (CCRP is 5m aft); fromCenter=3
+    // (starboard) -> body_y = -3 (CCRP is 3m to port of the antenna).
+    // Heading 090 (east): the bow points east, so "aft" is west and
+    // "port" is north.
+    //   north = body_x*cos(90) - body_y*sin(90) = 0 - (-3) = +3
+    //   east  = body_x*sin(90) + body_y*cos(90) = -5 + 0    = -5
+    const out = correctPosition(
+      { latitude: 60, longitude: 24 },
+      { fromBow: 5, fromCenter: 3 },
+      20,
+      Math.PI / 2
+    )
+    const latRad = (60 * Math.PI) / 180
+    const expectedDLat = ((3 / R) * 180) / Math.PI
+    const expectedDLon = ((-5 / (R * Math.cos(latRad))) * 180) / Math.PI
+    expect(out.latitude).to.be.closeTo(60 + expectedDLat, 1e-9)
     expect(out.longitude).to.be.closeTo(24 + expectedDLon, 1e-9)
   })
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on the specification.** This reverses the published `fromCenter` sign convention and must not merge before SignalK/specification#680 lands. The argument and decision live in RFC SignalK/specification#685. If the RFC resolves the other way, this PR is discarded.

`sensors.*.fromCenter` is the only signed athwartships quantity declaring **+ve to port**. Every other signed lateral or rotational key — `rudderAngle`, `attitude.roll`, `attitude.yaw`, `rateOfTurn`, `thrustAngle`, `keel.angle` — is +ve to starboard. Raised by @keesverruijt reviewing #2399.

The mismatch is load-bearing here rather than cosmetic. Lever-arm correction combines `fromCenter` with a heading taken from the same body frame as `attitude.yaw`, so a port-positive offset against a starboard-positive rotation forced a bespoke rotation matrix — the code carried a comment explaining that it deviated from standard NED. With `+y` to starboard it collapses to the textbook form and the note goes away.

This also resolves an existing self-contradiction: `@signalk/path-metadata` has described `fromCenter` as *"positive towards starboard"* since v2.28.0, while the OpenAPI description and the admin UI said the opposite.

In `BoatSchematicEditor` the SVG mapping loses its sign flip, since SVG x grows rightward — now the same direction as positive `fromCenter`.

## Depends on the spec

Convention change proposed in SignalK/specification#680. **Should not merge before that lands** — if it resolves the other way, this is discarded.

## Behaviour and migration

Net behaviour is unchanged for a given *physical* antenna: the same mounting position, written `+2` instead of `-2`, yields an identical CCRP.

`settings.gnssSensors` has only shipped in `2.31.0-beta.1`/`beta.2`, so there are no stable-release configs to migrate. Legacy `sensors.gps.fromCenter` and `/vessel`'s `gpsFromCenter` are passed through unchanged rather than silently negated — because the shipped metadata and the shipped UI disagreed, existing values are of ambiguous handedness and are better re-checked by the user than rewritten by the server. Worth a release note.

## Tested

`test/api/gnssOffsetCorrector.test.ts` passes (33). Verified invariance across multiple headings and offsets — the same physical antenna gives an identical CCRP under both conventions, including off-axis headings where a sign error in one rotation term cannot cancel out.

Adds a case with both body components non-zero and an off-axis heading: the two pre-existing non-zero fixtures were both due-north and symmetric, so a rotation-sign regression could have passed on them. Confirmed the updated tests fail if the old rotation is reintroduced.

`test/sensors.ts` and `test/staticData.js` each have one server-startup timeout that reproduces identically on clean master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR standardizes `sensors.*.fromCenter` so positive values indicate starboard and negative values indicate port.

- Updates GNSS lever-arm correction to use the standard body-to-earth rotation.
- Aligns `BoatSchematicEditor` and GNSS settings guidance with the convention.
- Documents the convention in the OpenAPI definition.
- Preserves physical antenna behavior with the new convention.
- Passes legacy `sensors.gps.fromCenter` and `/vessel` `gpsFromCenter` values through unchanged.
- Adds regression coverage for multiple headings and off-axis offsets.

This PR depends on Signal K specification change `#680` and must not merge before that change is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->