### PR TITLE
fix: declare explicit types in tsconfig base

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "@types/lodash": "^4.17.24",
     "@types/mocha": "^10.0.10",
     "@types/ncp": "^2.0.8",
+    "@types/node": "^26.1.0",
     "@types/semver": "^7.7.1",
     "@types/split": "^1.0.5",
     "@types/swagger-ui-express": "^4.1.8",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "rootDir": "${configDir}/src",
     "allowJs": true,
     "typeRoots": ["${configDir}/src/types", "./node_modules/@types"],
+    "types": ["node", "mocha"],
     "resolveJsonModule": true,
     "composite": true,
     "declaration": true,


### PR DESCRIPTION
Fixes #2963.

`tsconfig.base.json` extends `@tsconfig/node24/tsconfig.json`, unpinned and with no lockfile. `@tsconfig/node24@24.0.5` added `"types": ["node"]`, which turns off TypeScript's automatic `@types/*` inclusion — so `@types/mocha`'s globals become invisible to ts-node when mocha compiles the test files, and every fresh-install CI run dies in `TS2593: Cannot find name 'describe'` while the build step (src needs only node types) and locally-aged checkouts (still on 24.0.4) stay green. Full diagnosis in #2963.

The fix declares the globals the repo actually relies on explicitly in `tsconfig.base.json`, which also covers the four workspace packages that extend it and whose TypeScript test suites break the same way. An explicit `types` list is immune to future changes of the upstream base config's defaults.

Tested: on the pristine-master + fresh-install clone that reproduces #2963, this one-line change takes the server suite to 1232 passing / 0 failing with server-api and streams suites green; the full chain also passes against a pre-24.0.5 dependency tree, confirming no regression on the old default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes fresh-installation CI failures caused by TypeScript excluding Mocha globals. It explicitly includes `node` and `mocha` types in `tsconfig.base.json` and adds `@types/node` as a development dependency.

Fresh-installation testing passes 1,232 server tests with zero failures. The `server-api`, `streams`, and full test suites also pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->