### PR TITLE
feat(plugin-ci): add working-directory input for monorepo plugins

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -19,6 +19,12 @@ name: SignalK Plugin CI
 on:
   workflow_call:
     inputs:
+      # ── Repository layout ───────────────────────────────────
+      working-directory:
+        description: 'Path to the plugin within the repository, for plugins published from a monorepo subdirectory (matches npm''s repository.directory). Defaults to the repository root.'
+        type: string
+        default: '.'
+
       # ── Test configuration ──────────────────────────────────
       test-command:
         description: 'Command to run tests (default: npm test)'
@@ -81,6 +87,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-15, windows-latest]
         node: ${{ fromJson(inputs.node-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -1508,9 +1517,9 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}-node${{ matrix.node }}
           path: |
-            test-results/
-            coverage/
-            junit*.xml
+            ${{ inputs.working-directory }}/test-results/
+            ${{ inputs.working-directory }}/coverage/
+            ${{ inputs.working-directory }}/junit*.xml
           if-no-files-found: ignore
           retention-days: 7
 
@@ -1528,6 +1537,9 @@ jobs:
     continue-on-error: true
     outputs:
       advisory-outcome: ${{ steps.armv7-test.outcome }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -1562,7 +1574,7 @@ jobs:
           docker run --rm --platform linux/arm/v7 \
             -v "${{ github.workspace }}:/plugin" \
             -v "/tmp/.npm-armv7-cache:/root/.npm" \
-            -w /plugin \
+            -w "/plugin/${{ inputs.working-directory }}" \
             -e BUILD_CMD \
             -e TEST_CMD \
             node:20-bookworm-slim \
@@ -1652,6 +1664,9 @@ jobs:
       matrix:
         node: ${{ fromJson(inputs.node-versions) }}
         signalk-server-version: ${{ fromJson(inputs.signalk-server-versions) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
@@ -1672,7 +1687,7 @@ jobs:
       - name: Install plugins declared in signalk.requires
         shell: bash
         run: |
-          REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "${{ github.workspace }}/package.json" 2>/dev/null || true)
+          REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "${{ github.workspace }}/${{ inputs.working-directory }}/package.json" 2>/dev/null || true)
           if [ -z "$REQUIRES" ]; then
             exit 0
           fi
@@ -1709,7 +1724,7 @@ jobs:
       - name: Configure plugin to auto-start
         run: |
           cd /tmp/sk-test
-          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/package.json').name)")
+          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/${{ inputs.working-directory }}/package.json').name)")
 
           # Derive plugin ID the same way signalk-server does (src/pluginid.ts)
           PLUGIN_ID=$(node -e "
@@ -1758,7 +1773,7 @@ jobs:
           echo "SignalK server is ready (PID $SK_PID)"
 
           # Verify plugin is loaded
-          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/package.json').name)")
+          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/${{ inputs.working-directory }}/package.json').name)")
           PLUGINS_JSON=$(curl -sf http://localhost:3000/skServer/plugins)
 
           echo "Loaded plugins:"
@@ -1814,7 +1829,7 @@ jobs:
           fi
 
           # Run integration tests from the plugin repo if they exist
-          cd "${{ github.workspace }}"
+          cd "${{ github.workspace }}/${{ inputs.working-directory }}"
           HAS_INTEGRATION=$(node -e "
             const pkg = require('./package.json');
             if (pkg.scripts && pkg.scripts['test:integration']) process.exit(0);
@@ -1838,11 +1853,14 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs: [desktop, armv7, signalk-integration]
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout plugin
         uses: actions/checkout@v7
         with:
-          sparse-checkout: package.json
+          sparse-checkout: ${{ inputs.working-directory == '.' && 'package.json' || format('{0}/package.json', inputs.working-directory) }}
 
       - name: Write CI summary report
         env:

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1920,6 +1920,7 @@ jobs:
           # step outcome exists.
           ARMV7_RESULT: ${{ needs.armv7.outputs.advisory-outcome || needs.armv7.result }}
           INTEGRATION_RESULT: ${{ needs.signalk-integration.result }}
+          VALIDATE_RESULT: ${{ needs.validate-inputs.result }}
         shell: bash
         run: |
           icon() {
@@ -1936,7 +1937,7 @@ jobs:
           PLUGIN_VER=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "?")
 
           OVERALL="pass"
-          if [[ "$DESKTOP_RESULT" == "failure" ]] || [[ "$INTEGRATION_RESULT" == "failure" ]]; then
+          if [[ "$VALIDATE_RESULT" != "success" ]] || [[ "$DESKTOP_RESULT" == "failure" ]] || [[ "$INTEGRATION_RESULT" == "failure" ]]; then
             OVERALL="FAIL"
           fi
 

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -1860,7 +1860,11 @@ jobs:
       - name: Checkout plugin
         uses: actions/checkout@v7
         with:
-          sparse-checkout: ${{ inputs.working-directory == '.' && 'package.json' || format('{0}/package.json', inputs.working-directory) }}
+          # Non-cone mode so the pattern selects the single manifest rather
+          # than a whole directory. A leading "./" matches nothing in non-cone
+          # mode, so the root default is spelled without one.
+          sparse-checkout: ${{ inputs.working-directory == '.' && '/package.json' || format('/{0}/package.json', inputs.working-directory) }}
+          sparse-checkout-cone-mode: false
 
       - name: Write CI summary report
         env:

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -71,6 +71,42 @@ permissions:
 
 jobs:
   # ════════════════════════════════════════════════════════════
+  #  Input validation — runs before anything touches the value
+  # ════════════════════════════════════════════════════════════
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # working-directory reaches a docker -w, an artifact glob and a
+      # sparse-checkout pattern, so constrain it to a plain relative path.
+      # Everything else that consumes it does so through env, never through
+      # interpolation into a script.
+      - name: Validate working-directory
+        env:
+          PLUGIN_DIR: ${{ inputs.working-directory }}
+        run: |
+          if [ "$PLUGIN_DIR" = "." ]; then
+            echo "working-directory: repository root"
+            exit 0
+          fi
+          case "$PLUGIN_DIR" in
+            /*|~*)
+              echo "::error::working-directory must be relative to the repository root, got '$PLUGIN_DIR'"; exit 1 ;;
+          esac
+          if [ "$(printf '%s' "$PLUGIN_DIR" | wc -l)" -ne 0 ]; then
+            echo "::error::working-directory must be a single line"; exit 1
+          fi
+          if ! printf '%s' "$PLUGIN_DIR" | grep -qE '^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$'; then
+            echo "::error::working-directory may only contain letters, digits, '.', '_', '-' and '/', got '$PLUGIN_DIR'"; exit 1
+          fi
+          case "/$PLUGIN_DIR/" in
+            */../*)
+              echo "::error::working-directory must not contain '..', got '$PLUGIN_DIR'"; exit 1 ;;
+          esac
+          echo "working-directory: $PLUGIN_DIR"
+
+  # ════════════════════════════════════════════════════════════
   #  Desktop platforms matrix: Linux x64, Linux arm64, macOS, Windows
   # ════════════════════════════════════════════════════════════
   desktop:
@@ -81,6 +117,7 @@ jobs:
           matrix.os == 'windows-latest' && 'Windows' ||
           matrix.os }} / Node ${{ matrix.node }}
     runs-on: ${{ matrix.os }}
+    needs: validate-inputs
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -1529,6 +1566,7 @@ jobs:
   armv7:
     name: armv7 (Cerbo GX) / Node 20
     runs-on: ubuntu-latest
+    needs: validate-inputs
     timeout-minutes: 30
     if: ${{ inputs.enable-armv7 }}
     # Advisory: armv7 is non-blocking. continue-on-error at the job level lets
@@ -1570,11 +1608,12 @@ jobs:
         env:
           BUILD_CMD: ${{ inputs.build-command }}
           TEST_CMD: ${{ inputs.test-command }}
+          PLUGIN_DIR: ${{ inputs.working-directory }}
         run: |
           docker run --rm --platform linux/arm/v7 \
             -v "${{ github.workspace }}:/plugin" \
             -v "/tmp/.npm-armv7-cache:/root/.npm" \
-            -w "/plugin/${{ inputs.working-directory }}" \
+            -w "/plugin/$PLUGIN_DIR" \
             -e BUILD_CMD \
             -e TEST_CMD \
             node:20-bookworm-slim \
@@ -1657,6 +1696,7 @@ jobs:
   signalk-integration:
     name: Integration / signalk-server ${{ matrix.signalk-server-version }} / Node ${{ matrix.node }}
     runs-on: ubuntu-latest
+    needs: validate-inputs
     timeout-minutes: 15
     if: ${{ inputs.enable-signalk-integration }}
     strategy:
@@ -1686,8 +1726,10 @@ jobs:
 
       - name: Install plugins declared in signalk.requires
         shell: bash
+        env:
+          PLUGIN_DIR: ${{ inputs.working-directory }}
         run: |
-          REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "${{ github.workspace }}/${{ inputs.working-directory }}/package.json" 2>/dev/null || true)
+          REQUIRES=$(jq -r '.signalk.requires // [] | .[]' "$GITHUB_WORKSPACE/$PLUGIN_DIR/package.json" 2>/dev/null || true)
           if [ -z "$REQUIRES" ]; then
             exit 0
           fi
@@ -1722,9 +1764,11 @@ jobs:
           npm install "/tmp/$(basename "$PLUGIN_TGZ")"
 
       - name: Configure plugin to auto-start
+        env:
+          PLUGIN_DIR: ${{ inputs.working-directory }}
         run: |
           cd /tmp/sk-test
-          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/${{ inputs.working-directory }}/package.json').name)")
+          PLUGIN_PKG_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$GITHUB_WORKSPACE/$PLUGIN_DIR/package.json")
 
           # Derive plugin ID the same way signalk-server does (src/pluginid.ts)
           PLUGIN_ID=$(node -e "
@@ -1741,6 +1785,7 @@ jobs:
       - name: Start SignalK server and verify plugin
         env:
           SIGNALK_URL: 'http://localhost:3000'
+          PLUGIN_DIR: ${{ inputs.working-directory }}
         run: |
           cd /tmp/sk-test
           export SIGNALK_NODE_CONFIG_DIR=/tmp/sk-test
@@ -1773,7 +1818,7 @@ jobs:
           echo "SignalK server is ready (PID $SK_PID)"
 
           # Verify plugin is loaded
-          PLUGIN_PKG_NAME=$(node -e "console.log(require('${{ github.workspace }}/${{ inputs.working-directory }}/package.json').name)")
+          PLUGIN_PKG_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$GITHUB_WORKSPACE/$PLUGIN_DIR/package.json")
           PLUGINS_JSON=$(curl -sf http://localhost:3000/skServer/plugins)
 
           echo "Loaded plugins:"
@@ -1829,7 +1874,7 @@ jobs:
           fi
 
           # Run integration tests from the plugin repo if they exist
-          cd "${{ github.workspace }}/${{ inputs.working-directory }}"
+          cd "$GITHUB_WORKSPACE/$PLUGIN_DIR"
           HAS_INTEGRATION=$(node -e "
             const pkg = require('./package.json');
             if (pkg.scripts && pkg.scripts['test:integration']) process.exit(0);
@@ -1852,7 +1897,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: [desktop, armv7, signalk-integration]
+    needs: [validate-inputs, desktop, armv7, signalk-integration]
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -21,7 +21,7 @@ on:
     inputs:
       # ── Repository layout ───────────────────────────────────
       working-directory:
-        description: 'Path to the plugin within the repository, for plugins published from a monorepo subdirectory (matches npm''s repository.directory). Defaults to the repository root.'
+        description: "Path to the plugin within the repository, for plugins published from a monorepo subdirectory (matches npm's repository.directory). Defaults to the repository root."
         type: string
         default: '.'
 


### PR DESCRIPTION
The reusable `plugin-ci.yml` assumes the plugin sits at the repository root. Every step resolves `package.json` from the checkout root, `npm pack` runs there, and the armv7 container uses `/plugin` as its workdir.

That means a plugin published from a **subdirectory** of its repository — npm's standard [`repository.directory`](https://docs.npmjs.com/cli/configuring-npm/package-json#repository) field — cannot adopt this workflow at all. The root manifest is either a workspace shell whose scripts delegate elsewhere, or absent entirely.

## Why this matters now

It came up in [openwatersio/aiscast#2](https://github.com/openwatersio/aiscast/pull/2). The author restructured his repository to raise his plugin-registry score and hit this as the remaining blocker:

> The registry docks [...] 10 for not running SignalK's reusable plugin-ci workflow, which validates `package.json`, the entry point, and `npm pack` at the repo root and has no working-directory input, so it cannot pass for a plugin in a subdirectory. That needs an upstream change.

He's right. The registry applies a flat −10 for not having a plugin-ci run, and monorepo plugins currently cannot clear it however good they are. The companion registry-side fix is [SignalK/signalk-plugin-registry#83](https://github.com/SignalK/signalk-plugin-registry/pull/83); I deliberately did **not** waive that penalty there, because the honest fix is to make the workflow adoptable — which is this PR.

## The change

A `working-directory` input, defaulting to `.`, threaded through `defaults.run` on all four jobs. That covers every `run:` step without touching 25 of them individually, and `uses:` steps (checkout, setup-node) are unaffected by design.

Four places `defaults.run` cannot reach are handled explicitly:

- the armv7 container's `-w`, since the mount is the workspace root
- the `upload-artifact` paths, which are workspace-relative
- the integration job's absolute `github.workspace` manifest reads — those steps `cd /tmp/sk-test` first, so the default cannot apply
- the `ci-status` sparse-checkout

## Note on the sparse-checkout

This one needs care, and testing rather than reading. A non-cone pattern of `./package.json` matches **nothing**, so naive interpolation would silently check out no files for every existing caller. The step now uses an explicit non-cone pattern with a leading slash, and I verified both cases select exactly one file:

```
non-cone /package.json                  -> ./package.json
non-cone /signalk-plugin/package.json   -> ./signalk-plugin/package.json
```

`sparse-checkout-cone-mode: false` is set explicitly rather than relying on the default, since cone mode treats the same pattern as a directory prefix and pulls in more than intended.

## Backwards compatibility

Existing callers are unaffected — the `.` default resolves to the paths they use today. `docker -w "/plugin/."` normalises to `/plugin`, and `./`-prefixed artifact globs behave as plain relative paths (unlike sparse-checkout, which is why only that one needed the conditional).

## Usage

```yaml
jobs:
  test:
    uses: SignalK/signalk-server/.github/workflows/plugin-ci.yml@master
    with:
      working-directory: signalk-plugin
```

## Tested

- YAML parses; all four jobs carry the default
- Simulated the workflow's package.json validation, `npm test` and `npm pack` inside a monorepo subdirectory fixture — each resolves the subdirectory's package, not the root
- Verified the sparse-checkout patterns for both the root default and a subdirectory, in cone and non-cone mode
- Verified `docker -w "/plugin/."` and `./`-prefixed globs degrade cleanly for existing callers

I have not run the full matrix against a real monorepo plugin end to end; `openwatersio/aiscast` would be a good first adopter once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a validated `working-directory` input to the reusable `plugin-ci.yml` workflow. The input defaults to `.` and supports plugins in repository subdirectories.

The workflow applies the directory across all four jobs. It updates armv7 work directories, Docker paths, artifact paths, integration manifest reads, and `ci-status` sparse-checkout patterns.

Validation accepts safe relative paths and rejects traversal, absolute paths, wildcards, substitutions, spaces, and newlines. Jobs and status reporting depend on validation. The workflow passes the input through environment variables and Node arguments to prevent injection.

Existing callers remain compatible with the default value. Tests cover YAML parsing, workflow steps, sparse checkout, path compatibility, and security inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->