### PR TITLE
fix: prevent concurrent atomic file writes from sharing a temp file

### DIFF
--- a/src/atomicWrite.ts
+++ b/src/atomicWrite.ts
@@ -8,6 +8,13 @@ function uniqueTmpPath(filePath: string): string {
   return `${filePath}.${process.pid}.${tmpCounter++}.tmp`
 }
 
+/**
+ * Synchronous variant for boot-time migrations and other paths that run
+ * before the event loop serves traffic. It cannot join the async write
+ * queue, so it must not overlap an in-flight atomicWriteFile to the same
+ * path — the pending async write would rename its older content over the
+ * sync result.
+ */
 export function atomicWriteFileSync(filePath: string, data: string): void {
   const tmp = uniqueTmpPath(filePath)
   try {

--- a/src/atomicWrite.ts
+++ b/src/atomicWrite.ts
@@ -1,7 +1,15 @@
 import fs from 'fs'
 
+// Each write gets its own temp file, so a concurrent or failed write can
+// never corrupt another writer's data or unlink its temp file mid-flight.
+let tmpCounter = 0
+
+function uniqueTmpPath(filePath: string): string {
+  return `${filePath}.${process.pid}.${tmpCounter++}.tmp`
+}
+
 export function atomicWriteFileSync(filePath: string, data: string): void {
-  const tmp = filePath + '.tmp'
+  const tmp = uniqueTmpPath(filePath)
   try {
     fs.writeFileSync(tmp, data)
     fs.renameSync(tmp, filePath)
@@ -13,11 +21,8 @@ export function atomicWriteFileSync(filePath: string, data: string): void {
   }
 }
 
-export async function atomicWriteFile(
-  filePath: string,
-  data: string
-): Promise<void> {
-  const tmp = filePath + '.tmp'
+async function writeViaOwnTmp(filePath: string, data: string): Promise<void> {
+  const tmp = uniqueTmpPath(filePath)
   try {
     await fs.promises.writeFile(tmp, data)
     await fs.promises.rename(tmp, filePath)
@@ -27,4 +32,23 @@ export async function atomicWriteFile(
     } catch {}
     throw err
   }
+}
+
+// Writes to the same path are chained in call order, so a slow earlier
+// write can never rename stale content over a newer write. The stored
+// promise never rejects; each caller observes only its own failure.
+const writeQueues = new Map<string, Promise<void>>()
+
+export function atomicWriteFile(filePath: string, data: string): Promise<void> {
+  const previous = writeQueues.get(filePath) ?? Promise.resolve()
+  const write = previous.then(() => writeViaOwnTmp(filePath, data))
+  const settled: Promise<void> = write
+    .catch(() => undefined)
+    .then(() => {
+      if (writeQueues.get(filePath) === settled) {
+        writeQueues.delete(filePath)
+      }
+    })
+  writeQueues.set(filePath, settled)
+  return write
 }

--- a/test/atomic-write.ts
+++ b/test/atomic-write.ts
@@ -1,0 +1,75 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { atomicWriteFile, atomicWriteFileSync } from '../src/atomicWrite'
+
+describe('atomicWrite', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'atomic-write-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('persists the last write when many writes overlap', async () => {
+    const OVERLAPPING_WRITES = 25
+    const file = path.join(dir, 'config.json')
+
+    await Promise.all(
+      Array.from({ length: OVERLAPPING_WRITES }, (_, i) =>
+        atomicWriteFile(file, `content-${i}`)
+      )
+    )
+
+    expect(fs.readFileSync(file, 'utf8')).to.equal(
+      `content-${OVERLAPPING_WRITES - 1}`
+    )
+    expect(fs.readdirSync(dir)).to.deep.equal(['config.json'])
+  })
+
+  it('keeps writes to different paths independent', async () => {
+    const a = path.join(dir, 'a.json')
+    const b = path.join(dir, 'b.json')
+
+    await Promise.all([
+      atomicWriteFile(a, 'a-1'),
+      atomicWriteFile(b, 'b-1'),
+      atomicWriteFile(a, 'a-2')
+    ])
+
+    expect(fs.readFileSync(a, 'utf8')).to.equal('a-2')
+    expect(fs.readFileSync(b, 'utf8')).to.equal('b-1')
+    expect(fs.readdirSync(dir).sort()).to.deep.equal(['a.json', 'b.json'])
+  })
+
+  it('rejects the failing write and recovers for later writes', async () => {
+    const missingDir = path.join(dir, 'missing')
+    const file = path.join(missingDir, 'config.json')
+
+    try {
+      await atomicWriteFile(file, 'first')
+      expect.fail('expected the write to reject')
+    } catch (err) {
+      expect((err as NodeJS.ErrnoException).code).to.equal('ENOENT')
+    }
+
+    fs.mkdirSync(missingDir)
+    await atomicWriteFile(file, 'second')
+
+    expect(fs.readFileSync(file, 'utf8')).to.equal('second')
+    expect(fs.readdirSync(missingDir)).to.deep.equal(['config.json'])
+  })
+
+  it('atomicWriteFileSync writes content and leaves no temp file', () => {
+    const file = path.join(dir, 'config.json')
+
+    atomicWriteFileSync(file, 'sync-content')
+
+    expect(fs.readFileSync(file, 'utf8')).to.equal('sync-content')
+    expect(fs.readdirSync(dir)).to.deep.equal(['config.json'])
+  })
+})


### PR DESCRIPTION
Overlapping `atomicWriteFile` calls to the same path all used a fixed `<file>.tmp`: interleaved writes could rename corrupt content into place, a failing write's cleanup could unlink another writer's temp file mid-flight, and a slow older write could rename stale content over a newer write. `security.json` is the most exposed target, since every security-config mutation (users, ACLs, device access, OIDC provisioning) funnels through `saveSecurityConfig`. Surfaced during review of #2961.

Each write now uses its own `<file>.<pid>.<n>.tmp` (the pattern already used by the appstore icon probe), and async writes to the same path are chained in call order so the last caller's content always wins.

Tested: new `test/atomic-write.ts` covers 25 overlapping writes to one path (last content wins, no temp files left behind), independence of different paths, rejection propagation with queue recovery, and the sync variant. Full `npm test` chain passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Use unique per-write temporary files to prevent collisions and cleanup errors.
- Queue asynchronous writes by file path so writes complete in call order and the latest content wins.
- Preserve individual write failures and recover the queue after rejection.
- Apply unique temporary files to synchronous writes.
- Add tests for overlapping writes, independent paths, failure recovery, persisted content, cleanup, and synchronous writes.
- Full test suite passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->