### PR TITLE
docs(radar-api): specify how requests that change something are answered

### DIFF
--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -131,6 +131,50 @@ Some further considerations as how to show controls:
 
 ## REST API
 
+### Responses
+
+A request that reads something answers with the document described for that
+endpoint, on its own:
+
+```json
+{ "auto": false, "value": 50 }
+```
+
+A request that _changes_ something — setting a control, acquiring a target,
+cancelling one — answers with the Signal K request response:
+
+```json
+{ "state": "COMPLETED", "statusCode": 200, "message": "OK" }
+```
+
+| Field        | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| `state`      | `COMPLETED` when the request was carried out, `FAILED` otherwise |
+| `statusCode` | Repeats the HTTP status, which Signal K clients read from here   |
+| `message`    | Human-readable detail; `OK` on success, the reason on failure    |
+
+A failure answers with the same three fields and an HTTP status to match:
+
+```json
+{
+  "state": "FAILED",
+  "statusCode": 404,
+  "message": "Unknown radar 'nav9999' -- use [\"nav1034A\", \"nav1034B\"] instead"
+}
+```
+
+| Status | Meaning                                                                   |
+| ------ | ------------------------------------------------------------------------- |
+| 200    | The request was carried out                                               |
+| 400    | The body could not be read, or a value was outside what the control takes |
+| 404    | No such radar, control or target                                          |
+| 501    | An optional part of this API the server does not implement                |
+
+Note that a control being settable does not mean the radar has accepted the
+new value: a server answers once it has passed the request on, and the radar
+reports its own state back over the stream. A client that needs to know the
+radar agreed should watch for the control value it set coming back.
+
 ### Listing All Radars
 
 Retrieve all available radars with their current info:

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -166,9 +166,19 @@ A failure answers with the same three fields and an HTTP status to match:
 | Status | Meaning                                                                   |
 | ------ | ------------------------------------------------------------------------- |
 | 200    | The request was carried out                                               |
+| 201    | A target was acquired, and the response carries its `targetId`            |
 | 400    | The body could not be read, or a value was outside what the control takes |
+| 403    | The client may not change this                                            |
 | 404    | No such radar, control or target                                          |
+| 500    | The server failed to carry the request out                                |
 | 501    | An optional part of this API the server does not implement                |
+
+Acquiring a target answers 201 and carries the new target's id beside the
+three fields, since a client needs it to cancel the target later:
+
+```json
+{ "state": "COMPLETED", "statusCode": 201, "message": "OK", "targetId": 5 }
+```
 
 Note that a control being settable does not mean the radar has accepted the
 new value: a server answers once it has passed the request on, and the radar


### PR DESCRIPTION
The Radar API spec documents in detail what a client sends to set a control or acquire a target, but never what comes back. An implementer has nothing to write against, and a client has nothing to read to find out whether its request worked or why it did not.

This documents the response, matching what the rest of the Signal K REST API already answers with:

```json
{ "state": "COMPLETED", "statusCode": 200, "message": "OK" }
```

along with the failure form, the status codes that go with it, and — explicitly — that *reading* a control stays a bare value, since that is easy to get wrong in the other direction.

It also records something the spec left implicit: an answer means the server passed the request on to the radar, not that the radar accepted it. The radar reports its own state over the stream, so a client that needs certainty watches for the value it set coming back. Radars do reject settings in practice, so a client written on the assumption that 200 means "applied" will be wrong some of the time.

Nothing here changes behaviour — it writes down what implementations already do or should do. `mayara-server`, the reference implementation, is being brought in line in MarineYachtRadar/mayara-server#537.

Prettier clean.

## One inconsistency this exposes

`src/api/radar/index.ts` answers a control read as `{"value": {...}}`, where the spec documents a bare `{ "auto": false, "value": 50 }` (unchanged by this PR, at `radar_api.md` "Getting a Single Control Value"). Verified against a running server on the same host as mayara:

```
signalk-server :3000  {"value":{"auto":true,"autoValue":-20,"value":28,"timestamp":"..."}}
mayara-server  :6502  {"auto":true,"autoValue":-20.0,"value":28,"timestamp":"..."}
```

Left alone here so this PR stays documentation-only. Happy to fix it separately if you agree the spec is what should win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR documents Radar API responses for control updates and target acquisition requests.

- Defines successful responses and response fields.
- Documents failure responses and HTTP status codes `201`, `403`, and `500`.
- Documents the `targetId` returned for target acquisition requests.
- Clarifies that control reads return a bare value.
- Explains that success confirms server forwarding, not radar acceptance.
- Instructs clients to verify requested values through the radar state stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->