### PR TITLE
fix(ws): apply send-buffer limit to server events

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -1372,16 +1372,23 @@ function handleRealtimeConnection(
     sendLatestDeltas(app, app.deltaCache, app.selfContext, spark)
   }
 
+  // Server events are not accumulated by the BackpressureManager (they
+  // are not deltas), but they share the socket with it. Without this
+  // check a client that cannot keep up with a burst of server events
+  // — or a plugin emitting them in a loop — grows the send buffer
+  // without bound and never hits the overflow limit deltas already
+  // enforce.
+  const writeEvent = (event: Delta) => {
+    spark.write(event)
+    spark.backpressureManager?.assertBufferSize()
+  }
+
   if (spark.query.serverevents === 'all') {
     spark.hasServerEvents = true
     startServerEvents(
       app,
       spark,
-      wrapWithVerifyWS(
-        app.securityStrategy,
-        spark,
-        spark.write.bind(spark) as (delta: Delta) => void
-      )
+      wrapWithVerifyWS(app.securityStrategy, spark, writeEvent)
     )
   }
 
@@ -1389,11 +1396,7 @@ function handleRealtimeConnection(
     startEvents(
       app,
       spark,
-      wrapWithVerifyWS(
-        app.securityStrategy,
-        spark,
-        spark.write.bind(spark) as (delta: Delta) => void
-      ),
+      wrapWithVerifyWS(app.securityStrategy, spark, writeEvent),
       spark.query.events
     )
   }

