### PR TITLE
fix(config): do not persist settings that hold run-only state

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -77,6 +77,26 @@ export interface Config {
   baseDeltaEditor: DeltaEditor
   hasOldDefaults: boolean
   overrideTimestampWithNow: boolean
+  /** True while `settings` represents what the user configured, so it
+   * may be saved back to their file. Cleared in two cases: `--data` and
+   * the sample data flags change the data connections that are in
+   * effect for this run, and a settings file that exists but cannot be
+   * parsed falls back to empty settings. `--data` disables every
+   * configured provider and adds a FileStream for the log; the sample
+   * flags add a FileStream provider beside the configured ones.
+   * Writers that persist settings without a user asking must check
+   * this.
+   *
+   * A missing settings file does not clear it: there is nothing to
+   * overwrite, and a fresh install should still be able to save.
+   *
+   * Neither do the environment variables that set a single key
+   * (TRUST_PROXY, SSLPORT, WSCOMPRESSION) or --securityenabled. Those
+   * configure a container for the life of the installation, so
+   * blocking on them would stop automatic writes from ever succeeding
+   * there. They can still reach the file through any write, which is a
+   * wider problem than this flag solves. */
+  safeToPersistSettings: boolean
   security: boolean
   settings: {
     useBaseDeltas?: boolean
@@ -203,6 +223,7 @@ export function load(app: ConfigApp) {
 
   config.appPath = config.appPath || path.normalize(__dirname + '/../../')
   debug('appPath:' + config.appPath)
+  config.safeToPersistSettings = true
 
   try {
     config.name = packageJson.name
@@ -231,6 +252,12 @@ export function load(app: ConfigApp) {
   if (_.isObject(app.config.settings)) {
     debug('Using settings from constructor call, not reading defaults')
     disableWriteSettings = true
+    // The settings came from the caller, not from the user's file, so
+    // there is nothing they may be saved back over. writeSettingsFile
+    // already refuses; clearing this stops the writers that keep their
+    // own files, such as the sourceRef migration's channel labels, from
+    // persisting half of a change whose other half is refused.
+    config.safeToPersistSettings = false
     if (config.defaults) {
       convertOldDefaultsToDeltas(app.config.baseDeltaEditor, config.defaults)
     }
@@ -296,6 +323,7 @@ export function load(app: ConfigApp) {
       ],
       enabled: true
     })
+    app.config.safeToPersistSettings = false
   }
 
   if (app.argv['sample-n2k-data']) {
@@ -318,6 +346,7 @@ export function load(app: ConfigApp) {
       ],
       enabled: true
     })
+    app.config.safeToPersistSettings = false
   }
 
   if (app.argv.data) {
@@ -356,6 +385,7 @@ export function load(app: ConfigApp) {
       ],
       enabled: true
     })
