### PR TITLE
feat: enable stale data detection by default on new installations

### DIFF
--- a/docs/setup/staleness.md
+++ b/docs/setup/staleness.md
@@ -6,7 +6,7 @@ title: Stale Data Detection
 
 When a sensor or bus stops sending data, the last received value would otherwise be displayed forever — and zone-based alerting plugins stay silent because no new delta ever arrives. Signal K Server therefore enforces `meta.timeout` on the self vessel: when a path stops updating beyond its effective timeout, the server marks the value as timed out so displays and plugins can react.
 
-Enforcement is enabled by default on new installations, disabled on installations that predate it (see Configuration below), and applies to `vessels.self` paths only.
+Enforcement applies to `vessels.self` paths only. New installations start with it enabled; on existing installations the setting keeps its stored value, and when it is absent enforcement is off (see Configuration below).
 
 ## How It Works
 
@@ -66,7 +66,7 @@ Timeout enforcement and notifications complement each other: when a sensor path 
 
 ## Configuration
 
-Enforcement is on by default for new installations. Installations upgraded from a version that predates the enforcer keep it off until enabled. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it off there if a source's data is being marked stale unexpectedly while troubleshooting, or on to have sources' data marked stale when they fall silent. The following settings keys control it:
+New installations start with `enforceDataTimeouts` enabled. An existing settings file keeps its stored choice; when the key is absent, enforcement is off. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it off there if a source's data is being marked stale unexpectedly while troubleshooting, or on to have sources' data marked stale when they fall silent. The following settings keys control it:
 
 | Setting                    | Default                                   | Purpose                                                              |
 | -------------------------- | ----------------------------------------- | -------------------------------------------------------------------- |

--- a/docs/setup/staleness.md
+++ b/docs/setup/staleness.md
@@ -6,7 +6,7 @@ title: Stale Data Detection
 
 When a sensor or bus stops sending data, the last received value would otherwise be displayed forever — and zone-based alerting plugins stay silent because no new delta ever arrives. Signal K Server therefore enforces `meta.timeout` on the self vessel: when a path stops updating beyond its effective timeout, the server marks the value as timed out so displays and plugins can react.
 
-Enforcement is disabled by default (see Configuration below) and applies to `vessels.self` paths only.
+Enforcement is enabled by default on new installations, disabled on installations that predate it (see Configuration below), and applies to `vessels.self` paths only.
 
 ## How It Works
 
@@ -66,15 +66,15 @@ Timeout enforcement and notifications complement each other: when a sensor path 
 
 ## Configuration
 
-Enforcement is off by default for now, but the plan is to activate it in a future version. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it on there to have sources' data marked stale when they fall silent. The following settings keys control it:
+Enforcement is on by default for new installations. Installations upgraded from a version that predates the enforcer keep it off until enabled. The master switch is exposed in the Admin UI under **Server → Settings → Enforce Data Timeouts** — turn it off there if a source's data is being marked stale unexpectedly while troubleshooting, or on to have sources' data marked stale when they fall silent. The following settings keys control it:
 
-| Setting                    | Default | Purpose                                                              |
-| -------------------------- | ------- | -------------------------------------------------------------------- |
-| `enforceDataTimeouts`      | `false` | Master switch for the enforcer                                       |
-| `useDefaultTimeouts`       | `true`  | Apply the global default to periodic paths without their own timeout |
-| `defaultTimeout`           | `60`    | Global fallback timeout in seconds                                   |
-| `staleCheckIntervalMs`     | `1000`  | How often the enforcer checks, in milliseconds                       |
-| `autoTimeoutSamples`       | `10`    | Update intervals sampled for `timeout: "auto"`                       |
-| `autoTimeoutWarmupSeconds` | `30`    | Warm-up before a learned `auto` timeout takes effect                 |
+| Setting                    | Default                                   | Purpose                                                              |
+| -------------------------- | ----------------------------------------- | -------------------------------------------------------------------- |
+| `enforceDataTimeouts`      | `true` on new installations, else `false` | Master switch for the enforcer                                       |
+| `useDefaultTimeouts`       | `true`                                    | Apply the global default to periodic paths without their own timeout |
+| `defaultTimeout`           | `60`                                      | Global fallback timeout in seconds                                   |
+| `staleCheckIntervalMs`     | `1000`                                    | How often the enforcer checks, in milliseconds                       |
+| `autoTimeoutSamples`       | `10`                                      | Update intervals sampled for `timeout: "auto"`                       |
+| `autoTimeoutWarmupSeconds` | `30`                                      | Warm-up before a learned `auto` timeout takes effect                 |
 
 Per-path control is available to every user via the path's metadata: a numeric `timeout` to tighten or relax detection, `0` to exempt the path, `"auto"` to let the server learn, or `updateContract: "event"` to declare the path event-driven.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -100,7 +100,9 @@ export interface Config {
     logCountToKeep?: number
     enablePluginLogging?: boolean
     loggingDirectory?: string
