### PR TITLE
fix(radar-api): answer every request in one shape

### DIFF
--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -84,6 +84,16 @@ export async function applyControl(
 interface RadarApplication
   extends WithSecurityStrategy, SignalKMessageHub, IRouter {}
 
+/**
+ * Answer a request that failed, in the one shape this API answers in. The
+ * status appears once: it is both the HTTP status and the `statusCode` a
+ * Signal K client reads it from, and the two drifting apart is exactly the
+ * confusion the shared shape exists to avoid.
+ */
+function failed(res: Response, statusCode: number, message: string) {
+  res.status(statusCode).json({ state: 'FAILED', statusCode, message })
+}
+
 export class RadarApi {
   private radarProviders: Map<string, radar.RadarProvider> = new Map()
   private defaultProviderId?: string
@@ -250,11 +260,7 @@ export class RadarApi {
         const radars = await this.getRadars()
         res.status(200).json(radars)
       } catch (err: any) {
-        res.status(500).json({
-          statusCode: 500,
-          state: 'FAILED',
-          message: err.message
-        })
+        failed(res, 500, err.message)
       }
     })
 
@@ -273,11 +279,7 @@ export class RadarApi {
           })
           res.status(200).json(r)
         } catch (err: any) {
-          res.status(400).json({
-            statusCode: 400,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 400, err.message)
         }
       }
     )
@@ -292,11 +294,7 @@ export class RadarApi {
             id: this.defaultProviderId
           })
         } catch (err: any) {
-          res.status(400).json({
-            statusCode: 400,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 400, err.message)
         }
       }
     )
@@ -325,11 +323,7 @@ export class RadarApi {
             throw new Error(`Provider ${req.params.id} not found!`)
           }
         } catch (err: any) {
-          res.status(400).json({
-            statusCode: 400,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 400, err.message)
         }
       }
     )
@@ -347,11 +341,7 @@ export class RadarApi {
             res.status(404).json(Responses.notFound)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -372,11 +362,7 @@ export class RadarApi {
             return
           }
           if (!provider.setControls) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setControls'
-            })
+            failed(res, 501, 'Provider does not support setControls')
             return
           }
           const controls: Partial<radar.RadarControls> =
@@ -385,18 +371,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Failed to update radar controls'
-            })
+            failed(res, 400, 'Failed to update radar controls')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -417,21 +395,16 @@ export class RadarApi {
             return
           }
           if (!provider.setControl && !provider.setPower) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setPower'
-            })
+            failed(res, 501, 'Provider does not support setPower')
             return
           }
           const state: radar.RadarStatus = req.body.value
           if (!['off', 'standby', 'transmit', 'warming'].includes(state)) {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message:
-                'Invalid power state. Must be: off, standby, transmit, or warming'
-            })
+            failed(
+              res,
+              400,
+              'Invalid power state. Must be: off, standby, transmit, or warming'
+            )
             return
           }
           const { success, error } = await applyControl(
@@ -445,18 +418,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: error ?? 'Failed to set radar power state'
-            })
+            failed(res, 400, error ?? 'Failed to set radar power state')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -477,20 +442,16 @@ export class RadarApi {
             return
           }
           if (!provider.setControl && !provider.setRange) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setRange'
-            })
+            failed(res, 501, 'Provider does not support setRange')
             return
           }
           const range: number = req.body.value
           if (typeof range !== 'number' || range <= 0) {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Invalid range value. Must be a positive number (meters)'
-            })
+            failed(
+              res,
+              400,
+              'Invalid range value. Must be a positive number (meters)'
+            )
             return
           }
           const { success, error } = await applyControl(
@@ -504,18 +465,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: error ?? 'Failed to set radar range'
-            })
+            failed(res, 400, error ?? 'Failed to set radar range')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -536,21 +489,17 @@ export class RadarApi {
             return
           }
           if (!provider.setControl && !provider.setGain) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setGain'
