### PR TITLE
Fix the broken MB conversions shipped in custom-units-definitions.json

### DIFF
--- a/test/unitpreferences-shipped-files.ts
+++ b/test/unitpreferences-shipped-files.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import path from 'path'
+import { compile } from 'mathjs'
+import type { UnitDefinitions } from '../src/unitpreferences/types'
+
+const UNITPREFS_DIR = path.join(__dirname, '../unitpreferences')
+
+// custom-units-definitions.json is copied into the configuration directory on
+// first start, so its sample conversions become the starting point of every new
+// installation and have to hold up like the standard ones.
+const DEFINITION_FILES = [
+  'standard-units-definitions.json',
+  'custom-units-definitions.json'
+]
+
+// The duration conversions call formatters that the client evaluating the
+// formula supplies. Every other name in a formula has to resolve on its own.
+const CLIENT_HELPERS = {
+  formatDurationCompact: () => '',
+  formatDurationDHMS: () => '',
+  formatDurationHMS: () => '',
+  formatDurationHMSMillis: () => '',
+  formatDurationMS: () => '',
+  formatDurationMSMillis: () => '',
+  formatDurationVerbose: () => ''
+}
+
+const readShipped = (file: string): unknown =>
+  JSON.parse(fs.readFileSync(path.join(UNITPREFS_DIR, file), 'utf-8'))
+
+describe('Shipped unit preference files', function () {
+  it('has conversion formulas a client can evaluate', function () {
+    for (const file of DEFINITION_FILES) {
+      const definitions = readShipped(file) as UnitDefinitions
+      for (const [siUnit, definition] of Object.entries(definitions)) {
+        for (const [targetUnit, conversion] of Object.entries(
+          definition.conversions
+        )) {
+          for (const key of ['formula', 'inverseFormula'] as const) {
+            const where = `${file}: ${siUnit} -> ${targetUnit} ${key}`
+            expect(
+              () =>
+                compile(conversion[key]).evaluate({
+                  value: 1,
+                  ...CLIENT_HELPERS
+                }),
+              where
+            ).to.not.throw()
+          }
+        }
+      }
+    }
+  })
+})

--- a/unitpreferences/README.md
+++ b/unitpreferences/README.md
@@ -10,7 +10,8 @@ unitpreferences/
 ├── categories.json                  # Category → SI unit mapping
 ├── default-categories.json          # Default category assignments for paths
 ├── standard-units-definitions.json  # Unit conversion formulas
-├── custom-units-definitions.json    # Custom unit definitions (created on demand)
+├── custom-units-definitions.json    # User-added unit definitions (ships a sample)
+├── custom-categories.json           # User-added categories (ships a sample)
 └── presets/
     ├── metric.json                  # Built-in: Metric (SI)
     ├── imperial-us.json             # Built-in: Imperial (US)
@@ -37,10 +38,13 @@ Maps category names to their base SI units. Used to validate that a path's units
 
 ```json
 {
-  "temperature": "K",
-  "speed": "m/s",
-  "distance": "m",
-  ...
+  "categoryToBaseUnit": {
+    "temperature": "K",
+    "speed": "m/s",
+    "distance": "m",
+    ...
+  },
+  "coreCategories": ["speed", "temperature", "pressure", ...]
 }
 ```
 
@@ -82,7 +86,13 @@ Defines all unit conversions. Each SI unit has conversion formulas to display un
 
 ### custom-units-definitions.json
 
-User-defined unit conversions that extend or override standard definitions. Created when users add custom conversions via the API.
+User-defined unit conversions that extend or override the standard definitions. Ships a sample `MB` group to copy from. The API writes user additions to the copy in the configuration directory, never to this one.
+
+### custom-categories.json
+
+User-defined categories, each mapped to its base SI unit, merged into the `categoryToBaseUnit` map of `categories.json`. Ships the sample `Memory` category that the `MB` group serves.
+
+Both files, and `config.json`, are copied into the configuration directory on first start. A copy that is already there is never overwritten, on upgrade or otherwise, so anything shipped here becomes the starting state of a new installation only.
 
 ### Preset Files (presets/\*.json)
 

--- a/unitpreferences/custom-units-definitions.json
+++ b/unitpreferences/custom-units-definitions.json
@@ -3,12 +3,12 @@
     "conversions": {
       "Gigabyte": {
         "formula": "value / 1000",
-        "inverseFormula": "value *1000",
+        "inverseFormula": "value * 1000",
         "symbol": "GB"
       },
-      "Terrabyte": {
-        "formula": "value / 1_000_000",
-        "inverseFormula": "value * 1_000_000",
+      "Terabyte": {
+        "formula": "value / 1000000",
+        "inverseFormula": "value * 1000000",
         "symbol": "TB"
       }
     }


### PR DESCRIPTION
`unitpreferences/custom-units-definitions.json` is copied into the configuration directory on first start (`ensureConfigDir` in `src/unitpreferences/loader.ts`), so the sample `MB` conversions it carries become the starting state of every new installation. Both of them were broken.

`Terrabyte` is misspelled, and its two formulas use JavaScript numeric separators: mathjs parses `value / 1_000_000` as an implicit multiplication by the undefined symbol `_000_000`, so the conversion throws the moment a client evaluates it. Fixed in place rather than removed, so a working example of a custom category and its conversions still ships.

`test/unitpreferences-shipped-files.ts` evaluates every conversion formula in the shipped standard and custom definitions with only `value` and the duration formatters a client supplies in scope. It fails on the formulas this PR replaces.

The change is forward-only. `ensureConfigDir` seeds these files only when they are absent, so an installation that has already started keeps its broken copy and has to fix it by hand.

The `categories.json` example in `unitpreferences/README.md` showed a flat map rather than the actual `categoryToBaseUnit` / `coreCategories` shape; that is corrected here too.

One related gap is left alone: `validateFormula` in `src/interfaces/unitpreferences-api.js` only compiles a formula, and an undefined symbol is a runtime error in mathjs, so `PUT /unitpreferences/custom-definitions` still accepts `value / 1_000_000`. Evaluating during validation would close that, but it changes API behaviour and belongs in its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes shipped sample contents from `custom-units-definitions.json` and `custom-categories.json`.

- Removes the invalid `MB` sample conversion and unused `Memory` category.
- Adds tests that validate shipped conversion formulas.
- Verifies that custom definition files are empty.
- Corrects the unit preferences README example to use `categoryToBaseUnit` and `coreCategories`.
- Preserves existing configuration files. Users must clear existing custom files manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->