### PR TITLE
doc(admin-ui): describe boolean server options in Settings

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -53,6 +53,32 @@ const SettableInterfaces: Record<string, string> = {
   wasm: 'WebAssembly Runtime'
 }
 
+const OptionDescriptions: Record<string, React.ReactNode> = {
+  mdns: 'Advertise Signal K server over mDNS/DNS-SD',
+  wsCompression: 'Use compression on WebSocket connections',
+  wsPingInterval:
+    'Use WebSocket ping messages to terminate stale, inactive connections',
+  accessLogging: 'Log HTTP requests',
+  enablePluginLogging: "Global flag for plugin's debug logging",
+  trustProxy: (
+    <>
+      Trust proxy headers from a reverse proxy, see{' '}
+      <a href="/admin/#/documentation/Security.html#reverse-proxy-configuration-trust-proxy">
+        documentation
+      </a>
+    </>
+  ),
+  useBLEManager: (
+    <>
+      Server&apos;s Bluetooth Low Energy connection management, see{' '}
+      <a href="/admin/#/documentation/Developing/REST_APIs/BLE_API.html">
+        documentation
+      </a>
+    </>
+  ),
+  ssl: "Server's built-in SSL (HTTPS) support"
+}
+
 const ServerSettings: React.FC = () => {
   const loginStatus = useLoginStatus()
   const [settings, setSettings] = useState<ServerSettingsData>({
@@ -298,31 +324,45 @@ const ServerSettings: React.FC = () => {
               <Col xs="12" md={fieldColWidthMd}>
                 {settings.options &&
                   Object.keys(settings.options).map((name) => {
+                    const description = OptionDescriptions[name]
                     return (
-                      <div
-                        key={name}
-                        className="d-flex align-items-center mb-2"
-                      >
-                        <Form.Label
-                          style={{ marginRight: '15px', marginBottom: 0 }}
-                          className="switch switch-text switch-primary"
-                        >
-                          <input
-                            type="checkbox"
-                            id={`option-${name}`}
-                            name={name}
-                            className="switch-input"
-                            onChange={handleOptionChange}
-                            checked={settings.options?.[name] || false}
-                          />
-                          <span
-                            className="switch-label"
-                            data-on="On"
-                            data-off="Off"
-                          />
-                          <span className="switch-handle" />
-                        </Form.Label>
-                        <span>{name}</span>
+                      <div key={name} className="mb-2">
+                        <div className="d-flex align-items-center">
+                          <Form.Label
+                            style={{ marginRight: '15px', marginBottom: 0 }}
+                            className="switch switch-text switch-primary"
+                          >
+                            <input
+                              type="checkbox"
+                              id={`option-${name}`}
+                              name={name}
+                              className="switch-input"
+                              onChange={handleOptionChange}
+                              checked={settings.options?.[name] || false}
+                              aria-labelledby={`option-label-${name}`}
+                              aria-describedby={
+                                description
+                                  ? `option-description-${name}`
+                                  : undefined
+                              }
+                            />
+                            <span
+                              className="switch-label"
+                              data-on="On"
+                              data-off="Off"
+                            />
+                            <span className="switch-handle" />
+                          </Form.Label>
+                          <span id={`option-label-${name}`}>{name}</span>
+                        </div>
+                        {description && (
+                          <Form.Text
+                            id={`option-description-${name}`}
+                            className="text-muted"
+                          >
+                            {description}
+                          </Form.Text>
+                        )}
                       </div>
                     )
                   })}


### PR DESCRIPTION
Add human-readable descriptions below each boolean server option in the Server Config settings, replacing the bare config key names. Include documentation links for trustProxy and useBLEManager.

## What problem does this solve?

The boolean settings flags in Admin UI have been shown only with their property names, providing no further explanation of what the flags actually do.

## How was this tested?

Manually.

<img width="863" height="562" alt="image" src="https://github.com/user-attachments/assets/6b2a0924-6783-4461-94b5-42ceec0e517d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds human-readable descriptions for boolean server options in the Admin UI’s Server Config settings.

- Displays a description below each option toggle.
- Adds documentation links for `trustProxy` and `useBLEManager`.
- Preserves existing option state handling.
- Adds accessible label and description references.
- Manual testing confirms the UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->