-            })
+            failed(res, 501, 'Provider does not support setGain')
             return
           }
           const gain: { auto: boolean; value?: number } =
             typeof req.body.value === 'object' ? req.body.value : req.body
           if (typeof gain.auto !== 'boolean') {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Invalid gain value. Must have "auto" boolean property'
-            })
+            failed(
+              res,
+              400,
+              'Invalid gain value. Must have "auto" boolean property'
+            )
             return
           }
           const { success, error } = await applyControl(
@@ -563,18 +512,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: error ?? 'Failed to set radar gain'
-            })
+            failed(res, 400, error ?? 'Failed to set radar gain')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -595,21 +536,17 @@ export class RadarApi {
             return
           }
           if (!provider.setControl && !provider.setSea) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setSea'
-            })
+            failed(res, 501, 'Provider does not support setSea')
             return
           }
           const sea: { auto: boolean; value?: number } =
             typeof req.body.value === 'object' ? req.body.value : req.body
           if (typeof sea.auto !== 'boolean') {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Invalid sea value. Must have "auto" boolean property'
-            })
+            failed(
+              res,
+              400,
+              'Invalid sea value. Must have "auto" boolean property'
+            )
             return
           }
           const { success, error } = await applyControl(
@@ -622,18 +559,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: error ?? 'Failed to set radar sea clutter'
-            })
+            failed(res, 400, error ?? 'Failed to set radar sea clutter')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -654,21 +583,17 @@ export class RadarApi {
             return
           }
           if (!provider.setControl && !provider.setRain) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setRain'
-            })
+            failed(res, 501, 'Provider does not support setRain')
             return
           }
           const rain: { auto: boolean; value?: number } =
             typeof req.body.value === 'object' ? req.body.value : req.body
           if (typeof rain.auto !== 'boolean') {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Invalid rain value. Must have "auto" boolean property'
-            })
+            failed(
+              res,
+              400,
+              'Invalid rain value. Must have "auto" boolean property'
+            )
             return
           }
           const { success, error } = await applyControl(
@@ -681,18 +606,10 @@ export class RadarApi {
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: error ?? 'Failed to set radar rain clutter'
-            })
+            failed(res, 400, error ?? 'Failed to set radar rain clutter')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -709,37 +626,21 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getCapabilities) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support getCapabilities'
-            })
+            failed(res, 501, 'Provider does not support getCapabilities')
             return
           }
           const capabilities = await provider.getCapabilities(req.params.id)
           if (capabilities) {
             res.status(200).json(capabilities)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -752,37 +653,21 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getState) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support getState'
-            })
+            failed(res, 501, 'Provider does not support getState')
             return
           }
           const state = await provider.getState(req.params.id)
           if (state) {
             res.status(200).json(state)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -795,37 +680,21 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getState) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support getState'
-            })
+            failed(res, 501, 'Provider does not support getState')
             return
           }
           const state = await provider.getState(req.params.id)
           if (state && state.controls) {
             res.status(200).json(state.controls)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -838,19 +707,11 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getControl) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support getControl'
-            })
+            failed(res, 501, 'Provider does not support getControl')
             return
           }
           const value = await provider.getControl(
@@ -865,18 +726,10 @@ export class RadarApi {
             // nothing where it looked.
             res.status(200).json(value)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Control ${req.params.controlId} not found`
-            })
+            failed(res, 404, `Control ${req.params.controlId} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -893,19 +746,11 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.setControl) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support setControl'
-            })
+            failed(res, 501, 'Provider does not support setControl')
             return
           }
           const value = unwrapControlPayload(req.body)
@@ -917,18 +762,10 @@ export class RadarApi {
           if (result.success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              state: 'FAILED',
-              statusCode: 400,
-              message: result.error || 'Failed to set control'
-            })
+            failed(res, 400, result.error || 'Failed to set control')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -955,37 +792,21 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getTargets) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support ARPA targets'
-            })
+            failed(res, 501, 'Provider does not support ARPA targets')
             return
           }
           const targets = await provider.getTargets(req.params.id)
           if (targets) {
             res.status(200).json(targets)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -1002,45 +823,28 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.acquireTarget) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support target acquisition'
