### PR TITLE
fix(ble): local provider drops devices seen before the first subscriber

### DIFF
--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -292,7 +292,15 @@ export class BLEApi implements IBLEApi {
     // fully settled localProviders/bleProviders for a given providerId by
     // the time the loop below runs, so there's nothing left in flight to
     // race against.
-    if (this.localProviderInitializations.size > 0) {
+    //
+    // A single Promise.all() snapshot isn't enough: initLocalProviders()
+    // could still be running concurrently (e.g. a settings change firing
+    // again mid-shutdown) and add a *new* entry to
+    // localProviderInitializations while this method's own await is
+    // pending, and that new entry wouldn't be in the snapshot. Re-check
+    // and re-await until the map is actually empty, so a fresh entry
+    // added during the wait still gets caught before teardown proceeds.
+    while (this.localProviderInitializations.size > 0) {
       await Promise.all(this.localProviderInitializations.values())
     }
 

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -80,6 +80,18 @@ export class BLEApi implements IBLEApi {
   private wsClients: Set<WebSocket> = new Set()
   private localProviders: Map<string, LocalBLEProvider> = new Map() // key = providerId
   private localProviderErrors: Map<string, string> = new Map() // key = adapterName
+  // Tracks an initLocalProviders() attempt still in flight for a given
+  // providerId, from before provider.init() resolves through to
+  // register()/startDiscovery() (or the catch-block rollback). Without
+  // this, two overlapping initLocalProviders() calls for the same adapter
+  // (e.g. start() racing a PUT /settings-triggered reinit) can both pass
+  // the `localProviders.has(providerId)` skip-check before either await
+  // completes, each construct their own LocalBLEProvider, and the later
+  // one's register() ends up displacing the earlier one's registration -
+  // but the earlier LocalBLEProvider instance keeps running its own
+  // discovery loop, now unreferenced by localProviders and therefore
+  // unreachable by shutdown.
+  private localProviderInitializations: Map<string, Promise<void>> = new Map()
   private defaultProviderId: string | null = null
   private settings: BLESettings
   private remoteGatewayProvider: RemoteGatewayProvider | null = null
@@ -176,68 +188,95 @@ export class BLEApi implements IBLEApi {
     for (const adapterName of adapterNames) {
       const providerId = `_localBLE:${adapterName}`
       if (this.localProviders.has(providerId)) continue
-      let provider: LocalBLEProvider | undefined
-      let registeredProvider: BLEProvider | undefined
-      try {
-        provider = new LocalBLEProvider(
-          adapterName,
-          this.settings.localMaxGATTSlots,
-          providerId
-        )
-        await provider.init()
-        this.localProviders.set(providerId, provider)
-        this.localProviderErrors.delete(adapterName)
-        // Register (which wires up onAdvertisement -> _handleAdvertisement,
-        // populating deviceTable) before starting discovery. Discovery's
-        // first pass emits advertisements for every already-known device
-        // synchronously as part of startDiscovery(), and LocalBLEProvider's
-        // emitDeviceAdvertisement drops advertisements entirely when nobody
-        // has subscribed yet - registering afterward silently lost that
-        // whole first batch, leaving those devices absent from the device
-        // table (and therefore unreachable via subscribeGATT) until BlueZ
-        // happened to re-report one of their properties later.
-        registeredProvider = {
-          name: `Local Bluetooth (${adapterName})`,
-          methods: provider.getMethods()
-        }
-        this.register(providerId, registeredProvider)
-        await provider.startDiscovery()
-        debug.enabled &&
-          debug(`Local BLE provider registered and scanning: ${providerId}`)
-      } catch (e: any) {
-        // Roll back any partial state if init and/or register succeeded but
-        // startDiscovery failed. Only touch state that's still this
-        // provider's - a concurrent initLocalProviders() call for the same
-        // adapter could have already replaced it with a working instance by
-        // the time this catch runs, and unregistering/deleting on providerId
-        // alone would tear down that replacement instead of the one that
-        // actually failed.
-        if (this.localProviders.get(providerId) === provider) {
-          if (this.bleProviders.get(providerId) === registeredProvider) {
-            this.unRegister(providerId)
-          }
-          this.localProviders.delete(providerId)
-        }
-        if (provider) {
-          try {
-            provider.shutdown()
-          } catch (_e) {
-            /* ignore */
-          }
-        }
-        const msg = `Local BLE adapter ${adapterName} unavailable: ${e.message}`
-        debug(msg)
-        // Suppress console.log for expected "no hardware / no BlueZ" errors
-        const isExpected =
-          e.message?.includes('org.freedesktop.DBus.Error.ServiceUnknown') ||
-          e.message?.includes('not provided by any .service files') ||
-          e.message?.includes('ENOENT') ||
-          e.message?.includes('ECONNREFUSED')
-        if (!isExpected) {
-          console.log(`[BLE API] ${msg}`)
-        }
-        this.localProviderErrors.set(adapterName, e.message)
+
+      // Serialize against a concurrent initLocalProviders() call already
+      // in flight for this same adapter (see
+      // localProviderInitializations's comment) - await its result
+      // instead of racing it with a second LocalBLEProvider construction.
+      const inFlight = this.localProviderInitializations.get(providerId)
+      if (inFlight) {
+        await inFlight
+        continue
       }
+
+      const initialization = this.initOneLocalProvider(
+        adapterName,
+        providerId
+      )
+      this.localProviderInitializations.set(providerId, initialization)
+      try {
+        await initialization
+      } finally {
+        if (this.localProviderInitializations.get(providerId) === initialization) {
+          this.localProviderInitializations.delete(providerId)
+        }
+      }
+    }
+  }
+
+  private async initOneLocalProvider(adapterName: string, providerId: string) {
+    let provider: LocalBLEProvider | undefined
+    let registeredProvider: BLEProvider | undefined
+    try {
+      provider = new LocalBLEProvider(
+        adapterName,
+        this.settings.localMaxGATTSlots,
+        providerId
+      )
+      await provider.init()
+      this.localProviders.set(providerId, provider)
+      this.localProviderErrors.delete(adapterName)
+      // Register (which wires up onAdvertisement -> _handleAdvertisement,
+      // populating deviceTable) before starting discovery. Discovery's
+      // first pass emits advertisements for every already-known device
+      // synchronously as part of startDiscovery(), and LocalBLEProvider's
+      // emitDeviceAdvertisement drops advertisements entirely when nobody
+      // has subscribed yet - registering afterward silently lost that
+      // whole first batch, leaving those devices absent from the device
+      // table (and therefore unreachable via subscribeGATT) until BlueZ
+      // happened to re-report one of their properties later.
+      registeredProvider = {
+        name: `Local Bluetooth (${adapterName})`,
+        methods: provider.getMethods()
+      }
+      this.register(providerId, registeredProvider)
+      await provider.startDiscovery()
+      debug.enabled &&
+        debug(`Local BLE provider registered and scanning: ${providerId}`)
+    } catch (e: any) {
+      // Roll back any partial state if init and/or register succeeded but
+      // startDiscovery failed. Only touch state that's still this
+      // provider's - localProviderInitializations already prevents a
+      // concurrent initLocalProviders() call for the same adapter from
+      // running at the same time as this one, but the identity checks
+      // stay as defense in depth (e.g. a caller invoking
+      // initOneLocalProvider directly, or a future refactor that removes
+      // the serialization).
+      if (this.localProviders.get(providerId) === provider) {
+        if (this.bleProviders.get(providerId) === registeredProvider) {
+          this.unRegister(providerId)
+        }
+        this.localProviders.delete(providerId)
+      }
+      if (provider) {
+        try {
+          provider.shutdown()
+        } catch (_e) {
+          /* ignore */
+        }
+      }
+      const msg = `Local BLE adapter ${adapterName} unavailable: ${e.message}`
+      debug(msg)
+      // Suppress console.log for expected "no hardware / no BlueZ" errors
+      const isExpected =
+        e.message?.includes('org.freedesktop.DBus.Error.ServiceUnknown') ||
+        e.message?.includes('not provided by any .service files') ||
+        e.message?.includes('ENOENT') ||
+        e.message?.includes('ECONNREFUSED')
+      if (!isExpected) {
+        console.log(`[BLE API] ${msg}`)
+      }
+      this.localProviderErrors.set(adapterName, e.message)
     }
   }
 

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -281,6 +281,21 @@ export class BLEApi implements IBLEApi {
   }
 
   private async shutdownLocalProviders() {
+    // Wait out any initOneLocalProvider() calls still in flight before
+    // tearing anything down. Without this, a call still awaiting
+    // provider.startDiscovery() (DBus) can resolve *after* this method
+    // has already run - at that point it finishes registering/logging
+    // for a provider this method just unregistered and shut down, and
+    // its now-orphaned discovery loop is left running (unreferenced by
+    // localProviders, so a later shutdown can no longer find it either).
+    // Waiting first means initOneLocalProvider's own try/catch has always
+    // fully settled localProviders/bleProviders for a given providerId by
+    // the time the loop below runs, so there's nothing left in flight to
+    // race against.
+    if (this.localProviderInitializations.size > 0) {
+      await Promise.all(this.localProviderInitializations.values())
+    }
+
     for (const [providerId, provider] of this.localProviders) {
       // One misbehaving adapter must not keep the others registered
       try {

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -204,9 +204,17 @@ export class BLEApi implements IBLEApi {
           debug(`Local BLE provider registered and scanning: ${providerId}`)
       } catch (e: any) {
         // Roll back any partial state if init and/or register succeeded but
-        // startDiscovery failed
-        if (this.bleProviders.has(providerId)) {
-          this.unRegister(providerId)
+        // startDiscovery failed. Only touch state that's still this
+        // provider's - a concurrent initLocalProviders() call for the same
+        // adapter could have already replaced it with a working instance by
+        // the time this catch runs, and unregistering/deleting on providerId
+        // alone would tear down that replacement instead of the one that
+        // actually failed.
+        if (this.localProviders.get(providerId) === provider) {
+          if (this.bleProviders.has(providerId)) {
+            this.unRegister(providerId)
+          }
+          this.localProviders.delete(providerId)
         }
         if (provider) {
           try {
@@ -215,7 +223,6 @@ export class BLEApi implements IBLEApi {
             /* ignore */
           }
         }
-        this.localProviders.delete(providerId)
         const msg = `Local BLE adapter ${adapterName} unavailable: ${e.message}`
         debug(msg)
         // Suppress console.log for expected "no hardware / no BlueZ" errors

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -199,15 +199,14 @@ export class BLEApi implements IBLEApi {
         continue
       }
 
-      const initialization = this.initOneLocalProvider(
-        adapterName,
-        providerId
-      )
+      const initialization = this.initOneLocalProvider(adapterName, providerId)
       this.localProviderInitializations.set(providerId, initialization)
       try {
         await initialization
       } finally {
-        if (this.localProviderInitializations.get(providerId) === initialization) {
+        if (
+          this.localProviderInitializations.get(providerId) === initialization
+        ) {
           this.localProviderInitializations.delete(providerId)
         }
       }
@@ -333,7 +332,6 @@ export class BLEApi implements IBLEApi {
       throw new Error(`${pluginId} is missing BLEProvider properties/methods!`)
     }
     debug.enabled &&
-      debug.enabled &&
       debug(`Registering BLE provider: ${pluginId} "${provider.name}"`)
 
     if (this.bleProviders.has(pluginId)) {

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -177,6 +177,7 @@ export class BLEApi implements IBLEApi {
       const providerId = `_localBLE:${adapterName}`
       if (this.localProviders.has(providerId)) continue
       let provider: LocalBLEProvider | undefined
+      let registeredProvider: BLEProvider | undefined
       try {
         provider = new LocalBLEProvider(
           adapterName,
@@ -195,10 +196,11 @@ export class BLEApi implements IBLEApi {
         // whole first batch, leaving those devices absent from the device
         // table (and therefore unreachable via subscribeGATT) until BlueZ
         // happened to re-report one of their properties later.
-        this.register(providerId, {
+        registeredProvider = {
           name: `Local Bluetooth (${adapterName})`,
           methods: provider.getMethods()
-        })
+        }
+        this.register(providerId, registeredProvider)
         await provider.startDiscovery()
         debug.enabled &&
           debug(`Local BLE provider registered and scanning: ${providerId}`)
@@ -211,7 +213,7 @@ export class BLEApi implements IBLEApi {
         // alone would tear down that replacement instead of the one that
         // actually failed.
         if (this.localProviders.get(providerId) === provider) {
-          if (this.bleProviders.has(providerId)) {
+          if (this.bleProviders.get(providerId) === registeredProvider) {
             this.unRegister(providerId)
           }
           this.localProviders.delete(providerId)

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -184,17 +184,30 @@ export class BLEApi implements IBLEApi {
           providerId
         )
         await provider.init()
-        await provider.startDiscovery()
         this.localProviders.set(providerId, provider)
         this.localProviderErrors.delete(adapterName)
+        // Register (which wires up onAdvertisement -> _handleAdvertisement,
+        // populating deviceTable) before starting discovery. Discovery's
+        // first pass emits advertisements for every already-known device
+        // synchronously as part of startDiscovery(), and LocalBLEProvider's
+        // emitDeviceAdvertisement drops advertisements entirely when nobody
+        // has subscribed yet - registering afterward silently lost that
+        // whole first batch, leaving those devices absent from the device
+        // table (and therefore unreachable via subscribeGATT) until BlueZ
+        // happened to re-report one of their properties later.
         this.register(providerId, {
           name: `Local Bluetooth (${adapterName})`,
           methods: provider.getMethods()
         })
+        await provider.startDiscovery()
         debug.enabled &&
           debug(`Local BLE provider registered and scanning: ${providerId}`)
       } catch (e: any) {
-        // Roll back any partial state if init succeeded but startDiscovery failed
+        // Roll back any partial state if init and/or register succeeded but
+        // startDiscovery failed
+        if (this.bleProviders.has(providerId)) {
+          this.unRegister(providerId)
+        }
         if (provider) {
           try {
             provider.shutdown()

--- a/src/api/ble/localProvider.ts
+++ b/src/api/ble/localProvider.ts
@@ -287,7 +287,10 @@ export class LocalBLEProvider {
     // iterations don't both kick off an attach for the same MAC.
     this.deviceListeners.set(mac, () => {})
     try {
-      const device = await this.adapter.waitDevice(mac, DEVICE_ATTACH_TIMEOUT_MS)
+      const device = await this.adapter.waitDevice(
+        mac,
+        DEVICE_ATTACH_TIMEOUT_MS
+      )
       await device.helper._prepare()
       // Discovery may have been stopped while the awaits above ran —
       // registering now would repopulate the cleared listener table

--- a/src/api/ble/localProvider.ts
+++ b/src/api/ble/localProvider.ts
@@ -19,10 +19,17 @@ import {
 
 // How often to poll BlueZ for newly discovered devices
 const DEVICE_WATCH_INTERVAL_MS = 5000
-// waitDevice timeout when attaching a listener to an already-known device
-const DEVICE_ATTACH_TIMEOUT_S = 1
-// waitDevice timeout when establishing a GATT connection
-const GATT_CONNECT_TIMEOUT_S = 30
+// waitDevice timeout (ms) when attaching a listener to an already-known
+// device. @naugehyde/node-ble's Adapter#waitDevice races a timeout against
+// a discoveryHandler whose first check() only runs after one full
+// discoveryInterval (default 1000ms) has elapsed, via setInterval rather
+// than an immediate check - so a timeout at or below that interval loses
+// the race almost every time, before a single check can succeed. This must
+// stay comfortably above the default discoveryInterval.
+const DEVICE_ATTACH_TIMEOUT_MS = 5000
+// waitDevice timeout (ms) when establishing a GATT connection. Same
+// discoveryInterval-race constraint as above applies.
+const GATT_CONNECT_TIMEOUT_MS = 30000
 // GATT reconnect exponential backoff bounds
 const RECONNECT_BACKOFF_BASE_MS = 5000
 const RECONNECT_BACKOFF_MAX_MS = 60000
@@ -280,7 +287,7 @@ export class LocalBLEProvider {
     // iterations don't both kick off an attach for the same MAC.
     this.deviceListeners.set(mac, () => {})
     try {
-      const device = await this.adapter.waitDevice(mac, DEVICE_ATTACH_TIMEOUT_S)
+      const device = await this.adapter.waitDevice(mac, DEVICE_ATTACH_TIMEOUT_MS)
       await device.helper._prepare()
       // Discovery may have been stopped while the awaits above ran —
       // registering now would repopulate the cleared listener table
@@ -483,7 +490,7 @@ export class LocalBLEProvider {
       debug.enabled && debug(`GATT connecting to ${mac}`)
 
       // 1. Find device
-      const device = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_S)
+      const device = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_MS)
       session.device = device
 
       // 2. Connect
@@ -709,7 +716,7 @@ export class LocalBLEProvider {
     let device: any
     try {
       device = await this.connectQueue.enqueue(async () => {
-        const dev = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_S)
+        const dev = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_MS)
         await dev.helper.callMethod('Connect')
         if (this.scanning) {
           try {

--- a/test/ble-provider-registration-order.ts
+++ b/test/ble-provider-registration-order.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai'
+import { startServer, SERVER_START_TIMEOUT } from './ts-servertestutilities'
+import { BLEAdvertisement, BLEProvider } from '@signalk/server-api'
+
+const MAC = 'AA:BB:CC:DD:EE:FF'
+
+// A minimal BLEProvider double that stands in for LocalBLEProvider. It lets
+// the test control exactly when register() happens relative to
+// startDiscovery()'s first (synchronous) advertisement, without touching
+// BlueZ/DBus - the same shape BLEApi's own initOneLocalProvider() builds
+// around a real LocalBLEProvider (see src/api/ble/index.ts). This does not
+// exercise initOneLocalProvider() itself - that method is private, requires
+// a real LocalBLEProvider (Linux + BlueZ/DBus), and the codebase has no
+// mocking library to substitute one - so it can't catch a regression that
+// reorders register()/startDiscovery() at that call site. It locks in the
+// invariant those two calls exist to protect: a device reported during the
+// registering provider's own first discovery pass, before any subscriber
+// exists, must still reach deviceTable.
+const fakeProvider = (providerId: string): BLEProvider => {
+  let listener: ((adv: BLEAdvertisement) => void) | undefined
+  return {
+    name: `Fake (${providerId})`,
+    methods: {
+      // Mirrors LocalBLEProvider: the first startDiscovery() pass
+      // synchronously re-emits already-known devices.
+      startDiscovery: async () => {
+        listener?.({
+          providerId,
+          mac: MAC,
+          rssi: -50,
+          timestamp: Date.now(),
+          addressType: 'random',
+          connectable: true
+        })
+      },
+      stopDiscovery: async () => {},
+      getDevices: async () => [],
+      onAdvertisement: (callback) => {
+        listener = callback
+        return () => {
+          listener = undefined
+        }
+      },
+      supportsGATT: () => false,
+      availableGATTSlots: () => 0,
+      subscribeGATT: async () => {
+        throw new Error('not implemented')
+      }
+    }
+  }
+}
+
+describe('BLE provider registration order', () => {
+  let server: Awaited<ReturnType<typeof startServer>>['server']
+  let get: Awaited<ReturnType<typeof startServer>>['get']
+  let stop: Awaited<ReturnType<typeof startServer>>['stop']
+
+  before(async function () {
+    this.timeout(SERVER_START_TIMEOUT)
+    ;({ server, get, stop } = await startServer())
+  })
+
+  after(async () => {
+    await stop()
+  })
+
+  it('keeps a device seen during the first discovery pass reachable before any subscriber exists', async () => {
+    const providerId = 'test:register-order'
+    const provider = fakeProvider(providerId)
+
+    try {
+      // Mirrors initOneLocalProvider()'s ordering: register() first
+      // (wiring up onAdvertisement -> _handleAdvertisement), then
+      // startDiscovery() - whose first pass can emit advertisements for
+      // already-known devices synchronously, before any plugin has called
+      // subscribeGATT/attached an onAdvertisement listener of its own.
+      server.app.bleApi.register(providerId, provider)
+      await provider.methods.startDiscovery()
+
+      const devices = await get('/vessels/self/ble/devices').then((r) =>
+        r.json()
+      )
+      const device = devices.find((d: { mac: string }) => d.mac === MAC)
+      expect(device, 'device seen before any subscriber must reach deviceTable')
+        .to.exist
+      expect(device.seenBy).to.have.length(1)
+      expect(device.seenBy[0].providerId).to.equal(providerId)
+    } finally {
+      server.app.bleApi.unRegister(providerId)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Two related bugs in `LocalBLEProvider` (the built-in BlueZ-backed BLE provider added in #2588) can leave a GATT device permanently unreachable via `subscribeGATT()` (`"No provider with GATT support and available slots can see <mac>"`) even though the device is right there and BlueZ/`bluetoothctl` sees it fine. Both were found and fixed while migrating a plugin to the new BLE Provider API and verified against real BLE hardware (JK-BMS/Daly BMS devices).

1. **Registration-order bug** (`src/api/ble/index.ts`): `initLocalProviders()` called `provider.startDiscovery()` *before* `this.register(provider)`. Starting discovery synchronously emits an advertisement for every device BlueZ already knows about as part of its first pass, but `LocalBLEProvider.emitDeviceAdvertisement()` drops advertisements entirely when `advCallbacks` is empty — and `advCallbacks` is only populated once `register()` has wired the provider's `onAdvertisement()` into `BLEApi._handleAdvertisement()`, which is what actually populates `deviceTable` (the thing `selectGATTProvider()`/`subscribeGATT()` read from). So the entire first discovery batch was silently discarded, leaving those devices invisible to `subscribeGATT()` until BlueZ happened to re-report a property change for them later — which for some devices/environments can take a long time or never happen before a timeout gives up.

   Fixed by registering before starting discovery, and by unregistering in the `catch` block if `startDiscovery()` throws after registration succeeded (previously only `provider.shutdown()` + `localProviders.delete()` ran, leaving a registered-but-not-discovering provider dangling).

2. **`waitDevice()` timeout bug** (`src/api/ble/localProvider.ts`): `DEVICE_ATTACH_TIMEOUT_S` and `GATT_CONNECT_TIMEOUT_S` were named and documented as seconds but passed directly as the millisecond `timeout` parameter to `@naugehyde/node-ble`'s `Adapter#waitDevice()` — so the "1 second" attach timeout was actually 1ms. Beyond the unit bug, `waitDevice()` races that timeout against a `discoveryHandler` whose first `check()` only fires after one full `discoveryInterval` (default 1000ms) has elapsed (it's driven by `setInterval`, not an immediate check), so *any* timeout at or below ~1000ms loses the race almost every time, before a single check can even run.

   Renamed the constants to `DEVICE_ATTACH_TIMEOUT_MS` (5000) and `GATT_CONNECT_TIMEOUT_MS` (30000) — correct units, and comfortably above the default discovery interval.

Both bugs are independent; either one alone is enough to make `subscribeGATT()` fail for a device BlueZ can see fine.

## Test plan

- [x] `npx tsc --noEmit -p .` clean (0 errors) against the full core package
- [x] `npx eslint` clean on both changed files
- [x] Verified live against real JK-BMS/Daly BMS BLE hardware via a plugin consuming `app.bleApi.subscribeGATT()`: before the fix, `subscribeGATT()` failed with `"No provider with GATT support and available slots can see <mac>"` on every attempt; after the fix, devices are discovered and GATT-subscribed reliably on server startup
- [ ] Would appreciate a maintainer sanity-check on the registration-order change for any local-provider setups I don't have visibility into (multi-adapter configs, remote providers, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Serializes concurrent `initLocalProviders()` calls per adapter to prevent duplicate providers and orphaned discovery loops.
- Registers `LocalBLEProvider` before discovery so initial advertisements populate the device table.
- Rolls back the matching provider when discovery fails.
- Waits for in-flight initialization before shutting down local providers.
- Sets device attachment and GATT connection timeouts to 5 and 30 seconds.
- Expresses all `waitDevice()` timeout values in milliseconds.
- Validates the changes with TypeScript, ESLint, the full test suite, and JK-BMS/Daly BMS hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->