### PR TITLE
feat(admin-ui): choose a display unit target for any category

### DIFF
--- a/docs/guides/unitpreferences.md
+++ b/docs/guides/unitpreferences.md
@@ -45,7 +45,7 @@ Advanced users can upload **Custom Presets** to define specific combinations of 
 
 In addition to category-wide settings (e.g., "All speeds in Knots"), you can override units for specific data paths. For example, you might want _Boat Speed_ in Knots but _Wind Speed_ in Meters/Second.
 
-An override belongs to the path itself and is set under **Data → Metadata**. It names the category the path belongs to and, optionally, the target unit to display it in. A path that names no target unit of its own follows the active preset's choice for its category. A path that names one keeps that unit, and it takes precedence over the preset's setting for the category.
+An override is specific to a single path and is set under **Data → Metadata**. The override can specify either just the category for the path or directly the target unit. An override that names no target unit of its own follows the active preset's target unit choice for its category. An override that specifies the target unit takes precedence over the preset's setting for the category.
 
 ---
 

--- a/docs/guides/unitpreferences.md
+++ b/docs/guides/unitpreferences.md
@@ -45,7 +45,7 @@ Advanced users can upload **Custom Presets** to define specific combinations of 
 
 In addition to category-wide settings (e.g., "All speeds in Knots"), you can override units for specific data paths. For example, you might want _Boat Speed_ in Knots but _Wind Speed_ in Meters/Second.
 
-These overrides are typically managed by editing the server configuration. When a specific path has an override, it takes precedence over the general category setting in your active preset.
+An override belongs to the path itself and is set under **Data → Metadata**. It names the category the path belongs to and, optionally, the target unit to display it in. A path that names no target unit of its own follows the active preset's choice for its category. A path that names one keeps that unit, and it takes precedence over the preset's setting for the category.
 
 ---
 

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -51,8 +51,9 @@ export class WebSocketService {
     }
 
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    // The metadata editor has to tell a unit the path pinned from one the
-    // preset lends it, and the server names that only when asked.
+    // The metadata editor needs to tell a path specific unit override from a
+    // unit that comes from the applied preset, and the server reports the
+    // override only when asked.
     const url =
       proto +
       '://' +

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -51,7 +51,7 @@ export class WebSocketService {
     }
 
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    // The metadata editor needs to tell a path specific unit override from a
+    // The metadata editor needs to tell a path-specific unit override from a
     // unit that comes from the applied preset, and the server reports the
     // override only when asked.
     const url =

--- a/packages/server-admin-ui/src/services/WebSocketService.ts
+++ b/packages/server-admin-ui/src/services/WebSocketService.ts
@@ -51,11 +51,13 @@ export class WebSocketService {
     }
 
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    // The metadata editor has to tell a unit the path pinned from one the
+    // preset lends it, and the server names that only when asked.
     const url =
       proto +
       '://' +
       window.location.host +
-      `/signalk/v1/stream?serverevents=all&subscribe=none&sendMeta=all`
+      `/signalk/v1/stream?serverevents=all&subscribe=none&sendMeta=all&displayUnitsOverride=true`
 
     this.updateState({ status: 'connecting' })
 

--- a/packages/server-admin-ui/src/store/slices/wsSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/wsSlice.ts
@@ -87,7 +87,7 @@ export const createWsSlice: StateCreator<WsSlice, [], [], WsSlice> = (
         proto +
         '://' +
         window.location.host +
-        `/signalk/v1/stream?serverevents=all&subscribe=none&sendMeta=all`
+        `/signalk/v1/stream?serverevents=all&subscribe=none&sendMeta=all&displayUnitsOverride=true`
 
       set({ wsStatus: 'connecting' })
 

--- a/packages/server-admin-ui/src/utils/unitConversion.test.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  convertValue,
+  type PresetDetails,
+  type UnitDefinitions
+} from './unitConversion'
+
+const DEFINITIONS: UnitDefinitions = {
+  'm/s': {
+    conversions: {
+      kn: {
+        formula: 'value * 1.94384',
+        inverseFormula: 'value * 0.514444',
+        symbol: 'kn'
+      },
+      'km/h': {
+        formula: 'value * 3.6',
+        inverseFormula: 'value * 0.277778',
+        symbol: 'km/h'
+      }
+    }
+  }
+}
+
+const PRESET: PresetDetails = {
+  categories: { speed: { targetUnit: 'kn' } }
+}
+
+describe('convertValue', () => {
+  it('converts to the target unit the path asks for', () => {
+    const converted = convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS, {
+      targetUnit: 'km/h'
+    })
+    expect(converted).toEqual({ value: 36, unit: 'km/h' })
+  })
+
+  it('converts to the preset target unit when the path asks for none', () => {
+    const converted = convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS)
+    expect(converted?.unit).toBe('kn')
+  })
+
+  it('converts to the target unit without a preset', () => {
+    const converted = convertValue(10, 'm/s', 'speed', null, DEFINITIONS, {
+      targetUnit: 'km/h'
+    })
+    expect(converted).toEqual({ value: 36, unit: 'km/h' })
+  })
+
+  it('reports no conversion when the target unit is the SI unit', () => {
+    expect(
+      convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS, {
+        targetUnit: 'm/s'
+      })
+    ).toBeNull()
+  })
+
+  it('uses the formula a custom unit carries', () => {
+    const converted = convertValue(10, 'm/s', 'custom', PRESET, DEFINITIONS, {
+      targetUnit: 'kn',
+      formula: 'value * 2',
+      symbol: 'kn'
+    })
+    expect(converted).toEqual({ value: 20, unit: 'kn' })
+  })
+
+  it('leaves the base category in SI units', () => {
+    expect(convertValue(10, 'm/s', 'base', PRESET, DEFINITIONS)).toEqual({
+      value: 10,
+      unit: 'm/s'
+    })
+  })
+})

