### PR TITLE
fix(oidc): rename auto-created users on any username collision

### DIFF
--- a/src/oidc/oidc-auth.ts
+++ b/src/oidc/oidc-auth.ts
@@ -24,7 +24,8 @@ import {
   ExternalUserService,
   ExternalUser,
   STATE_COOKIE_NAME,
-  STATE_MAX_AGE_MS
+  STATE_MAX_AGE_MS,
+  UsernameConflictError
 } from './types'
 import { isOIDCEnabled } from './config'
 import {
@@ -156,6 +157,38 @@ function isSafeRelativeUrl(url: unknown): url is string {
  * current group memberships. This allows permission changes to take effect
  * when group assignments change in the identity provider.
  */
+const SUB_SUFFIX_LENGTH = 8
+const MAX_USERNAME_ATTEMPTS = 100
+
+/**
+ * Find a username no stored record claims yet.
+ *
+ * Callers reach this only when no record matches the identity's sub+issuer, so
+ * any record holding the preferred name belongs to someone else — providers do
+ * not guarantee that preferred_username is unique, and reusing it would create
+ * records that no username-keyed operation can tell apart. The subject
+ * disambiguates; a numeric suffix covers subjects sharing a prefix.
+ */
+async function findFreeUsername(
+  preferred: string,
+  sub: string,
+  deps: Pick<OIDCAuthDependencies, 'userService'>
+): Promise<string> {
+  if (!(await deps.userService.findUserByUsername(preferred))) {
+    return preferred
+  }
+
+  const withSub = `${preferred}-${sub.substring(0, SUB_SUFFIX_LENGTH)}`
+  for (let attempt = 0; attempt < MAX_USERNAME_ATTEMPTS; attempt++) {
+    const candidate = attempt === 0 ? withSub : `${withSub}-${attempt}`
+    if (!(await deps.userService.findUserByUsername(candidate))) {
+      return candidate
+    }
+  }
+
+  throw new Error(`Could not derive a free username from ${preferred}`)
+}
+
 export async function findOrCreateOIDCUser(
   userInfo: OIDCUserInfo,
   oidcConfig: OIDCConfig,
@@ -223,36 +256,50 @@ export async function findOrCreateOIDCUser(
     return null
   }
 
-  // Create new user
+  // Create new user. findFreeUsername and createUser are separate awaits, so
+  // a concurrent request can claim the candidate in between; createUser
+  // rejects the loser, which rechecks the identity and tries again. Every
+  // retry means another request created a user, so the loop terminates; the
+  // bound mirrors the candidate space findFreeUsername can allocate.
   const username =
     userInfo.preferredUsername || userInfo.email || `oidc-${userInfo.sub}`
 
-  // Check for username collision with non-OIDC user
-  const existingUser = await deps.userService.findUserByUsername(username)
-  // Only consider it a collision if the existing user is NOT an OIDC user
-  const isCollision = existingUser && !existingUser.providerData
-  const finalUsername = isCollision
-    ? `${username}-${userInfo.sub.substring(0, 8)}`
-    : username
+  for (let attempt = 0; attempt < MAX_USERNAME_ATTEMPTS; attempt++) {
+    const finalUsername = await findFreeUsername(username, userInfo.sub, deps)
 
-  const newUser: ExternalUser = {
-    username: finalUsername,
-    type: mappedPermission,
-    providerData: { oidc: oidcMetadata }
+    const newUser: ExternalUser = {
+      username: finalUsername,
+      type: mappedPermission,
+      providerData: { oidc: oidcMetadata }
+    }
+
+    debug(
+      `OIDC: creating new user ${newUser.username} with permission ${newUser.type}`
+    )
+
+    try {
+      await deps.userService.createUser(newUser)
+      return newUser
+    } catch (err) {
+      if (!(err instanceof UsernameConflictError)) {
+        console.error('Failed to create OIDC user:', err)
+        throw err
+      }
+      // The request that won the race may have provisioned this very
+      // identity (e.g. a double-submitted login); reuse its record.
+      const existing = await deps.userService.findUserByProvider({
+        provider: 'oidc',
+        criteria: { sub: userInfo.sub, issuer }
+      })
+      if (existing) {
+        return existing
+      }
+    }
   }
 
-  debug(
-    `OIDC: creating new user ${newUser.username} with permission ${newUser.type}`
+  throw new Error(
+    `Could not create a user for ${username} after ${MAX_USERNAME_ATTEMPTS} attempts`
   )
-
-  try {
-    await deps.userService.createUser(newUser)
-  } catch (err) {
-    console.error('Failed to create OIDC user:', err)
-    throw err
-  }
-
-  return newUser
 }
 
 /**

--- a/src/oidc/types.ts
+++ b/src/oidc/types.ts
@@ -218,6 +218,19 @@ export interface ProviderUserLookup {
 }
 
 /**
+ * Thrown by ExternalUserService.createUser when the username is already
+ * taken. Lets provisioning distinguish a lost creation race (retry with
+ * another candidate) from storage failures (propagate).
+ */
+export class UsernameConflictError extends Error {
+  constructor(username: string) {
+    super(`Username already exists: ${username}`)
+    this.name = 'UsernameConflictError'
+    Error.captureStackTrace(this, UsernameConflictError)
+  }
+}
+
+/**
  * Generic user service interface for external authentication providers.
  * Named generically to support future auth providers beyond OIDC.
  *
@@ -232,7 +245,10 @@ export interface ExternalUserService {
   /** Find a user by username (for collision detection) */
   findUserByUsername(username: string): Promise<ExternalUser | null>
 
-  /** Create a new user */
+  /**
+   * Create a new user. The uniqueness check and the insert must be atomic;
+   * rejects with UsernameConflictError if the username is already taken.
+   */
   createUser(user: ExternalUser): Promise<void>
 
   /** Update an existing user's type and/or provider data */

--- a/src/tokensecurity.ts
+++ b/src/tokensecurity.ts
@@ -74,7 +74,8 @@ import {
   ProviderUserLookup,
   PartialOIDCConfig,
   OIDCError,
-  OIDC_DEFAULTS
+  OIDC_DEFAULTS,
+  UsernameConflictError
 } from './oidc'
 import { SERVERROUTESPREFIX } from './constants'
 import { ICallback } from './types'
@@ -335,6 +336,12 @@ function tokenSecurityFactory(
     },
 
     async createUser(externalUser: ExternalUser): Promise<void> {
+      // Check and insert with no await between them, so concurrent
+      // provisioning requests cannot both claim the same username.
+      if (options.users.some((u) => u.username === externalUser.username)) {
+        throw new UsernameConflictError(externalUser.username)
+      }
+
       const newUser: User = {
         username: externalUser.username,
         type: externalUser.type

--- a/test/oidc/oidc-user-provisioning.test.ts
+++ b/test/oidc/oidc-user-provisioning.test.ts
@@ -1,0 +1,290 @@
+import { expect } from 'chai'
+import { findOrCreateOIDCUser } from '../../src/oidc/oidc-auth'
+import {
+  ExternalUser,
+  ExternalUserService,
+  OIDCConfig,
+  OIDCUserInfo,
+  ProviderUserLookup,
+  UsernameConflictError
+} from '../../src/oidc/types'
+
+const ISSUER = 'https://idp.example.com'
+
+function makeConfig(overrides: Partial<OIDCConfig> = {}): OIDCConfig {
+  const config: OIDCConfig = {
+    enabled: true,
+    issuer: ISSUER,
+    clientId: 'client',
+    clientSecret: 'secret',
+    redirectUri: 'http://localhost:3000/callback',
+    scope: 'openid profile email',
+    defaultPermission: 'readonly',
+    autoCreateUsers: true,
+    providerName: 'SSO Login',
+    autoLogin: false
+  }
+  return { ...config, ...overrides }
+}
+
+/** In-memory user store mirroring tokensecurity's externalUserService. */
+function makeUserService(initial: ExternalUser[] = []) {
+  const users: ExternalUser[] = [...initial]
+  const service: ExternalUserService = {
+    async findUserByProvider(lookup: ProviderUserLookup) {
+      if (lookup.provider !== 'oidc') {
+        return null
+      }
+      const { sub, issuer } = lookup.criteria
+      const found = users.find((user) => {
+        const oidc = user.providerData?.oidc as
+          { sub?: string; issuer?: string } | undefined
+        return oidc?.sub === sub && oidc?.issuer === issuer
+      })
+      if (!found) {
+        return null
+      }
+      // Mirror production: providerData holds the OIDC metadata directly
+      return {
+        username: found.username,
+        type: found.type,
+        providerData: found.providerData?.oidc as
+          Record<string, unknown> | undefined
+      }
+    },
+    async findUserByUsername(username: string) {
+      return users.find((user) => user.username === username) ?? null
+    },
+    async createUser(user: ExternalUser) {
+      if (users.some((u) => u.username === user.username)) {
+        throw new UsernameConflictError(user.username)
+      }
+      users.push(user)
+    },
+    async updateUser(username, updates) {
+      const user = users.find((u) => u.username === username)
+      if (!user) {
+        throw new Error(`User not found: ${username}`)
+      }
+      if (updates.type) {
+        user.type = updates.type
+      }
+      if (updates.providerData) {
+        user.providerData = updates.providerData
+      }
+    }
+  }
+  return { service, users }
+}
+
+function oidcUser(username: string, sub: string): ExternalUser {
+  return {
+    username,
+    type: 'readonly',
+    providerData: { oidc: { sub, issuer: ISSUER } }
+  }
+}
+
+function userInfo(sub: string, preferredUsername: string): OIDCUserInfo {
+  return { sub, preferredUsername }
+}
+
+/**
+ * Hold every request at the availability check until `count` of them have
+ * seen a name as free, so all of them race into createUser together.
+ */
+function forceCreationRace(service: ExternalUserService, count: number) {
+  let seenFree = 0
+  let racing = true
+  let release!: () => void
+  const allChecked = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const lookup = service.findUserByUsername.bind(service)
+  service.findUserByUsername = async (username: string) => {
+    const result = await lookup(username)
+    if (racing && result === null) {
+      if (++seenFree === count) {
+        racing = false
+        release()
+      }
+      await allChecked
+    }
+    return result
+  }
+}
+
+describe('OIDC user provisioning', () => {
+  it('uses the preferred username when no record claims it', async () => {
+    const { service, users } = makeUserService()
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('sub-1', 'alice'),
+      makeConfig(),
+      { userService: service }
+    )
+
+    expect(result?.username).to.equal('alice')
+    expect(users.map((u) => u.username)).to.deep.equal(['alice'])
+  })
+
+  it('reuses the record matching the same subject', async () => {
+    const { service, users } = makeUserService([oidcUser('alice', 'sub-1')])
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('sub-1', 'alice'),
+      makeConfig(),
+      { userService: service }
+    )
+
+    expect(result?.username).to.equal('alice')
+    expect(users).to.have.length(1)
+  })
+
+  it('renames when a local user already holds the name', async () => {
+    const { service, users } = makeUserService([
+      { username: 'alice', type: 'admin' }
+    ])
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('sub-abcdefgh12345', 'alice'),
+      makeConfig(),
+      { userService: service }
+    )
+
+    expect(result?.username).to.equal('alice-sub-abcd')
+    expect(users).to.have.length(2)
+  })
+
+  it('renames when a different OIDC identity already holds the name', async () => {
+    const { service, users } = makeUserService([oidcUser('alice', 'sub-1')])
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('sub-2', 'alice'),
+      makeConfig(),
+      { userService: service }
+    )
+
+    expect(result?.username).to.equal('alice-sub-2')
+    expect(users.map((u) => u.username)).to.deep.equal(['alice', 'alice-sub-2'])
+  })
+
+  it('keeps deriving a free name when subjects share a prefix', async () => {
+    const { service, users } = makeUserService([
+      oidcUser('alice', 'sub-1'),
+      oidcUser('alice-subjectA', 'subjectAAAA')
+    ])
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('subjectABBB', 'alice'),
+      makeConfig(),
+      { userService: service }
+    )
+
+    expect(result?.username).to.equal('alice-subjectA-1')
+    expect(users).to.have.length(3)
+  })
+
+  it('gives concurrent requests sharing a preferred name unique usernames', async () => {
+    const { service, users } = makeUserService()
+    forceCreationRace(service, 2)
+
+    const [a, b] = await Promise.all([
+      findOrCreateOIDCUser(userInfo('sub-aaaa1111', 'alice'), makeConfig(), {
+        userService: service
+      }),
+      findOrCreateOIDCUser(userInfo('sub-bbbb2222', 'alice'), makeConfig(), {
+        userService: service
+      })
+    ])
+
+    const usernames = users.map((u) => u.username)
+    expect(new Set(usernames).size).to.equal(2)
+    expect([a?.username, b?.username]).to.have.members(usernames)
+  })
+
+  it('provisions many concurrent identities sharing a name and subject prefix', async () => {
+    const { service, users } = makeUserService()
+    const subs = [1, 2, 3, 4, 5, 6].map((n) => `samepref-${n}`)
+    forceCreationRace(service, subs.length)
+
+    const results = await Promise.all(
+      subs.map((sub) =>
+        findOrCreateOIDCUser(userInfo(sub, 'alice'), makeConfig(), {
+          userService: service
+        })
+      )
+    )
+
+    const usernames = users.map((u) => u.username)
+    expect(new Set(usernames).size).to.equal(subs.length)
+    expect(results.map((r) => r?.username)).to.have.members(usernames)
+  })
+
+  it('creates a single record when the same identity provisions concurrently', async () => {
+    const { service, users } = makeUserService()
+    forceCreationRace(service, 2)
+
+    const [a, b] = await Promise.all([
+      findOrCreateOIDCUser(userInfo('sub-1', 'alice'), makeConfig(), {
+        userService: service
+      }),
+      findOrCreateOIDCUser(userInfo('sub-1', 'alice'), makeConfig(), {
+        userService: service
+      })
+    ])
+
+    expect(users).to.have.length(1)
+    expect(a?.username).to.equal('alice')
+    expect(b?.username).to.equal('alice')
+  })
+
+  it('does not create a user when auto-creation is disabled', async () => {
+    const { service, users } = makeUserService()
+
+    const result = await findOrCreateOIDCUser(
+      userInfo('sub-1', 'alice'),
+      makeConfig({ autoCreateUsers: false }),
+      { userService: service }
+    )
+
+    expect(result).to.equal(null)
+    expect(users).to.be.empty
+  })
+
+  it('propagates storage failures from createUser unchanged', async () => {
+    const { service } = makeUserService()
+    service.createUser = async () => {
+      throw new Error('disk full')
+    }
+
+    try {
+      await findOrCreateOIDCUser(userInfo('sub-1', 'alice'), makeConfig(), {
+        userService: service
+      })
+      expect.fail('expected findOrCreateOIDCUser to reject')
+    } catch (err) {
+      expect((err as Error).message).to.equal('disk full')
+    }
+  })
+
+  it('gives up when every candidate keeps losing the creation race', async () => {
+    const service: ExternalUserService = {
+      findUserByProvider: async () => null,
+      findUserByUsername: async () => null,
+      createUser: async (user) => {
+        throw new UsernameConflictError(user.username)
+      },
+      updateUser: async () => undefined
+    }
+
+    try {
+      await findOrCreateOIDCUser(userInfo('sub-1', 'alice'), makeConfig(), {
+        userService: service
+      })
+      expect.fail('expected findOrCreateOIDCUser to reject')
+    } catch (err) {
+      expect((err as Error).message).to.match(/after 100 attempts/)
+    }
+  })
+})


### PR DESCRIPTION
OIDC auto-creation could create two user records with the same username, which is the source of the duplicate records #2954 works around.

The collision check only renamed when the existing record was a *local* user:

```ts
const isCollision = existingUser && !existingUser.providerData
```

That branch is only reached when `findUserByProvider` found nothing, so an existing OIDC record there belongs to a *different* subject. Providers do not guarantee `preferred_username` is unique, so two IdP identities sharing one — or one identity whose issuer reuses a name after an account is recreated — both got stored under the same username. Once that happens no username-keyed operation can tell the records apart: `getPrincipal` authenticates the first, `PUT /security/users/:id` updates the first, and the admin UI shows two identical rows.

Any existing record claiming the name is now treated as a collision. The subject suffix disambiguates as before, with a numeric suffix appended when subjects share their first 8 characters, so the derived name is free rather than merely likely to be.

Tested: new unit tests for subject reuse, local-user collision, OIDC-vs-OIDC collision, shared subject prefixes, and auto-creation disabled; verified the two duplicate-scenario tests fail against the previous behavior. Full repo-root test chain locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Ensure auto-created OIDC usernames are unique across local and OIDC users.
- Resolve collisions by appending the subject prefix and numeric suffixes when subjects share a prefix.
- Handle concurrent username conflicts and reuse existing OIDC identities.
- Add coverage for subject reuse, username collisions, shared subject prefixes, concurrent provisioning, storage failures, repeated conflicts, and disabled auto-creation.
- The CI failure is unrelated to this PR. Issue `#2963` tracks the `TS2593` configuration issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->