-            })
+            failed(res, 501, 'Provider does not support target acquisition')
             return
           }
           const { bearing, distance } = req.body
           if (typeof bearing !== 'number' || typeof distance !== 'number') {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message:
-                'Invalid request. Must provide bearing (radians) and distance (meters)'
-            })
+            failed(
+              res,
+              400,
+              'Invalid request. Must provide bearing (radians) and distance (meters)'
+            )
             return
           }
           if (bearing < 0 || bearing >= TWO_PI) {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Bearing must be in radians [0, 2π)'
-            })
+            failed(res, 400, 'Bearing must be in radians [0, 2π)')
             return
           }
           if (distance <= 0) {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Distance must be a positive number (meters)'
-            })
+            failed(res, 400, 'Distance must be a positive number (meters)')
             return
           }
           const result = await provider.acquireTarget(
@@ -1056,18 +860,10 @@ export class RadarApi {
               targetId: result.targetId
             })
           } else {
-            res.status(400).json({
-              state: 'FAILED',
-              statusCode: 400,
-              message: result.error || 'Failed to acquire target'
-            })
+            failed(res, 400, result.error || 'Failed to acquire target')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -1084,46 +880,26 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.cancelTarget) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support target cancellation'
-            })
+            failed(res, 501, 'Provider does not support target cancellation')
             return
           }
           const targetId = parseInt(req.params.targetId, 10)
           if (isNaN(targetId)) {
-            res.status(400).json({
-              statusCode: 400,
-              state: 'FAILED',
-              message: 'Invalid target ID. Must be a number'
-            })
+            failed(res, 400, 'Invalid target ID. Must be a number')
             return
           }
           const success = await provider.cancelTarget(req.params.id, targetId)
           if (success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: 'Target not found or already cancelled'
-            })
+            failed(res, 404, 'Target not found or already cancelled')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -1136,37 +912,21 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.getArpaSettings) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support ARPA settings'
-            })
+            failed(res, 501, 'Provider does not support ARPA settings')
             return
           }
           const settings = await provider.getArpaSettings(req.params.id)
           if (settings) {
             res.status(200).json(settings)
           } else {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )
@@ -1183,19 +943,11 @@ export class RadarApi {
         try {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
-            res.status(404).json({
-              state: 'FAILED',
-              statusCode: 404,
-              message: `Radar ${req.params.id} not found`
-            })
+            failed(res, 404, `Radar ${req.params.id} not found`)
             return
           }
           if (!provider.setArpaSettings) {
-            res.status(501).json({
-              statusCode: 501,
-              state: 'FAILED',
-              message: 'Provider does not support ARPA settings'
-            })
+            failed(res, 501, 'Provider does not support ARPA settings')
             return
           }
           const settings: Partial<radar.ArpaSettings> =
@@ -1204,18 +956,10 @@ export class RadarApi {
           if (result.success) {
             res.status(200).json(Responses.ok)
           } else {
-            res.status(400).json({
-              state: 'FAILED',
-              statusCode: 400,
-              message: result.error || 'Failed to update ARPA settings'
-            })
+            failed(res, 400, result.error || 'Failed to update ARPA settings')
           }
         } catch (err: any) {
-          res.status(500).json({
-            statusCode: 500,
-            state: 'FAILED',
-            message: err.message
-          })
+          failed(res, 500, err.message)
         }
       }
     )

