### PR TITLE
fix: Delete all user records matching a username and show the OIDC subject in the users list

### DIFF
--- a/packages/server-admin-ui/src/views/security/Users.tsx
+++ b/packages/server-admin-ui/src/views/security/Users.tsx
@@ -27,11 +27,34 @@ type UserType = 'readonly' | 'readwrite' | 'admin'
 interface User {
   userId: string
   type?: UserType
-  email?: string
+  oidc?: {
+    issuer?: string
+    email?: string
+    name?: string
+    sub?: string
+  }
   isOIDC?: boolean
   isNew?: boolean
   password?: string
   confirmPassword?: string
+}
+
+/**
+ * Row keys for the users table. The API exposes no per-record identifier and
+ * usernames are not unique, so identity is the username plus the OIDC
+ * issuer/sub pair — sub is unique only within its issuer — with an occurrence
+ * suffix for records that are indistinguishable even then.
+ */
+function userRowKeys(users: User[]): string[] {
+  const seen = new Map<string, number>()
+  return users.map((user) => {
+    const identity = `${user.userId}:${user.oidc?.issuer ?? ''}:${
+      user.oidc?.sub ?? 'local'
+    }`
+    const occurrence = seen.get(identity) ?? 0
+    seen.set(identity, occurrence + 1)
+    return `${identity}#${occurrence}`
+  })
 }
 
 function convertType(type: UserType | undefined): string {
@@ -205,14 +228,15 @@ export default function Users() {
                   </tr>
                 </thead>
                 <tbody>
-                  {(users || []).map((user) => {
+                  {userRowKeys(users).map((key, index) => {
+                    const user = users[index]
                     return (
-                      <tr key={user.userId} onClick={() => userClicked(user)}>
+                      <tr key={key} onClick={() => userClicked(user)}>
                         <td>
                           {user.userId}
-                          {user.email && (
+                          {user.oidc?.email && (
                             <small className="text-muted ms-2">
-                              ({user.email})
+                              ({user.oidc.email})
                             </small>
                           )}
                         </td>
@@ -271,13 +295,30 @@ export default function Users() {
                       )}
                     </Col>
                   </Form.Group>
-                  {selectedUser.email && (
+                  {selectedUser.oidc?.email && (
                     <Form.Group as={Row} className="mb-3">
                       <Col md="2">
                         <Form.Label>Email</Form.Label>
                       </Col>
                       <Col xs="12" md="9">
-                        <Form.Label>{selectedUser.email}</Form.Label>
+                        <Form.Label>{selectedUser.oidc.email}</Form.Label>
+                      </Col>
+                    </Form.Group>
+                  )}
+                  {selectedUser.oidc?.sub && (
+                    <Form.Group as={Row} className="mb-3">
+                      <Col md="2">
+                        <Form.Label>Subject</Form.Label>
+                      </Col>
+                      <Col xs="12" md="9">
+                        <Form.Label>
+                          {selectedUser.oidc.sub}
+                          {selectedUser.oidc.issuer && (
+                            <small className="text-muted ms-2">
+                              ({selectedUser.oidc.issuer})
+                            </small>
+                          )}
+                        </Form.Label>
                       </Col>
                     </Form.Group>
                   )}

--- a/src/security.ts
+++ b/src/security.ts
@@ -94,6 +94,13 @@ export interface User {
 export interface UserData {
   userId: string
   type: string
+  isOIDC?: boolean
+  /**
+   * OIDC claims for a user authenticated through an external provider. sub is
+   * unique only within its issuer, so the issuer/sub pair is what tells two
+   * records apart when they share a username.
+   */
+  oidc?: Omit<OIDCUserIdentifier, 'groups'>
 }
 export interface UserDataUpdate {
   type?: string

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -1060,20 +1060,17 @@ function tokenSecurityFactory(
   strategy.getUsers = (aConfig: SecurityConfig): UserData[] => {
     if (aConfig && aConfig.users) {
       return aConfig.users.map((user) => {
-        const userData: UserData & {
-          isOIDC?: boolean
-          oidc?: { issuer?: string; email?: string; name?: string }
-        } = {
+        const userData: UserData = {
           userId: user.username,
           type: user.type,
           isOIDC: !!user.oidc
         }
-        // Include OIDC metadata for OIDC users
         if (user.oidc) {
           userData.oidc = {
             issuer: user.oidc.issuer,
             email: user.oidc.email,
-            name: user.oidc.name
+            name: user.oidc.name,
+            sub: user.oidc.sub
           }
         }
         return userData
@@ -1216,12 +1213,13 @@ function tokenSecurityFactory(
     callback: ICallback<SecurityConfig>
   ): void => {
     assertConfigImmutability()
-    for (let i = theConfig.users.length - 1; i >= 0; i--) {
-      if (theConfig.users[i].username === username) {
-        theConfig.users.splice(i, 1)
-        break
-      }
-    }
+    // Duplicate usernames can exist (OIDC auto-creation does not rename on
+    // OIDC-vs-OIDC collisions), and getPrincipal authenticates the first
+    // match. The API is keyed by username, so remove every record claiming
+    // it — deleting a single one would leave the username able to log in.
+    theConfig.users = theConfig.users.filter(
+      (user) => user.username !== username
+    )
     options = theConfig as TokenSecurityOptions
     callback(null, theConfig)
   }

--- a/test/tokensecurity-deleteuser-duplicates.ts
+++ b/test/tokensecurity-deleteuser-duplicates.ts
@@ -1,0 +1,118 @@
+import { expect } from 'chai'
+import type { SecurityConfig, User } from '../src/security'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tokenSecurityFactory = require('../dist/tokensecurity.js')
+
+interface UserData {
+  userId: string
+  type: string
+  isOIDC?: boolean
+  oidc?: { issuer?: string; email?: string; name?: string; sub?: string }
+}
+
+interface UsersStrategy {
+  deleteUser(
+    config: Partial<SecurityConfig>,
+    username: string,
+    callback: (err: Error | null, config?: SecurityConfig) => void
+  ): void
+  getUsers(config: Partial<SecurityConfig>): UserData[]
+}
+
+function makeStrategy(): UsersStrategy {
+  // setupApp() registers express routes during construction; stub the
+  // router verbs as no-ops since this test only exercises user records.
+  const noop = () => undefined
+  const app = {
+    config: {},
+    use: noop,
+    get: noop,
+    post: noop,
+    put: noop,
+    delete: noop
+  }
+  return tokenSecurityFactory(app, { secretKey: 'test-key' })
+}
+
+function deleteUser(
+  strategy: UsersStrategy,
+  config: Partial<SecurityConfig>,
+  username: string
+): Promise<SecurityConfig> {
+  return new Promise((resolve, reject) => {
+    strategy.deleteUser(config, username, (err, theConfig) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(theConfig as SecurityConfig)
+      }
+    })
+  })
+}
+
+const usernames = (config: { users?: User[] }): string[] =>
+  (config.users ?? []).map((u) => u.username)
+
+describe('tokensecurity deleteUser', () => {
+  it('removes the single record for a unique username', async () => {
+    const config: Partial<SecurityConfig> = {
+      users: [
+        { username: 'alice', type: 'admin' },
+        { username: 'bob', type: 'readonly' }
+      ]
+    }
+    const result = await deleteUser(makeStrategy(), config, 'alice')
+    expect(usernames(result)).to.deep.equal(['bob'])
+  })
+
+  it('removes every record when duplicates share the username', async () => {
+    const config: Partial<SecurityConfig> = {
+      users: [
+        { username: 'alice', type: 'admin' },
+        {
+          username: 'alice',
+          type: 'readonly',
+          oidc: { sub: 'sub-2', issuer: 'https://idp.example.com' }
+        },
+        { username: 'bob', type: 'readonly' }
+      ]
+    }
+    const result = await deleteUser(makeStrategy(), config, 'alice')
+    expect(usernames(result)).to.deep.equal(['bob'])
+  })
+
+  it('leaves the config unchanged for an unknown username', async () => {
+    const config: Partial<SecurityConfig> = {
+      users: [{ username: 'alice', type: 'admin' }]
+    }
+    const result = await deleteUser(makeStrategy(), config, 'carol')
+    expect(usernames(result)).to.deep.equal(['alice'])
+  })
+})
+
+describe('tokensecurity getUsers', () => {
+  it('surfaces the OIDC sub so duplicate usernames are distinguishable', () => {
+    const config: Partial<SecurityConfig> = {
+      users: [
+        { username: 'alice', type: 'admin' },
+        {
+          username: 'alice',
+          type: 'readonly',
+          oidc: {
+            sub: 'sub-2',
+            issuer: 'https://idp.example.com',
+            email: 'alice@example.com'
+          }
+        }
+      ]
+    }
+    const users = makeStrategy().getUsers(config)
+    expect(users).to.have.length(2)
+    expect(users[0].isOIDC).to.equal(false)
+    expect(users[0].oidc).to.equal(undefined)
+    expect(users[1].isOIDC).to.equal(true)
+    expect(users[1].oidc?.sub).to.equal('sub-2')
+    expect(users[1].oidc?.issuer).to.equal('https://idp.example.com')
+  })
+})


### PR DESCRIPTION
`deleteUser` removed the **last** record matching a username while `getPrincipal` authenticates the **first**, so when duplicate records exist, deleting a user left the record that actually logs in untouched (#2954).

The users API is keyed by username and cannot address an individual record, so `deleteUser` now removes **every** record with that username. This is the only variant where deleting a user deterministically revokes its access — first-match agreement would merely shift authentication to the surviving record, which would keep logging in with that record's permissions.

For distinguishability, `getUsers` now includes the OIDC `sub` and the admin UI shows it (with issuer) in the user detail card. This also fixes the email display, which read a flat `email` field the server never sends — OIDC metadata is nested under `oidc` — and gives table rows a unique React key so duplicate usernames don't collide.

Duplicate usernames can genuinely arise: OIDC auto-creation only renames on collision with a *local* user, so two IdP accounts sharing a `preferred_username` produce two records with the same username.

Tested: new unit tests for `deleteUser` (unique, duplicate, unknown username) and `getUsers` sub surfacing; full repo-root test chain locally.

closes #2954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates `deleteUser` to remove all records that match a username.
- Exposes the OIDC `sub` value through `getUsers`.
- Displays OIDC issuer, subject, and email in the admin user details.
- Adds unique keys for user table rows.
- Adds tests for unique, duplicate, and unknown username deletion, plus OIDC subject exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->