### PR TITLE
fix: crash on NMEA0183 deltas when a bare $source created the talker node first

### DIFF
--- a/packages/server-api/src/fullsignalk.test.ts
+++ b/packages/server-api/src/fullsignalk.test.ts
@@ -729,3 +729,35 @@ describe('Mixed source shapes for one N2K source', function () {
     expect(entry.n2k.pgns).to.have.property('127508')
   })
 })
+
+describe('Mixed source shapes for one NMEA0183 source', function () {
+  const bareDollarSourceFirst = {
+    context: 'vessels.urn:mrn:imo:mmsi:200000000',
+    updates: [
+      {
+        $source: '0183-1.II',
+        timestamp: '2016-07-28T18:18:46.000Z',
+        values: [{ path: 'navigation.headingTrue', value: 0.1 }]
+      },
+      {
+        source: {
+          label: '0183-1',
+          type: 'NMEA0183',
+          talker: 'II',
+          sentence: 'HDM'
+        },
+        timestamp: '2016-07-28T18:18:47.000Z',
+        values: [{ path: 'navigation.headingTrue', value: 0.2 }]
+      }
+    ]
+  }
+
+  it('accepts a structured 0183 source after a bare $source created the key', function () {
+    const fullSignalK = new FullSignalK('urn:mrn:imo:mmsi:200000000')
+    expect(() => fullSignalK.addDelta(bareDollarSourceFirst)).to.not.throw()
+
+    const entry = fullSignalK.retrieve().sources['0183-1']['II']
+    expect(entry.talker).to.equal('II')
+    expect(entry.sentences).to.have.property('HDM', '2016-07-28T18:18:47.000Z')
+  })
+})

--- a/packages/server-api/src/fullsignalk.ts
+++ b/packages/server-api/src/fullsignalk.ts
@@ -85,8 +85,15 @@ function handleNmea0183Source(
   meta: SourceMetaEntry
 ): void {
   const talker = source.talker || 'XX'
-  if (!labelSource[talker]) {
+  const existing = labelSource[talker]
+  if (!existing) {
     labelSource[talker] = { talker, sentences: {} }
+  } else {
+    // As with the N2K node, updateDollarSource may already have created
+    // this key as a bare {} from a "label.talker" $source string, so the
+    // sentences sub-object cannot be assumed to exist.
+    if (!existing.talker) existing.talker = talker
+    if (!existing.sentences) existing.sentences = {}
   }
   labelSource[talker].sentences[source.sentence] = timestamp
   meta.lastSeen = Date.now()


### PR DESCRIPTION
## Motivation

Follow-up to #2986, which fixed this shape collision on the N2K node. The sibling handler has the same hole and is reachable by the same path.

`handleNmea0183Source` assumes a truthy `labelSource[talker]` was created by its own initializer and therefore carries a `sentences` sub-object. `updateDollarSource` also writes that key — it splits a `"label.talker"` `$source` string into nested plain objects, leaving a bare `{}`. When such a delta arrives first, the next structured 0183 delta for the same talker throws:

```
TypeError: Cannot set properties of undefined (setting 'HDM')
```

Reachability is the same as in #2986: `stampRemoteUpdates` in `packages/streams/src/remote-deltas.ts` stamps a fallback `$source` on remote updates lacking identity, and `hasIdentifiableSource` treats a `talker` as identifying — so remote servers alternating between the two update shapes on reconnect produce exactly this ordering for 0183 sources.

## Solution

Same approach as #2986: adopt an existing node rather than assuming this function's own initializer created it, filling in `talker` and `sentences` when absent instead of overwriting.

`handleOtherSource` was checked too and needs no change — it only writes a `timestamp` scalar and assumes no sub-object.

## Tested

- New regression test reproduces the exact `TypeError` against the unpatched code and passes with the fix.
- `packages/server-api`: 59 passing.
- Repo-root `npm run format`, `npm run build:all`, and full `npm test`: 1409 passing, 0 failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR prevents a crash when a bare `$source` entry precedes a structured NMEA0183 source.

- `handleNmea0183Source` adopts existing nodes and initializes missing `talker` and `sentences` properties.
- Regression tests cover mixed source shapes and verify sentence timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->