### PR TITLE
test: clean up temp directories that tests leave behind in os.tmpdir()

### DIFF
--- a/test/appstore/icon-probe.test.ts
+++ b/test/appstore/icon-probe.test.ts
@@ -3,9 +3,11 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import {
-  createIconProbeCache,
+  createIconProbeCache as createCache,
   probeIconUrl
 } from '../../dist/appstore/icon-probe.js'
+
+type IconProbeCache = ReturnType<typeof createCache>
 
 // Mirrors PERSIST_DEBOUNCE_MS in src/appstore/icon-probe.ts. Kept as a
 // local constant rather than exporting an internal purely for tests.
@@ -18,14 +20,25 @@ function tmpDir(): string {
   return dir
 }
 
-describe('appstore/icon-probe cache', () => {
-  afterEach(() => {
-    while (tmpDirs.length > 0) {
-      const dir = tmpDirs.pop()
-      if (dir) fs.rmSync(dir, { recursive: true, force: true })
-    }
-  })
+// A cache left holding a debounced write recreates its directory when the
+// timer fires, so cleanup has to cancel pending writes before removing the
+// directories, not just after the last assertion.
+const caches: IconProbeCache[] = []
+function createIconProbeCache(cacheDir: string): IconProbeCache {
+  const cache = createCache(cacheDir)
+  caches.push(cache)
+  return cache
+}
 
+afterEach(() => {
+  while (caches.length > 0) caches.pop()?.invalidate()
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()
+    if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('appstore/icon-probe cache', () => {
   it('returns undefined for unknown entries', () => {
     const cache = createIconProbeCache(tmpDir())
     expect(cache.get('@signalk/foo', '1.0.0', './icon.svg')).to.equal(undefined)

--- a/test/modules.js
+++ b/test/modules.js
@@ -13,6 +13,15 @@ const {
 } = require('../dist/modules')
 
 describe('modulesWithKeyword', () => {
+  let testTempDir
+
+  afterEach(() => {
+    if (testTempDir) {
+      fs.rmSync(testTempDir, { recursive: true, force: true })
+      testTempDir = undefined
+    }
+  })
+
   it('returns a list of modules with one "installed" update in config dir', () => {
     const expectedModules = [
       '@signalk/app-dock',
@@ -23,9 +32,8 @@ describe('modulesWithKeyword', () => {
     ]
     const updateInstalledModule = '@signalk/instrumentpanel'
 
-    const testTempDir = path.join(
-      require('os').tmpdir(),
-      '_skservertest_modules' + Date.now()
+    testTempDir = fs.mkdtempSync(
+      path.join(require('os').tmpdir(), '_skservertest_modules')
     )
 
     const app = {
@@ -35,7 +43,6 @@ describe('modulesWithKeyword', () => {
       }
     }
 
-    fs.mkdirSync(testTempDir)
     const tempNodeModules = path.join(testTempDir, 'node_modules/')
     fs.mkdirSync(path.join(testTempDir, 'node_modules'))
     fs.mkdirSync(path.join(testTempDir, 'node_modules/@signalk'))
@@ -317,11 +324,9 @@ describe('getPluginDataSize', () => {
   let tempDir
 
   beforeEach(() => {
-    tempDir = path.join(
-      require('os').tmpdir(),
-      '_skservertest_datasize' + Date.now()
+    tempDir = fs.mkdtempSync(
+      path.join(require('os').tmpdir(), '_skservertest_datasize')
     )
-    fs.mkdirSync(tempDir, { recursive: true })
   })
 
   afterEach(() => {

--- a/test/security-config-missing.ts
+++ b/test/security-config-missing.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -24,6 +24,7 @@ describe('getSecurityConfig', () => {
 
     afterEach(() => {
       restoreConsoleError()
+      rmSync(configPath, { recursive: true, force: true })
     })
 
     it('returns {} and does not log when securityStrategy is not initialized', () => {


### PR DESCRIPTION
Three test files created directories under `os.tmpdir()` and never removed them. On a dev machine these accumulated to roughly 1200 entries over a week of test runs; where `/tmp` is a tmpfs that is unreclaimable RAM until reboot. A full `npm run test-only` leaked 9 directories per run.

`test/modules.js` and `test/security-config-missing.ts` had no cleanup at all. `test/appstore/icon-probe.test.ts` scoped its `afterEach` to the first of its two `describe` blocks, so the second block's directories always leaked.

`icon-probe` needed a second fix. `persist()` calls `mkdirSync(cacheDir, { recursive: true })`, so a debounced write firing after cleanup recreated the directory that had just been removed — which is why the leaked directories still contained `iconUrls.json`. Tests that `set()` without `flush()` leave that timer live. Cleanup now calls `invalidate()` on each cache, which cancels any pending write, before removing the directories. This uses the existing public API; no production code changed.

`modules.js` also moves from `Date.now()` to `mkdtempSync` so concurrent runs cannot collide on the same path.

Tested: full suite passes (1194 tests), and `/tmp` entry count is unchanged across a run, down from +9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Cleans up temporary directories created by tests in `os.tmpdir()`.
- Uses `mkdtempSync` to create unique test directories.
- Invalidates icon caches before cleanup to prevent directories from being recreated.
- Corrects `afterEach` cleanup scoping in `test/appstore/icon-probe.test.ts`.
- Adds cleanup for `test/modules.js` and `test/security-config-missing.ts`.
- Updates `getPluginDataSize` test paths to avoid collisions.
- Makes no production code changes.

The full test suite passes with 1,194 tests, and temporary-directory counts remain unchanged after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->