### PR TITLE
fix(server): do not store preset-derived display units on a metadata PUT

### DIFF
--- a/docs/guides/unitpreferences.md
+++ b/docs/guides/unitpreferences.md
@@ -130,17 +130,17 @@ The `displayUnits` object provides everything you need to display the value:
 - **symbol**: The symbol to display next to the value.
 - **displayFormat**: (Optional) A format pattern for consistency (e.g., "0.0" for one decimal place).
 
-### Asking Which Choices the Path Owns
+### Asking for Path Specific Overrides
 
-A resolved response reads the same whether the target unit comes from the path
-or from the active preset. An editor has to tell the two apart, so it asks for
-the answer with `displayUnitsOverride=true`:
+A resolved response reads the same whether the target unit comes from a path
+specific override or from the applied preset. An editor has to tell the two
+apart, so it asks for the answer with `displayUnitsOverride=true`:
 
 `GET /signalk/v1/api/vessels/self/navigation/speedOverGround/meta?displayUnitsOverride=true`
 
 The response then carries one more field in `displayUnits`:
 
-- **override**: What the path itself chose rather than the active preset, as `targetUnit` and `displayFormat`. Empty when the path follows the preset.
+- **override**: Path specific unit override, as `targetUnit` and `displayFormat`. Empty when the path follows the preset.
 
 The same parameter works on the WebSocket stream URL, next to `sendMeta=all`:
 
@@ -149,8 +149,9 @@ The same parameter works on the WebSocket stream URL, next to `sendMeta=all`:
 Display code needs none of this, so the field is absent unless it is asked for.
 
 A metadata `PUT` reads `override` even when the request did not ask for one, so
-saving a resolved response back does not turn the preset's current choices into
-a path override. The metadata delta a `PUT` triggers names the field as well.
+saving a resolved response back does not turn the preset's current settings into
+a path specific override. The metadata delta a `PUT` triggers carries the field
+as well.
 
 ### WebSocket Stream
 

--- a/docs/guides/unitpreferences.md
+++ b/docs/guides/unitpreferences.md
@@ -130,17 +130,17 @@ The `displayUnits` object provides everything you need to display the value:
 - **symbol**: The symbol to display next to the value.
 - **displayFormat**: (Optional) A format pattern for consistency (e.g., "0.0" for one decimal place).
 
-### Asking for Path Specific Overrides
+### Asking for Path-Specific Overrides
 
-A resolved response reads the same whether the target unit comes from a path
-specific override or from the applied preset. An editor has to tell the two
-apart, so it asks for the answer with `displayUnitsOverride=true`:
+A resolved response reads the same whether the target unit comes from a
+path-specific override or from the applied preset. An editor has to tell the
+two apart, so it asks for the answer with `displayUnitsOverride=true`:
 
 `GET /signalk/v1/api/vessels/self/navigation/speedOverGround/meta?displayUnitsOverride=true`
 
 The response then carries one more field in `displayUnits`:
 
-- **override**: Path specific unit override, as `targetUnit` and `displayFormat`. Empty when the path follows the preset.
+- **override**: Path-specific unit override, as `targetUnit` and `displayFormat`. Empty when the path follows the preset.
 
 The same parameter works on the WebSocket stream URL, next to `sendMeta=all`:
 
@@ -150,7 +150,7 @@ Display code needs none of this, so the field is absent unless it is asked for.
 
 A metadata `PUT` reads `override` even when the request did not ask for one, so
 saving a resolved response back does not turn the preset's current settings into
-a path specific override. The metadata delta a `PUT` triggers carries the field
+a path-specific override. The metadata delta a `PUT` triggers carries the field
 as well.
 
 ### WebSocket Stream

--- a/docs/guides/unitpreferences.md
+++ b/docs/guides/unitpreferences.md
@@ -130,6 +130,28 @@ The `displayUnits` object provides everything you need to display the value:
 - **symbol**: The symbol to display next to the value.
 - **displayFormat**: (Optional) A format pattern for consistency (e.g., "0.0" for one decimal place).
 
+### Asking Which Choices the Path Owns
+
+A resolved response reads the same whether the target unit comes from the path
+or from the active preset. An editor has to tell the two apart, so it asks for
+the answer with `displayUnitsOverride=true`:
+
+`GET /signalk/v1/api/vessels/self/navigation/speedOverGround/meta?displayUnitsOverride=true`
+
+The response then carries one more field in `displayUnits`:
+
+- **override**: What the path itself chose rather than the active preset, as `targetUnit` and `displayFormat`. Empty when the path follows the preset.
+
+The same parameter works on the WebSocket stream URL, next to `sendMeta=all`:
+
+`ws://localhost:3000/signalk/v1/stream?subscribe=none&sendMeta=all&displayUnitsOverride=true`
+
+Display code needs none of this, so the field is absent unless it is asked for.
+
+A metadata `PUT` reads `override` even when the request did not ask for one, so
+saving a resolved response back does not turn the preset's current choices into
+a path override. The metadata delta a `PUT` triggers names the field as well.
+
 ### WebSocket Stream
 
 When subscribing to the WebSocket stream, add `sendMeta=all` to receive metadata once for each path (sent with the first delta for that path, and again only if it changes):

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -584,22 +584,11 @@ const METAFIELDRENDERERS: Record<
 }
 
 const saveMeta = (path: string, meta: MetaData) => {
-  // Mark displayUnits as explicit (manually set) so patterns don't overwrite
-  const metaToSave = {
-    ...meta,
-    displayUnits: meta.displayUnits
-      ? {
-          ...meta.displayUnits,
-          explicit: true
-        }
-      : undefined
-  }
-
   fetch(`/signalk/v1/api/vessels/self/${pathToUrlSegments(path)}/meta`, {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ value: metaToSave })
+    body: JSON.stringify({ value: meta })
   })
 }
 

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -25,7 +25,18 @@ const {
   getDefaultCategory
 } = require('../unitpreferences')
 