-    /** Master switch for the staleness enforcer */
+    /** Master switch for the staleness enforcer. Seeded `true` when no
+     * settings file exists (fresh installation); absent — and therefore
+     * off — on installations that predate the enforcer. */
     enforceDataTimeouts?: boolean
     /** When true, paths without an explicit numeric `meta.timeout`
      * fall back to `defaultTimeout` instead of being skipped. Default
@@ -577,6 +579,10 @@ function readSettingsFile(app: ConfigApp) {
   if (!app.argv.s && !fs.existsSync(settings)) {
     console.log('Settings file does not exist, using empty settings')
     app.config.settings = {
+      // No settings file means a fresh installation: enforce staleness
+      // from the start. Installations that predate the enforcer have a
+      // settings file without the key and stay opt-in.
+      enforceDataTimeouts: true,
       pipedProviders: []
     }
   } else {

--- a/test/settings-fresh-install.ts
+++ b/test/settings-fresh-install.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { load } from '../src/config/config'
+import { ConfigApp } from '../src/config/config'
+
+// load() consults these before config.configPath / the temp dir, so they
+// must not leak in from the environment (and must be restored afterwards).
+const ENV_OVERRIDES = [
+  'SIGNALK_NODE_SETTINGS',
+  'SIGNALK_NODE_CONFIG_DIR',
+  'SIGNALK_NODE_CONDFIG_DIR'
+]
+
+function makeApp(configPath: string): ConfigApp {
+  return {
+    config: { configPath },
+    argv: {},
+    // load() ends by wiring development/production middleware into what
+    // is normally the express app; the stubs keep the test at the config
+    // layer and make both branches no-ops.
+    get: () => 'test',
+    use: () => undefined
+  } as unknown as ConfigApp
+}
+
+describe('settings defaults on fresh install', () => {
+  let dir: string
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-fresh-install-'))
+    savedEnv = {}
+    for (const key of ENV_OVERRIDES) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+    for (const key of ENV_OVERRIDES) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = savedEnv[key]
+      }
+    }
+  })
+
+  it('seeds enforceDataTimeouts true when no settings file exists', () => {
+    const app = makeApp(dir)
+
+    load(app)
+
+    expect(app.config.settings.enforceDataTimeouts).to.equal(true)
+    // The seed is an in-memory default, not an eager write: settings.json
+    // appears only when the user first saves settings.
+    expect(fs.existsSync(path.join(dir, 'settings.json'))).to.equal(false)
+  })
+
+  it('leaves enforceDataTimeouts unset when a settings file predates it', () => {
+    fs.writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({ pipedProviders: [] })
+    )
+    const app = makeApp(dir)
+
+    load(app)
+
+    expect(app.config.settings.enforceDataTimeouts).to.equal(undefined)
+  })
+
+  it('keeps an explicit enforceDataTimeouts false', () => {
+    fs.writeFileSync(
+      path.join(dir, 'settings.json'),
+      JSON.stringify({ enforceDataTimeouts: false, pipedProviders: [] })
+    )
+    const app = makeApp(dir)
+
+    load(app)
+
+    expect(app.config.settings.enforceDataTimeouts).to.equal(false)
+  })
+})

--- a/test/settings-fresh-install.ts
+++ b/test/settings-fresh-install.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { load } from '../src/config/config'
+import { load, writeSettingsFile } from '../src/config/config'
 import { ConfigApp } from '../src/config/config'
 
 // load() consults these before config.configPath / the temp dir, so they
@@ -82,5 +82,36 @@ describe('settings defaults on fresh install', () => {
     load(app)
 
     expect(app.config.settings.enforceDataTimeouts).to.equal(false)
+  })
+
+  it('does not seed when the settings file is unreadable', () => {
+    // The recovery path for a corrupt settings file must not switch
+    // enforcement on: that is an existing installation, not a fresh one.
+    fs.writeFileSync(path.join(dir, 'settings.json'), '{ not json')
+    const app = makeApp(dir)
+
+    load(app)
+
+    expect(app.config.settings.enforceDataTimeouts).to.equal(undefined)
+  })
+
+  it('persists the seeded value with the first settings save', (done) => {
+    const app = makeApp(dir)
+    load(app)
+
+    writeSettingsFile(app, app.config.settings, (err: unknown) => {
+      if (err) {
+        return done(err)
+      }
+      const onDisk = JSON.parse(
+        fs.readFileSync(path.join(dir, 'settings.json'), 'utf8')
+      )
+      expect(onDisk.enforceDataTimeouts).to.equal(true)
+
+      const reloaded = makeApp(dir)
+      load(reloaded)
+      expect(reloaded.config.settings.enforceDataTimeouts).to.equal(true)
+      done()
+    })
   })
 })


### PR DESCRIPTION
#2689 shipped stale data detection disabled by default, with the stated plan to flip the default once it has seen real-world use (c088ce9c). This flips it for new installations only, as a safe middle step: fresh installs get stale data detection out of the box, while existing installations are unaffected on upgrade.

A missing settings file marks a fresh installation, so `readSettingsFile` seeds `enforceDataTimeouts: true` into the initial in-memory settings there; the value is persisted with the first settings save. Installations with an existing settings file keep the key absent (off) or their explicit choice, and the corrupt-settings-file recovery path stays off. The Admin UI switch and `GET /settings` follow the live setting, so no UI changes are needed.

Tested: new `test/settings-fresh-install.ts` covers the seeded fresh-install case, a pre-existing settings file without the key, and an explicit `false`; staleness, security, and settings suites pass; repo-root format, build:all, and full npm test are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enables `enforceDataTimeouts` by default for new installations.
- Preserves existing behavior for installations with existing settings, including missing or explicit `false` values.
- Keeps corrupt-settings-file recovery disabled.
- Documents the installation-dependent default.
- Adds tests for fresh installations, legacy settings, corrupt settings, explicit `false` values, and first-save persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->