### PR TITLE
fix(radar-api): answer a control read as the spec documents it

### DIFF
--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -851,7 +851,12 @@ export class RadarApi {
             req.params.controlId
           )
           if (value !== null && value !== undefined) {
-            res.status(200).json({ value })
+            // Bare, as radar_api.md documents it: `{ "auto": false, "value":
+            // 50 }`. A control's own `value` is one field among siblings, so
+            // wrapping it in a Signal K value envelope nests one `value`
+            // inside another and a client reading the documented shape finds
+            // nothing where it looked.
+            res.status(200).json(value)
           } else {
             res.status(404).json({
               error: 'Control not found',

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -114,7 +114,11 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
         ) => {
           onSetControl(radarId, controlId, value)
           return { success: true }
-        }
+        },
+        getControl: async (_radarId: string, controlId: string) =>
+          controlId === 'gain'
+            ? { auto: false, value: 50 }
+            : { auto: true, autoValue: -20, value: 28 }
       }
     } as unknown as radar.RadarProvider)
 
@@ -130,7 +134,8 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
-        })
+        }),
+      get: (path: string) => fetch(`http://127.0.0.1:${port}${path}`)
     }
   }
 
@@ -159,5 +164,78 @@ describe('Radar API: PUT /controls/{controlId} route', () => {
 
     expect(res.status).to.equal(200)
     expect(seen).to.deep.equal([[RADAR, 'range', 1852]])
+  })
+})
+
+// radar_api.md, "Getting a Single Control Value", documents the response as
+// `{ "auto": false, "value": 50 }`. Wrapping that in a Signal K value envelope
+// put the documented object one level down, so `body.value` was the whole
+// control rather than the control's value — and a compound control ended up
+// with a `value` inside a `value`.
+
+describe('Radar API: GET /controls/{controlId} route', () => {
+  const RADAR = 'radar-0'
+  const base = `/signalk/v2/api/vessels/self/radars/${RADAR}/controls`
+
+  const started: Array<() => Promise<void>> = []
+  afterEach(async () => {
+    while (started.length) await started.pop()!()
+  })
+
+  async function startRadarApi() {
+    const app = express() as unknown as express.Express & {
+      securityStrategy: { shouldAllowPut: () => boolean }
+    }
+    app.use(express.json())
+    app.securityStrategy = { shouldAllowPut: () => true }
+
+    const api = new RadarApi(
+      app as unknown as ConstructorParameters<typeof RadarApi>[0]
+    )
+    await api.start()
+    api.register('test-provider', {
+      name: 'Test Radar Provider',
+      methods: {
+        getRadars: async () => [RADAR],
+        getRadarInfo: async () => ({
+          name: 'Test',
+          brand: 'Test',
+          radarIpAddress: '10.0.0.1'
+        }),
+        getControl: async (_radarId: string, controlId: string) =>
+          controlId === 'gain'
+            ? { auto: false, value: 50 }
+            : { auto: true, autoValue: -20, value: 28 }
+      }
+    } as unknown as radar.RadarProvider)
+
+    const server = app.listen(0)
+    await new Promise((resolve) => server.once('listening', resolve))
+    const { port } = server.address() as AddressInfo
+    started.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve()))
+    )
+    return { get: (path: string) => fetch(`http://127.0.0.1:${port}${path}`) }
+  }
+
+  it('answers with the control as documented, not wrapped', async () => {
+    const { get } = await startRadarApi()
+
+    const res = await get(`${base}/gain`)
+
+    expect(res.status).to.equal(200)
+    expect(await res.json()).to.deep.equal({ auto: false, value: 50 })
+  })
+
+  it('keeps an auto adjustment beside the value it belongs to', async () => {
+    const { get } = await startRadarApi()
+
+    const res = await get(`${base}/sea`)
+
+    expect(await res.json()).to.deep.equal({
+      auto: true,
+      autoValue: -20,
+      value: 28
+    })
   })
 })


### PR DESCRIPTION
A client asking for one radar control got the control wrapped in a value envelope, so it found the whole control where the documentation says the control's value is. For a compound control that produced a `value` inside a `value`, and a client reading the documented shape got a number that meant nothing.

`radar_api.md`, "Getting a Single Control Value", documents:

```json
{ "auto": false, "value": 50 }
```

Observed against 2.31.0-beta.2 and mayara-server 3.8.1 on the same host, same radar, same instant:

```
signalk-server  {"value":{"auto":true,"autoValue":-20,"value":28,"timestamp":"…"}}
mayara-server   {"auto":true,"autoValue":-20,"value":28,"timestamp":"…"}
```

Reading *all* controls at once was already bare (`res.status(200).json(state.controls)`), so this also removes an inconsistency between the two read endpoints of the same API.

## Compatibility

This changes a response shape, so a client that learned to unwrap the envelope will need updating. Two things make that narrow: the shape never matched the specification, so any client written from the docs is currently broken and this fixes it; and the sibling endpoint already answered bare, so a client handling both was already dealing with the documented form.

## Testing

Two route tests cover it — a simple control and one carrying an auto adjustment alongside its value, which is the case the nesting mangled.

I could not run mocha locally: `test/api/radar-*.ts` fails with `ERR_UNSUPPORTED_DIR_IMPORT` on the directory import of `src/api/radar`, on a clean tree as well as with this change. That is Node 26 here against the repo's `>=22`, not something this PR introduces — so these tests are unverified on my side and I am relying on CI. `tsc --noEmit` reports nothing for radar or the test file.

Companion to #2945, which documents the response shapes for this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the radar API single-control GET endpoint to return the control object directly. The response now matches the documented shape and the all-controls endpoint. Compound controls retain their `auto`, `autoValue`, and `value` fields without an extra `value` envelope.

The PR adds route tests for simple controls and controls with auto adjustments. Mocha tests are not run because of an existing Node 26 directory-import error. TypeScript compilation reports no radar-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->