### PR TITLE
fix(admin-ui): resolve remaining eslint warnings and show vessel names in context selectors

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.tsx
@@ -569,9 +569,11 @@ export default function Sidebar({ location }: SidebarProps) {
       return (
         <>
           {item.badges.map(
-            (b, index) =>
+            (b) =>
               b && (
-                <React.Fragment key={`badge-${index}`}>
+                <React.Fragment
+                  key={`${b.variant ?? ''}-${b.class ?? ''}-${b.text ?? ''}`}
+                >
                   {renderBadge(b)}
                 </React.Fragment>
               )

--- a/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
@@ -265,6 +265,75 @@ describe('dataSlice', () => {
     })
   })
 
+  describe('contextNames', () => {
+    const ctx = 'vessels.urn:mrn:imo:mmsi:123456789'
+
+    it('resolves a name leaf that arrives after the context appears', () => {
+      useStore.getState().updatePath(ctx, 'mmsi$AIS.1', { value: '123456789' })
+      expect(useStore.getState().contextNames[ctx]).toBeUndefined()
+
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      expect(useStore.getState().contextNames[ctx]).toBe('Black Pearl')
+    })
+
+    it('picks up an in-place name value change', () => {
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      useStore.getState().updatePath(ctx, 'name$AIS.1', { value: 'Queen Anne' })
+      expect(useStore.getState().contextNames[ctx]).toBe('Queen Anne')
+    })
+
+    it('keeps the map identity stable for non-name updates', () => {
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      const before = useStore.getState().contextNames
+      useStore.getState().updatePath(ctx, 'navigation.position$AIS.1', {
+        value: { latitude: 1, longitude: 2 }
+      })
+      expect(useStore.getState().contextNames).toBe(before)
+    })
+
+    it('ignores paths that merely start with name', () => {
+      useStore.getState().updatePath(ctx, 'nameplate$AIS.1', { value: 'ABC' })
+      expect(useStore.getState().contextNames[ctx]).toBeUndefined()
+    })
+
+    it('falls back to another source when a name leaf is removed', () => {
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      useStore.getState().updatePath(ctx, 'name$AIS.2', { value: 'Queen Anne' })
+
+      useStore.getState().removePath(ctx, 'name$AIS.1')
+      expect(useStore.getState().contextNames[ctx]).toBe('Queen Anne')
+
+      useStore.getState().removePath(ctx, 'name$AIS.2')
+      expect(useStore.getState().contextNames[ctx]).toBeUndefined()
+    })
+
+    it('drops the name when its source is evicted', () => {
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      useStore.getState().updatePath(ctx, 'mmsi$AIS.2', { value: '123456789' })
+
+      useStore.getState().evictSource('AIS.1')
+      expect(useStore.getState().contextNames[ctx]).toBeUndefined()
+    })
+
+    it('resets with clearData', () => {
+      useStore
+        .getState()
+        .updatePath(ctx, 'name$AIS.1', { value: 'Black Pearl' })
+      useStore.getState().clearData()
+      expect(useStore.getState().contextNames).toEqual({})
+    })
+  })
+
   describe('evictSource', () => {
     it('removes every leaf whose key ends with $sourceRef across contexts', () => {
       useStore

--- a/packages/server-admin-ui/src/store/slices/dataSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import { findContextName, isNameKey } from '../../utils/pathKeys'
 
 export interface PathData {
   path?: string
@@ -40,6 +41,16 @@ export interface DataSliceState {
   signalkMeta: Record<string, Record<string, MetaData>>
   /** Version counter - increments when structure changes (new paths added) */
   dataVersion: number
+  /**
+   * Derived map of context key → vessel display name, maintained
+   * incrementally as `name` leaves arrive, change, or are removed.
+   * Contexts without a resolved name have no entry. Kept here rather
+   * than computed in a selector so readers get O(1) access and the
+   * object's identity only changes when a name actually changes —
+   * scanning every context on each store update would put a full
+   * cache sweep on the per-delta path.
+   */
+  contextNames: Record<string, string>
 }
 
 export interface DataSliceActions {
@@ -67,7 +78,25 @@ export type DataSlice = DataSliceState & DataSliceActions
 const initialDataState: DataSliceState = {
   signalkData: {},
   signalkMeta: {},
-  dataVersion: 0
+  dataVersion: 0,
+  contextNames: {}
+}
+
+// Re-resolve one context's entry in the contextNames map after its data
+// changed in a way that can affect the name. Returns the previous map
+// unchanged (same identity) when the resolved name is the same.
+function withContextName(
+  contextNames: Record<string, string>,
+  context: string,
+  contextData: Record<string, PathData>
+): Record<string, string> {
+  const resolved = findContextName(contextData)
+  if (resolved === contextNames[context]) return contextNames
+  if (resolved === undefined) {
+    const { [context]: _, ...rest } = contextNames
+    return rest
+  }
+  return { ...contextNames, [context]: resolved }
 }
 
 export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
@@ -96,7 +125,10 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
 
       return {
         signalkData: newSignalkData,
-        dataVersion: newVersion
+        dataVersion: newVersion,
+        contextNames: isNameKey(path$SourceKey)
+          ? withContextName(state.contextNames, context, newContextData)
+          : state.contextNames
       }
     })
   },
@@ -146,7 +178,10 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
       const { [path$SourceKey]: _, ...rest } = contextData
       return {
         signalkData: { ...state.signalkData, [context]: rest },
-        dataVersion: state.dataVersion + 1
+        dataVersion: state.dataVersion + 1,
+        contextNames: isNameKey(path$SourceKey)
+          ? withContextName(state.contextNames, context, rest)
+          : state.contextNames
       }
     })
   },
@@ -159,21 +194,27 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
       // so a sourceRef match shows up as a `$<ref>` suffix.
       const suffix = `$${sourceRef}`
       let changed = false
+      let contextNames = state.contextNames
       const next: typeof state.signalkData = {}
       for (const ctx of Object.keys(state.signalkData)) {
         const contextData = state.signalkData[ctx]
         const keptEntries: [string, PathData][] = []
         let ctxChanged = false
+        let nameDropped = false
         for (const key of Object.keys(contextData)) {
           if (key.endsWith(suffix)) {
             ctxChanged = true
             changed = true
+            if (isNameKey(key)) nameDropped = true
             continue
           }
           keptEntries.push([key, contextData[key]])
         }
         if (ctxChanged) {
           next[ctx] = Object.fromEntries(keptEntries)
+          if (nameDropped) {
+            contextNames = withContextName(contextNames, ctx, next[ctx])
+          }
         } else {
           next[ctx] = contextData
         }
@@ -181,7 +222,8 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
       if (!changed) return state
       return {
         signalkData: next,
-        dataVersion: state.dataVersion + 1
+        dataVersion: state.dataVersion + 1,
+        contextNames
       }
     })
   },

