### PR TITLE
fix: crash on every N2K delta when a bare $source created the source node first

### DIFF
--- a/packages/server-api/src/fullsignalk.test.ts
+++ b/packages/server-api/src/fullsignalk.test.ts
@@ -697,3 +697,35 @@ describe('Delta with source.instance', function () {
     expect(sources['ws-pi4']).to.not.have.property('local:3000 (192')
   })
 })
+
+describe('Mixed source shapes for one N2K source', function () {
+  const bareDollarSourceFirst = {
+    context: 'vessels.urn:mrn:imo:mmsi:200000000',
+    updates: [
+      {
+        $source: 'N2000-01.37',
+        timestamp: '2016-07-28T18:18:46.000Z',
+        values: [{ path: 'electrical.batteries.0.voltage', value: 12.6 }]
+      },
+      {
+        source: {
+          label: 'N2000-01',
+          type: 'NMEA2000',
+          src: '37',
+          pgn: 127508
+        },
+        timestamp: '2016-07-28T18:18:47.000Z',
+        values: [{ path: 'electrical.batteries.0.voltage', value: 12.7 }]
+      }
+    ]
+  }
+
+  it('accepts a structured N2K source after a bare $source created the key', function () {
+    const fullSignalK = new FullSignalK('urn:mrn:imo:mmsi:200000000')
+    expect(() => fullSignalK.addDelta(bareDollarSourceFirst)).to.not.throw()
+
+    const entry = fullSignalK.retrieve().sources['N2000-01']['37']
+    expect(entry.n2k.src).to.equal('37')
+    expect(entry.n2k.pgns).to.have.property('127508')
+  })
+})

--- a/packages/server-api/src/fullsignalk.ts
+++ b/packages/server-api/src/fullsignalk.ts
@@ -37,6 +37,15 @@ function handleNmea2000Source(
   let existing = labelSource[source.src]
   if (!existing) {
     existing = labelSource[source.src] = { n2k: { pgns: {} } }
+  } else if (!existing.n2k) {
+    // The same key may already have been created as a bare {} by
+    // updateDollarSource, which splits a "label.src" $source string into
+    // nested keys without the n2k sub-object. Deltas for one source can
+    // arrive in both shapes, so adopt the existing node rather than
+    // assuming our own initializer created it.
+    existing.n2k = { pgns: {} }
+  } else if (!existing.n2k.pgns) {
+    existing.n2k.pgns = {}
   }
 
   Object.assign(existing.n2k, source)


### PR DESCRIPTION
## Motivation

`handleNmea2000Source` throws `TypeError: Cannot convert undefined or null to object` on **every** delta from an affected source, flooding the log:

```
Delta input handler threw: TypeError: Cannot convert undefined or null to object
    at Object.assign (<anonymous>)
    at handleNmea2000Source (.../fullsignalk.js:28:12)
    at FullSignalK.updateSource (.../fullsignalk.js:463:13)
```

Two writers populate `sources[label][src]` with different shapes. `handleNmea2000Source` creates it as `{ n2k: { pgns: {} } }`, but `updateDollarSource` also creates the same key — it splits a `"label.src"` `$source` string into nested plain objects, leaving a bare `{}`.

The `if (!existing)` guard only tests for the container, then unconditionally dereferences `existing.n2k`. When a bare `$source` delta lands first, the node exists without `n2k`, and the next structured N2K delta for that source hits `Object.assign(undefined, source)`.

Remote Signal K servers alternate between the two update shapes on reconnect (see the existing comment in `addUpdate`, and the fallback `$source` stamping in `packages/streams/src/remote-deltas.ts`), so this is reachable in normal operation and is not attributable to any plugin — it reproduces with all plugins disabled.

Reported on Discord by a user whose logs were full of these; it was initially misdiagnosed as a duplicate N2K unique number on the bus.

## Solution

Adopt an existing node rather than assuming this function's own initializer created it: fill in `n2k` (and `pgns`) when they are absent instead of overwriting the node, so state recorded under either shape is preserved.

## Tested

- New regression test in `fullsignalk.test.ts` reproduces the exact `TypeError` against the unpatched code and passes with the fix.
- `packages/server-api`: 58 passing.
- Repo-root `npm run format`, `npm run build:all`, and full `npm test`: 1406 passing, 0 failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a crash in `handleNmea2000Source` when a bare `$source` update precedes a structured N2K update.

The handler preserves existing source-node state and initializes missing `n2k` and `n2k.pgns` objects before merging updates.

A regression test covers alternating bare and structured source updates.

Validation includes 58 passing `packages/server-api` tests, a successful build and format check, and 1,406 passing tests overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->