--- a/test/serverevents-backpressure.ts
+++ b/test/serverevents-backpressure.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai'
+import WebSocket from 'ws'
+import type { Socket } from 'net'
+import { freeport } from './ts-servertestutilities'
+import { startServerP } from './servertestutilities'
+
+// Server events are written straight to the socket, outside the delta
+// accumulator. They must still count against the send-buffer overflow
+// limit, otherwise a client that stops reading (or a plugin emitting
+// events in a loop) grows the socket buffer without bound.
+
+const MAX_SEND_BUFFER = 64 * 1024
+const MAX_BUFFER_CHECK_TIME_MS = 500
+const EVENT_PAYLOAD = 'x'.repeat(100 * 1024)
+const EMIT_INTERVAL_MS = 10
+const FLOOD_MS = 1500
+const OVERFLOW_MESSAGE =
+  'Server outgoing buffer overflow, terminating connection'
+
+describe('Server events send-buffer overflow', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let server: any
+  let port: number
+
+  before(async function () {
+    this.timeout(90000)
+    port = await freeport()
+    server = await startServerP(port, false, {
+      maxSendBufferSize: MAX_SEND_BUFFER,
+      maxSendBufferCheckTime: MAX_BUFFER_CHECK_TIME_MS
+    })
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  it('terminates a serverevents client whose send buffer stays over the limit', async function () {
+    this.timeout(30000)
+    const ws = new WebSocket(
+      `ws://0.0.0.0:${port}/signalk/v1/stream?serverevents=all&subscribe=none&sendCachedValues=false`
+    )
+    const received: string[] = []
+    ws.on('message', (data) => received.push(String(data)))
+    const closed = new Promise<void>((resolve) =>
+      ws.on('close', () => resolve())
+    )
+    await new Promise<void>((resolve) => ws.on('open', () => resolve()))
+
+    // Stop reading so the server-side buffer fills up.
+    const socket = (ws as unknown as { _socket?: Socket })._socket
+    if (!socket) {
+      throw new Error('ws client exposes no _socket to pause')
+    }
+    socket.pause()
+
+    const flood = setInterval(() => {
+      server.app.emit('serverevent', {
+        type: 'FLOOD_TEST',
+        data: EVENT_PAYLOAD
+      })
+    }, EMIT_INTERVAL_MS)
+    await new Promise((resolve) => setTimeout(resolve, FLOOD_MS))
+    clearInterval(flood)
+
+    // Let the client drain what was queued: the overflow notice and the
+    // close frame are at the end of that backlog.
+    socket.resume()
+    await closed
+
+    const overflow = received
+      .map((m) => {
+        try {
+          return JSON.parse(m)
+        } catch (_e) {
+          return null
+        }
+      })
+      .find((m) => m && m.errorMessage === OVERFLOW_MESSAGE)
+    expect(overflow, 'overflow notice').to.exist
+  })
+})

--- a/test/serverevents-backpressure.ts
+++ b/test/serverevents-backpressure.ts
@@ -16,19 +16,27 @@ const EMIT_INTERVAL_MS = 10
 const FLOOD_MS = 1500
 const OVERFLOW_MESSAGE =
   'Server outgoing buffer overflow, terminating connection'
+const SERVER_START_TIMEOUT_MS = 90_000
+const TEST_TIMEOUT_MS = 30_000
+
+// startServerP is untyped JavaScript; this is the slice of the server the
+// test touches.
+interface TestServer {
+  app: { emit: (event: string, data: unknown) => void }
+  stop: () => Promise<unknown>
+}
 
 describe('Server events send-buffer overflow', function () {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let server: any
+  let server: TestServer
   let port: number
 
   before(async function () {
-    this.timeout(90000)
+    this.timeout(SERVER_START_TIMEOUT_MS)
     port = await freeport()
-    server = await startServerP(port, false, {
+    server = (await startServerP(port, false, {
       maxSendBufferSize: MAX_SEND_BUFFER,
       maxSendBufferCheckTime: MAX_BUFFER_CHECK_TIME_MS
-    })
+    })) as TestServer
   })
 
   after(async function () {
@@ -36,7 +44,7 @@ describe('Server events send-buffer overflow', function () {
   })
 
   it('terminates a serverevents client whose send buffer stays over the limit', async function () {
-    this.timeout(30000)
+    this.timeout(TEST_TIMEOUT_MS)
     const ws = new WebSocket(
       `ws://0.0.0.0:${port}/signalk/v1/stream?serverevents=all&subscribe=none&sendCachedValues=false`
     )

--- a/test/serverevents-backpressure.ts
+++ b/test/serverevents-backpressure.ts
@@ -27,7 +27,9 @@ interface TestServer {
 }
 
 describe('Server events send-buffer overflow', function () {
-  let server: TestServer
+  // Unset when startServerP fails, so a setup error surfaces as itself
+  // rather than as a TypeError from the teardown.
+  let server: TestServer | undefined
   let port: number
 
   before(async function () {
@@ -40,11 +42,15 @@ describe('Server events send-buffer overflow', function () {
   })
 
   after(async function () {
-    await server.stop()
+    await server?.stop()
   })
 
   it('terminates a serverevents client whose send buffer stays over the limit', async function () {
     this.timeout(TEST_TIMEOUT_MS)
+    if (!server) {
+      throw new Error('server did not start')
+    }
+    const app = server.app
     const ws = new WebSocket(
       `ws://0.0.0.0:${port}/signalk/v1/stream?serverevents=all&subscribe=none&sendCachedValues=false`
     )
@@ -63,7 +69,7 @@ describe('Server events send-buffer overflow', function () {
     socket.pause()
 
     const flood = setInterval(() => {
-      server.app.emit('serverevent', {
+      app.emit('serverevent', {
         type: 'FLOOD_TEST',
         data: EVENT_PAYLOAD
       })


### PR DESCRIPTION
Server events (`?serverevents=all`, `?events=`) are written straight to the WebSocket, outside the `BackpressureManager` that guards deltas. A client that cannot keep up — or a plugin emitting events in a loop — therefore grows the send buffer without bound and never reaches the overflow limit deltas already enforce. #2972 shows the effect: 196 MB queued on one admin-UI socket, the cut only happening once the Data Browser subscribed and its first delta `send()` ran the check.

This routes server-event writes through the connection's existing `assertBufferSize()`, so a socket whose buffer stays over `maxSendBufferSize` for `maxSendBufferCheckTime` is terminated the same way a delta-flooded one is. No accumulation or coalescing of events — that would need per-type semantics (snapshot vs. incremental) and is out of scope here.

Related: #2972 (the emitter side is addressed separately in #2974 by throttling `PROVIDERSTATUS`).

## Tested

- `npm run format`, `npm run build:all`, `npm test`
- New integration test `test/serverevents-backpressure.ts`: a `serverevents=all` client pauses its socket, the server floods 100 KB events; the client receives the overflow notice and is closed. Verified the test times out (client never closed) with the `ws.ts` change stashed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR applies `assertBufferSize()` to WebSocket server-event and regular-event writes. It terminates clients whose send buffers exceed `maxSendBufferSize` for `maxSendBufferCheckTime`.

It adds an integration test that pauses a client, floods it with server events, and verifies the overflow notice and connection closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->