-function enhanceMetadataResponse(metadata, signalkPath, username) {
+// An editor needs to tell the path's own display unit choices from the
+// preset's; nothing else does, so the answer comes only when asked for.
+function wantsDisplayUnitsOverride(req) {
+  return req.query.displayUnitsOverride === 'true'
+}
+
+function enhanceMetadataResponse(
+  metadata,
+  signalkPath,
+  username,
+  includeOverride
+) {
   if (!metadata) return metadata
 
   let storedDisplayUnits = metadata.displayUnits
@@ -46,7 +57,8 @@ function enhanceMetadataResponse(metadata, signalkPath, username) {
       const enhanced = resolveDisplayUnits(
         storedDisplayUnits,
         metadata.units,
-        username
+        username,
+        includeOverride
       )
       if (enhanced) {
         metadata.displayUnits = enhanced
@@ -69,17 +81,22 @@ const SKIP_KEYS = new Set([
   'values'
 ])
 
-function enhanceTreeMetadata(node, pathParts, username) {
+function enhanceTreeMetadata(node, pathParts, username, includeOverride) {
   if (node === null || typeof node !== 'object') return
   if (node.meta) {
     const signalkPath = pathParts.join('.')
     const metaCopy = structuredClone(node.meta)
-    enhanceMetadataResponse(metaCopy, signalkPath, username)
+    enhanceMetadataResponse(metaCopy, signalkPath, username, includeOverride)
     node.meta = metaCopy
   }
   for (const key in node) {
     if (!SKIP_KEYS.has(key)) {
-      enhanceTreeMetadata(node[key], pathParts.concat(key), username)
+      enhanceTreeMetadata(
+        node[key],
+        pathParts.concat(key),
+        username,
+        includeOverride
+      )
     }
   }
 }
@@ -195,8 +212,14 @@ module.exports = function (app) {
             const result = {}
             const username = req.skPrincipal?.identifier
             collectMeta(vessel, [], result)
+            const includeOverride = wantsDisplayUnitsOverride(req)
             for (const skPath in result) {
-              enhanceMetadataResponse(result[skPath], skPath, username)
+              enhanceMetadataResponse(
+                result[skPath],
+                skPath,
+                username,
+                includeOverride
+              )
             }
             res.json(result)
           } else {
@@ -213,7 +236,14 @@ module.exports = function (app) {
             const metaCopy = structuredClone(meta)
             const signalkPath = metaPath.replace(/^vessels\.[^.]+\./, '')
             const username = req.skPrincipal?.identifier
-            res.json(enhanceMetadataResponse(metaCopy, signalkPath, username))
+            res.json(
+              enhanceMetadataResponse(
+                metaCopy,
+                signalkPath,
+                username,
+                wantsDisplayUnitsOverride(req)
+              )
+            )
             return
           }
         }
@@ -249,7 +279,12 @@ module.exports = function (app) {
               aPath[0] === 'vessels' && aPath.length >= 2
                 ? aPath.slice(2)
                 : aPath.slice()
-            enhanceTreeMetadata(last, baseParts, username)
+            enhanceTreeMetadata(
+              last,
+              baseParts,
+              username,
+              wantsDisplayUnitsOverride(req)
+            )
           }
 
           return res.json(last)

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -25,7 +25,7 @@ const {
   getDefaultCategory
 } = require('../unitpreferences')
 
-// An editor needs to tell a path specific display unit override from the
+// An editor needs to tell a path-specific display unit override from the
 // preset's setting; nothing else does, so the answer comes only when asked for.
 function wantsDisplayUnitsOverride(req) {
   return req.query.displayUnitsOverride === 'true'

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -25,8 +25,8 @@ const {
   getDefaultCategory
 } = require('../unitpreferences')
 
-// An editor needs to tell the path's own display unit choices from the
-// preset's; nothing else does, so the answer comes only when asked for.
+// An editor needs to tell a path specific display unit override from the
+// preset's setting; nothing else does, so the answer comes only when asked for.
 function wantsDisplayUnitsOverride(req) {
   return req.query.displayUnitsOverride === 'true'
 }

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -106,9 +106,11 @@ interface Spark {
     events?: string
     sendCachedValues?: string
     sourcePolicy?: SourcePolicy
+    displayUnitsOverride?: string
   }
   request: SignalKSparkRequest
   sendMetaDeltas: boolean
+  sendDisplayUnitsOverride: boolean
   sourcePolicy: SourcePolicy
   sentMetaData: Record<string, boolean>
   backpressureManager?: BackpressureManager
@@ -535,6 +537,10 @@ function wsInterface(app: WsApp): WsApi {
           )
 
           spark.sendMetaDeltas = spark.query.sendMeta === 'all'
+          // An editor needs to tell the path's own display unit choices from
+          // the preset's; nothing else does, so it comes only when asked for.
+          spark.sendDisplayUnitsOverride =
+            spark.query.displayUnitsOverride === 'true'
           spark.sourcePolicy = spark.query.sourcePolicy || 'preferred'
           spark.sentMetaData = {}
 
@@ -1077,7 +1083,8 @@ function handleValuesMeta(
                 displayFormat?: string
               },
               metaClone.units as string | undefined,
-              username
+              username,
+              this.spark.sendDisplayUnitsOverride
             )
             if (enhanced) {
               metaClone.displayUnits = enhanced
@@ -1339,7 +1346,8 @@ function handleRealtimeConnection(
             const displayUnits = resolveDisplayUnits(
               { ...storedDU, category },
               pathMeta.units as string | undefined,
-              username
+              username,
+              spark.sendDisplayUnitsOverride
             )
             if (displayUnits) {
               acc.push({ path, value: { ...pathMeta, displayUnits } })

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -537,7 +537,7 @@ function wsInterface(app: WsApp): WsApi {
           )
 
           spark.sendMetaDeltas = spark.query.sendMeta === 'all'
-          // An editor needs to tell a path specific display unit override
+          // An editor needs to tell a path-specific display unit override
           // from the preset's setting; nothing else does, so it comes only
           // when asked for.
           spark.sendDisplayUnitsOverride =

--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -537,8 +537,9 @@ function wsInterface(app: WsApp): WsApi {
           )
 
           spark.sendMetaDeltas = spark.query.sendMeta === 'all'
-          // An editor needs to tell the path's own display unit choices from
-          // the preset's; nothing else does, so it comes only when asked for.
+          // An editor needs to tell a path specific display unit override
+          // from the preset's setting; nothing else does, so it comes only
+          // when asked for.
           spark.sendDisplayUnitsOverride =
             spark.query.displayUnitsOverride === 'true'
           spark.sourcePolicy = spark.query.sourcePolicy || 'preferred'

--- a/src/put.ts
+++ b/src/put.ts
@@ -276,13 +276,16 @@ export function start(app: PutApp): void {
     }
 
     // Clients read displayUnits resolved, so the update they get carries the
-    // conversion rather than the override that was stored.
+    // conversion rather than the override that was stored. This delta also
+    // merges into the metadata registry, which resolves from it again, so it
+    // names the override whether or not any client asked for one.
     const metaUpdate: Record<string, unknown> = { ...full_meta, ...metaValue }
     if (metaValue.displayUnits) {
       const resolved = resolveDisplayUnits(
         metaValue.displayUnits as DisplayUnitsMetadata,
         (metaValue.units ?? full_meta?.units) as string | undefined,
-        username
+        username,
+        true
       )
       if (resolved) {
         metaUpdate.displayUnits = resolved

--- a/src/put.ts
+++ b/src/put.ts
@@ -106,12 +106,8 @@ interface SkRequest extends Request {
 // Metadata is stored per path but resolved per user, so the handler needs the
 // requesting user that the generic ActionHandler signature does not carry.
 type MetaActionHandler = (
-  context: string,
-  path: string,
-  value: unknown,
-  callback: (result: ActionResult) => void,
-  username?: string
-) => ActionResult | void
+  ...args: [...Parameters<ActionHandler>, username?: string]
+) => ReturnType<ActionHandler>
 
 const actionHandlers: ActionHandlers = {}
 let putMetaHandler: MetaActionHandler

--- a/src/put.ts
+++ b/src/put.ts
@@ -11,7 +11,12 @@ import {
 import * as skConfig from './config/config'
 import { ConfigApp } from './config/config'
 import { getMetadata } from '@signalk/path-metadata'
-import { validateCategoryAssignment } from './unitpreferences'
+import {
+  resolveDisplayUnits,
+  stripResolvedDisplayUnits,
+  validateCategoryAssignment
+} from './unitpreferences'
+import { DisplayUnitsMetadata } from './unitpreferences/types'
 import { WithSecurityStrategy } from './security'
 
 const debug = createDebug('signalk-server:put')
@@ -98,8 +103,18 @@ interface SkRequest extends Request {
   }
 }
 
+// Metadata is stored per path but resolved per user, so the handler needs the
+// requesting user that the generic ActionHandler signature does not carry.
+type MetaActionHandler = (
+  context: string,
+  path: string,
+  value: unknown,
+  callback: (result: ActionResult) => void,
+  username?: string
+) => ActionResult | void
+
 const actionHandlers: ActionHandlers = {}
-let putMetaHandler: ActionHandler
+let putMetaHandler: MetaActionHandler
 let deleteMetaHandler: DeleteHandler
 let putNotificationHandler: (
   context: string,
@@ -181,7 +196,7 @@ export function start(app: PutApp): void {
       })
   })
 
-  putMetaHandler = (context, path, value, cb) => {
+  putMetaHandler = (context, path, value, cb, username) => {
     const parts = path.split('.')
     let metaPath = path
     let metaValue = value as Record<string, unknown>
@@ -234,6 +249,16 @@ export function start(app: PutApp): void {
     }
 
     const previousMeta = app.config.baseDeltaEditor.getMeta(context, metaPath)
+
+    if (metaValue.displayUnits) {
+      metaValue.displayUnits = stripResolvedDisplayUnits(
+        metaValue.displayUnits as DisplayUnitsMetadata,
+        (previousMeta as { displayUnits?: DisplayUnitsMetadata } | null)
+          ?.displayUnits,
+        username
+      )
+    }
+
     app.config.baseDeltaEditor.setMeta(context, metaPath, metaValue)
 
     // Remove fields that were deleted from the in-memory metadata registry
@@ -250,6 +275,20 @@ export function start(app: PutApp): void {
       }
     }
 
+    // Clients read displayUnits resolved, so the update they get carries the
+    // conversion rather than the override that was stored.
+    const metaUpdate: Record<string, unknown> = { ...full_meta, ...metaValue }
+    if (metaValue.displayUnits) {
+      const resolved = resolveDisplayUnits(
+        metaValue.displayUnits as DisplayUnitsMetadata,
+        (metaValue.units ?? full_meta?.units) as string | undefined,
+        username
+      )
+      if (resolved) {
+        metaUpdate.displayUnits = resolved
+      }
+    }
+
     app.handleMessage('defaults', {
       context: 'vessels.self' as Context,
       updates: [
@@ -257,7 +296,7 @@ export function start(app: PutApp): void {
           meta: [
             {
               path: metaPath as Path,
-              value: { ...full_meta, ...metaValue }
+              value: metaUpdate
             }
           ]
         }
@@ -282,8 +321,10 @@ export function start(app: PutApp): void {
         }
       }
 
-      const pathWithContext = context + '.' + path
-      _set(data, pathWithContext, value)
+      // Write the merged, normalized object rather than the request value:
+      // for a single-field PUT the raw value carries none of the
+      // displayUnits stripping or empty-array normalization done above.
+      _set(data, context + '.' + metaPath + '.meta', metaValue)
 
       skConfig.writeDefaultsFile(
         app as unknown as ConfigApp,
@@ -535,7 +576,9 @@ export function putPath(
           (parts.length > 1 && parts[parts.length - 1] === 'meta') ||
           (parts.length > 1 && parts[parts.length - 2] === 'meta')
         ) {
-          handler = putMetaHandler
+          const username = req?.skPrincipal?.identifier
+          handler = (metaContext, metaPath, value, cb) =>
+            putMetaHandler(metaContext, metaPath, value, cb, username)
         } else {
           const handlers = actionHandlers[context]
             ? actionHandlers[context][path]

--- a/src/unitpreferences/index.ts
+++ b/src/unitpreferences/index.ts
@@ -19,5 +19,9 @@ export {
   saveUserPreferences,
   DEFAULT_PRESET
 } from './loader'
-export { resolveDisplayUnits, validateCategoryAssignment } from './resolver'
+export {
+  resolveDisplayUnits,
+  stripResolvedDisplayUnits,
+  validateCategoryAssignment
+} from './resolver'
 export * from './types'

--- a/src/unitpreferences/resolver.ts
+++ b/src/unitpreferences/resolver.ts
@@ -11,22 +11,22 @@ import {
 } from './types'
 
 /**
- * What the path itself chose, as opposed to what the preset supplied.
+ * The path specific unit override, as opposed to what the preset supplied.
  *
- * A response this server resolved carries that answer in its `override`
+ * A response this server resolved carries the override in its `override`
  * field; anything else is the stored metadata, where every field present is
- * the path's own.
+ * part of the override.
  */
 function pathOverride(
   displayUnits: DisplayUnitsMetadata
 ): DisplayUnitsOverride {
-  const owned = displayUnits.override ?? displayUnits
+  const source = displayUnits.override ?? displayUnits
   const override: DisplayUnitsOverride = {}
-  if (owned.targetUnit !== undefined) {
-    override.targetUnit = owned.targetUnit
+  if (source.targetUnit !== undefined) {
+    override.targetUnit = source.targetUnit
   }
-  if (owned.displayFormat !== undefined) {
-    override.displayFormat = owned.displayFormat
+  if (source.displayFormat !== undefined) {
+    override.displayFormat = source.displayFormat
   }
   return override
 }
@@ -37,7 +37,7 @@ function pathOverride(
  * @param storedDisplayUnits - What's in baseDeltas.json (category, optional targetUnit)
  * @param pathSiUnit - The SI unit for this path (optional)
  * @param username - Username for per-user preset resolution (optional)
- * @param includeOverride - Name the path's own choices in an `override` field
+ * @param includeOverride - Report the path specific override in an `override` field
  * @returns Full displayUnits with formula, or null if can't resolve
  */
 export function resolveDisplayUnits(
@@ -51,17 +51,18 @@ export function resolveDisplayUnits(
   }
 
   const category = storedDisplayUnits.category
-  const owned = pathOverride(storedDisplayUnits)
-  // Only an editor needs to tell the path's own choices from the preset's, so
-  // the field rides along only where the request asked for it. It stays in
-  // the object literal either way to keep one shape; JSON drops it when unset.
-  const override = includeOverride ? owned : undefined
+  const pathSpecific = pathOverride(storedDisplayUnits)
+  // Only an editor needs to tell a path specific override from the preset's
+  // settings, so the field rides along only where the request asked for it. It
+  // stays in the object literal either way to keep one shape; JSON drops it
+  // when unset.
+  const override = includeOverride ? pathSpecific : undefined
   // Resolving a response this server already resolved is the same job as
   // resolving the stored metadata it came from.
   const stored: DisplayUnitsMetadata = storedDisplayUnits.override
     ? {
         category,
-        ...owned,
+        ...pathSpecific,
         formula: storedDisplayUnits.formula,
         inverseFormula: storedDisplayUnits.inverseFormula,
         symbol: storedDisplayUnits.symbol
@@ -193,10 +194,10 @@ export function resolveDisplayUnits(
  * Reduce displayUnits to the override it expresses.
  *
  * Clients read metadata back resolved — target unit, formulas and format
- * filled in from the active preset — so writing it back verbatim would store
- * the preset's current choices as a path override and detach the path from
- * the preset. A resolved response names the path's own choices in its
- * `override` field, which settles the question outright. A client that sends
+ * filled in from the applied preset — so writing it back verbatim would store
+ * the preset's current settings as a path specific override and detach the
+ * path from the preset. A resolved response reports the path specific override
+ * in its `override` field, which settles the question outright. A client that sends
  * neither is read by shape: the resolved shape carries a formula and the
  * stored shape does not, and in a formula-carrying echo a value the preset
  * would have produced anyway is dropped unless the path already stored it.

--- a/src/unitpreferences/resolver.ts
+++ b/src/unitpreferences/resolver.ts
@@ -11,7 +11,7 @@ import {
 } from './types'
 
 /**
- * The path specific unit override, as opposed to what the preset supplied.
+ * The path-specific unit override, as opposed to what the preset supplied.
  *
  * A response this server resolved carries the override in its `override`
  * field; anything else is the stored metadata, where every field present is
@@ -37,7 +37,7 @@ function pathOverride(
  * @param storedDisplayUnits - What's in baseDeltas.json (category, optional targetUnit)
  * @param pathSiUnit - The SI unit for this path (optional)
  * @param username - Username for per-user preset resolution (optional)
- * @param includeOverride - Report the path specific override in an `override` field
+ * @param includeOverride - Report the path-specific override in an `override` field
  * @returns Full displayUnits with formula, or null if can't resolve
  */
 export function resolveDisplayUnits(
@@ -52,7 +52,7 @@ export function resolveDisplayUnits(
 
   const category = storedDisplayUnits.category
   const pathSpecific = pathOverride(storedDisplayUnits)
-  // Only an editor needs to tell a path specific override from the preset's
+  // Only an editor needs to tell a path-specific override from the preset's
   // settings, so the field rides along only where the request asked for it. It
   // stays in the object literal either way to keep one shape; JSON drops it
   // when unset.
@@ -195,8 +195,8 @@ export function resolveDisplayUnits(
  *
  * Clients read metadata back resolved — target unit, formulas and format
  * filled in from the applied preset — so writing it back verbatim would store
- * the preset's current settings as a path specific override and detach the
- * path from the preset. A resolved response reports the path specific override
+ * the preset's current settings as a path-specific override and detach the
+ * path from the preset. A resolved response reports the path-specific override
  * in its `override` field, which settles the question outright. A client that sends
  * neither is read by shape: the resolved shape carries a formula and the
  * stored shape does not, and in a formula-carrying echo a value the preset

--- a/src/unitpreferences/resolver.ts
+++ b/src/unitpreferences/resolver.ts
@@ -143,6 +143,77 @@ export function resolveDisplayUnits(
 }
 
 /**
+ * Reduce displayUnits to the override it expresses.
+ *
+ * Clients read metadata back resolved — target unit, formulas and format
+ * filled in from the active preset — so writing it back verbatim would store
+ * the preset's current choices as a path override and detach the path from
+ * the preset. The resolved shape carries a formula and the stored shape does
+ * not, which is what tells an echo of the resolution apart from an override
+ * the client states itself. In an echo, a value the preset would have
+ * produced anyway is dropped unless the path already stored it.
+ *
+ * @param incoming - displayUnits as received in a metadata PUT
+ * @param previous - displayUnits currently stored for the path
+ * @param username - Username for per-user preset resolution (optional)
+ * @returns displayUnits to store
+ */
+export function stripResolvedDisplayUnits(
+  incoming: DisplayUnitsMetadata | undefined,
+  previous: DisplayUnitsMetadata | undefined,
+  username?: string
+): DisplayUnitsMetadata | undefined {
+  if (!incoming?.category) {
+    return incoming
+  }
+
+  const category = incoming.category
+
+  // A custom unit is nothing but its explicit conversion, and "base" needs
+  // no conversion at all.
+  if (category === 'custom') {
+    return incoming
+  }
+  if (category === 'base') {
+    return { category }
+  }
+
+  const echoesResolution = incoming.formula !== undefined
+  const preset = username ? getActivePresetForUser(username) : getActivePreset()
+  const presetCategory = preset?.categories?.[category]
+  const stored: DisplayUnitsMetadata = { category }
+
+  const overrides = (
+    value?: string,
+    presetValue?: string,
+    storedValue?: string
+  ) =>
+    value !== undefined &&
+    (!echoesResolution || value !== presetValue || storedValue !== undefined)
+
+  if (
+    overrides(
+      incoming.targetUnit,
+      presetCategory?.targetUnit,
+      previous?.targetUnit
+    )
+  ) {
+    stored.targetUnit = incoming.targetUnit
+  }
+  if (
+    overrides(
+      incoming.displayFormat,
+      presetCategory?.displayFormat,
+      previous?.displayFormat
+    )
+  ) {
+    stored.displayFormat = incoming.displayFormat
+  }
+
+  return stored
+}
+
+/**
  * Validate that a category assignment is valid for a path
  *
  * @param pathSiUnit - The SI unit from SignalK schema for this path (may be undefined)

--- a/src/unitpreferences/resolver.ts
+++ b/src/unitpreferences/resolver.ts
@@ -4,7 +4,32 @@ import {
   getActivePreset,
   getActivePresetForUser
 } from './loader'
-import { EnhancedDisplayUnits, DisplayUnitsMetadata } from './types'
+import {
+  EnhancedDisplayUnits,
+  DisplayUnitsMetadata,
+  DisplayUnitsOverride
+} from './types'
+
+/**
+ * What the path itself chose, as opposed to what the preset supplied.
+ *
+ * A response this server resolved carries that answer in its `override`
+ * field; anything else is the stored metadata, where every field present is
+ * the path's own.
+ */
+function pathOverride(
+  displayUnits: DisplayUnitsMetadata
+): DisplayUnitsOverride {
+  const owned = displayUnits.override ?? displayUnits
+  const override: DisplayUnitsOverride = {}
+  if (owned.targetUnit !== undefined) {
+    override.targetUnit = owned.targetUnit
+  }
+  if (owned.displayFormat !== undefined) {
+    override.displayFormat = owned.displayFormat
+  }
+  return override
+}
 
 /**
  * Given stored displayUnits metadata, resolve the full conversion info
@@ -12,18 +37,36 @@ import { EnhancedDisplayUnits, DisplayUnitsMetadata } from './types'
  * @param storedDisplayUnits - What's in baseDeltas.json (category, optional targetUnit)
  * @param pathSiUnit - The SI unit for this path (optional)
  * @param username - Username for per-user preset resolution (optional)
+ * @param includeOverride - Name the path's own choices in an `override` field
  * @returns Full displayUnits with formula, or null if can't resolve
  */
 export function resolveDisplayUnits(
   storedDisplayUnits: DisplayUnitsMetadata | undefined,
   pathSiUnit?: string,
-  username?: string
+  username?: string,
+  includeOverride = false
 ): EnhancedDisplayUnits | null {
   if (!storedDisplayUnits?.category) {
     return null
   }
 
   const category = storedDisplayUnits.category
+  const owned = pathOverride(storedDisplayUnits)
+  // Only an editor needs to tell the path's own choices from the preset's, so
+  // the field rides along only where the request asked for it. It stays in
+  // the object literal either way to keep one shape; JSON drops it when unset.
+  const override = includeOverride ? owned : undefined
+  // Resolving a response this server already resolved is the same job as
+  // resolving the stored metadata it came from.
+  const stored: DisplayUnitsMetadata = storedDisplayUnits.override
+    ? {
+        category,
+        ...owned,
+        formula: storedDisplayUnits.formula,
+        inverseFormula: storedDisplayUnits.inverseFormula,
+        symbol: storedDisplayUnits.symbol
+      }
+    : storedDisplayUnits
 
   // "base" category means display in SI units without conversion
   if (category === 'base') {
@@ -33,50 +76,54 @@ export function resolveDisplayUnits(
       formula: 'value',
       inverseFormula: 'value',
       symbol: pathSiUnit || '',
-      displayFormat: undefined
+      displayFormat: undefined,
+      override
     }
   }
 
   // "custom" category stores explicit conversion info
   if (category === 'custom') {
-    if (!storedDisplayUnits.targetUnit) {
+    if (!stored.targetUnit) {
       return null
     }
     // Identity conversion: targetUnit matches the path's SI unit
-    if (pathSiUnit && storedDisplayUnits.targetUnit === pathSiUnit) {
+    if (pathSiUnit && stored.targetUnit === pathSiUnit) {
       return {
         category: 'custom',
-        targetUnit: storedDisplayUnits.targetUnit,
+        targetUnit: stored.targetUnit,
         formula: 'value',
         inverseFormula: 'value',
-        symbol: storedDisplayUnits.symbol || storedDisplayUnits.targetUnit,
-        displayFormat: storedDisplayUnits.displayFormat
+        symbol: stored.symbol || stored.targetUnit,
+        displayFormat: stored.displayFormat,
+        override
       }
     }
     // If formula is stored, use it directly
-    if (storedDisplayUnits.formula) {
+    if (stored.formula) {
       return {
         category: 'custom',
-        targetUnit: storedDisplayUnits.targetUnit,
-        formula: storedDisplayUnits.formula,
-        inverseFormula: storedDisplayUnits.inverseFormula || '',
-        symbol: storedDisplayUnits.symbol || storedDisplayUnits.targetUnit,
-        displayFormat: storedDisplayUnits.displayFormat
+        targetUnit: stored.targetUnit,
+        formula: stored.formula,
+        inverseFormula: stored.inverseFormula || '',
+        symbol: stored.symbol || stored.targetUnit,
+        displayFormat: stored.displayFormat,
+        override
       }
     }
     // Otherwise look up from definitions using pathSiUnit
     if (pathSiUnit) {
       const definitions = getMergedDefinitions()
       const conversion =
-        definitions[pathSiUnit]?.conversions?.[storedDisplayUnits.targetUnit]
+        definitions[pathSiUnit]?.conversions?.[stored.targetUnit]
       if (conversion) {
         return {
           category: 'custom',
-          targetUnit: storedDisplayUnits.targetUnit,
+          targetUnit: stored.targetUnit,
           formula: conversion.formula,
           inverseFormula: conversion.inverseFormula,
-          symbol: conversion.symbol || storedDisplayUnits.targetUnit,
-          displayFormat: storedDisplayUnits.displayFormat
+          symbol: conversion.symbol || stored.targetUnit,
+          displayFormat: stored.displayFormat,
+          override
         }
       }
     }
@@ -96,8 +143,8 @@ export function resolveDisplayUnits(
   // Step 2: Determine target unit
   // Priority: path override > preset default
   let targetUnit: string
-  if (storedDisplayUnits.targetUnit) {
-    targetUnit = storedDisplayUnits.targetUnit
+  if (stored.targetUnit) {
+    targetUnit = stored.targetUnit
   } else if (preset?.categories?.[category]?.targetUnit) {
     targetUnit = preset.categories[category].targetUnit
   } else {
@@ -113,8 +160,8 @@ export function resolveDisplayUnits(
       inverseFormula: 'value',
       symbol: siUnit,
       displayFormat:
-        storedDisplayUnits.displayFormat ||
-        preset?.categories?.[category]?.displayFormat
+        stored.displayFormat || preset?.categories?.[category]?.displayFormat,
+      override
     }
   }
 
@@ -137,8 +184,8 @@ export function resolveDisplayUnits(
     inverseFormula: conversion.inverseFormula,
     symbol: conversion.symbol,
     displayFormat:
-      storedDisplayUnits.displayFormat ||
-      preset?.categories?.[category]?.displayFormat
+      stored.displayFormat || preset?.categories?.[category]?.displayFormat,
+    override
   }
 }
 
@@ -148,10 +195,11 @@ export function resolveDisplayUnits(
  * Clients read metadata back resolved — target unit, formulas and format
  * filled in from the active preset — so writing it back verbatim would store
  * the preset's current choices as a path override and detach the path from
- * the preset. The resolved shape carries a formula and the stored shape does
- * not, which is what tells an echo of the resolution apart from an override
- * the client states itself. In an echo, a value the preset would have
- * produced anyway is dropped unless the path already stored it.
+ * the preset. A resolved response names the path's own choices in its
+ * `override` field, which settles the question outright. A client that sends
+ * neither is read by shape: the resolved shape carries a formula and the
+ * stored shape does not, and in a formula-carrying echo a value the preset
+ * would have produced anyway is dropped unless the path already stored it.
  *
  * @param incoming - displayUnits as received in a metadata PUT
  * @param previous - displayUnits currently stored for the path
@@ -172,10 +220,15 @@ export function stripResolvedDisplayUnits(
   // A custom unit is nothing but its explicit conversion, and "base" needs
   // no conversion at all.
   if (category === 'custom') {
-    return incoming
+    const { override: _override, ...stored } = incoming
+    return stored
   }
   if (category === 'base') {
     return { category }
+  }
+
+  if (incoming.override) {
+    return { category, ...incoming.override }
   }
 
   const echoesResolution = incoming.formula !== undefined

--- a/src/unitpreferences/types.ts
+++ b/src/unitpreferences/types.ts
@@ -69,7 +69,7 @@ export interface DisplayUnitsMetadata {
   override?: DisplayUnitsOverride // Only on the way out, never stored
 }
 
-// The path specific unit override in a resolved response, as opposed to the
+// The path-specific unit override in a resolved response, as opposed to the
 // part the applied preset supplied. Empty when the path follows the preset.
 // Only present when the request asked for it.
 export interface DisplayUnitsOverride {

--- a/src/unitpreferences/types.ts
+++ b/src/unitpreferences/types.ts
@@ -66,6 +66,15 @@ export interface DisplayUnitsMetadata {
   inverseFormula?: string // Only if custom category
   symbol?: string // Only if custom category
   displayFormat?: string // Only if path override
+  override?: DisplayUnitsOverride // Only on the way out, never stored
+}
+
+// The part of a resolved response the path itself chose, as opposed to the
+// part the active preset supplied. Empty when the path follows the preset.
+// Only present when the request asked for it.
+export interface DisplayUnitsOverride {
+  targetUnit?: string
+  displayFormat?: string
 }
 
 // What server returns in GET /meta response
@@ -76,4 +85,5 @@ export interface EnhancedDisplayUnits {
   inverseFormula: string
   symbol: string
   displayFormat?: string
+  override?: DisplayUnitsOverride
 }

--- a/src/unitpreferences/types.ts
+++ b/src/unitpreferences/types.ts
@@ -69,8 +69,8 @@ export interface DisplayUnitsMetadata {
   override?: DisplayUnitsOverride // Only on the way out, never stored
 }
 
-// The part of a resolved response the path itself chose, as opposed to the
-// part the active preset supplied. Empty when the path follows the preset.
+// The path specific unit override in a resolved response, as opposed to the
+// part the applied preset supplied. Empty when the path follows the preset.
 // Only present when the request asked for it.
 export interface DisplayUnitsOverride {
   targetUnit?: string

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -1,17 +1,54 @@
 import { expect } from 'chai'
 import {
   serverTestConfigDirectory,
+  startServerFromConfigP,
   startServerP,
   WsPromiser
 } from './servertestutilities'
 import { freeport, SERVER_START_TIMEOUT } from './ts-servertestutilities'
+import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { rimraf } from 'rimraf'
 import { SERVERSTATEDIRNAME } from '../src/serverstate/store'
 import DeltaEditor from '../src/deltaeditor'
+import { DisplayUnitsMetadata } from '../src/unitpreferences/types'
 
 const TEST_PATH_DOTS = 'a.test.path'
 const TEST_PATH_SLASHES = 'a/test/path'
+// A speed path no other suite reads: meta deltas land in a process-wide
+// registry that outlives the server they were sent to.
+const SPEED_PATH_DOTS = 'performance.velocityMadeGoodToWaypoint'
+const SPEED_PATH_SLASHES = 'performance/velocityMadeGoodToWaypoint'
+
+// A metadata PUT answers 202 before it persists anything; the write is done
+// once the request the response links to leaves PENDING.
+const REQUEST_DEADLINE_MS = 5000
+const REQUEST_POLL_MS = 10
+// WsPromiser resolves 'timeout' after this much silence.
+const WS_MESSAGE_TIMEOUT_MS = 500
+
+type ServerHandle = { stop: () => Promise<unknown> }
+
+const awaitPutSuccess = async (port: number, response: Response) => {
+  expect(response.status).to.equal(202)
+  const { href } = (await response.json()) as { href: string }
+  const until = Date.now() + REQUEST_DEADLINE_MS
+  let request = { state: 'PENDING', statusCode: 202 }
+  while (Date.now() < until) {
+    request = (await fetch(`http://localhost:${port}${href}`).then((r) =>
+      r.json()
+    )) as { state: string; statusCode: number }
+    if (request.state !== 'PENDING') {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, REQUEST_POLL_MS))
+  }
+  // A finished handler reports COMPLETED either way; the status code says
+  // whether the write succeeded.
+  expect(request.state).to.equal('COMPLETED')
+  expect(request.statusCode).to.equal(200)
+}
 
 const emptyConfigDirectory = () =>
   Promise.all(
@@ -215,6 +252,237 @@ describe('Metadata end to end', function () {
       'description',
       'Updated description'
     )
+  })
+})
+
+// The active preset is nautical-metric: speeds in knots, formatted "0.0".
+const PRESET_SPEED_UNIT = 'kn'
+
+describe('Display unit metadata', function () {
+  this.timeout(SERVER_START_TIMEOUT)
+
+  let port: number
+  let server: ServerHandle
+  let v1Api: string
+
+  const putSpeedMeta = async (
+    displayUnits: DisplayUnitsMetadata,
+    description?: string
+  ) => {
+    const result = await fetch(
+      `${v1Api}/vessels/self/${SPEED_PATH_SLASHES}/meta`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          value: { units: 'm/s', description, displayUnits }
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+    await awaitPutSuccess(port, result)
+  }
+
+  const storedDisplayUnits = (): DisplayUnitsMetadata | undefined => {
+    const deltas = JSON.parse(
+      fs.readFileSync(
+        path.join(serverTestConfigDirectory(), 'baseDeltas.json'),
+        'utf8'
+      )
+    )
+    for (const delta of deltas) {
+      for (const update of delta.updates || []) {
+        for (const meta of update.meta || []) {
+          if (meta.path === SPEED_PATH_DOTS) {
+            return meta.value.displayUnits
+          }
+        }
+      }
+    }
+    return undefined
+  }
+
+  before(async () => {
+    port = await freeport()
+    v1Api = `http://localhost:${port}/signalk/v1/api`
+    await emptyConfigDirectory()
+    server = await startServerP(port, false, {
+      settings: { interfaces: { plugins: false } }
+    })
+  })
+
+  after(async () => {
+    await server.stop()
+    await rimraf(path.join(serverTestConfigDirectory(), 'baseDeltas.json'))
+  })
+
+  it('stores no override when the metadata carries the preset unit', async () => {
+    await putSpeedMeta({
+      category: 'speed',
+      targetUnit: PRESET_SPEED_UNIT,
+      formula: 'value * 1.94384',
+      inverseFormula: 'value * 0.514444',
+      symbol: PRESET_SPEED_UNIT,
+      displayFormat: '0.0'
+    })
+    expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
+  })
+
+  it('stores a target unit that differs from the preset unit', async () => {
+    await putSpeedMeta({
+      category: 'speed',
+      targetUnit: 'm/s',
+      formula: 'value',
+      inverseFormula: 'value',
+      symbol: 'm/s',
+      displayFormat: '0.0'
+    })
+    expect(storedDisplayUnits()).to.deep.equal({
+      category: 'speed',
+      targetUnit: 'm/s'
+    })
+  })
+
+  it('keeps the stored target unit when other metadata changes', async () => {
+    await putSpeedMeta(
+      {
+        category: 'speed',
+        targetUnit: 'm/s',
+        formula: 'value',
+        inverseFormula: 'value',
+        symbol: 'm/s',
+        displayFormat: '0.0'
+      },
+      'Apparent wind speed'
+    )
+    expect(storedDisplayUnits()).to.deep.equal({
+      category: 'speed',
+      targetUnit: 'm/s'
+    })
+  })
+
+  it('stores the preset unit when it is stated as an override', async () => {
+    await putSpeedMeta({ category: 'speed', targetUnit: PRESET_SPEED_UNIT })
+    expect(storedDisplayUnits()).to.deep.equal({
+      category: 'speed',
+      targetUnit: PRESET_SPEED_UNIT
+    })
+  })
+
+  it('drops an override the metadata no longer states', async () => {
+    await putSpeedMeta({ category: 'speed' })
+    expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
+  })
+
+  it('sends the resolved conversion to connected clients', async () => {
+    const receiver = new WsPromiser(
+      `ws://localhost:${port}/signalk/v1/stream?subscribe=self&sendMeta=all&sendCachedValues=false`,
+      WS_MESSAGE_TIMEOUT_MS
+    )
+    await receiver.nextMsg() // hello
+    const metaMsgPromise = receiver.nextMsg()
+
+    await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
+
+    const metaMsg = await metaMsgPromise
+    expect(metaMsg).to.not.equal('timeout')
+    const metaUpdate = JSON.parse(metaMsg).updates[0].meta[0]
+    expect(metaUpdate.path).to.equal(SPEED_PATH_DOTS)
+    expect(metaUpdate.value.displayUnits).to.include({
+      category: 'speed',
+      targetUnit: 'm/s',
+      symbol: 'm/s',
+      formula: 'value'
+    })
+  })
+
+  it('stores a custom unit with its conversion', async () => {
+    await putSpeedMeta({
+      category: 'custom',
+      targetUnit: 'Bf',
+      formula: '(value / 0.836)^(2/3)',
+      inverseFormula: '0.836 * value^1.5',
+      symbol: 'Bf'
+    })
+    expect(storedDisplayUnits()).to.deep.equal({
+      category: 'custom',
+      targetUnit: 'Bf',
+      formula: '(value / 0.836)^(2/3)',
+      inverseFormula: '0.836 * value^1.5',
+      symbol: 'Bf'
+    })
+  })
+})
+
+// A config directory from before baseDeltas.json holds a defaults.json and
+// opts out of conversion with useBaseDeltas: false. Metadata PUTs then
+// persist through the defaults-file branch of putMetaHandler, which must
+// apply the same displayUnits normalization as the base-deltas branch.
+describe('Display unit metadata with a legacy defaults file', function () {
+  this.timeout(SERVER_START_TIMEOUT)
+
+  let port: number
+  let server: ServerHandle
+  let configDir: string
+
+  const storedLegacyMeta = () => {
+    const defaults = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'defaults.json'), 'utf8')
+    )
+    return SPEED_PATH_DOTS.split('.').reduce(
+      (node, key) => node?.[key],
+      defaults?.vessels?.self
+    )?.meta
+  }
+
+  before(async () => {
+    port = await freeport()
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-legacy-'))
+    fs.writeFileSync(
+      path.join(configDir, 'settings.json'),
+      JSON.stringify({
+        port,
+        interfaces: { plugins: false },
+        useBaseDeltas: false,
+        pipedProviders: []
+      })
+    )
+    fs.writeFileSync(
+      path.join(configDir, 'defaults.json'),
+      JSON.stringify({ vessels: { self: { name: 'legacy' } } })
+    )
+    server = await startServerFromConfigP(configDir)
+  })
+
+  after(async () => {
+    await server.stop()
+    await rimraf(configDir)
+  })
+
+  // The single-field form: metaValue is a fresh merge here, so nothing
+  // aliases the raw request value into the normalized object.
+  it('strips preset-derived fields before writing the defaults file', async () => {
+    const result = await fetch(
+      `http://localhost:${port}/signalk/v1/api/vessels/self/${SPEED_PATH_SLASHES}/meta/displayUnits`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          value: {
+            category: 'speed',
+            targetUnit: PRESET_SPEED_UNIT,
+            formula: 'value * 1.94384',
+            inverseFormula: 'value * 0.514444',
+            symbol: PRESET_SPEED_UNIT,
+            displayFormat: '0.0'
+          }
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      }
+    )
+    await awaitPutSuccess(port, result)
+
+    expect(storedLegacyMeta().displayUnits).to.deep.equal({
+      category: 'speed'
+    })
   })
 })
 

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -282,6 +282,53 @@ describe('Display unit metadata', function () {
     await awaitPutSuccess(port, result)
   }
 
+  const servedDisplayUnits = async (
+    skPath = SPEED_PATH_SLASHES,
+    includeOverride = false
+  ) => {
+    const query = includeOverride ? '?displayUnitsOverride=true' : ''
+    const meta = await fetch(
+      `${v1Api}/vessels/self/${skPath}/meta${query}`
+    ).then((r) => r.json())
+    return meta.displayUnits
+  }
+
+  // The metadata a client receives for a path once a value for it arrives.
+  // The stream carries other traffic, so read on until the metadata shows up.
+  const streamedDisplayUnits = async (includeOverride: boolean) => {
+    const receiver = new WsPromiser(
+      `ws://localhost:${port}/signalk/v1/stream?subscribe=self&sendMeta=all&sendCachedValues=false` +
+        (includeOverride ? '&displayUnitsOverride=true' : ''),
+      WS_MESSAGE_TIMEOUT_MS
+    )
+    await receiver.nextMsg() // hello
+
+    const sender = new WsPromiser(
+      `ws://localhost:${port}/signalk/v1/stream?subscribe=none&sendCachedValues=false`,
+      WS_MESSAGE_TIMEOUT_MS
+    )
+    await sender.nextMsg() // hello
+    await sender.send({
+      context: 'vessels.self',
+      updates: [{ values: [{ path: SPEED_PATH_DOTS, value: 1 }] }]
+    })
+
+    const until = Date.now() + REQUEST_DEADLINE_MS
+    while (Date.now() < until) {
+      for (const msg of receiver.parsedMessages()) {
+        for (const update of msg.updates ?? []) {
+          for (const entry of update.meta ?? []) {
+            if (entry.path === SPEED_PATH_DOTS && entry.value?.displayUnits) {
+              return entry.value.displayUnits
+            }
+          }
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, REQUEST_POLL_MS))
+    }
+    throw new Error('no displayUnits metadata on the stream')
+  }
+
   const storedDisplayUnits = (): DisplayUnitsMetadata | undefined => {
     const deltas = JSON.parse(
       fs.readFileSync(
@@ -373,6 +420,72 @@ describe('Display unit metadata', function () {
     expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
   })
 
+  it('names the path override when the request asks for it', async () => {
+    await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
+    expect(await servedDisplayUnits()).to.include({
+      targetUnit: 'm/s',
+      symbol: 'm/s'
+    })
+    expect(
+      (await servedDisplayUnits(SPEED_PATH_SLASHES, true)).override
+    ).to.deep.equal({ targetUnit: 'm/s' })
+  })
+
+  it('names no override unless the request asks for it', async () => {
+    await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
+    expect(await servedDisplayUnits()).to.not.have.property('override')
+  })
+
+  it('leaves the override empty for a path that follows the preset', async () => {
+    const displayUnits = await servedDisplayUnits(
+      'navigation/speedOverGround',
+      true
+    )
+    expect(displayUnits.targetUnit).to.equal(PRESET_SPEED_UNIT)
+    expect(displayUnits.override).to.deep.equal({})
+  })
+
+  it('names the path override on a stream that asks for it', async () => {
+    await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
+    expect((await streamedDisplayUnits(true)).override).to.deep.equal({
+      targetUnit: 'm/s'
+    })
+  })
+
+  it('names no override on a stream that does not ask for it', async () => {
+    await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
+    expect(await streamedDisplayUnits(false)).to.not.have.property('override')
+  })
+
+  it('keeps the override a resolved response is saved back with', async () => {
+    await putSpeedMeta({
+      category: 'speed',
+      targetUnit: PRESET_SPEED_UNIT,
+      formula: 'value * 1.94384',
+      inverseFormula: 'value * 0.514444',
+      symbol: PRESET_SPEED_UNIT,
+      displayFormat: '0.0',
+      override: { targetUnit: PRESET_SPEED_UNIT }
+    })
+    expect(storedDisplayUnits()).to.deep.equal({
+      category: 'speed',
+      targetUnit: PRESET_SPEED_UNIT
+    })
+  })
+
+  it('drops what a resolved response says the path does not own', async () => {
+    await putSpeedMeta({
+      category: 'speed',
+      targetUnit: 'm/s',
+      formula: 'value',
+      inverseFormula: 'value',
+      symbol: 'm/s',
+      displayFormat: '0.0',
+      override: {}
+    })
+    expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
+  })
+
   it('sends the resolved conversion to connected clients', async () => {
     const receiver = new WsPromiser(
       `ws://localhost:${port}/signalk/v1/stream?subscribe=self&sendMeta=all&sendCachedValues=false`,
@@ -392,6 +505,11 @@ describe('Display unit metadata', function () {
       targetUnit: 'm/s',
       symbol: 'm/s',
       formula: 'value'
+    })
+    // The metadata registry resolves from this delta again, so it names the
+    // override whether or not any client asked for one.
+    expect(metaUpdate.value.displayUnits.override).to.deep.equal({
+      targetUnit: 'm/s'
     })
   })
 

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -418,7 +418,7 @@ describe('Display unit metadata', function () {
     expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
   })
 
-  it('reports the path specific override when the request asks for it', async () => {
+  it('reports the path-specific override when the request asks for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect(await servedDisplayUnits()).to.include({
       targetUnit: 'm/s',
@@ -443,7 +443,7 @@ describe('Display unit metadata', function () {
     expect(displayUnits.override).to.deep.equal({})
   })
 
-  it('reports the path specific override on a stream that asks for it', async () => {
+  it('reports the path-specific override on a stream that asks for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect((await streamedDisplayUnits(true)).override).to.deep.equal({
       targetUnit: 'm/s'

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -61,8 +61,7 @@ describe('Metadata end to end', function () {
   this.timeout(SERVER_START_TIMEOUT)
 
   let port: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let server: any
+  let server: ServerHandle
   let v1Api: string
 
   const getV1 = (p: string) => fetch(`${v1Api}${p}`)
@@ -77,7 +76,7 @@ describe('Metadata end to end', function () {
   const createMetaWsPromiser = () =>
     new WsPromiser(
       `ws://localhost:${port}/signalk/v1/stream?subscribe=self&sendMeta=all&sendCachedValues=false`,
-      500
+      WS_MESSAGE_TIMEOUT_MS
     )
 
   before(async () => {
@@ -213,8 +212,7 @@ describe('Metadata end to end', function () {
     const setupResult = await selfPutV1(`${TEST_PATH_SLASHES}/meta/zones`, {
       value: zones
     })
-    expect(setupResult.status).to.equal(202)
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    await awaitPutSuccess(port, setupResult)
 
     const metaBefore = await selfGetMetaJson()
     expect(metaBefore).to.have.property('zones')

--- a/test/metadata-e2e.ts
+++ b/test/metadata-e2e.ts
@@ -418,7 +418,7 @@ describe('Display unit metadata', function () {
     expect(storedDisplayUnits()).to.deep.equal({ category: 'speed' })
   })
 
-  it('names the path override when the request asks for it', async () => {
+  it('reports the path specific override when the request asks for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect(await servedDisplayUnits()).to.include({
       targetUnit: 'm/s',
@@ -429,7 +429,7 @@ describe('Display unit metadata', function () {
     ).to.deep.equal({ targetUnit: 'm/s' })
   })
 
-  it('names no override unless the request asks for it', async () => {
+  it('reports no override unless the request asks for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect(await servedDisplayUnits()).to.not.have.property('override')
   })
@@ -443,14 +443,14 @@ describe('Display unit metadata', function () {
     expect(displayUnits.override).to.deep.equal({})
   })
 
-  it('names the path override on a stream that asks for it', async () => {
+  it('reports the path specific override on a stream that asks for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect((await streamedDisplayUnits(true)).override).to.deep.equal({
       targetUnit: 'm/s'
     })
   })
 
-  it('names no override on a stream that does not ask for it', async () => {
+  it('reports no override on a stream that does not ask for it', async () => {
     await putSpeedMeta({ category: 'speed', targetUnit: 'm/s' })
     expect(await streamedDisplayUnits(false)).to.not.have.property('override')
   })
@@ -471,7 +471,7 @@ describe('Display unit metadata', function () {
     })
   })
 
-  it('drops what a resolved response says the path does not own', async () => {
+  it('drops what a resolved response does not mark as an override', async () => {
     await putSpeedMeta({
       category: 'speed',
       targetUnit: 'm/s',

--- a/test/servertestutilities.js
+++ b/test/servertestutilities.js
@@ -123,6 +123,23 @@ module.exports = {
       headers: { 'Content-Type': 'application/json' }
     })
   },
+  // Starts a server that reads settings from files in configDir instead of
+  // taking them through the constructor. Constructor-supplied settings
+  // disable settings writes and never enter the legacy old-defaults mode
+  // (settings.json with useBaseDeltas: false plus a defaults.json), so that
+  // mode can only be tested this way. The port comes from the settings file.
+  startServerFromConfigP: function startServerFromConfigP(configDir) {
+    const Server = require('../dist')
+    try {
+      require('../dist/requestResponse').resetRequests()
+    } catch (_e) {
+      // ignore - not critical for non-test usage
+    }
+    require('../dist/modules').resetModuleCaches()
+    process.env.SIGNALK_NODE_CONFIG_DIR = configDir
+    process.env.SIGNALK_DISABLE_SERVER_UPDATES = 'true'
+    return new Server({ config: {} }).start()
+  },
   startServerP: function startServerP(
     port,
     enableSecurity,


### PR DESCRIPTION
Closes #2967.

Clients read `displayUnits` back resolved: the server fills in the target unit, the formulas and the display format from the active preset, for every path with a category, whether or not the path overrides anything. The metadata editor saves what it read, so editing a description on a speed path wrote `"targetUnit": "kn"` into `baseDeltas.json` and detached that path from the preset, with the conversion strings frozen alongside it.

A metadata PUT now stores only what `DisplayUnitsMetadata` documents: the category, a target unit and a display format. A resolved response also reports the path specific override, in an `override` object holding the target unit and display format that override the preset, empty when the path follows the preset, and a PUT that carries it is taken at its word. A client that sends neither is read by shape: the resolved shape carries a formula and the stored shape does not, and in a formula-carrying echo a value the preset would have produced anyway is dropped unless the path already stored it. Connected clients keep receiving the resolved conversion in the metadata delta the PUT triggers.

The `override` field is what lets an editor tell "knots because this path has an override" from "knots because the preset says so"; display code can ignore it. `docs/guides/unitpreferences.md` documents it.

The requesting user now reaches the meta handler, so per-user presets resolve against the right preset.

Both persistence branches store the normalized object: the legacy defaults-file branch (`useBaseDeltas: false`) used to write the raw request value, which a single-field PUT never normalizes.

Twelve end-to-end tests in `test/metadata-e2e.ts` cover what lands in `baseDeltas.json` or a legacy `defaults.json`, what a resolved response reports, and what goes out over the websocket. Four of them fail without this change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR enables metadata editors to create per-path display-unit overrides with a category and target unit.

It normalizes metadata before persistence. The server stores documented fields and explicit overrides only. It excludes preset-derived conversion data and the unused `explicit` flag.

Resolved metadata continues to include preset-derived conversions. REST and WebSocket clients can request path-owned values with `displayUnitsOverride=true`.

Per-user presets resolve against the requesting user. Both metadata persistence paths store normalized metadata.

The PR adds documentation and 12 end-to-end tests for persistence, resolved responses, override removal, metadata merging, and WebSocket deltas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