--- a/packages/server-admin-ui/src/utils/pathKeys.ts
+++ b/packages/server-admin-ui/src/utils/pathKeys.ts
@@ -1,0 +1,37 @@
+// The same Signal K path can have multiple values from different sources.
+// We combine them as "path$source" to create a unique key.
+
+export function getPath$SourceKey(path: string, source?: string): string {
+  return `${path}$${source ?? ''}`
+}
+
+export function getPathFromKey(path$SourceKey: string): string {
+  const idx = path$SourceKey.indexOf('$')
+  return idx >= 0 ? path$SourceKey.substring(0, idx) : path$SourceKey
+}
+
+// True when the key's path component is `name` — the vessel display-name
+// leaf — regardless of source suffix. Allocation-free so the per-delta
+// updatePath store action can call it for every incoming value.
+export function isNameKey(path$SourceKey: string): boolean {
+  return path$SourceKey === 'name' || path$SourceKey.startsWith('name$')
+}
+
+// Resolve a vessel's display name from its stored context data. The
+// `name` leaf arrives flattened under the empty-path object and is
+// keyed per source as `name$<source>`, so a bare `['name']` lookup
+// never matches — scan for a key whose path is `name`. Keep scanning
+// past a non-string value so a malformed entry from one source doesn't
+// hide a valid name reported by another.
+export function findContextName(
+  contextData: Record<string, { value?: unknown }> | undefined
+): string | undefined {
+  if (!contextData) return undefined
+  for (const key of Object.keys(contextData)) {
+    if (getPathFromKey(key) === 'name') {
+      const value = contextData[key]?.value
+      if (typeof value === 'string') return value
+    }
+  }
+  return undefined
+}

--- a/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/DataBrowser.tsx
@@ -26,7 +26,7 @@ import {
   type SourcesData
 } from '../../utils/sourceLabels'
 import granularSubscriptionManager from './GranularSubscriptionManager'