--- a/packages/server-admin-ui/src/utils/unitConversion.test.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.test.ts
@@ -27,14 +27,14 @@ const PRESET: PresetDetails = {
 }
 
 describe('convertValue', () => {
-  it('converts to the target unit the path asks for', () => {
+  it('converts to the path specific override unit', () => {
     const converted = convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS, {
       targetUnit: 'km/h'
     })
     expect(converted).toEqual({ value: 36, unit: 'km/h' })
   })
 
-  it('converts to the preset target unit when the path asks for none', () => {
+  it('converts to the preset target unit when there is no override', () => {
     const converted = convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS)
     expect(converted?.unit).toBe('kn')
   })

--- a/packages/server-admin-ui/src/utils/unitConversion.test.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.test.ts
@@ -27,7 +27,7 @@ const PRESET: PresetDetails = {
 }
 
 describe('convertValue', () => {
-  it('converts to the path specific override unit', () => {
+  it('converts to the path-specific override unit', () => {
     const converted = convertValue(10, 'm/s', 'speed', PRESET, DEFINITIONS, {
       targetUnit: 'km/h'
     })

--- a/packages/server-admin-ui/src/utils/unitConversion.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.ts
@@ -72,7 +72,6 @@ export function convertValue(
   if (!unitDefinitions) {
     return null
   }
-  // A path specific target unit takes precedence over the preset's setting.
   const targetUnit =
     displayUnits?.targetUnit ||
     presetDetails?.categories?.[category]?.targetUnit

--- a/packages/server-admin-ui/src/utils/unitConversion.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.ts
@@ -69,12 +69,14 @@ export function convertValue(
       return null
     }
   }
-  if (!presetDetails || !unitDefinitions) {
+  if (!unitDefinitions) {
     return null
   }
-  const targetConfig = presetDetails.categories?.[category]
-  if (!targetConfig?.targetUnit) return null
-  const targetUnit = targetConfig.targetUnit
+  // A target unit on the path overrides the preset's choice for the category.
+  const targetUnit =
+    displayUnits?.targetUnit ||
+    presetDetails?.categories?.[category]?.targetUnit
+  if (!targetUnit) return null
   if (targetUnit === siUnit) return null
   const formula = unitDefinitions[siUnit]?.conversions?.[targetUnit]?.formula
   const symbol =

--- a/packages/server-admin-ui/src/utils/unitConversion.ts
+++ b/packages/server-admin-ui/src/utils/unitConversion.ts
@@ -72,7 +72,7 @@ export function convertValue(
   if (!unitDefinitions) {
     return null
   }
-  // A target unit on the path overrides the preset's choice for the category.
+  // A path specific target unit takes precedence over the preset's setting.
   const targetUnit =
     displayUnits?.targetUnit ||
     presetDetails?.categories?.[category]?.targetUnit

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -43,8 +43,8 @@ const renderSelect = (
   )
 
 // What the server sends back for a path that follows the preset: the target
-// unit comes with the conversion it resolved, and the override it names is
-// empty. An older server names no override at all.
+// unit comes with the conversion it resolved, and the override it reports is
+// empty. An older server reports no override at all.
 const RESOLVED_PRESET_UNITS = {
   category: 'speed',
   targetUnit: 'kn',
@@ -114,12 +114,12 @@ describe('CategorySelect', () => {
     expect(targetSelect()).toHaveValue('m/s')
   })
 
-  it('shows the default as chosen when the named override is empty', () => {
+  it('shows the default as chosen when the reported override is empty', () => {
     renderSelect({ ...RESOLVED_PRESET_UNITS, override: {} })
     expect(targetSelect()).toHaveValue('')
   })
 
-  it('shows a pinned unit as chosen even when the preset agrees with it', () => {
+  it('shows an override unit as chosen even when the preset agrees with it', () => {
     renderSelect({ ...RESOLVED_PRESET_UNITS, override: { targetUnit: 'kn' } })
     expect(targetSelect()).toHaveValue('kn')
   })
@@ -166,7 +166,7 @@ describe('CategorySelect', () => {
     })
   })
 
-  it('keeps a display format the path owns across a unit change', () => {
+  it('keeps a display format from an override across a unit change', () => {
     const setValue = vi.fn()
     renderSelect(
       {
@@ -184,7 +184,7 @@ describe('CategorySelect', () => {
     })
   })
 
-  it('drops a display format the preset lends the path', () => {
+  it('drops a display format that comes from the preset', () => {
     const setValue = vi.fn()
     renderSelect(
       { ...RESOLVED_PRESET_UNITS, displayFormat: '0.0', override: {} },
@@ -227,12 +227,12 @@ const renderZones = (targetUnit?: string) =>
   )
 
 describe('Zones', () => {
-  it('edits thresholds in the unit the path asks for', () => {
+  it('edits thresholds in the path specific override unit', () => {
     renderZones('m/s')
     expect(screen.getByLabelText('Zone unit')).toHaveValue('m/s')
   })
 
-  it('edits thresholds in the preset unit when the path asks for none', () => {
+  it('edits thresholds in the preset unit when there is no override', () => {
     renderZones()
     expect(screen.getByLabelText('Zone unit')).toHaveValue('kn')
   })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -43,7 +43,8 @@ const renderSelect = (
   )
 
 // What the server sends back for a path that follows the preset: the target
-// unit comes with the conversion it resolved.
+// unit comes with the conversion it resolved, and the override it names is
+// empty. An older server names no override at all.
 const RESOLVED_PRESET_UNITS = {
   category: 'speed',
   targetUnit: 'kn',
@@ -113,6 +114,16 @@ describe('CategorySelect', () => {
     expect(targetSelect()).toHaveValue('m/s')
   })
 
+  it('shows the default as chosen when the named override is empty', () => {
+    renderSelect({ ...RESOLVED_PRESET_UNITS, override: {} })
+    expect(targetSelect()).toHaveValue('')
+  })
+
+  it('shows a pinned unit as chosen even when the preset agrees with it', () => {
+    renderSelect({ ...RESOLVED_PRESET_UNITS, override: { targetUnit: 'kn' } })
+    expect(targetSelect()).toHaveValue('kn')
+  })
+
   it('does not turn the preset unit into an override on a category change', () => {
     const setValue = vi.fn()
     renderSelect(RESOLVED_PRESET_UNITS, setValue)
@@ -152,6 +163,37 @@ describe('CategorySelect', () => {
       formula: 'value * 1.94384',
       inverseFormula: 'value * 0.514444',
       symbol: 'kn'
+    })
+  })
+
+  it('keeps a display format the path owns across a unit change', () => {
+    const setValue = vi.fn()
+    renderSelect(
+      {
+        ...RESOLVED_PRESET_UNITS,
+        displayFormat: '0.0',
+        override: { displayFormat: '0.0' }
+      },
+      setValue
+    )
+    fireEvent.change(targetSelect()!, { target: { value: 'm/s' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'speed',
+      targetUnit: 'm/s',
+      displayFormat: '0.0'
+    })
+  })
+
+  it('drops a display format the preset lends the path', () => {
+    const setValue = vi.fn()
+    renderSelect(
+      { ...RESOLVED_PRESET_UNITS, displayFormat: '0.0', override: {} },
+      setValue
+    )
+    fireEvent.change(targetSelect()!, { target: { value: 'm/s' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'speed',
+      targetUnit: 'm/s'
     })
   })
 

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -227,7 +227,7 @@ const renderZones = (targetUnit?: string) =>
   )
 
 describe('Zones', () => {
-  it('edits thresholds in the path specific override unit', () => {
+  it('edits thresholds in the path-specific override unit', () => {
     renderZones('m/s')
     expect(screen.getByLabelText('Zone unit')).toHaveValue('m/s')
   })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CategorySelect } from './Meta'
+import type { PresetDetails, UnitDefinitions } from '../../utils/unitConversion'
+
+const DEFINITIONS: UnitDefinitions = {
+  'm/s': {
+    conversions: {
+      'm/s': {
+        formula: 'value * 1',
+        inverseFormula: 'value * 1',
+        symbol: 'm/s',
+        longName: 'meters per second'
+      },
+      kn: {
+        formula: 'value * 1.94384',
+        inverseFormula: 'value * 0.514444',
+        symbol: 'kn',
+        longName: 'knots'
+      }
+    }
+  }
+}
+
+const PRESET: PresetDetails = {
+  categories: { speed: { targetUnit: 'kn' } }
+}
+
+const renderSelect = (
+  value: unknown,
+  setValue: (value: unknown) => void = () => {}
+) =>
+  render(
+    <CategorySelect
+      disabled={false}
+      value={value}
+      setValue={setValue}
+      categories={['speed', 'windSpeed']}
+      siUnit="m/s"
+      unitDefinitions={DEFINITIONS}
+      presetDetails={PRESET}
+    />
+  )
+
+// What the server sends back for a path that follows the preset: the target
+// unit comes with the conversion it resolved.
+const RESOLVED_PRESET_UNITS = {
+  category: 'speed',
+  targetUnit: 'kn',
+  formula: 'value * 1.94384',
+  inverseFormula: 'value * 0.514444',
+  symbol: 'kn'
+}
+
+const categorySelect = () => screen.getByLabelText('Display unit category')
+const targetSelect = () => screen.queryByLabelText('Target unit')
+
+describe('CategorySelect', () => {
+  it('offers a target unit for a named category', () => {
+    renderSelect({ category: 'speed' })
+    expect(targetSelect()).toBeInTheDocument()
+  })
+
+  it('stores the target unit a named category was given', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed' }, setValue)
+    fireEvent.change(targetSelect()!, { target: { value: 'm/s' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'speed',
+      targetUnit: 'm/s'
+    })
+  })
+
+  it('leaves the conversion for the server to resolve', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed' }, setValue)
+    fireEvent.change(targetSelect()!, { target: { value: 'kn' } })
+    expect(setValue.mock.calls[0][0]).not.toHaveProperty('formula')
+    expect(setValue.mock.calls[0][0]).not.toHaveProperty('symbol')
+  })
+
+  it('drops the target unit when the default is chosen', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed', targetUnit: 'm/s' }, setValue)
+    fireEvent.change(targetSelect()!, { target: { value: '' } })
+    expect(setValue).toHaveBeenCalledWith({ category: 'speed' })
+  })
+
+  it('names the unit the default follows', () => {
+    renderSelect({ category: 'speed' })
+    expect(
+      screen.getByRole('option', { name: 'default (kn)' })
+    ).toBeInTheDocument()
+  })
+
+  it('offers the default unit as an explicit choice as well', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed' }, setValue)
+    fireEvent.change(targetSelect()!, { target: { value: 'kn' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'speed',
+      targetUnit: 'kn'
+    })
+  })
+
+  it('shows the default as chosen for a path that follows the preset', () => {
+    renderSelect(RESOLVED_PRESET_UNITS)
+    expect(targetSelect()).toHaveValue('')
+  })
+
+  it('shows the target unit as chosen for a path that overrides the preset', () => {
+    renderSelect({ category: 'speed', targetUnit: 'm/s' })
+    expect(targetSelect()).toHaveValue('m/s')
+  })
+
+  it('does not turn the preset unit into an override on a category change', () => {
+    const setValue = vi.fn()
+    renderSelect(RESOLVED_PRESET_UNITS, setValue)
+    fireEvent.change(categorySelect(), { target: { value: 'windSpeed' } })
+    expect(setValue).toHaveBeenCalledWith({ category: 'windSpeed' })
+  })
+
+  it('keeps a still valid target unit across a category change', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed', targetUnit: 'm/s' }, setValue)
+    fireEvent.change(categorySelect(), { target: { value: 'windSpeed' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'windSpeed',
+      targetUnit: 'm/s'
+    })
+  })
+
+  it('drops the target unit when the base category is chosen', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed', targetUnit: 'kn' }, setValue)
+    fireEvent.change(categorySelect(), { target: { value: 'base' } })
+    expect(setValue).toHaveBeenCalledWith({ category: 'base' })
+  })
+
+  it('hides the target unit for the base category', () => {
+    renderSelect({ category: 'base' })
+    expect(targetSelect()).not.toBeInTheDocument()
+  })
+
+  it('stores the explicit conversion a custom unit carries', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'custom' }, setValue)
+    fireEvent.change(targetSelect()!, { target: { value: 'kn' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'custom',
+      targetUnit: 'kn',
+      formula: 'value * 1.94384',
+      inverseFormula: 'value * 0.514444',
+      symbol: 'kn'
+    })
+  })
+
+  it('gives a unit kept into the custom category its conversion', () => {
+    const setValue = vi.fn()
+    renderSelect({ category: 'speed', targetUnit: 'm/s' }, setValue)
+    fireEvent.change(categorySelect(), { target: { value: 'custom' } })
+    expect(setValue).toHaveBeenCalledWith({
+      category: 'custom',
+      targetUnit: 'm/s',
+      formula: 'value * 1',
+      inverseFormula: 'value * 1',
+      symbol: 'm/s'
+    })
+  })
+})

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { CategorySelect } from './Meta'
+import { CategorySelect, Zones } from './Meta'
 import type { PresetDetails, UnitDefinitions } from '../../utils/unitConversion'
 
 const DEFINITIONS: UnitDefinitions = {
@@ -166,5 +166,32 @@ describe('CategorySelect', () => {
       inverseFormula: 'value * 1',
       symbol: 'm/s'
     })
+  })
+})
+
+const renderZones = (targetUnit?: string) =>
+  render(
+    <Zones
+      zones={[]}
+      isEditing={true}
+      setZones={() => {}}
+      idPrefix="test"
+      siUnit="m/s"
+      category="speed"
+      targetUnit={targetUnit}
+      presetDetails={PRESET}
+      unitDefinitions={DEFINITIONS}
+    />
+  )
+
+describe('Zones', () => {
+  it('edits thresholds in the unit the path asks for', () => {
+    renderZones('m/s')
+    expect(screen.getByLabelText('Zone unit')).toHaveValue('m/s')
+  })
+
+  it('edits thresholds in the preset unit when the path asks for none', () => {
+    renderZones()
+    expect(screen.getByLabelText('Zone unit')).toHaveValue('kn')
   })
 })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -942,6 +942,7 @@ const Meta: React.FC<MetaProps> = ({ meta, path, context, showContext }) => {
               idPrefix={idPrefix}
               siUnit={siUnit}
               category={category}
+              targetUnit={localMeta.displayUnits?.targetUnit}
               presetDetails={presetDetails}
               unitDefinitions={unitDefinitions}
             />
@@ -1242,29 +1243,30 @@ interface ZonesProps {
   idPrefix: string
   siUnit: string
   category: string | undefined
+  targetUnit: string | undefined
   presetDetails: ReturnType<typeof usePresetDetails>
   unitDefinitions: UnitDefinitions | null
 }
 
-function Zones({
+export function Zones({
   zones,
   isEditing,
   setZones,
   idPrefix,
   siUnit,
   category,
+  targetUnit,
   presetDetails,
   unitDefinitions
 }: ZonesProps) {
   const availableUnits = getAvailableUnits(siUnit, unitDefinitions)
 
-  // Default display unit: preset's target unit for the category, or SI unit
-  const presetTargetUnit = category
-    ? (presetDetails?.categories?.[category]?.targetUnit ?? '')
-    : ''
+  const preferredUnit =
+    targetUnit ||
+    (category ? (presetDetails?.categories?.[category]?.targetUnit ?? '') : '')
   const defaultUnit =
-    presetTargetUnit && availableUnits.some((u) => u.unit === presetTargetUnit)
-      ? presetTargetUnit
+    preferredUnit && availableUnits.some((u) => u.unit === preferredUnit)
+      ? preferredUnit
       : siUnit
 
   const [displayUnit, setDisplayUnit] = useState(defaultUnit)
@@ -1334,6 +1336,7 @@ function Zones({
                 Unit:
               </Form.Text>
               <Form.Select
+                aria-label="Zone unit"
                 size="sm"
                 style={{ width: 'auto', display: 'inline-block' }}
                 value={displayUnit}

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -23,7 +23,7 @@ import {
   convertValue,
   getAvailableUnits
 } from '../../utils/unitConversion'
-import type { UnitDefinitions } from '../../utils/unitConversion'
+import type { PresetDetails, UnitDefinitions } from '../../utils/unitConversion'
 import Col from 'react-bootstrap/Col'
 import Form from 'react-bootstrap/Form'
 import Row from 'react-bootstrap/Row'
@@ -98,6 +98,7 @@ interface MetaFormRowProps {
   categories?: string[]
   siUnit?: string
   unitDefinitions?: UnitDefinitions | null
+  presetDetails?: PresetDetails | null
   description?: string
 }
 
@@ -207,16 +208,21 @@ interface CategorySelectProps extends ValueRenderProps {
   categories?: string[]
   siUnit?: string
   unitDefinitions?: UnitDefinitions | null
+  presetDetails?: PresetDetails | null
 }
 
-const CategorySelect: React.FC<CategorySelectProps> = ({
+// Categories without their own target unit follow the active preset, so the
+// server resolves the conversion; "custom" has no category to fall back on and
+// carries its conversion explicitly.
+export const CategorySelect: React.FC<CategorySelectProps> = ({
   disabled,
   value,
   setValue,
   inputId,
   categories,
   siUnit,
-  unitDefinitions
+  unitDefinitions,
+  presetDetails
 }) => {
   const displayUnits = value as DisplayUnits | undefined
   const category = displayUnits?.category || ''
@@ -224,14 +230,72 @@ const CategorySelect: React.FC<CategorySelectProps> = ({
     categories !== undefined ? categories : DEFAULT_CATEGORIES
   const conversions =
     siUnit && unitDefinitions ? unitDefinitions[siUnit]?.conversions : undefined
+  const isCustom = category === 'custom'
+  const showTargetUnit = category !== '' && category !== 'base'
+
+  const presetTargetUnit = isCustom
+    ? undefined
+    : presetDetails?.categories?.[category]?.targetUnit
+  // Metadata read back from the server carries the conversion, so a target
+  // unit that came with one and matches the preset is the preset's choice
+  // rather than an override of it.
+  const followsPreset =
+    displayUnits?.targetUnit === undefined ||
+    (displayUnits.formula !== undefined &&
+      displayUnits.targetUnit === presetTargetUnit)
+  const presetTargetSymbol = presetTargetUnit
+    ? conversions?.[presetTargetUnit]?.symbol || presetTargetUnit
+    : undefined
+
+  // Only the custom category carries its conversion, so that a unit outside
+  // the server's definitions stays convertible. A named category leaves the
+  // conversion for the server to resolve from the target unit.
+  const displayUnitsFor = (
+    category: string,
+    targetUnit: string | undefined
+  ): DisplayUnits => {
+    if (targetUnit === undefined) {
+      return { category }
+    }
+    if (category !== 'custom') {
+      return { category, targetUnit }
+    }
+    const conv = conversions?.[targetUnit]
+    return {
+      category,
+      targetUnit,
+      formula: conv?.formula,
+      inverseFormula: conv?.inverseFormula,
+      symbol: conv?.symbol || targetUnit
+    }
+  }
+
+  const selectCategory = (nextCategory: string) => {
+    const targetUnit = displayUnits?.targetUnit
+    const keepsTargetUnit =
+      !followsPreset &&
+      nextCategory !== '' &&
+      nextCategory !== 'base' &&
+      targetUnit !== undefined &&
+      conversions?.[targetUnit] !== undefined
+    setValue(
+      displayUnitsFor(nextCategory, keepsTargetUnit ? targetUnit : undefined)
+    )
+  }
+
+  const selectTargetUnit = (targetUnit: string) => {
+    setValue(displayUnitsFor(category, targetUnit || undefined))
+  }
+
   return (
     <>
       <Form.Select
         id={inputId}
+        aria-label="Display unit category"
         disabled={disabled}
         value={category}
         size="sm"
-        onChange={(e) => setValue({ category: e.target.value })}
+        onChange={(e) => selectCategory(e.target.value)}
       >
         <option value="">-- No category --</option>
         {siUnit && <option value="base">base ({siUnit})</option>}
@@ -242,29 +306,22 @@ const CategorySelect: React.FC<CategorySelectProps> = ({
           </option>
         ))}
       </Form.Select>
-      {category === 'custom' && conversions && (
+      {showTargetUnit && conversions && (
         <Form.Select
+          aria-label="Target unit"
           disabled={disabled}
-          value={displayUnits?.targetUnit || ''}
+          value={followsPreset ? '' : displayUnits?.targetUnit || ''}
           size="sm"
           style={{ marginTop: '4px' }}
-          onChange={(e) => {
-            const targetUnit = e.target.value
-            if (!targetUnit) {
-              setValue({ category: 'custom' })
-              return
-            }
-            const conv = conversions[targetUnit]
-            setValue({
-              category: 'custom',
-              targetUnit,
-              formula: conv?.formula,
-              inverseFormula: conv?.inverseFormula,
-              symbol: conv?.symbol || targetUnit
-            })
-          }}
+          onChange={(e) => selectTargetUnit(e.target.value)}
         >
-          <option value="">-- Select unit --</option>
+          <option value="">
+            {isCustom
+              ? '-- Select unit --'
+              : presetTargetSymbol
+                ? `default (${presetTargetSymbol})`
+                : 'default'}
+          </option>
           {Object.entries(conversions).map(([unit, conv]) => (
             <option key={unit} value={unit}>
               {conv.symbol || unit}
@@ -527,6 +584,7 @@ const DisplayUnitsView: React.FC<CategorySelectProps> = (props) => {
       categories={categories}
       siUnit={siUnit}
       unitDefinitions={unitDefinitions}
+      presetDetails={props.presetDetails}
     />
   )
 }
@@ -559,6 +617,7 @@ const METAFIELDRENDERERS: Record<
           categories={props.categories}
           siUnit={props.siUnit}
           unitDefinitions={props.unitDefinitions}
+          presetDetails={props.presetDetails}
         />
       )}
       description={
@@ -826,6 +885,7 @@ const Meta: React.FC<MetaProps> = ({ meta, path, context, showContext }) => {
                     categories: filteredCategories,
                     siUnit,
                     unitDefinitions,
+                    presetDetails,
                     setValue: (metaFieldValue) =>
                       setLocalMeta({ ...localMeta, [key]: metaFieldValue }),
                     setKey: (metaFieldKey) => {

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -42,9 +42,14 @@ interface DisplayScaleValue {
 interface DisplayUnits {
   category?: string
   targetUnit?: string
+  displayFormat?: string
   formula?: string
   inverseFormula?: string
   symbol?: string
+  override?: {
+    targetUnit?: string
+    displayFormat?: string
+  }
 }
 
 interface MetaData {
@@ -236,16 +241,25 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
   const presetTargetUnit = isCustom
     ? undefined
     : presetDetails?.categories?.[category]?.targetUnit
-  // Metadata read back from the server carries the conversion, so a target
-  // unit that came with one and matches the preset is the preset's choice
-  // rather than an override of it.
-  const followsPreset =
-    displayUnits?.targetUnit === undefined ||
-    (displayUnits.formula !== undefined &&
-      displayUnits.targetUnit === presetTargetUnit)
+  // A server that names the path's own choices settles which target unit is
+  // an override. An older one does not, so a target unit that arrived with
+  // the conversion and matches the preset is read as the preset's choice.
+  const pinnedTargetUnit = displayUnits?.override
+    ? displayUnits.override.targetUnit
+    : displayUnits?.formula !== undefined &&
+        displayUnits.targetUnit === presetTargetUnit
+      ? undefined
+      : displayUnits?.targetUnit
   const presetTargetSymbol = presetTargetUnit
     ? conversions?.[presetTargetUnit]?.symbol || presetTargetUnit
     : undefined
+
+  // A display format the path owns outlives a unit edit; one the preset lends
+  // it is the preset's to change, and the server names which is which.
+  const ownedFormat =
+    displayUnits?.override?.displayFormat === undefined
+      ? {}
+      : { displayFormat: displayUnits.override.displayFormat }
 
   // Only the custom category carries its conversion, so that a unit outside
   // the server's definitions stays convertible. A named category leaves the
@@ -255,15 +269,16 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
     targetUnit: string | undefined
   ): DisplayUnits => {
     if (targetUnit === undefined) {
-      return { category }
+      return { category, ...ownedFormat }
     }
     if (category !== 'custom') {
-      return { category, targetUnit }
+      return { category, targetUnit, ...ownedFormat }
     }
     const conv = conversions?.[targetUnit]
     return {
       category,
       targetUnit,
+      ...ownedFormat,
       formula: conv?.formula,
       inverseFormula: conv?.inverseFormula,
       symbol: conv?.symbol || targetUnit
@@ -271,9 +286,8 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
   }
 
   const selectCategory = (nextCategory: string) => {
-    const targetUnit = displayUnits?.targetUnit
+    const targetUnit = pinnedTargetUnit
     const keepsTargetUnit =
-      !followsPreset &&
       nextCategory !== '' &&
       nextCategory !== 'base' &&
       targetUnit !== undefined &&
@@ -310,7 +324,7 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
         <Form.Select
           aria-label="Target unit"
           disabled={disabled}
-          value={followsPreset ? '' : displayUnits?.targetUnit || ''}
+          value={pinnedTargetUnit || ''}
           size="sm"
           style={{ marginTop: '4px' }}
           onChange={(e) => selectTargetUnit(e.target.value)}

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -241,10 +241,10 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
   const presetTargetUnit = isCustom
     ? undefined
     : presetDetails?.categories?.[category]?.targetUnit
-  // A server that names the path's own choices settles which target unit is
-  // an override. An older one does not, so a target unit that arrived with
-  // the conversion and matches the preset is read as the preset's choice.
-  const pinnedTargetUnit = displayUnits?.override
+  // A server that reports path specific overrides settles which target unit
+  // is an override. An older one does not, so a target unit that arrived with
+  // the conversion and matches the preset is read as coming from the preset.
+  const overrideTargetUnit = displayUnits?.override
     ? displayUnits.override.targetUnit
     : displayUnits?.formula !== undefined &&
         displayUnits.targetUnit === presetTargetUnit
@@ -254,9 +254,10 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
     ? conversions?.[presetTargetUnit]?.symbol || presetTargetUnit
     : undefined
 
-  // A display format the path owns outlives a unit edit; one the preset lends
-  // it is the preset's to change, and the server names which is which.
-  const ownedFormat =
+  // A display format from a path specific override outlives a unit edit; one
+  // that comes from the preset is the preset's to change, and the server
+  // reports which is which.
+  const overrideFormat =
     displayUnits?.override?.displayFormat === undefined
       ? {}
       : { displayFormat: displayUnits.override.displayFormat }
@@ -269,16 +270,16 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
     targetUnit: string | undefined
   ): DisplayUnits => {
     if (targetUnit === undefined) {
-      return { category, ...ownedFormat }
+      return { category, ...overrideFormat }
     }
     if (category !== 'custom') {
-      return { category, targetUnit, ...ownedFormat }
+      return { category, targetUnit, ...overrideFormat }
     }
     const conv = conversions?.[targetUnit]
     return {
       category,
       targetUnit,
-      ...ownedFormat,
+      ...overrideFormat,
       formula: conv?.formula,
       inverseFormula: conv?.inverseFormula,
       symbol: conv?.symbol || targetUnit
@@ -286,7 +287,7 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
   }
 
   const selectCategory = (nextCategory: string) => {
-    const targetUnit = pinnedTargetUnit
+    const targetUnit = overrideTargetUnit
     const keepsTargetUnit =
       nextCategory !== '' &&
       nextCategory !== 'base' &&
@@ -324,7 +325,7 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
         <Form.Select
           aria-label="Target unit"
           disabled={disabled}
-          value={pinnedTargetUnit || ''}
+          value={overrideTargetUnit || ''}
           size="sm"
           style={{ marginTop: '4px' }}
           onChange={(e) => selectTargetUnit(e.target.value)}

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -241,7 +241,7 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
   const presetTargetUnit = isCustom
     ? undefined
     : presetDetails?.categories?.[category]?.targetUnit
-  // A server that reports path specific overrides settles which target unit
+  // A server that reports path-specific overrides settles which target unit
   // is an override. An older one does not, so a target unit that arrived with
   // the conversion and matches the preset is read as coming from the preset.
   const overrideTargetUnit = displayUnits?.override
@@ -254,7 +254,7 @@ export const CategorySelect: React.FC<CategorySelectProps> = ({
     ? conversions?.[presetTargetUnit]?.symbol || presetTargetUnit
     : undefined
 
-  // A display format from a path specific override outlives a unit edit; one
+  // A display format from a path-specific override outlives a unit edit; one
   // that comes from the preset is the preset's to change, and the server
   // reports which is which.
   const overrideFormat =


### PR DESCRIPTION
Part of #2967.

A path specific display unit override was only reachable through the `custom` pseudo-category: picking a real category replaced the whole value, so a stored target unit was discarded and `{ "category": "speed", "targetUnit": "m/s" }` could not be expressed in the editor at all. Two more places read the target unit from the active preset and ignored the path specific override, so a path overridden to m/s still showed knots in the Data Browser, in the metadata editor's own preview, and in the unit the zone editor expects thresholds in.

The target unit is now a second dropdown for every category whose SI unit has conversions. Its first entry names the unit the active preset resolves to — `default (kn)` — and leaves the path following the preset; the same unit is also selectable on its own, which makes it an override that survives later preset changes. A named category stores the category and the target unit only, leaving the conversion for the server to resolve, so nothing freezes a formula into the configuration. `custom` keeps carrying its explicit conversion.

`convertValue` now prefers a path specific target unit over the preset's, which fixes both value previews, and the zone editor defaults to the same unit.

Telling an override apart from the preset's own setting needs the `override` field #2969 adds to a resolved response. Against a server without that field the editor falls back to reading the response by its shape, so this stands on its own and gets sharper once #2969 lands.

17 component tests cover the selector and the zone default; 6 cover `convertValue`. The three that reproduce the preview bug fail without this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enables target-unit selection for SI-compatible categories.
- Preserves path-specific target-unit overrides.
- Supports preset following and explicit unit pinning.
- Stores only the category and target unit for named categories.
- Keeps explicit conversion formulas for the `custom` category.
- Prioritizes path target units in `convertValue`.
- Uses path target units for zone threshold inputs.
- Handles metadata responses without the `override` field.
- Requests path-specific unit overrides through WebSocket metadata.
- Documents path-specific unit configuration in Data → Metadata.

## Tests

- Adds 17 component tests for category selection and zone defaults.
- Adds 6 `convertValue` tests for target-unit resolution and conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
