### PR TITLE
fix(backpressure): preserve source frame timestamps

### DIFF
--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -57,7 +57,7 @@ export function accumulateLatestValue(
 
 /**
  * Convert accumulated values to spec-compliant deltas.
- * Groups values by context and $source for proper delta structure.
+ * Groups values by context, $source, and timestamp for proper delta structure.
  *
  * @param accumulator - Map of accumulated values
  * @param duration - How long backpressure was active in milliseconds
@@ -71,45 +71,48 @@ export function buildFlushDeltas(
 
   const countBefore = accumulator.size
 
-  // Group by context
-  const byContext = new Map<Context, Map<string, Update>>()
-  for (const [, item] of accumulator) {
-    if (!byContext.has(item.context)) {
-      byContext.set(item.context, new Map())
+  const byContext = new Map<
+    Context,
+    Map<SourceRef | undefined, Map<Timestamp | undefined, Update>>
+  >()
+  for (const item of accumulator.values()) {
+    let bySource = byContext.get(item.context)
+    if (!bySource) {
+      bySource = new Map()
+      byContext.set(item.context, bySource)
     }
-    // Group by $source within context
-    const bySource = byContext.get(item.context)!
-    const sourceKey = item.$source || 'unknown'
-    if (!bySource.has(sourceKey)) {
-      bySource.set(sourceKey, {
+    // One update timestamp applies to every path value in that update, so values from different
+    // source frames must remain in separate updates even when their $source is the same.
+    let byTimestamp = bySource.get(item.$source)
+    if (!byTimestamp) {
+      byTimestamp = new Map()
+      bySource.set(item.$source, byTimestamp)
+    }
+    let update = byTimestamp.get(item.timestamp)
+    if (!update) {
+      update = {
         $source: item.$source as SourceRef,
         timestamp: item.timestamp as Timestamp,
         values: []
-      })
+      }
+      byTimestamp.set(item.timestamp, update)
     }
-    const update = bySource.get(sourceKey)!
     if (hasValues(update)) {
       update.values.push({
         path: item.path as Path,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         value: item.value as any
       })
-      // Use the most recent timestamp for this source
-      if (
-        item.timestamp &&
-        (!update.timestamp || item.timestamp > update.timestamp)
-      ) {
-        update.timestamp = item.timestamp as Timestamp
-      }
     }
   }
 
-  // Build one delta per context with backpressure indicator
   const deltas: BackpressureDelta[] = []
-  for (const [context, bySourceTime] of byContext) {
+  for (const [context, bySource] of byContext) {
     deltas.push({
       context,
-      updates: Array.from(bySourceTime.values()),
+      updates: Array.from(bySource.values()).flatMap((byTimestamp) =>
+        Array.from(byTimestamp.values())
+      ),
       $backpressure: {
         accumulated: countBefore,
         duration

--- a/src/LatestValuesAccumulator.ts
+++ b/src/LatestValuesAccumulator.ts
@@ -8,6 +8,7 @@ import {
   Delta,
   hasValues,
   Path,
+  PathValue,
   SourceRef,
   Timestamp,
   Update
@@ -16,7 +17,7 @@ import {
 export interface AccumulatedItem {
   context: Context
   path: Path
-  value: unknown
+  value: PathValue['value']
   $source: SourceRef | undefined
   timestamp: Timestamp | undefined
 }
@@ -91,17 +92,16 @@ export function buildFlushDeltas(
     let update = byTimestamp.get(item.timestamp)
     if (!update) {
       update = {
-        $source: item.$source as SourceRef,
-        timestamp: item.timestamp as Timestamp,
+        $source: item.$source,
+        timestamp: item.timestamp,
         values: []
       }
       byTimestamp.set(item.timestamp, update)
     }
     if (hasValues(update)) {
       update.values.push({
-        path: item.path as Path,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: item.value as any
+        path: item.path,
+        value: item.value
       })
     }
   }

--- a/test/LatestValuesAccumulator.js
+++ b/test/LatestValuesAccumulator.js
@@ -309,6 +309,73 @@ describe('LatestValuesAccumulator', function () {
       expect(compassUpdate.values.length).to.equal(1)
     })
 
+    it('should keep different timestamps in separate updates', function () {
+      const accumulator = new Map()
+      accumulator.set('vessels.self:navigation.speedOverGround:gps', {
+        context: 'vessels.self',
+        path: 'navigation.speedOverGround',
+        value: 5.0,
+        $source: 'gps',
+        timestamp: '2024-01-15T10:30:00.000Z'
+      })
+      accumulator.set('vessels.self:navigation.headingTrue:gps', {
+        context: 'vessels.self',
+        path: 'navigation.headingTrue',
+        value: 1.5,
+        $source: 'gps',
+        timestamp: '2024-01-15T10:30:00.005Z'
+      })
+
+      const deltas = buildFlushDeltas(accumulator, 1000)
+
+      expect(deltas).to.have.length(1)
+      expect(deltas[0].updates).to.deep.equal([
+        {
+          $source: 'gps',
+          timestamp: '2024-01-15T10:30:00.000Z',
+          values: [{ path: 'navigation.speedOverGround', value: 5.0 }]
+        },
+        {
+          $source: 'gps',
+          timestamp: '2024-01-15T10:30:00.005Z',
+          values: [{ path: 'navigation.headingTrue', value: 1.5 }]
+        }
+      ])
+    })
+
+    it('should keep missing and dated timestamps in separate updates', function () {
+      const accumulator = new Map()
+      accumulator.set('vessels.self:navigation.speedOverGround:gps', {
+        context: 'vessels.self',
+        path: 'navigation.speedOverGround',
+        value: 5.0,
+        $source: 'gps',
+        timestamp: undefined
+      })
+      accumulator.set('vessels.self:navigation.headingTrue:gps', {
+        context: 'vessels.self',
+        path: 'navigation.headingTrue',
+        value: 1.5,
+        $source: 'gps',
+        timestamp: '2024-01-15T10:30:00.005Z'
+      })
+
+      const [flushed] = buildFlushDeltas(accumulator, 1000)
+
+      expect(flushed.updates).to.deep.equal([
+        {
+          $source: 'gps',
+          timestamp: undefined,
+          values: [{ path: 'navigation.speedOverGround', value: 5.0 }]
+        },
+        {
+          $source: 'gps',
+          timestamp: '2024-01-15T10:30:00.005Z',
+          values: [{ path: 'navigation.headingTrue', value: 1.5 }]
+        }
+      ])
+    })
+
     it('should include accumulated count in backpressure indicator', function () {
       const accumulator = new Map()
       for (let i = 0; i < 10; i++) {

--- a/test/LatestValuesAccumulator.js
+++ b/test/LatestValuesAccumulator.js
@@ -6,6 +6,8 @@ const {
   buildFlushDeltas
 } = require('../dist/LatestValuesAccumulator')
 
+const FLUSH_DURATION_MS = 1000
+
 describe('LatestValuesAccumulator', function () {
   describe('accumulateLatestValue', function () {
     it('should accumulate a single value', function () {
@@ -326,7 +328,7 @@ describe('LatestValuesAccumulator', function () {
         timestamp: '2024-01-15T10:30:00.005Z'
       })
 
-      const deltas = buildFlushDeltas(accumulator, 1000)
+      const deltas = buildFlushDeltas(accumulator, FLUSH_DURATION_MS)
 
       expect(deltas).to.have.length(1)
       expect(deltas[0].updates).to.deep.equal([
@@ -360,7 +362,7 @@ describe('LatestValuesAccumulator', function () {
         timestamp: '2024-01-15T10:30:00.005Z'
       })
 
-      const [flushed] = buildFlushDeltas(accumulator, 1000)
+      const [flushed] = buildFlushDeltas(accumulator, FLUSH_DURATION_MS)
 
       expect(flushed.updates).to.deep.equal([
         {


### PR DESCRIPTION
## What problem does this solve?

When backpressure ends, `buildFlushDeltas` groups every value from the same context and source into one update, then assigns the newest timestamp in that group to all values. Signal K update timestamps apply to the complete update, so older samples are incorrectly retimed.

The flush path now groups accumulated values by context, source, and timestamp. Values from one source frame remain together, while values sampled at different times receive separate updates. Missing timestamps remain a distinct group.

Fixes #2716.

## How was this tested?

- `npm run format`
- `npm run build`
- `npx mocha test/LatestValuesAccumulator.js`: 15 passing
- `npm run ci-lint`

The focused tests cover different timestamps from one source, missing versus dated timestamps, same-frame grouping, different sources, and different contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR preserves source frame timestamps during backpressure flushing.

- `buildFlushDeltas` groups values by context, source, and timestamp.
- Values from the same source frame remain in one update.
- Values with different timestamps use separate updates.
- Values without timestamps remain separate from dated values.
- Tests cover timestamp separation and missing timestamps.
- Formatting, build, lint, and focused accumulator tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->