-import { getPath$SourceKey, getPathFromKey, findContextName } from './pathUtils'
+import { getPath$SourceKey, getPathFromKey } from './pathUtils'
 import {
   useWebSocket,
   useDeltaMessages,
@@ -150,6 +150,7 @@ const DataBrowser: React.FC = () => {
   const contextKeys = useStore(
     useShallow((s) => Object.keys(s.signalkData).sort())
   )
+  const contextNames = useStore((s) => s.contextNames)
 
   const updatePath = useStore((s) => s.updatePath)
   const updateMeta = useStore((s) => s.updateMeta)
@@ -444,13 +445,12 @@ const DataBrowser: React.FC = () => {
   }, [discoveredAddresses, loadSources, pause])
 
   const contextOptions: SelectOption[] = useMemo(() => {
-    const currentData = getSignalkData()
     const options: SelectOption[] = [
       { value: 'all', label: 'ALL', section: 'all' }
     ]
 
     if (contextKeys.includes('self')) {
-      const contextName = findContextName(currentData['self'])
+      const contextName = contextNames['self']
       options.push({
         value: 'self',
         label: `${contextName || ''} self`,
@@ -461,7 +461,7 @@ const DataBrowser: React.FC = () => {
     let isFirst = true
     contextKeys.forEach((key) => {
       if (key !== 'self') {
-        const contextName = findContextName(currentData[key])
+        const contextName = contextNames[key]
         options.push({
           value: key,
           label: `${contextName || ''} ${key}`,
@@ -473,9 +473,7 @@ const DataBrowser: React.FC = () => {
     })
 
     return options
-    // dataVersion is included so the labels pick up a vessel's `name`
-    // leaf, which arrives in a delta after the context key first appears.
-  }, [contextKeys, dataVersion])
+  }, [contextKeys, contextNames])
 
   useEffect(() => {
     subscribeToDataIfNeeded()

--- a/packages/server-admin-ui/src/views/DataBrowser/SourceDiscovery.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/SourceDiscovery.tsx
@@ -2301,10 +2301,13 @@ const InlineTextField: React.FC<{
   const isMountedRef = useRef(true)
   const refreshTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   useEffect(() => {
+    // The Set's identity never changes; the copy just satisfies the
+    // effect-cleanup rule about reading refs at cleanup time.
+    const timers = refreshTimersRef.current
     return () => {
       isMountedRef.current = false
-      for (const t of refreshTimersRef.current) clearTimeout(t)
-      refreshTimersRef.current.clear()
+      for (const t of timers) clearTimeout(t)
+      timers.clear()
     }
   }, [])
   const scheduleRefresh = (delay: number, fn: () => void) => {

--- a/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/pathUtils.ts
@@ -1,33 +1,10 @@
-// The same Signal K path can have multiple values from different sources.
-// We combine them as "path$source" to create a unique key.
-
-export function getPath$SourceKey(path: string, source?: string): string {
-  return `${path}$${source ?? ''}`
-}
-
-export function getPathFromKey(path$SourceKey: string): string {
-  const idx = path$SourceKey.indexOf('$')
-  return idx >= 0 ? path$SourceKey.substring(0, idx) : path$SourceKey
-}
-
-// Resolve a vessel's display name from its stored context data. The
-// `name` leaf arrives flattened under the empty-path object and is
-// keyed per source as `name$<source>`, so a bare `['name']` lookup
-// never matches — scan for a key whose path is `name`. Keep scanning
-// past a non-string value so a malformed entry from one source doesn't
-// hide a valid name reported by another.
-export function findContextName(
-  contextData: Record<string, { value?: unknown }> | undefined
-): string | undefined {
-  if (!contextData) return undefined
-  for (const key of Object.keys(contextData)) {
-    if (getPathFromKey(key) === 'name') {
-      const value = contextData[key]?.value
-      if (typeof value === 'string') return value
-    }
-  }
-  return undefined
-}
+// The path$source key helpers live in utils so the data slice can use
+// them too; re-exported here for the Data Browser modules built on them.
+export {
+  getPath$SourceKey,
+  getPathFromKey,
+  findContextName
+} from '../../utils/pathKeys'
 
 // Signal K paths originate from data providers and are not guaranteed
 // URL-safe. Encode each segment before embedding a path into an API URL.

--- a/packages/server-admin-ui/src/views/DataBrowser/useSignalKData.ts
+++ b/packages/server-admin-ui/src/views/DataBrowser/useSignalKData.ts
@@ -18,8 +18,6 @@ import {
 } from '../../hooks/useWebSocket'
 import { useStore, useShallow } from '../../store'
 
-const getSignalkData = () => useStore.getState().signalkData
-
 const TIMESTAMP_FORMAT = 'MM/DD HH:mm:ss'
 const TIME_ONLY_FORMAT = 'HH:mm:ss'
 const SOURCES_FETCH_TIMEOUT_MS = 10_000
@@ -92,6 +90,7 @@ export function useSignalKData() {
   const contextKeys = useStore(
     useShallow((s) => Object.keys(s.signalkData).sort())
   )
+  const contextNames = useStore((s) => s.contextNames)
 
   const updatePath = useStore((s) => s.updatePath)
   const updateMeta = useStore((s) => s.updateMeta)
@@ -249,15 +248,12 @@ export function useSignalKData() {
   }, [loadSources])
 
   const contextOptions: SelectOption[] = useMemo(() => {
-    const currentData = getSignalkData()
     const options: SelectOption[] = [
       { value: 'all', label: 'ALL', section: 'all' }
     ]
 
     if (contextKeys.includes('self')) {
-      const contextData = currentData['self']?.['name'] as
-        { value?: string } | undefined
-      const contextName = contextData?.value
+      const contextName = contextNames['self']
       options.push({
         value: 'self',
         label: `${contextName || ''} self`,
@@ -268,9 +264,7 @@ export function useSignalKData() {
     let isFirst = true
     contextKeys.forEach((key) => {
       if (key !== 'self') {
-        const contextData = currentData[key]?.['name'] as
-          { value?: string } | undefined
-        const contextName = contextData?.value
+        const contextName = contextNames[key]
         options.push({
           value: key,
           label: `${contextName || ''} ${key}`,
@@ -282,7 +276,7 @@ export function useSignalKData() {
     })
 
     return options
-  }, [contextKeys, dataVersion])
+  }, [contextKeys, contextNames])
 
   useEffect(() => {
     subscribeToDataIfNeeded()

--- a/packages/server-admin-ui/src/views/ServerConfig/BLESettings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/BLESettings.tsx
@@ -14,11 +14,21 @@ const MIN_GATT_SLOTS = 1
 const MAX_GATT_SLOTS = 10
 
 const BLESettings: React.FC = () => {
-  const { settings, saving, saveError } = useStore(
+  const {
+    settings,
+    saving,
+    saveError,
+    setBleSettingsLocal,
+    saveBleSettings,
+    clearBleSettingsSaveError
+  } = useStore(
     useShallow((s) => ({
       settings: s.bleSettings,
       saving: s.bleSettingsSaving,
-      saveError: s.bleSettingsSaveError
+      saveError: s.bleSettingsSaveError,
+      setBleSettingsLocal: s.setBleSettingsLocal,
+      saveBleSettings: s.saveBleSettings,
+      clearBleSettingsSaveError: s.clearBleSettingsSaveError
     }))
   )
 
@@ -29,8 +39,6 @@ const BLESettings: React.FC = () => {
   if (!settings) return null
 
   const supported = settings.localBLESupported
-  const { setBleSettingsLocal, saveBleSettings, clearBleSettingsSaveError } =
-    useStore.getState()
 
   return (
     <Card className="mt-3">

--- a/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PriorityGroupCard.tsx
@@ -620,10 +620,14 @@ const PriorityGroupCard: React.FC<PriorityGroupCardProps> = ({
   // The content-derived key is deliberate: memoising on identity would defeat
   // the purpose, since the array is a fresh reference with identical contents.
   // JSON.stringify rather than join() so a source ref containing the separator
-  // cannot collide with a differently-split array.
+  // cannot collide with a differently-split array. Parsing the key back
+  // instead of closing over group.sources keeps the memo's dependency
+  // honest: the value is derived from exactly what it is keyed on.
   const sourcesKey = JSON.stringify(group.sources)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableSources = useMemo(() => group.sources, [sourcesKey])
+  const stableSources = useMemo(
+    () => JSON.parse(sourcesKey) as string[],
+    [sourcesKey]
+  )
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.tsx
@@ -41,7 +41,6 @@ function stripFilterKeys(provider: Provider): void {
     if (!subOpts || !Array.isArray(subOpts.filters)) continue
     subOpts.filters = (subOpts.filters as Array<Record<string, unknown>>).map(
       (f) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { _key, ...rest } = f
         return rest
       }

--- a/packages/server-admin-ui/src/views/Webapps/EmbeddedAsyncApi.tsx
+++ b/packages/server-admin-ui/src/views/Webapps/EmbeddedAsyncApi.tsx
@@ -138,6 +138,10 @@ export default function EmbeddedAsyncApi() {
           {doc.info.descriptionHtml && (
             <div
               style={{ marginTop: 12, fontSize: 14, lineHeight: 1.6 }}
+              // descriptionHtml is rendered by this server itself from its
+              // own AsyncAPI spec (marked() in src/api/swagger.ts), not
+              // from user- or plugin-supplied input.
+              // eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
               dangerouslySetInnerHTML={{ __html: doc.info.descriptionHtml }}
             />
           )}

--- a/packages/server-admin-ui/src/views/appstore/Detail/ChangelogTab.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/ChangelogTab.tsx
@@ -26,7 +26,7 @@ const markdownComponents: Components = {
   // inline. Runs through React rendering so we never need to inject raw
   // HTML into the markdown pipeline.
   li({ children, ...rest }) {
-    const arr = React.Children.toArray(children)
+    const arr = Array.isArray(children) ? children : [children]
     const first = arr[0]
     if (typeof first === 'string') {
       const m = PREFIX_RE.exec(first)

--- a/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/PluginCiMatrix.tsx
@@ -187,6 +187,7 @@ const PluginCiMatrix: React.FC<PluginCiMatrixProps> = ({ data }) => {
               // both lack server_version (e.g. two non-integration runs
               // on the same matrix cell). The array order is stable
               // for the lifetime of one render's data.
+              // eslint-disable-next-line @eslint-react/no-array-index-key
               key={`${i}-${j.platform}-${j.node}-${j.server_version ?? ''}`}
               bg={conclusionVariant(j.conclusion)}
               className="fw-normal plugin-detail__plugin-ci-cell"

--- a/packages/server-admin-ui/src/views/appstore/Detail/ReadmeTab.tsx
+++ b/packages/server-admin-ui/src/views/appstore/Detail/ReadmeTab.tsx
@@ -90,6 +90,11 @@ const ReadmeTab: React.FC<ReadmeTabProps> = ({
         >
           <div className="row g-2">
             {screenshots.slice(0, MAX_SCREENSHOTS).map((src, idx) => (
+              // The index keeps keys unique when an author lists the same
+              // screenshot path twice; it is also the identity the
+              // lightbox uses (onScreenshotClick(idx)), so order is the
+              // key's true meaning here.
+              // eslint-disable-next-line @eslint-react/no-array-index-key
               <div className="col-6" key={`${src}-${idx}`}>
                 <button
                   type="button"


### PR DESCRIPTION
Since #2941 re-enabled eslint for the admin UI, `npm run format` still reported 10 warnings. This clears all of them so the admin UI lints at 0 errors / 0 warnings.

Most fixes remove the flagged pattern outright:

- Badge list keys in the sidebar derive from badge content instead of the array index.
- `BLESettings` selects its store actions through the `useShallow` hook instead of reading `useStore.getState()` in the render body.
- `SourceDiscovery`'s unmount cleanup copies the timers `Set` into the effect scope instead of reading the ref at cleanup time.
- `ChangelogTab` normalizes `children` with `Array.isArray` instead of `React.Children.toArray`.
- `PriorityGroupCard`'s dnd-kit stable-items memo now derives its value from its own content key (`JSON.parse(sourcesKey)`), which removes the `exhaustive-deps` disable and lets React Compiler optimize the component again.
- The Data Browser context-selector options previously depended on the `dataVersion` counter to pick up vessel names. The data slice now maintains a `contextNames` map incrementally — updated only when a `name` leaf arrives, changes, or is removed — so consumers read it with an O(1) selector and the options memo depends on the data it renders. This also fixes the Meta Data page, whose copy looked up a bare `name` key that never matches the `name$<source>` storage format and therefore never showed vessel names, and it picks up in-place name value changes, which the version counter (bumped only for new keys) missed.

Three warnings flag patterns that are intentional; those sites get an `eslint-disable` with the reasoning in a comment: the AsyncAPI description HTML is rendered by the server itself from its own spec, and the two remaining index keys are semantically positional (CI matrix cells that can be identical in every field, and screenshot tiles whose index is the lightbox identity).

Tested: `npm test` at the repo root (build, mocha, ci-lint, admin UI vitest incl. new `contextNames` slice tests, server-api, streams, path-metadata) and a production admin UI build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Resolves all remaining admin UI ESLint warnings.
- Adds documented ESLint exceptions for intentional patterns.
- Adds the derived `contextNames` map for O(1) vessel-name lookups.
- Fixes vessel names in the Data Browser and Meta Data page, including updates and removals.
- Centralizes path-key and context-name utilities.
- Improves React key generation, state selection, effect cleanup, child normalization, and memoization stability.
- Adds tests for context-name resolution and cleanup behavior.
- Verifies the repository test suite and production admin UI build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->