### PR TITLE
feat: default server-managed Bluetooth connections as false

### DIFF
--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -64,7 +64,7 @@ interface GATTClaim {
 }
 
 const DEFAULT_BLE_SETTINGS: BLESettings = {
-  localBluetoothManaged: true,
+  localBluetoothManaged: false,
   localAdapters: [],
   localMaxGATTSlots: 3
 }

--- a/src/api/ble/localProvider.ts
+++ b/src/api/ble/localProvider.ts
@@ -2,7 +2,7 @@
 /**
  * Local BLE Provider — wraps BlueZ via @naugehyde/node-ble as a standard
  * BLE provider.  Registered automatically by BLEApi when the
- * `localBluetoothManaged` setting is enabled (default: true on Linux).
+ * `localBluetoothManaged` setting is enabled (default: false).
  */
 
 import { createDebug } from '../../debug'


### PR DESCRIPTION
Flip the default for server managed Bluetooth
connections to false so that simply updating the
server will not break plugins, notably
bt-sensors-plugin-sk.