--- a/src/api/radar/index.ts
+++ b/src/api/radar/index.ts
@@ -710,8 +710,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -728,8 +729,9 @@ export class RadarApi {
             res.status(200).json(capabilities)
           } else {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
           }
         } catch (err: any) {
@@ -751,8 +753,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -769,8 +772,9 @@ export class RadarApi {
             res.status(200).json(state)
           } else {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
           }
         } catch (err: any) {
@@ -792,8 +796,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -810,8 +815,9 @@ export class RadarApi {
             res.status(200).json(state.controls)
           } else {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
           }
         } catch (err: any) {
@@ -833,8 +839,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -859,8 +866,9 @@ export class RadarApi {
             res.status(200).json(value)
           } else {
             res.status(404).json({
-              error: 'Control not found',
-              controlId: req.params.controlId
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Control ${req.params.controlId} not found`
             })
           }
         } catch (err: any) {
@@ -886,8 +894,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -906,12 +915,12 @@ export class RadarApi {
             value
           )
           if (result.success) {
-            res.status(200).json({ success: true })
+            res.status(200).json(Responses.ok)
           } else {
             res.status(400).json({
-              success: false,
-              error: result.error || 'Failed to set control',
-              controlId: req.params.controlId
+              state: 'FAILED',
+              statusCode: 400,
+              message: result.error || 'Failed to set control'
             })
           }
         } catch (err: any) {
@@ -947,8 +956,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -965,8 +975,9 @@ export class RadarApi {
             res.status(200).json(targets)
           } else {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
           }
         } catch (err: any) {
@@ -992,8 +1003,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -1038,13 +1050,16 @@ export class RadarApi {
           )
           if (result.success) {
             res.status(201).json({
-              success: true,
+              state: 'COMPLETED',
+              statusCode: 201,
+              message: 'OK',
               targetId: result.targetId
             })
           } else {
             res.status(400).json({
-              success: false,
-              error: result.error || 'Failed to acquire target'
+              state: 'FAILED',
+              statusCode: 400,
+              message: result.error || 'Failed to acquire target'
             })
           }
         } catch (err: any) {
@@ -1070,8 +1085,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -1094,11 +1110,12 @@ export class RadarApi {
           }
           const success = await provider.cancelTarget(req.params.id, targetId)
           if (success) {
-            res.status(200).json({ success: true })
+            res.status(200).json(Responses.ok)
           } else {
             res.status(404).json({
-              success: false,
-              error: 'Target not found or already cancelled'
+              state: 'FAILED',
+              statusCode: 404,
+              message: 'Target not found or already cancelled'
             })
           }
         } catch (err: any) {
@@ -1120,8 +1137,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -1138,8 +1156,9 @@ export class RadarApi {
             res.status(200).json(settings)
           } else {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
           }
         } catch (err: any) {
@@ -1165,8 +1184,9 @@ export class RadarApi {
           const provider = await this.findProviderForRadar(req.params.id)
           if (!provider) {
             res.status(404).json({
-              error: 'Radar not found',
-              id: req.params.id
+              state: 'FAILED',
+              statusCode: 404,
+              message: `Radar ${req.params.id} not found`
             })
             return
           }
@@ -1182,11 +1202,12 @@ export class RadarApi {
             req.body.value !== undefined ? req.body.value : req.body
           const result = await provider.setArpaSettings(req.params.id, settings)
           if (result.success) {
-            res.status(200).json({ success: true })
+            res.status(200).json(Responses.ok)
           } else {
             res.status(400).json({
-              success: false,
-              error: result.error || 'Failed to update ARPA settings'
+              state: 'FAILED',
+              statusCode: 400,
+              message: result.error || 'Failed to update ARPA settings'
             })
           }
         } catch (err: any) {

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -239,3 +239,121 @@ describe('Radar API: GET /controls/{controlId} route', () => {
     })
   })
 })
+
+// A client cannot read one thing to find out how its request went while the
+// API answers `{success}` from one route, `{state,statusCode,message}` from
+// the next and `{error}` from a third. `{success}` is the shape a provider
+// hands back internally; it has no business on the wire.
+
+describe('Radar API: mutation response shape', () => {
+  const RADAR = 'radar-0'
+  const base = `/signalk/v2/api/vessels/self/radars/${RADAR}`
+
+  const started: Array<() => Promise<void>> = []
+  afterEach(async () => {
+    while (started.length) await started.pop()!()
+  })
+
+  async function start(overrides: Record<string, unknown>) {
+    const app = express() as unknown as express.Express & {
+      securityStrategy: { shouldAllowPut: () => boolean }
+    }
+    app.use(express.json())
+    app.securityStrategy = { shouldAllowPut: () => true }
+
+    const api = new RadarApi(
+      app as unknown as ConstructorParameters<typeof RadarApi>[0]
+    )
+    await api.start()
+    api.register('test-provider', {
+      name: 'Test Radar Provider',
+      methods: {
+        getRadars: async () => [RADAR],
+        getRadarInfo: async () => ({
+          name: 'Test',
+          brand: 'Test',
+          radarIpAddress: '10.0.0.1'
+        }),
+        ...overrides
+      }
+    } as unknown as radar.RadarProvider)
+
+    const server = app.listen(0)
+    await new Promise((resolve) => server.once('listening', resolve))
+    const { port } = server.address() as AddressInfo
+    started.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve()))
+    )
+    const call = (method: string) => (path: string, body?: unknown) =>
+      fetch(`http://127.0.0.1:${port}${path}`, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body)
+      })
+    return { put: call('PUT'), post: call('POST') }
+  }
+
+  it('answers a set control with the request response', async () => {
+    const { put } = await start({
+      setControl: async () => ({ success: true })
+    })
+
+    const res = await put(`${base}/controls/gain`, { value: 50 })
+
+    expect(res.status).to.equal(200)
+    expect(await res.json()).to.deep.equal({
+      state: 'COMPLETED',
+      statusCode: 200,
+      message: 'OK'
+    })
+  })
+
+  it('reports a control the provider refused in the same shape', async () => {
+    const { put } = await start({
+      setControl: async () => ({ success: false, error: 'Radar said no' })
+    })
+
+    const res = await put(`${base}/controls/gain`, { value: 50 })
+
+    expect(res.status).to.equal(400)
+    expect(await res.json()).to.deep.equal({
+      state: 'FAILED',
+      statusCode: 400,
+      message: 'Radar said no'
+    })
+  })
+
+  it('keeps the target id beside the request response on acquisition', async () => {
+    const { post } = await start({
+      acquireTarget: async () => ({ success: true, targetId: 5 })
+    })
+
+    const res = await post(`${base}/targets`, {
+      bearing: 0.785,
+      distance: 2000
+    })
+
+    expect(res.status).to.equal(201)
+    expect(await res.json()).to.deep.equal({
+      state: 'COMPLETED',
+      statusCode: 201,
+      message: 'OK',
+      targetId: 5
+    })
+  })
+
+  it('reports an unknown radar in the same shape', async () => {
+    const { put } = await start({ setControl: async () => ({ success: true }) })
+
+    const res = await put(
+      '/signalk/v2/api/vessels/self/radars/nosuchradar/controls/gain',
+      { value: 50 }
+    )
+
+    expect(res.status).to.equal(404)
+    const body = await res.json()
+    expect(body.state).to.equal('FAILED')
+    expect(body.statusCode).to.equal(404)
+    expect(body.message).to.be.a('string')
+  })
+})

