### PR TITLE
fix: Keep in-memory users consistent with security.json when a save fails

### DIFF
--- a/src/atomicWrite.ts
+++ b/src/atomicWrite.ts
@@ -15,11 +15,20 @@ export function atomicWriteFileSync(filePath: string, data: string): void {
 
 export async function atomicWriteFile(
   filePath: string,
-  data: string
+  data: string,
+  mode?: number
 ): Promise<void> {
   const tmp = filePath + '.tmp'
   try {
-    await fs.promises.writeFile(tmp, data)
+    // mode on writeFile only applies when the file is created; the chmod
+    // covers a tmp file left over from a crashed earlier attempt. Doing
+    // both before the rename means a permission failure surfaces while
+    // nothing has been persisted at the final path, and the file never
+    // exists anywhere with looser permissions than asked.
+    await fs.promises.writeFile(tmp, data, { mode })
+    if (mode !== undefined) {
+      await fs.promises.chmod(tmp, mode)
+    }
     await fs.promises.rename(tmp, filePath)
   } catch (err) {
     try {

--- a/src/security.ts
+++ b/src/security.ts
@@ -326,6 +326,9 @@ export function pathForSecurityConfig(app: WithConfig) {
   return path.join(app.config.configPath, 'security.json')
 }
 
+/** security.json holds the secret key, so only its owner may read it. */
+export const SECURITY_CONFIG_FILE_MODE = 0o600
+
 export function saveSecurityConfig(
   app: WithSecurityStrategy & WithConfig,
   data: any,
@@ -338,9 +341,12 @@ export function saveSecurityConfig(
     }
   } else {
     const configPath = pathForSecurityConfig(app)
-    atomicWriteFile(configPath, JSON.stringify(data, null, 2))
+    atomicWriteFile(
+      configPath,
+      JSON.stringify(data, null, 2),
+      SECURITY_CONFIG_FILE_MODE
+    )
       .then(() => {
-        chmodSync(configPath, '600')
         if (callback) {
           callback(null)
         }

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -214,6 +214,7 @@ interface TokenSecurityStrategy extends SecurityStrategy {
   authorizeWS: (req: WSConnection) => void
   shouldAllowWrite: (req: Request, delta: Delta) => boolean
   canAuthorizeWS: () => boolean
+  externalUserService: ExternalUserService
 }
 
 /**
@@ -352,6 +353,12 @@ function tokenSecurityFactory(
           options,
           (err: Error | null) => {
             if (err) {
+              // Keep memory consistent with disk: an unsaved record would
+              // authenticate until the next config reload silently drops it.
+              const index = options.users.indexOf(newUser)
+              if (index !== -1) {
+                options.users.splice(index, 1)
+              }
               reject(err)
             } else {
               resolve()
@@ -370,6 +377,9 @@ function tokenSecurityFactory(
         throw new Error(`User not found: ${username}`)
       }
 
+      const previousType = user.type
+      const previousOidc = user.oidc
+
       if (updates.type) {
         user.type = updates.type
       }
@@ -384,6 +394,10 @@ function tokenSecurityFactory(
           options,
           (err: Error | null) => {
             if (err) {
+              // Keep memory consistent with disk so a failed save does not
+              // leave the record with permissions that were never stored.
+              user.type = previousType
+              user.oidc = previousOidc
               reject(err)
             } else {
               resolve()
@@ -393,6 +407,8 @@ function tokenSecurityFactory(
       })
     }
   }
+
+  strategy.externalUserService = externalUserService
 
   if (process.env.ADMINUSER) {
     const adminUserParts = process.env.ADMINUSER.split(':')

--- a/test/tokensecurity-externaluser-rollback.ts
+++ b/test/tokensecurity-externaluser-rollback.ts
@@ -1,0 +1,195 @@
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import type { SecurityConfig } from '../src/security'
+import { SECURITY_CONFIG_FILE_MODE } from '../src/security'
+import { atomicWriteFile } from '../src/atomicWrite'
+
+// tokensecurity is only reachable as CommonJS; the compiled factory carries
+// no types, so the strategy shape is declared below.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const tokenSecurityFactory = require('../dist/tokensecurity.js')
+
+interface ExternalUser {
+  username: string
+  type: string
+  providerData?: Record<string, unknown>
+}
+
+interface ExternalUserService {
+  findUserByUsername(username: string): Promise<ExternalUser | null>
+  createUser(user: ExternalUser): Promise<void>
+  updateUser(
+    username: string,
+    updates: { type?: string; providerData?: Record<string, unknown> }
+  ): Promise<void>
+}
+
+interface RollbackStrategy {
+  externalUserService: ExternalUserService
+}
+
+function makeStrategy(
+  configPath: string,
+  config: Partial<SecurityConfig> = {}
+): RollbackStrategy {
+  // setupApp() registers express routes during construction; stub the
+  // router verbs as no-ops since this test only exercises the user service.
+  const noop = () => undefined
+  const app: Record<string, unknown> = {
+    config: { configPath },
+    use: noop,
+    get: noop,
+    post: noop,
+    put: noop,
+    delete: noop
+  }
+  const strategy = tokenSecurityFactory(app, {
+    secretKey: 'test-key',
+    users: [],
+    ...config
+  })
+  // saveSecurityConfig consults app.securityStrategy.configFromArguments;
+  // mirror startSecurity(), which assigns the strategy onto the app.
+  app.securityStrategy = strategy
+  return strategy
+}
+
+const oidcIdentity = { sub: 'sub-1', issuer: 'https://idp.example.com' }
+
+const MODE_MASK = 0o777
+
+function savedUsernames(saved: unknown): string[] {
+  const users = (saved as { users?: unknown }).users
+  if (!Array.isArray(users)) {
+    throw new Error('saved config has no users array')
+  }
+  return users.map((user) => (user as { username: string }).username)
+}
+
+describe('tokensecurity externalUserService', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-security-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('persists a created user to security.json', async () => {
+    const service = makeStrategy(tempDir).externalUserService
+    await service.createUser({
+      username: 'oidc-user',
+      type: 'readonly',
+      providerData: { oidc: oidcIdentity }
+    })
+
+    expect(await service.findUserByUsername('oidc-user')).to.not.equal(null)
+
+    const configFile = path.join(tempDir, 'security.json')
+    const saved: unknown = JSON.parse(fs.readFileSync(configFile, 'utf8'))
+    expect(savedUsernames(saved)).to.include('oidc-user')
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(configFile).mode & MODE_MASK).to.equal(
+        SECURITY_CONFIG_FILE_MODE
+      )
+    }
+  })
+
+  it('rolls the created user back out of memory when the save fails', async () => {
+    const service = makeStrategy(
+      path.join(tempDir, 'missing', 'nested')
+    ).externalUserService
+
+    let error: Error | undefined
+    try {
+      await service.createUser({
+        username: 'oidc-user',
+        type: 'readonly',
+        providerData: { oidc: oidcIdentity }
+      })
+    } catch (err) {
+      error = err as Error
+    }
+
+    expect(error).to.be.an('error')
+    expect(await service.findUserByUsername('oidc-user')).to.equal(null)
+  })
+
+  it('restores the previous record when an update fails to save', async () => {
+    const service = makeStrategy(path.join(tempDir, 'missing', 'nested'), {
+      users: [{ username: 'alice', type: 'readonly', oidc: oidcIdentity }]
+    }).externalUserService
+
+    let error: Error | undefined
+    try {
+      await service.updateUser('alice', {
+        type: 'admin',
+        providerData: {
+          oidc: { sub: 'sub-2', issuer: 'https://other.example.com' }
+        }
+      })
+    } catch (err) {
+      error = err as Error
+    }
+
+    expect(error).to.be.an('error')
+    const alice = await service.findUserByUsername('alice')
+    expect(alice?.type).to.equal('readonly')
+    expect(alice?.providerData).to.deep.equal(oidcIdentity)
+  })
+})
+
+describe('atomicWriteFile', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-atomic-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('applies the requested mode before the file appears', async () => {
+    const target = path.join(tempDir, 'out.json')
+    await atomicWriteFile(target, '{}', SECURITY_CONFIG_FILE_MODE)
+    expect(fs.readFileSync(target, 'utf8')).to.equal('{}')
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(target).mode & MODE_MASK).to.equal(
+        SECURITY_CONFIG_FILE_MODE
+      )
+    }
+  })
+
+  it('leaves an existing file untouched when the write fails', async () => {
+    const target = path.join(tempDir, 'out.json')
+    fs.writeFileSync(target, '{"existing":true}')
+
+    // A directory at the tmp path makes the write fail, standing in for any
+    // mid-write failure: the point is that the target keeps its old contents.
+    const tmpPath = target + '.tmp'
+    fs.mkdirSync(tmpPath)
+
+    let error: Error | undefined
+    try {
+      await atomicWriteFile(target, '{"new":true}', SECURITY_CONFIG_FILE_MODE)
+    } catch (err) {
+      error = err as Error
+    } finally {
+      fs.rmSync(tmpPath, { recursive: true, force: true })
+    }
+
+    expect(error).to.be.an('error')
+    expect(fs.readFileSync(target, 'utf8')).to.equal('{"existing":true}')
+  })
+
+  it('writes without a mode as before', async () => {
+    const target = path.join(tempDir, 'out.json')
+    await atomicWriteFile(target, '{"a":1}')
+    expect(fs.readFileSync(target, 'utf8')).to.equal('{"a":1}')
+  })
+})


### PR DESCRIPTION
`externalUserService.createUser` pushed the new record into the in-memory user array before the write to `security.json` was known to have succeeded, and left it there when the save failed; `updateUser` mutated `type`/`oidc` in place the same way (#2955). On a failed save (full or read-only filesystem) the phantom record authenticates, then silently vanishes on the next config reload — so the account works or doesn't depending on what has happened since.

`createUser` now splices the record back out in the rejection branch and `updateUser` restores the previous `type`/`oidc`, keeping memory consistent with what is actually stored.

The same issue notes the inverted error in `saveSecurityConfig`: the post-rename `chmodSync` could fail *after* the data had persisted, telling the caller the save failed when it hadn't. `atomicWriteFile` now takes an optional mode and applies it to the tmp file before the rename — a permission failure is reported while nothing has been persisted at the final path, and the file never appears there with looser permissions than intended.

`externalUserService` is exposed on the token-security strategy so the rollback behavior is unit-testable, following the pattern of the other token-security-only members.

Tested: new unit tests for create/update rollback on save failure, successful persistence with `0600`, and `atomicWriteFile` mode handling; full repo-root test chain locally.

closes #2955


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Keeps in-memory users consistent with `security.json` when persistence fails.
- Rolls back failed external-user creation and restores previous values after failed updates.
- Adds optional file modes to `atomicWriteFile` and applies mode before rename.
- Persists `security.json` with mode `0600` without post-rename permission changes.
- Exposes `externalUserService` on `TokenSecurityStrategy`.
- Adds tests for rollback behavior, file modes, and atomic writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->