### PR TITLE
Add Hat Labs HALPI2 and Halos to the hardware and prebuilt image options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are a boat owner, you can easily run Signal K Server on a Victron Cerbo G
 
 For Marine vendors who build marine hardware and software, for example those developing navigation, monitoring and tracking systems, Signal K Server is an opportunity to accelerate development and decrease time to market, by taking advantage of a proven, modern and extensible software platform that is open source and available with a permissive Apache 2.0 license. Signal K Server is implemented in Node.js and is easy to integrate into modern systems that run Linux derivatives.
 
-Signal K Server is already running inside products developed by Victron Energy, Airmar Technology and others.
+Signal K Server is already running inside products developed by Victron Energy, Airmar Technology, Hat Labs and others.
 
 ### Software Developers & Boat Electronics Hobbyists
 
@@ -82,6 +82,7 @@ There is a [Signal K Server FAQ Frequently Asked Questions](https://github.com/S
 
 For the typical boater, not being a software developer nor electrical engineer, the best option is to get a (commercially available) product that already has Signal K Server inside. These are the currently available devices:
 
+- [HALPI2](https://shop.hatlabs.fi/products/halpi2-computer) by Hat Labs, a Raspberry Pi Compute Module 5 boat computer with Signal K Server preconfigured
 - [Cerbo GX](https://www.victronenergy.com/panel-systems-remote-monitoring/cerbo-gx) and other GX Devices by Victron Energy ([see Venus OS Large manual](https://www.victronenergy.com/live/venus-os:large))
 - [SmartBoat module](https://www.airmar.com/Catalog/SmartBoat-SmartFlex) by Airmar
 
@@ -90,6 +91,7 @@ Read [this FAQ entry](https://github.com/SignalK/signalk-server/wiki/FAQ:-Freque
 
 These prebuilt images for RaspberryPis take away most of the complexity involved from the software side:
 
+- [Halos](https://docs.halos.fi/getting-started/choosing-an-image/) by Hat Labs, whose Marine images include Signal K Server
 - [BBN Marine OS](https://github.com/bareboat-necessities/lysmarine_gen#what-is-lysmarine-bbn-edition)
 - [OpenPlotter](https://openmarine.net/openplotter) by OpenMarine
 - [Venus OS for RaspberryPis](https://github.com/victronenergy/venus/wiki/raspberrypi-install-venus-image) by Victron Energy

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -16,6 +16,10 @@ Signal K Server is a [NodeJS](https://nodejs.org/en) application which can run o
 Currently the most cost effective, powerful and best supported hardware platform for a Signal K server is the [Raspberry
 Pi](https://www.raspberrypi.com). Any Raspberry Pi (even the very first model) can be used but for best performance we recommend Raspberry Pi 4 model B or 5. If you don't have a Raspberry Pi, any old laptop or computer you have sitting around would make a good initial test platform, although for permanent use on a yacht, more power efficient hardware like a Raspberry Pi is strongly recommended.
 
+## Ready-made options
+
+You do not have to install Signal K Server yourself. Several commercially available devices ship with it inside, and several prebuilt Raspberry Pi images install it for you. Both are listed under [How to get Signal K Server?](https://github.com/SignalK/signalk-server#how-to-get-signal-k-server) in the project README. If one of them suits your boat, you do not need the instructions below.
+
 ## Prerequisites
 
 > [!NOTE]

--- a/docs/installation/raspberry_pi_installation.md
+++ b/docs/installation/raspberry_pi_installation.md
@@ -12,6 +12,9 @@ Installation of Signal K server consists of the following steps:
 
 _**Important:** If you are updating a Signal K server installation, especially if upgrading an installed version <= 1.40.0, [please check here first](./updating.md)._
 
+> [!TIP]
+> You can skip these steps entirely by flashing a prebuilt image that already includes Signal K Server. See [How to get Signal K Server?](https://github.com/SignalK/signalk-server#how-to-get-signal-k-server) for the available images.
+
 ## Prerequisites:
 
 **64-bit** Raspberry Pi OS is installed on the device (Pi 3, 4 or 5 required). Node.js 24 does not support 32-bit ARM (armv7).


### PR DESCRIPTION
HALPI2 ships with Signal K Server preconfigured, and Halos Marine images include it, so both fit the two lists under "How to get Signal K Server?" but were missing from them.

While adding them I hit a gap that affects every option in those lists rather than only these two: the installation pages never mention that ready-made options exist at all. `docs/installation/README.md` sends the reader straight from "Raspberry Pi is the best supported platform" into the manual NodeSource and npm install, and `raspberry_pi_installation.md` opens with the dependency steps. Both now point at the README section first. Neither repeats the list, so the two surfaces cannot drift apart.

I deliberately left the Admin UI walkthrough alone. It tells the reader to open `http://[ipaddress]:3000/`, which is not the right URL on a HALPI2, where Signal K sits behind a reverse proxy with TLS.

Disclosure: I work at Hat Labs, so two of these entries are ours. The installation-page changes are vendor-neutral and help OpenPlotter, BBN, Venus OS and AvNav equally. I put the two new entries at the head of their lists; happy to append them instead if you would rather.

Verified: every link resolves, and `prettier --check` passes on all three files. No version numbers touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds Hat Labs HALPI2 and Halos Marine images to the available Signal K Server options.
- Adds links to ready-made devices and prebuilt Raspberry Pi images before manual installation steps.
- Keeps the Admin UI walkthrough unchanged because HALPI2 uses a TLS reverse proxy.
- Avoids duplicating option lists across documentation pages.
- Confirms that all links resolve and `prettier --check` passes for the modified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->