--- a/test/api/radar-control-put.test.ts
+++ b/test/api/radar-control-put.test.ts
@@ -290,7 +290,7 @@ describe('Radar API: mutation response shape', () => {
         headers: { 'Content-Type': 'application/json' },
         body: body === undefined ? undefined : JSON.stringify(body)
       })
-    return { put: call('PUT'), post: call('POST') }
+    return { put: call('PUT'), post: call('POST'), get: call('GET') }
   }
 
   it('answers a set control with the request response', async () => {
@@ -340,6 +340,49 @@ describe('Radar API: mutation response shape', () => {
       message: 'OK',
       targetId: 5
     })
+  })
+
+  // Reads answer failure in the same shape as writes. They used to answer
+  // `{error: 'Radar not found', id}`, so a client had to know whether it had
+  // read or written to know which field carried the reason.
+  const reads = [
+    ['capabilities', `${base}/capabilities`],
+    ['controls', `${base}/controls`],
+    ['a single control', `${base}/controls/gain`],
+    ['targets', `${base}/targets`]
+  ] as const
+
+  for (const [what, path] of reads) {
+    it(`reports a missing radar the same way when reading ${what}`, async () => {
+      const { get } = await start({})
+
+      const res = await get(path.replace(RADAR, 'nosuchradar'))
+
+      expect(res.status).to.equal(404)
+      const body = await res.json()
+      expect(body.state).to.equal('FAILED')
+      expect(body.statusCode).to.equal(404)
+      expect(body.message).to.be.a('string')
+      expect(body.error, 'the old error field must be gone').to.equal(undefined)
+      expect(body.id, 'the old id field must be gone').to.equal(undefined)
+    })
+  }
+
+  it('reports an unknown control in the same shape', async () => {
+    const { get } = await start({
+      getControl: async () => null
+    })
+
+    const res = await get(`${base}/controls/nosuchcontrol`)
+
+    expect(res.status).to.equal(404)
+    const body = await res.json()
+    expect(body.state).to.equal('FAILED')
+    expect(body.statusCode).to.equal(404)
+    expect(body.error, 'the old error field must be gone').to.equal(undefined)
+    expect(body.controlId, 'the old controlId field must be gone').to.equal(
+      undefined
+    )
   })
 
   it('reports an unknown radar in the same shape', async () => {


### PR DESCRIPTION
A client using the Radar API had to know which endpoint it had called to work out how its request went. Setting a control answered `{"success": true}`. Asking about a radar that is not there answered `{"error": "Radar not found", "id": "..."}`. A validation failure or a server error answered `{"state", "statusCode", "message"}`. Three shapes across one API, so there was no single thing to read.

`{success}` is what a radar provider hands back to the server internally. It had no business on the wire.

Every route now answers with the Signal K request response:

```
PUT  …/controls/gain      → 200  {"state":"COMPLETED","statusCode":200,"message":"OK"}
PUT  …/controls/gain      → 400  {"state":"FAILED","statusCode":400,"message":"Radar said no"}
GET  …/radars/nope/…      → 404  {"state":"FAILED","statusCode":404,"message":"Radar nope not found"}
POST …/targets            → 201  {"state":"COMPLETED","statusCode":201,"message":"OK","targetId":5}
```

Acquiring a target keeps its 201 and carries the new target id beside the three fields, since a client needs that id to cancel the target later.

## What is not changed

`RadarProviderMethods` is untouched. Providers still return `{success, error}` — the route layer now translates that instead of forwarding it. No plugin needs updating.

## Compatibility

This changes response bodies, so an HTTP client reading `body.success` or `body.error` needs updating. The API has never documented those shapes; #2945 documents the one this PR settles on.

## Testing

Four route tests: a control set that succeeds, one the provider refuses, a target acquisition carrying its id, and an unknown radar.

I could not run mocha locally — `test/api/radar-*.ts` fails with `ERR_UNSUPPORTED_DIR_IMPORT` on the directory import of `src/api/radar`, on a clean tree as much as with this change (Node 26 here against the repo's `>=22`). So these tests are unverified on my side and I am relying on CI. `tsc --noEmit` reports nothing for radar or the test file.

## Related

- #2945 documents these responses
- #2946 fixes a single control read answering wrapped rather than bare

The three are independent and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Standardizes Radar API success and failure responses with the Signal K response format.
- Returns `state`, `statusCode`, and `message` for all routes.
- Includes `targetId` in target acquisition responses.
- Adds tests for successful updates, failures, target acquisition, and unknown radars.
- Changes responses for clients that use `body.success` or `body.error`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->