+    app.config.safeToPersistSettings = false
   }
 
   if (app.argv['override-timestamps']) {
@@ -590,6 +620,9 @@ function readSettingsFile(app: ConfigApp) {
       app.config.settings = {
         pipedProviders: []
       }
+      // The file is still there and still the user's, so nothing may
+      // save these empty settings over it while they are unreadable.
+      app.config.safeToPersistSettings = false
     }
   }
   if (_.isUndefined(app.config.settings.pipedProviders)) {

--- a/src/sourceref-migration.ts
+++ b/src/sourceref-migration.ts
@@ -11,6 +11,8 @@ const LABELS_FILENAME = 'n2k-channel-labels.json'
 interface MigrationApp {
   config: {
     configPath: string
+    /** See Config.safeToPersistSettings. */
+    safeToPersistSettings: boolean
     settings: {
       priorityOverrides?: Record<
         string,
@@ -97,7 +99,12 @@ export function migrateSourceRef(
   }
   const settings = app.config.settings
   let settingsChanged = false
+  let labelsChanged = false
   const migrated = new Set<string>()
+  // Both files this function writes are covered: persisting one half of
+  // a migration would leave the channel labels keyed by newRef while
+  // settings still name oldRef.
+  const mayPersist = app.config.safeToPersistSettings
 
   // 1. priorityOverrides (path-level) — dedupe per path if newRef already present
   if (settings.priorityOverrides) {
@@ -197,18 +204,21 @@ export function migrateSourceRef(
       }
     }
     if (labelUpdates.length > 0) {
+      labelsChanged = true
       for (const [oldKey, newKey, value] of labelUpdates) {
         delete labels[oldKey]
         if (!(newKey in labels)) {
           labels[newKey] = value
         }
       }
-      // Sync write keeps callers (including the migration tests) able to
-      // observe the new file shape immediately on return. Channel labels
-      // files are tiny (one entry per N2K instance) so the blocking cost
-      // is negligible at startup.
-      fs.writeFileSync(labelsPath, JSON.stringify(labels, null, 2))
-      migrated.add('channelLabels')
+      if (mayPersist) {
+        // Sync write keeps callers (including the migration tests) able to
+        // observe the new file shape immediately on return. Channel labels
+        // files are tiny (one entry per N2K instance) so the blocking cost
+        // is negligible at startup.
+        fs.writeFileSync(labelsPath, JSON.stringify(labels, null, 2))
+        migrated.add('channelLabels')
+      }
     }
   } catch (e: unknown) {
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -259,7 +269,22 @@ export function migrateSourceRef(
     )
   }
 
-  if (settingsChanged) {
+  if ((settingsChanged || labelsChanged) && !mayPersist) {
+    // Saving would put this run's replaced data connections, or empty
+    // settings standing in for a file that would not parse, into the
+    // user's settings.json. The rewrites still apply in memory, so the
+    // running server is consistent with itself, but the rename is not
+    // deferred: migration runs from the sourceRefChanged event, and a
+    // later start of a device already at its new address raises no such
+    // event. The refs are logged so the rename can be made by hand.
+    // Channel labels count as a change of their own: a device whose ref
+    // appears only there still needs the hand rename, and nothing else
+    // would report it.
+    console.log(
+      `sourceRef migration ${oldRef} -> ${newRef} not persisted: settings do not represent the configured state`
+    )
+    finalize()
+  } else if (settingsChanged) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     writeSettingsFile(app as any, settings, (err: Error) => {
       if (err) {
@@ -273,7 +298,8 @@ export function migrateSourceRef(
       finalize()
     })
   } else {
-    // Nothing to persist (e.g. only channelLabels file was rewritten).
+    // Nothing left to persist: either nothing matched, or the channel
+    // labels file was the only match and has already been written.
     finalize()
   }
 }

--- a/test/config-safe-to-persist.ts
+++ b/test/config-safe-to-persist.ts
@@ -1,0 +1,126 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { load, ConfigApp } from '../src/config/config'
+
+// load() reads process.argv directly, so each case swaps it and restores
+// it afterwards. Settings are read from a config directory rather than
+// handed to the constructor: constructor-supplied settings set the
+// module-global disableWriteSettings for the rest of the process, which
+// would disarm the file assertions in the other suites.
+function withArgv<T>(args: string[], run: () => T): T {
+  const saved = process.argv
+  process.argv = ['node', 'signalk-server', ...args]
+  try {
+    return run()
+  } finally {
+    process.argv = saved
+  }
+}
+
+// load() ends by handing the app to config/development and
+// config/production, which ask it for express-style accessors.
+function loadInto(dir: string, args: string[]) {
+  const app = {
+    config: {},
+    get: (key: string) => (key === 'env' ? 'test' : undefined),
+    set: () => undefined,
+    use: () => undefined
+  } as unknown as ConfigApp
+  withArgv(args, () => load(app))
+  return app
+}
+
+describe('load() decides when settings are safe to persist', () => {
+  let dir: string
+  let savedConfigDir: string | undefined
+  let savedSettingsEnv: string | undefined
+  let savedSkipCheck: string | undefined
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sk-config-'))
+    savedConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
+    savedSettingsEnv = process.env.SIGNALK_NODE_SETTINGS
+    savedSkipCheck = process.env.SKIP_ADMINUI_VERSION_CHECK
+    process.env.SIGNALK_NODE_CONFIG_DIR = dir
+    delete process.env.SIGNALK_NODE_SETTINGS
+    process.env.SKIP_ADMINUI_VERSION_CHECK = '1'
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+    const restore = (name: string, value: string | undefined) => {
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+    restore('SIGNALK_NODE_CONFIG_DIR', savedConfigDir)
+    restore('SIGNALK_NODE_SETTINGS', savedSettingsEnv)
+    restore('SKIP_ADMINUI_VERSION_CHECK', savedSkipCheck)
+  })
+
+  const writeSettings = (contents: string) =>
+    fs.writeFileSync(path.join(dir, 'settings.json'), contents)
+
+  it('stays true for an ordinary start', () => {
+    writeSettings(JSON.stringify({ pipedProviders: [] }))
+    expect(loadInto(dir, []).config.safeToPersistSettings).to.be.true
+  })
+
+  it('is cleared by --data', () => {
+    writeSettings(JSON.stringify({ pipedProviders: [] }))
+    expect(
+      loadInto(dir, ['--data', path.join(dir, 'trip.log')]).config
+        .safeToPersistSettings
+    ).to.be.false
+  })
+
+  it('is cleared by --sample-nmea0183-data', () => {
+    writeSettings(JSON.stringify({ pipedProviders: [] }))
+    expect(
+      loadInto(dir, ['--sample-nmea0183-data']).config.safeToPersistSettings
+    ).to.be.false
+  })
+
+  it('is cleared by --sample-n2k-data', () => {
+    writeSettings(JSON.stringify({ pipedProviders: [] }))
+    expect(loadInto(dir, ['--sample-n2k-data']).config.safeToPersistSettings).to
+      .be.false
+  })
+
+  it('is cleared when the settings file cannot be parsed', () => {
+    writeSettings('{ this is not json')
+    expect(loadInto(dir, []).config.safeToPersistSettings).to.be.false
+  })
+
+  it('stays true when there is no settings file at all', () => {
+    expect(loadInto(dir, []).config.safeToPersistSettings).to.be.true
+  })
+
+  it('is cleared when settings come from the constructor call', () => {
+    // That branch sets the module-global disableWriteSettings, which no
+    // export resets, and every suite shares one mocha process. Loading a
+    // private copy of the module confines the flag to this case: the
+    // instance the other suites hold never runs this branch, and the
+    // second purge stops a later importer from inheriting this one.
+    const modulePath = require.resolve('../src/config/config')
+    delete require.cache[modulePath]
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const isolated = require('../src/config/config')
+      const app = {
+        config: { settings: { pipedProviders: [] } },
+        get: (key: string) => (key === 'env' ? 'test' : undefined),
+        set: () => undefined,
+        use: () => undefined
+      } as unknown as ConfigApp
+      withArgv([], () => isolated.load(app))
+      expect(app.config.safeToPersistSettings).to.be.false
+    } finally {
+      delete require.cache[modulePath]
+    }
+  })
+})

--- a/test/sourceref-migration.ts
+++ b/test/sourceref-migration.ts
@@ -19,6 +19,7 @@ function createMockApp(
     argv: { s: 'settings.json' },
     config: {
       configPath: configPath ?? os.tmpdir(),
+      safeToPersistSettings: true,
       settings: {
         ...settingsOverrides
       }
@@ -157,6 +158,118 @@ describe('migrateSourceRef', () => {
     expect(prios['navigation.speedOverGround'][0].sourceRef).to.equal(
       'canhat.other'
     )
+  })
+
+  // The settings write is queued and asynchronous. Poll for the file so
+  // the positive case cannot pass on a slow box only because it waited
+  // long enough, and so the negative case below is measured against a
+  // deadline the positive case has already shown to be generous.
+  const WRITE_DEADLINE_MS = 2000
+  const WRITE_POLL_MS = 10
+  const settledSettingsFile = async (dir: string): Promise<boolean> => {
+    const target = path.join(dir, 'settings.json')
+    const until = Date.now() + WRITE_DEADLINE_MS
+    while (Date.now() < until) {
+      if (fs.existsSync(target)) return true
+      await new Promise((resolve) => setTimeout(resolve, WRITE_POLL_MS))
+    }
+    return false
+  }
+
+  const labelsFixture = (dir: string) => {
+    const labelsPath = path.join(dir, 'n2k-channel-labels.json')
+    fs.writeFileSync(
+      labelsPath,
+      JSON.stringify({ [`${OLD_REF}:130316:0`]: 'Engine Room' })
+    )
+    return labelsPath
+  }
+
+  it('persists the migration by default', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sktest-'))
+    try {
+      const labelsPath = labelsFixture(tmpDir)
+      const app = createMockApp(
+        { sourceAliases: { [OLD_REF]: 'Engine' } },
+        tmpDir
+      )
+      migrateSourceRef(app, OLD_REF, NEW_REF)
+
+      expect(await settledSettingsFile(tmpDir)).to.be.true
+      // writeSettingsFile splits the priority keys, and sourceAliases is
+      // one of them, so the migrated alias lands in priorities.json.
+      const saved = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, 'priorities.json'), 'utf-8')
+      )
+      expect(saved.sourceAliases[NEW_REF]).to.equal('Engine')
+      const labels = JSON.parse(fs.readFileSync(labelsPath, 'utf-8'))
+      expect(labels).to.have.property(`${NEW_REF}:130316:0`)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes neither file when settings cannot be persisted', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sktest-'))
+    try {
+      const labelsPath = labelsFixture(tmpDir)
+      const labelsBefore = fs.readFileSync(labelsPath, 'utf-8')
+      // sourceAliases is a priority key, so writeSettingsFile puts it in
+      // priorities.json — and writes that file first. Asserting only on
+      // settings.json would miss a migration that persisted there.
+      const prioritiesPath = path.join(tmpDir, 'priorities.json')
+      const prioritiesBefore = JSON.stringify({
+        sourceAliases: { [OLD_REF]: 'Engine' }
+      })
+      fs.writeFileSync(prioritiesPath, prioritiesBefore)
+      const app = createMockApp(
+        { sourceAliases: { [OLD_REF]: 'Engine' } },
+        tmpDir
+      )
+      app.config.safeToPersistSettings = false
+      migrateSourceRef(app, OLD_REF, NEW_REF)
+
+      expect(await settledSettingsFile(tmpDir)).to.be.false
+      expect(fs.readFileSync(prioritiesPath, 'utf-8')).to.equal(
+        prioritiesBefore
+      )
+      const aliases = app.config.settings.sourceAliases as Record<
+        string,
+        string
+      >
+      expect(aliases[NEW_REF]).to.equal('Engine')
+      expect(fs.readFileSync(labelsPath, 'utf-8')).to.equal(labelsBefore)
+      expect(app._activateCalled).to.be.true
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a label-only migration it cannot persist', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sktest-'))
+    const logged: string[] = []
+    const savedLog = console.log
+    console.log = (...args: unknown[]) => logged.push(args.join(' '))
+    try {
+      // No settings key names the old ref, so the labels file is the
+      // only place the rename applies. Without a report the operator has
+      // nothing to act on: the file keeps the old ref and the event that
+      // triggered this does not come again.
+      const labelsPath = labelsFixture(tmpDir)
+      const labelsBefore = fs.readFileSync(labelsPath, 'utf-8')
+      const app = createMockApp({}, tmpDir)
+      app.config.safeToPersistSettings = false
+      migrateSourceRef(app, OLD_REF, NEW_REF)
+
+      expect(fs.readFileSync(labelsPath, 'utf-8')).to.equal(labelsBefore)
+      const report = logged.find((line) => line.includes('not persisted'))
+      expect(report, `no skip report in ${JSON.stringify(logged)}`).to.exist
+      expect(report).to.include(OLD_REF)
+      expect(report).to.include(NEW_REF)
+    } finally {
+      console.log = savedLog
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 
   it('handles missing channel labels file gracefully', () => {


### PR DESCRIPTION
`app.config.settings` does not always hold what the user configured. `--data` disables
every configured `pipedProvider` and adds a FileStream for the log, the sample data flags
add providers, and a settings file that exists but cannot be parsed falls back to empty
settings. Any writer that serialises that object saves the stand-in over the real file, and
the next ordinary start reads it back as configuration.

The sourceRef migration is such a writer and needs no user action: it runs ten seconds
after a device changes bus address. Replaying an N2K log with `--data` is enough to save a
`settings.json` with every real connection disabled.

This records the state in `config.safeToPersistSettings` and skips both of the
migration's writes while it is cleared — `settings.json` and the channel labels file — so a run
persists the whole rename or none of it. The rewrites still apply in memory, so the running
server stays consistent with itself. The skip is permanent rather than deferred: migration
runs from the `sourceRefChanged` event, and a later start of a device already at its new
address raises no such event, so the log line names both refs for a manual rename.

Settings handed in by an embedding caller clear it too. `writeSettingsFile` already refuses
those through `disableWriteSettings`, so without this the migration wrote its channel labels
while its settings write was refused, splitting a rename across the two files.

A missing settings file does not set the flag; there is nothing to overwrite and a fresh
install must still be able to save. Neither do the environment variables that set a single
key (`TRUST_PROXY`, `SSLPORT`, `WSCOMPRESSION`) or `--securityenabled`: those configure a
container for the life of the installation, so blocking on them would stop automatic writes
from ever succeeding there.

This does not make settings safe in general — every writer serialises the whole object, so
`ResourcesApi.saveSettings` and the admin UI routes can still persist a replaced connection
list. Issue #2983 describes that class with a reproduction; we are happy to implement
whichever direction you prefer there, and this PR is deliberately narrow in the meantime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds `Config.safeToPersistSettings` to identify configuration that must not be persisted.

When the flag is `false`, source-reference migration updates settings and channel labels in memory but skips both file writes. The flag is cleared for sample data modes, raw `--data` playback, and malformed existing settings files. Missing settings files and selected overrides keep the flag enabled.

The PR adds tests for configuration loading and migration behavior. The tests verify default persistence, blocked file writes, in-memory updates, aliases, and channel labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

