### PR TITLE
perf: scan cached contexts once per subscribe row

### DIFF
--- a/src/deltacache.ts
+++ b/src/deltacache.ts
@@ -49,6 +49,10 @@ interface StringKeyed {
   [key: string]: any
 }
 
+// Opaque handle for consumers: context branches of the cache as returned
+// by getMatchingContexts and consumed by getCachedDeltasForContexts.
+export type CachedContexts = StringKeyed[]
+
 /**
  * Build a `<label>.<src>` → `<label>.<canName>` map from the Signal K
  * sources summary tree.
@@ -1511,8 +1515,43 @@ export default class DeltaCache {
     return result.concat(Array.from(byPath.values()))
   }
 
+  // Enumerate the context branches matching contextFilter. Subscribe
+  // handling evaluates the filter once per context via this method and
+  // reuses the result across every subscribed path, instead of paying
+  // O(paths × contexts) by re-scanning the whole cache per path. The
+  // returned array holds live references into the cache — hand it to
+  // getCachedDeltasForContexts within the same synchronous task, before
+  // ingestion can add or expire contexts.
+  getMatchingContexts(contextFilter: ContextMatcher): CachedContexts {
+    const contextNodes: StringKeyed[] = []
+    for (const type in this.cache) {
+      const contextsOfType: StringKeyed = this.cache[type]
+      for (const id in contextsOfType) {
+        const context = `${type}.${id}` as Context
+        if (contextFilter({ context })) {
+          contextNodes.push(contextsOfType[id])
+        }
+      }
+    }
+    return contextNodes
+  }
+
   getCachedDeltas(
     contextFilter: ContextMatcher,
+    user?: string,
+    key?: string,
+    sourcePolicy?: 'preferred' | 'all'
+  ) {
+    return this.getCachedDeltasForContexts(
+      this.getMatchingContexts(contextFilter),
+      user,
+      key,
+      sourcePolicy
+    )
+  }
+
+  getCachedDeltasForContexts(
+    contextNodes: CachedContexts,
     user?: string,
     key?: string,
     sourcePolicy?: 'preferred' | 'all'
@@ -1524,34 +1563,26 @@ export default class DeltaCache {
     const keyParts: string[] = key ? key.split('.') : []
 
     const deltas: NormalizedDelta[] = []
-    for (const type in this.cache) {
-      const contextsOfType: StringKeyed = this.cache[type]
-      for (const id in contextsOfType) {
-        const context = `${type}.${id}` as Context
-        if (!contextFilter({ context })) {
-          continue
+    for (const contextNode of contextNodes) {
+      if (key === undefined) {
+        findDeltas(contextNode, deltas)
+      } else if (key === '') {
+        // An empty-path subscription targets values stored at the
+        // context root (e.g. mmsi, name), which live intermixed with
+        // nested path branches. Collect every cached delta and keep
+        // only those whose own path is empty. Testing `if (key)` here
+        // would treat '' as "no key" and leak every path into the
+        // bootstrap snapshot.
+        findDeltas(contextNode, deltas, hasEmptyPath)
+      } else {
+        let node: StringKeyed | undefined = contextNode
+        for (let i = 0; i < keyParts.length; i++) {
+          node = node?.[keyParts[i]]
         }
-        const contextNode: StringKeyed = contextsOfType[id]
-        if (key === undefined) {
-          findDeltas(contextNode, deltas)
-        } else if (key === '') {
-          // An empty-path subscription targets values stored at the
-          // context root (e.g. mmsi, name), which live intermixed with
-          // nested path branches. Collect every cached delta and keep
-          // only those whose own path is empty. Testing `if (key)` here
-          // would treat '' as "no key" and leak every path into the
-          // bootstrap snapshot.
-          findDeltas(contextNode, deltas, hasEmptyPath)
-        } else {
-          let node: StringKeyed | undefined = contextNode
-          for (let i = 0; i < keyParts.length; i++) {
-            node = node?.[keyParts[i]]
-          }
-          if (node) {
-            for (const akey in node) {
-              if (akey !== 'meta') {
-                deltas.push(node[akey])
-              }
+        if (node) {
+          for (const akey in node) {
+            if (akey !== 'meta') {
+              deltas.push(node[akey])
             }
           }
         }

--- a/src/subscriptionmanager.ts
+++ b/src/subscriptionmanager.ts
@@ -36,7 +36,7 @@ import * as Bacon from 'baconjs'
 import { isPointWithinRadius } from 'geolib'
 import _, { forOwn, get, isString } from 'lodash'
 import { createDebug } from './debug'
-import DeltaCache from './deltacache'
+import DeltaCache, { CachedContexts } from './deltacache'
 import { ToPreferredDelta } from './deltaPriority'
 import { StreamBundle, toDelta } from './streambundle'
 import { ContextMatcher } from './types'
@@ -357,6 +357,19 @@ function handleSubscribeRow(
   bootstrapFromCache?: boolean
 ) {
   const matcher = pathMatcher(subscribeRow.path)
+  // The set of cached contexts matching filter is invariant across this
+  // row's synchronous bus sweep — enumerate it once, lazily, instead of
+  // re-scanning the whole cache and re-running the filter per context
+  // for every matching path, which made a wildcard row's subscribe
+  // O(paths × contexts) (#2874). Lazy: rows that never bootstrap from
+  // the cache don't pay for the scan.
+  let matchingContexts: CachedContexts | null = null
+  const getMatchingContexts = () => {
+    if (matchingContexts === null) {
+      matchingContexts = app.deltaCache.getMatchingContexts(filter)
+    }
+    return matchingContexts
+  }
   // iterate over all the buses, checking if we want to subscribe to its values
   forOwn(buses, (bus, key) => {
     // Root deltas (path '') carry vessel identity fields (name, mmsi,
@@ -486,8 +499,8 @@ function handleSubscribeRow(
       // the excluded source — and the subscriber would see it once on
       // startup.
       if (bootstrapFromCache) {
-        const cached = app.deltaCache.getCachedDeltas(
-          filter,
+        const cached = app.deltaCache.getCachedDeltasForContexts(
+          getMatchingContexts(),
           user,
           key,
           perSubEngine ? 'all' : sourcePolicy

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -390,6 +390,31 @@ describe('Deltacache', () => {
     sources.should.deep.equal(['gps.backup', 'gps.primary'])
   })
 
+  it('getCachedDeltasForContexts over getMatchingContexts equals getCachedDeltas', function () {
+    // subscribe enumerates matching contexts once and reuses them across
+    // paths — the split path must return exactly what the single-call
+    // path does, for every key mode (all paths, root values, one path)
+    const selfContext = 'vessels.' + theServer.app.selfId
+    const contextFilter = (d) => d.context === selfContext
+    const cache = theServer.app.deltaCache
+
+    for (const key of [undefined, '', 'navigation.speedOverGround']) {
+      const direct = cache.getCachedDeltas(contextFilter, null, key)
+      const viaContexts = cache.getCachedDeltasForContexts(
+        cache.getMatchingContexts(contextFilter),
+        null,
+        key
+      )
+      direct.length.should.be.greaterThan(0)
+      viaContexts.should.deep.equal(direct)
+    }
+
+    cache.getMatchingContexts(() => false).should.deep.equal([])
+    cache
+      .getCachedDeltasForContexts(cache.getMatchingContexts(() => false))
+      .should.deep.equal([])
+  })
+
   it('getMultiSourcePaths excludes notifications', function () {
     return doSendADelta({
       context: 'vessels.self',

--- a/test/subscriptionmanager-bootstrap.ts
+++ b/test/subscriptionmanager-bootstrap.ts
@@ -68,7 +68,12 @@ describe('SubscriptionManager cache bootstrap', () => {
       streambundle: bundle,
       selfContext: SELF_CONTEXT,
       deltaCache: {
-        getCachedDeltas: (_filter: unknown, _user: unknown, key?: string) => {
+        getMatchingContexts: () => [],
+        getCachedDeltasForContexts: (
+          _contexts: unknown,
+          _user: unknown,
+          key?: string
+        ) => {
           if (key !== undefined) {
             const hit = cache.get(key)
             return hit ? [hit] : []
@@ -120,6 +125,46 @@ describe('SubscriptionManager cache bootstrap', () => {
     dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_SECOND))
 
     expect(valuesOf(received)).to.deep.equal([SOG_FIRST, SOG_SECOND])
+  })
+
+  it('enumerates matching contexts once per row across its matching paths', () => {
+    const cogPath = 'navigation.courseOverGroundTrue' as Path
+    dispatch(valueDelta(SELF_CONTEXT, SOG_PATH, SOG_FIRST))
+    dispatch(valueDelta(SELF_CONTEXT, cogPath, 1.2))
+
+    const sentinelContexts: unknown[] = []
+    let enumerations = 0
+    const contextsSeen: unknown[] = []
+    const manager = new SubscriptionManager({
+      streambundle: bundle,
+      selfContext: SELF_CONTEXT,
+      deltaCache: {
+        getMatchingContexts: () => {
+          enumerations++
+          return sentinelContexts
+        },
+        getCachedDeltasForContexts: (contexts: unknown) => {
+          contextsSeen.push(contexts)
+          return []
+        }
+      },
+      signalk: { root: {} }
+    })
+    manager.subscribe(
+      {
+        context: '*' as Context,
+        subscribe: [{ path: 'navigation.*' as Path }]
+      },
+      unsubscribes,
+      () => undefined,
+      (delta: Delta) => received.push(delta),
+      undefined,
+      'preferred'
+    )
+
+    expect(contextsSeen.length).to.equal(2)
+    expect(enumerations).to.equal(1)
+    contextsSeen.forEach((c) => expect(c).to.equal(sentinelContexts))
   })
 
   it('still replays the cached value at subscribe time for known paths', () => {

--- a/test/subscriptionmanager-callback-isolation.ts
+++ b/test/subscriptionmanager-callback-isolation.ts
@@ -80,7 +80,12 @@ describe('SubscriptionManager callback isolation', () => {
     streambundle: bundle,
     selfContext: SELF_CONTEXT,
     deltaCache: {
-      getCachedDeltas: (_filter: unknown, _user: unknown, key?: string) => {
+      getMatchingContexts: () => [],
+      getCachedDeltasForContexts: (
+        _contexts: unknown,
+        _user: unknown,
+        key?: string
+      ) => {
         if (key !== undefined) {
           const hit = cache.get(key)
           return hit ? [hit] : []

--- a/test/subscriptionmanager-delivery.ts
+++ b/test/subscriptionmanager-delivery.ts
@@ -54,7 +54,10 @@ function mockApp(bundle: StreamBundle, cached: Delta[] = []) {
   return {
     streambundle: bundle,
     selfContext: SELF_CONTEXT,
-    deltaCache: { getCachedDeltas: () => cached },
+    deltaCache: {
+      getMatchingContexts: () => [],
+      getCachedDeltasForContexts: () => cached
+    },
     securityStrategy: {
       filterReadDelta: (_user: unknown, delta: Delta) => delta,
       shouldFilterDeltas: () => false


### PR DESCRIPTION
Closes #2874.

`handleSubscribeRow` fetched its bootstrap snapshot with `getCachedDeltas`, which enumerates every cached context and re-runs the context filter against each one — once per matching path. A wildcard row therefore paid O(paths × contexts) on every subscribe, with the filter result identical every time; the relative-position filter (the most expensive matcher) amplified the cost further.

The context enumeration now lives in `DeltaCache.getMatchingContexts()`, and `handleSubscribeRow` evaluates it lazily at most once per row, reusing the list across the row's synchronous bus sweep via the new `getCachedDeltasForContexts()`. `getCachedDeltas()` remains as the composition of the two, so its other callers are unchanged. Scoping the reuse to a single row's sweep — exactly the loop the filter result is invariant across — keeps cross-row semantics identical to the previous per-path rescan.

Tested: a new equivalence test verifies the split path returns exactly what `getCachedDeltas` returns for all three key modes (all paths, root values, single path) plus empty matches; a new bootstrap test pins one context scan per row across multiple matching paths; the existing deltacache, subscriptionmanager and subscriptions suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR optimizes subscription bootstrap handling by scanning cached contexts once per subscription row. It reuses the matching contexts during the synchronous bus sweep.

`DeltaCache` separates context matching from cached-delta retrieval. `getCachedDeltas()` preserves existing behavior through the new methods.

Tests verify equivalent results, empty matches, and one context scan per subscription row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->