### PR TITLE
fix(ble): stop a missing D-Bus socket killing the server

### DIFF
--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -536,6 +536,30 @@ jobs:
           cat << 'LIFECYCLE' > /tmp/check-lifecycle.js
           const path = require('path');
           const pkg = require(process.cwd() + '/package.json');
+
+          // ── Async crash trap ─────────────────────────────────────
+          // A plugin can start cleanly and still take the server down a
+          // moment later: an 'error' event emitted on a socket/emitter with
+          // no listener, or a floating promise that rejects after start()
+          // has already resolved. Neither travels the promise path, so the
+          // try/catch around `await plugin.start({})` below cannot see them.
+          //
+          // In production the server has no such trap either — Node's
+          // default action for an unhandled 'error' event is to throw, and
+          // under systemd Restart=always the result is an endless
+          // crash-restart loop rather than one bad plugin.
+          //
+          // Recording them here (rather than dying immediately) lets the
+          // lifecycle run finish and report every problem it found, which
+          // is more useful than surfacing whichever one happened to fire
+          // first. Anything caught is fatal — see the report below.
+          const asyncCrashes = [];
+          process.on('uncaughtException', (e) => {
+            asyncCrashes.push('uncaught exception: ' + ((e && e.message) || String(e)));
+          });
+          process.on('unhandledRejection', (e) => {
+            asyncCrashes.push('unhandled rejection: ' + ((e && e.message) || String(e)));
+          });
           // See validate-entry.js for the rationale — object/conditional
           // exports must be resolved, not flattened to 'index.js'.
           function resolveEntry(p, fallback) {
@@ -802,6 +826,40 @@ jobs:
             console.log('');
             console.log('Malformed deltas are silently discarded by the server —');
             console.log('the plugin appears to work but data never reaches consumers.');
+            process.exit(1);
+          }
+
+          // ── Report async crashes ────────────────────────────────
+          // Let queued failures surface before deciding the verdict. A
+          // microtask turn would cover an 'error' already sitting on the
+          // queue, but the failures worth catching are slower than that: a
+          // socket connect, a D-Bus handshake or a DNS lookup started during
+          // start() typically fails a second or so in, which is exactly the
+          // "started fine, died shortly after" shape this check exists for.
+          //
+          // 1.5s covers those while staying far inside the step's 2-minute
+          // budget. It is a fixed cost on every run, so it is not raised
+          // further: this drains what start() already kicked off, and is not
+          // meant to wait out a slow remote endpoint.
+          const ASYNC_CRASH_DRAIN_MS = 1500;
+          await new Promise((resolve) => setTimeout(resolve, ASYNC_CRASH_DRAIN_MS));
+
+          if (asyncCrashes.length > 0) {
+            console.log('');
+            // start() runs twice (initial + restart), so one faulty code path
+            // reports the same message twice. Collapse duplicates — two
+            // identical lines read as two separate problems.
+            [...new Set(asyncCrashes)].forEach(c => console.log('::error::Lifecycle: ' + c));
+            console.log('');
+            console.log('The plugin crashed the process after start() had already');
+            console.log('returned. The server does not sandbox plugins: an unhandled');
+            console.log("'error' event or a rejected floating promise terminates the");
+            console.log('whole server, and under systemd it then restart-loops.');
+            console.log('');
+            console.log('Common cause: an emitter or socket used without an error');
+            console.log("listener. Attach one ('error' handlers are required, not");
+            console.log('optional), or await the operation so the failure reaches the');
+            console.log('try/catch in start().');
             process.exit(1);
           }
 
@@ -1895,7 +1953,7 @@ jobs:
             echo "- **package.json** — \`signalk-node-server-plugin\` keyword, \`main\`/\`exports\` field, \`engines.node\`"
             echo "- **Entry point** — Plugin exports a constructor function"
             echo "- **plugin.schema()** — Returns valid JSON Schema without crashing"
-            echo "- **Lifecycle** — start()/stop()/restart cycle works without errors"
+            echo "- **Lifecycle** — start()/stop()/restart cycle works without errors, and the plugin does not crash the process asynchronously afterwards"
             echo "- **API usage** — No deprecated (\`setProviderStatus\`), internal (\`app.server\`), file storage, or security anti-patterns"
             echo "- **Node built-in modules** — \`node:sqlite\` requires \`engines.node >= 22.5.0\` declared in package.json"
             echo "- **npm pack** — All files referenced by \`main\`/\`exports\` are included in the package"

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -553,6 +553,7 @@ jobs:
           // lifecycle run finish and report every problem it found, which
           // is more useful than surfacing whichever one happened to fire
           // first. Anything caught is fatal — see the report below.
+          const ASYNC_CRASH_DRAIN_MS = 1500;
           const asyncCrashes = [];
           process.on('uncaughtException', (e) => {
             asyncCrashes.push('uncaught exception: ' + ((e && e.message) || String(e)));
@@ -560,6 +561,48 @@ jobs:
           process.on('unhandledRejection', (e) => {
             asyncCrashes.push('unhandled rejection: ' + ((e && e.message) || String(e)));
           });
+
+          // Every exit from the lifecycle check goes through here, including
+          // the early returns taken when start() or stop() throws. A plugin
+          // can schedule a failing timer and *then* throw synchronously from
+          // start(): the server catches that throw and keeps running (see
+          // doPluginStart in src/interfaces/plugins.ts), so the timer still
+          // fires and still kills the server. Exiting on the throw alone
+          // would report success for exactly that plugin.
+          const finish = async (code) => {
+            // Let queued failures surface before deciding the verdict. A
+            // microtask turn would cover an 'error' already on the queue, but
+            // the failures worth catching are slower: a socket connect, a
+            // D-Bus handshake or a DNS lookup started during start()
+            // typically fails a second or so in, which is exactly the
+            // "started fine, died shortly after" shape this check exists for.
+            //
+            // 1.5s covers those while staying far inside the step's 2-minute
+            // budget. It is a fixed cost on every run, so it is not raised
+            // further: this drains what start() already kicked off, and is
+            // not meant to wait out a slow remote endpoint.
+            await new Promise((resolve) => setTimeout(resolve, ASYNC_CRASH_DRAIN_MS));
+
+            if (asyncCrashes.length > 0) {
+              console.log('');
+              // start() may run twice (initial + restart), so one faulty code
+              // path reports the same message twice. Collapse duplicates —
+              // two identical lines read as two separate problems.
+              [...new Set(asyncCrashes)].forEach(c => console.log('::error::Lifecycle: ' + c));
+              console.log('');
+              console.log('The plugin crashed the process after start() had already');
+              console.log('returned. The server does not sandbox plugins: an unhandled');
+              console.log("'error' event or a rejected floating promise terminates the");
+              console.log('whole server, and under systemd it then restart-loops.');
+              console.log('');
+              console.log('Common cause: an emitter or socket used without an error');
+              console.log("listener. Attach one ('error' handlers are required, not");
+              console.log('optional), or await the operation so the failure reaches the');
+              console.log('try/catch in start().');
+              process.exit(1);
+            }
+            process.exit(code);
+          };
           // See validate-entry.js for the rationale — object/conditional
           // exports must be resolved, not flattened to 'index.js'.
           function resolveEntry(p, fallback) {
@@ -737,6 +780,8 @@ jobs:
             plugin = ctor(mockApp);
           } catch (e) {
             console.log('Plugin constructor requires server context — skipping lifecycle check');
+            // Pre-IIFE skip path: start() never ran, so there is nothing for
+            // finish() to drain (and top-level await is not available here).
             process.exit(0);
           }
 
@@ -778,7 +823,7 @@ jobs:
             } else {
               console.log('::warning::Plugins should handle empty/default configuration gracefully.');
             }
-            process.exit(0);
+            await finish(0);
           }
 
           try {
@@ -806,7 +851,7 @@ jobs:
             if (isMockGap(msg)) {
               console.log('::warning::plugin.start({}) threw on restart: ' + msg);
               console.log('::warning::This looks like a missing CI mock method, not a plugin bug. Please report at https://github.com/SignalK/signalk-server/issues');
-              process.exit(0);
+              await finish(0);
             }
             console.log('::error::plugin.start({}) threw on second call: ' + msg);
             console.log('::error::Plugins must support restart (stop then start). This fails when users toggle the plugin in the server UI.');
@@ -826,45 +871,11 @@ jobs:
             console.log('');
             console.log('Malformed deltas are silently discarded by the server —');
             console.log('the plugin appears to work but data never reaches consumers.');
-            process.exit(1);
-          }
-
-          // ── Report async crashes ────────────────────────────────
-          // Let queued failures surface before deciding the verdict. A
-          // microtask turn would cover an 'error' already sitting on the
-          // queue, but the failures worth catching are slower than that: a
-          // socket connect, a D-Bus handshake or a DNS lookup started during
-          // start() typically fails a second or so in, which is exactly the
-          // "started fine, died shortly after" shape this check exists for.
-          //
-          // 1.5s covers those while staying far inside the step's 2-minute
-          // budget. It is a fixed cost on every run, so it is not raised
-          // further: this drains what start() already kicked off, and is not
-          // meant to wait out a slow remote endpoint.
-          const ASYNC_CRASH_DRAIN_MS = 1500;
-          await new Promise((resolve) => setTimeout(resolve, ASYNC_CRASH_DRAIN_MS));
-
-          if (asyncCrashes.length > 0) {
-            console.log('');
-            // start() runs twice (initial + restart), so one faulty code path
-            // reports the same message twice. Collapse duplicates — two
-            // identical lines read as two separate problems.
-            [...new Set(asyncCrashes)].forEach(c => console.log('::error::Lifecycle: ' + c));
-            console.log('');
-            console.log('The plugin crashed the process after start() had already');
-            console.log('returned. The server does not sandbox plugins: an unhandled');
-            console.log("'error' event or a rejected floating promise terminates the");
-            console.log('whole server, and under systemd it then restart-loops.');
-            console.log('');
-            console.log('Common cause: an emitter or socket used without an error');
-            console.log("listener. Attach one ('error' handlers are required, not");
-            console.log('optional), or await the operation so the failure reaches the');
-            console.log('try/catch in start().');
-            process.exit(1);
+            await finish(1);
           }
 
           console.log('Plugin lifecycle (start/stop/restart) is clean');
-          process.exit(0);
+          await finish(0);
           })().catch(e => {
             console.log('::error::Unexpected error during lifecycle check: ' + (e && e.message || String(e)));
             process.exit(1);

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -838,7 +838,10 @@ jobs:
             } else {
               console.log('::error::plugin.stop() threw: ' + msg);
               console.log('::error::This causes the server to leak resources when the plugin is disabled or restarted.');
-              process.exit(1);
+              // finish() rather than a bare exit: the job already fails here,
+              // but stop() may also have scheduled a delayed failure, and
+              // reporting it tells the author about both problems at once.
+              return await finish(1);
             }
           }
 
@@ -855,7 +858,7 @@ jobs:
             }
             console.log('::error::plugin.start({}) threw on second call: ' + msg);
             console.log('::error::Plugins must support restart (stop then start). This fails when users toggle the plugin in the server UI.');
-            process.exit(1);
+            return await finish(1);
           }
 
           try { await Promise.resolve(plugin.stop()); } catch (e) { /* ignore */ }

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -194,47 +194,23 @@ that emits it with no listener attached throws, and there is nothing up the
 stack to catch it. Sockets, streams, D-Bus connections, serial ports and MQTT
 clients all report failures this way.
 
-```js
-// BAD — start() resolves cleanly, the server dies a moment later
-const client = net.connect('/var/run/some.sock')
-client.on('data', handle)
+Attach an `'error'` listener to every emitter your plugin holds, at the point
+you create it, and report the failure through `app.setPluginError()`. A
+listener that only handles the success event (`'data'`, `'message'`,
+`'connect'`) leaves the failure path unguarded.
 
-// GOOD — the failure is handled where it happens
-const client = net.connect('/var/run/some.sock')
-client.on('data', handle)
-client.on('error', (err) => {
-  app.setPluginError(`connection failed: ${err.message}`)
-})
-```
-
-Note that a library opening the connection for you does not remove the
-obligation — if it hands back an emitter and attaches no listener itself, the
-responsibility is still yours.
+A library opening the connection for you does not remove the obligation — if it
+hands back an emitter and attaches no listener itself, the responsibility is
+still yours.
 
 **Floating promises.** An async call started but never awaited (and with no
 `.catch()`) becomes an unhandled rejection, which terminates the process on
 Node 15 and later.
 
-```js
-// BAD — nothing observes the rejection
-start: () => {
-  connectToDevice()
-}
-
-// GOOD — await it so start()'s own error handling applies...
-start: async () => {
-  try {
-    await connectToDevice()
-  } catch (err) {
-    app.setPluginError(err.message)
-  }
-}
-
-// ...or attach a handler if it must run in the background
-start: () => {
-  connectToDevice().catch((err) => app.setPluginError(err.message))
-}
-```
+Either await the call inside `start()`, so its own error handling applies, or —
+when the work must continue in the background — attach a rejection handler when
+you kick it off. What fails the check is a call whose rejection nothing
+observes.
 
 The general rule: a plugin should report failures through
 `app.setPluginError()` and keep the process alive. Hardware that is absent, a

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -58,7 +58,7 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **Lifecycle** — Runs `start()` → `stop()` → `start()` (restart) with an empty configuration. Validates delta messages emitted during startup and checks that `registerDeltaInputHandler` handlers forward deltas correctly.
 
-**Async crashes** — Fails the job if the plugin fails asynchronously _after_ `start()` has returned — an unhandled `'error'` event (which ends the server process) or a floating promise that rejects late. See [Crashing the server after start()](#crashing-the-server-after-start) below.
+**Async crashes** — Watches for roughly 1.5 seconds after the lifecycle calls return and fails the job if the plugin fails asynchronously in that window — an unhandled `'error'` event (which ends the server process) or a floating promise that rejects late. A failure that takes longer to surface will not be caught, so a clean run is not proof there is none. See [Crashing the server after start()](#crashing-the-server-after-start) below.
 
 **API usage** — Scans source files for:
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -58,7 +58,7 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **Lifecycle** — Runs `start()` → `stop()` → `start()` (restart) with an empty configuration. Validates delta messages emitted during startup and checks that `registerDeltaInputHandler` handlers forward deltas correctly.
 
-**Async crashes** — Fails the job if the plugin terminates the process _after_ `start()` has returned — an unhandled `'error'` event or a floating promise that rejects late. See [Crashing the server after start()](#crashing-the-server-after-start) below.
+**Async crashes** — Fails the job if the plugin fails asynchronously _after_ `start()` has returned — an unhandled `'error'` event (which ends the server process) or a floating promise that rejects late. See [Crashing the server after start()](#crashing-the-server-after-start) below.
 
 **API usage** — Scans source files for:
 
@@ -204,8 +204,12 @@ hands back an emitter and attaches no listener itself, the responsibility is
 still yours.
 
 **Floating promises.** An async call started but never awaited (and with no
-`.catch()`) becomes an unhandled rejection, which terminates the process on
-Node 15 and later.
+`.catch()`) becomes an unhandled rejection. Node terminates the process for
+these by default, but the server installs an `unhandledRejection` handler: it
+logs the rejection and, when the originating plugin can be identified from the
+stack, records a plugin error. So a floating rejection usually degrades your
+plugin rather than killing the server — the failure is silent from the user's
+point of view, and the work you meant to do never happened.
 
 Either await the call inside `start()`, so its own error handling applies, or —
 when the work must continue in the background — attach a rejection handler when
@@ -219,10 +223,14 @@ conditions on a boat, not reasons to take navigation data offline.
 
 CI installs `uncaughtException` and `unhandledRejection` handlers around the
 lifecycle check and **fails the job** if either fires, including when
-`start()`, `stop()` and restart all report success. The check is an error
-rather than a warning because the consequence is not confined to the plugin:
-one faulty plugin makes the entire server unusable, and the resulting
-crash-loop is difficult for users to trace back to its cause.
+`start()`, `stop()` and restart all report success.
+
+The check is an error rather than a warning because of the first case. The
+server's own `uncaughtException` handler logs the error and flags the plugin,
+but it cannot stop an unhandled `'error'` event: Node throws on those
+synchronously, and the throw ends the process regardless of what the handler
+logged. One faulty emitter therefore takes the whole server down, and the
+resulting crash-loop is difficult for users to trace back to its cause.
 
 ## See also
 

--- a/docs/develop/plugins/ci.md
+++ b/docs/develop/plugins/ci.md
@@ -58,6 +58,8 @@ The desktop jobs (Linux, Linux arm64, macOS, Windows) run these checks, even if 
 
 **Lifecycle** — Runs `start()` → `stop()` → `start()` (restart) with an empty configuration. Validates delta messages emitted during startup and checks that `registerDeltaInputHandler` handlers forward deltas correctly.
 
+**Async crashes** — Fails the job if the plugin terminates the process _after_ `start()` has returned — an unhandled `'error'` event or a floating promise that rejects late. See [Crashing the server after start()](#crashing-the-server-after-start) below.
+
 **API usage** — Scans source files for:
 
 - Deprecated APIs (`setProviderStatus` → `setPluginStatus`, `setProviderError` → `setPluginError`)
@@ -174,6 +176,77 @@ test-cerbo-hardware:
     - run: npm ci
     - run: npm test
 ```
+
+## Crashing the server after start()
+
+The server does not sandbox plugins. Everything runs in one Node process, so
+an error your plugin fails to handle does not disable just that plugin — it
+terminates the whole server. Under a process supervisor (`Restart=always`,
+Docker's `restart: unless-stopped`) the server then restart-loops: it comes up,
+runs for a few seconds, dies again, and keeps going indefinitely.
+
+The dangerous case is the one that escapes `try/catch`. Wrapping the body of
+`start()` is not enough, because two common failures arrive _after_ `start()`
+has already returned successfully:
+
+**Unhandled `'error'` events.** In Node, `'error'` is special: an `EventEmitter`
+that emits it with no listener attached throws, and there is nothing up the
+stack to catch it. Sockets, streams, D-Bus connections, serial ports and MQTT
+clients all report failures this way.
+
+```js
+// BAD — start() resolves cleanly, the server dies a moment later
+const client = net.connect('/var/run/some.sock')
+client.on('data', handle)
+
+// GOOD — the failure is handled where it happens
+const client = net.connect('/var/run/some.sock')
+client.on('data', handle)
+client.on('error', (err) => {
+  app.setPluginError(`connection failed: ${err.message}`)
+})
+```
+
+Note that a library opening the connection for you does not remove the
+obligation — if it hands back an emitter and attaches no listener itself, the
+responsibility is still yours.
+
+**Floating promises.** An async call started but never awaited (and with no
+`.catch()`) becomes an unhandled rejection, which terminates the process on
+Node 15 and later.
+
+```js
+// BAD — nothing observes the rejection
+start: () => {
+  connectToDevice()
+}
+
+// GOOD — await it so start()'s own error handling applies...
+start: async () => {
+  try {
+    await connectToDevice()
+  } catch (err) {
+    app.setPluginError(err.message)
+  }
+}
+
+// ...or attach a handler if it must run in the background
+start: () => {
+  connectToDevice().catch((err) => app.setPluginError(err.message))
+}
+```
+
+The general rule: a plugin should report failures through
+`app.setPluginError()` and keep the process alive. Hardware that is absent, a
+socket that is missing, a remote service that is down — these are normal
+conditions on a boat, not reasons to take navigation data offline.
+
+CI installs `uncaughtException` and `unhandledRejection` handlers around the
+lifecycle check and **fails the job** if either fires, including when
+`start()`, `stop()` and restart all report success. The check is an error
+rather than a warning because the consequence is not confined to the plugin:
+one faulty plugin makes the entire server unusable, and the resulting
+crash-loop is difficult for users to trace back to its cause.
 
 ## See also
 

--- a/src/api/ble/index.ts
+++ b/src/api/ble/index.ts
@@ -15,6 +15,7 @@ import { SignalKMessageHub, WithConfig } from '../../app'
 import WebSocket from 'ws'
 import { writeSettingsFile } from '../../config/config'
 import { LocalBLEProvider } from './localProvider'
+import { createBluetoothSafe } from './safeBluetooth'
 import { RemoteGatewayProvider } from './remoteProvider'
 import { bleVendorName } from './bleCompanyIds'
 
@@ -150,12 +151,16 @@ export class BLEApi implements IBLEApi {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createBluetooth } = require('@naugehyde/node-ble')
-      const { bluetooth, destroy } = createBluetooth()
-      const adapters = await bluetooth.activeAdapters()
-      destroy()
-      return adapters.map((a: any) => a.adapter as string)
+      const { bluetooth, destroy } = createBluetoothSafe()
+      // destroy() in finally: activeAdapters() rejects on a host with no
+      // usable bus, and skipping the teardown would leak the D-Bus
+      // connection every time this probe runs.
+      try {
+        const adapters = await bluetooth.activeAdapters()
+        return adapters.map((a: any) => a.adapter as string)
+      } finally {
+        destroy()
+      }
     } catch {
       return []
     }

--- a/src/api/ble/localProvider.ts
+++ b/src/api/ble/localProvider.ts
@@ -17,6 +17,8 @@ import {
   GATTSubscriptionHandle
 } from '@signalk/server-api'
 
+import { createBluetoothSafe } from './safeBluetooth'
+
 // How often to poll BlueZ for newly discovered devices
 const DEVICE_WATCH_INTERVAL_MS = 5000
 // waitDevice timeout when attaching a listener to an already-known device
@@ -113,9 +115,7 @@ export class LocalBLEProvider {
 
   async init(): Promise<void> {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { createBluetooth } = require('@naugehyde/node-ble')
-      const bt = createBluetooth()
+      const bt = createBluetoothSafe()
       this.bluetooth = bt.bluetooth
       this.destroy = bt.destroy
       this.adapter = await this.bluetooth.getAdapter(this.adapterName)

--- a/src/api/ble/safeBluetooth.ts
+++ b/src/api/ble/safeBluetooth.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Safe wrapper around `@naugehyde/node-ble`'s `createBluetooth()`.
  *
@@ -24,48 +23,99 @@
 import { createDebug } from '../../debug'
 const debug = createDebug('signalk-server:api:ble:safe')
 
+/**
+ * The parts of node-ble's Bluetooth object this codebase actually uses.
+ * node-ble's shipped declarations are incomplete relative to its runtime —
+ * they expose neither `activeAdapters()` (already used here) nor `dbus` — so
+ * the surface is described locally instead.
+ */
+export interface SafeBluetooth {
+  activeAdapters(): Promise<Array<{ adapter: string }>>
+  getAdapter(adapter: string): Promise<unknown>
+}
+
 export interface BluetoothSession {
-  bluetooth: any
+  bluetooth: SafeBluetooth
   destroy: () => void
 }
 
-/**
- * The only part of the dbus-next connection this module touches. node-ble
- * ships no types, so the surface is declared here rather than pulling in an
- * `any` and losing the check on the call below.
- */
+/** The only part of the dbus-next connection this module touches. */
 interface ErrorEmitter {
   on(event: 'error', listener: (err: unknown) => void): void
 }
 
 /**
  * Creates a node-ble session whose D-Bus connection can never raise an
- * unhandled `error` event.
+ * unhandled `error` event, and whose pending operations never hang.
  *
- * The listener is attached synchronously, before the caller gets a chance to
- * await anything, so there is no window in which an early transport error can
- * escape. Errors are logged to debug only: every caller already treats "no
- * usable adapter" as a normal outcome, and a missing system bus is the
- * expected case on non-BlueZ hosts rather than something worth logging loudly.
+ * Two failure modes have to be handled together:
+ *
+ * 1. `createBluetooth()` opens the system-bus connection eagerly and attaches
+ *    no `error` listener. dbus-next reports transport failures by emitting
+ *    `error` rather than by rejecting the pending call, so a missing or
+ *    unreachable `/var/run/dbus/system_bus_socket` surfaces as an `error`
+ *    event with no listener — which Node escalates into an uncaught
+ *    exception. Because it arrives on the event emitter and not the promise
+ *    chain, `await`ing inside `try/catch` never sees it.
+ *
+ * 2. Merely swallowing that event is not enough. dbus-next does not settle
+ *    in-flight calls when the connection dies, so an operation issued before
+ *    the failure stays pending forever and `await bluetooth.activeAdapters()`
+ *    never returns — trading a crash for a hang, which is harder to diagnose.
+ *
+ * So the listener is attached synchronously (before the caller can await
+ * anything, leaving no window for an early error to escape) and the recorded
+ * failure is replayed as a rejection from every method this codebase calls.
+ * Callers already treat "no usable adapter" as a normal outcome, so the
+ * rejection lands in error handling that exists.
  */
 export function createBluetoothSafe(): BluetoothSession {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { createBluetooth } = require('@naugehyde/node-ble')
-  const session: BluetoothSession = createBluetooth()
+  const session = createBluetooth() as {
+    bluetooth: SafeBluetooth
+    destroy: () => void
+  }
+
+  // Set once the bus reports a transport failure. Every later call fails
+  // fast with this rather than waiting on a connection that is gone.
+  let busError: Error | undefined
 
   // node-ble keeps the dbus-next connection on the Bluetooth instance; guard
   // the lookup so an upstream rename degrades to today's behaviour rather
   // than throwing from inside the safety wrapper itself.
-  const bus = (session.bluetooth as { dbus?: ErrorEmitter } | undefined)?.dbus
+  const bus = (session.bluetooth as unknown as { dbus?: ErrorEmitter })?.dbus
   if (bus && typeof bus.on === 'function') {
     bus.on('error', (err: unknown) => {
-      debug(
-        `D-Bus system bus error: ${err instanceof Error ? err.message : String(err)}`
-      )
+      busError =
+        err instanceof Error ? err : new Error(String(err ?? 'unknown error'))
+      debug.enabled && debug(`D-Bus system bus error: ${busError.message}`)
     })
   } else {
     debug('Could not attach D-Bus error listener — node-ble internals changed')
   }
 
-  return session
+  // Races each call against the bus failing under it. Without this an
+  // operation already in flight when the socket dies never settles.
+  const guard = <T>(op: () => Promise<T>): Promise<T> => {
+    if (busError) return Promise.reject(busError)
+    return new Promise<T>((resolve, reject) => {
+      if (bus && typeof bus.on === 'function') {
+        bus.on('error', (err: unknown) =>
+          reject(
+            err instanceof Error ? err : new Error(String(err ?? 'bus error'))
+          )
+        )
+      }
+      op().then(resolve, reject)
+    })
+  }
+
+  const bluetooth: SafeBluetooth = {
+    activeAdapters: () => guard(() => session.bluetooth.activeAdapters()),
+    getAdapter: (adapter: string) =>
+      guard(() => session.bluetooth.getAdapter(adapter))
+  }
+
+  return { bluetooth, destroy: session.destroy }
 }

--- a/src/api/ble/safeBluetooth.ts
+++ b/src/api/ble/safeBluetooth.ts
@@ -108,15 +108,19 @@ export function createBluetoothSafe(): BluetoothSession {
     if (busError) return Promise.reject(busError)
     if (!canListen) return op()
     return new Promise<T>((resolve, reject) => {
-      const onBusError = (err: unknown) =>
+      // Detached on every settle path, including the bus-error one: when the
+      // bus fails the underlying operation stays pending forever, so the
+      // op().then() handlers below never run and would leave the listener
+      // attached. A long-lived session would then trip Node's max-listeners
+      // warning after ten failed operations.
+      const done = () => bus.off('error', onBusError)
+      function onBusError(err: unknown) {
+        done()
         reject(
           err instanceof Error ? err : new Error(String(err ?? 'bus error'))
         )
+      }
       bus.on('error', onBusError)
-      // Removed on settle: without this every call would leave a listener
-      // behind and a long-lived session would trip Node's max-listeners
-      // warning after ten operations.
-      const done = () => bus.off('error', onBusError)
       op().then(
         (v) => {
           done()

--- a/src/api/ble/safeBluetooth.ts
+++ b/src/api/ble/safeBluetooth.ts
@@ -42,6 +42,7 @@ export interface BluetoothSession {
 /** The only part of the dbus-next connection this module touches. */
 interface ErrorEmitter {
   on(event: 'error', listener: (err: unknown) => void): void
+  off(event: 'error', listener: (err: unknown) => void): void
 }
 
 /**
@@ -84,8 +85,14 @@ export function createBluetoothSafe(): BluetoothSession {
   // node-ble keeps the dbus-next connection on the Bluetooth instance; guard
   // the lookup so an upstream rename degrades to today's behaviour rather
   // than throwing from inside the safety wrapper itself.
-  const bus = (session.bluetooth as unknown as { dbus?: ErrorEmitter })?.dbus
-  if (bus && typeof bus.on === 'function') {
+  const maybeBus = (session.bluetooth as unknown as { dbus?: ErrorEmitter })
+    ?.dbus
+  const canListen =
+    !!maybeBus &&
+    typeof maybeBus.on === 'function' &&
+    typeof maybeBus.off === 'function'
+  const bus = maybeBus as ErrorEmitter
+  if (canListen) {
     bus.on('error', (err: unknown) => {
       busError =
         err instanceof Error ? err : new Error(String(err ?? 'unknown error'))
@@ -99,15 +106,27 @@ export function createBluetoothSafe(): BluetoothSession {
   // operation already in flight when the socket dies never settles.
   const guard = <T>(op: () => Promise<T>): Promise<T> => {
     if (busError) return Promise.reject(busError)
+    if (!canListen) return op()
     return new Promise<T>((resolve, reject) => {
-      if (bus && typeof bus.on === 'function') {
-        bus.on('error', (err: unknown) =>
-          reject(
-            err instanceof Error ? err : new Error(String(err ?? 'bus error'))
-          )
+      const onBusError = (err: unknown) =>
+        reject(
+          err instanceof Error ? err : new Error(String(err ?? 'bus error'))
         )
-      }
-      op().then(resolve, reject)
+      bus.on('error', onBusError)
+      // Removed on settle: without this every call would leave a listener
+      // behind and a long-lived session would trip Node's max-listeners
+      // warning after ten operations.
+      const done = () => bus.off('error', onBusError)
+      op().then(
+        (v) => {
+          done()
+          resolve(v)
+        },
+        (e) => {
+          done()
+          reject(e)
+        }
+      )
     })
   }
 

--- a/src/api/ble/safeBluetooth.ts
+++ b/src/api/ble/safeBluetooth.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Safe wrapper around `@naugehyde/node-ble`'s `createBluetooth()`.
+ *
+ * `createBluetooth()` opens a D-Bus system-bus connection eagerly and returns
+ * synchronously, without attaching an `error` listener to it. The underlying
+ * `@jellybrick/dbus-next` connection reports transport failures by emitting
+ * `error` on that connection rather than by rejecting the pending call, so a
+ * missing or unreachable `/var/run/dbus/system_bus_socket` surfaces as an
+ * `error` event with no listener — which Node escalates into an uncaught
+ * exception. Because it arrives on the event emitter and not through the
+ * promise chain, an `await createBluetooth()...` inside `try/catch` never sees
+ * it: the process dies with `connect ENOENT /var/run/dbus/system_bus_socket`
+ * a few seconds after the server has otherwise started cleanly.
+ *
+ * This happens on any host without a reachable system bus — most commonly a
+ * container that does not bind-mount the socket, but also a stripped-down
+ * Linux install with no D-Bus daemon running.
+ *
+ * Attaching a listener before handing the session back keeps the failure on
+ * the promise path, where the existing `try/catch` blocks already handle it.
+ */
+
+import { createDebug } from '../../debug'
+const debug = createDebug('signalk-server:api:ble:safe')
+
+export interface BluetoothSession {
+  bluetooth: any
+  destroy: () => void
+}
+
+/**
+ * The only part of the dbus-next connection this module touches. node-ble
+ * ships no types, so the surface is declared here rather than pulling in an
+ * `any` and losing the check on the call below.
+ */
+interface ErrorEmitter {
+  on(event: 'error', listener: (err: unknown) => void): void
+}
+
+/**
+ * Creates a node-ble session whose D-Bus connection can never raise an
+ * unhandled `error` event.
+ *
+ * The listener is attached synchronously, before the caller gets a chance to
+ * await anything, so there is no window in which an early transport error can
+ * escape. Errors are logged to debug only: every caller already treats "no
+ * usable adapter" as a normal outcome, and a missing system bus is the
+ * expected case on non-BlueZ hosts rather than something worth logging loudly.
+ */
+export function createBluetoothSafe(): BluetoothSession {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createBluetooth } = require('@naugehyde/node-ble')
+  const session: BluetoothSession = createBluetooth()
+
+  // node-ble keeps the dbus-next connection on the Bluetooth instance; guard
+  // the lookup so an upstream rename degrades to today's behaviour rather
+  // than throwing from inside the safety wrapper itself.
+  const bus = (session.bluetooth as { dbus?: ErrorEmitter } | undefined)?.dbus
+  if (bus && typeof bus.on === 'function') {
+    bus.on('error', (err: unknown) => {
+      debug(
+        `D-Bus system bus error: ${err instanceof Error ? err.message : String(err)}`
+      )
+    })
+  } else {
+    debug('Could not attach D-Bus error listener — node-ble internals changed')
+  }
+
+  return session
+}

--- a/src/api/ble/safeBluetooth.ts
+++ b/src/api/ble/safeBluetooth.ts
@@ -5,19 +5,21 @@
  * synchronously, without attaching an `error` listener to it. The underlying
  * `@jellybrick/dbus-next` connection reports transport failures by emitting
  * `error` on that connection rather than by rejecting the pending call, so a
- * missing or unreachable `/var/run/dbus/system_bus_socket` surfaces as an
- * `error` event with no listener — which Node escalates into an uncaught
- * exception. Because it arrives on the event emitter and not through the
- * promise chain, an `await createBluetooth()...` inside `try/catch` never sees
- * it: the process dies with `connect ENOENT /var/run/dbus/system_bus_socket`
- * a few seconds after the server has otherwise started cleanly.
+ * missing or unreachable `/var/run/dbus/system_bus_socket` — a container that
+ * does not bind-mount it, or a host with no D-Bus daemon — surfaces as an
+ * `error` event with no listener, which Node escalates into an uncaught
+ * exception. Arriving on the emitter and not the promise chain, it slips past
+ * the `try/catch` around the awaited call and kills the process seconds after
+ * the server has otherwise started cleanly.
  *
- * This happens on any host without a reachable system bus — most commonly a
- * container that does not bind-mount the socket, but also a stripped-down
- * Linux install with no D-Bus daemon running.
- *
- * Attaching a listener before handing the session back keeps the failure on
- * the promise path, where the existing `try/catch` blocks already handle it.
+ * Swallowing that event alone would trade the crash for a hang: dbus-next
+ * leaves in-flight calls unsettled when the connection dies, so an operation
+ * issued before the failure would never return. So the listener goes on
+ * synchronously — before the caller can await anything, leaving no window for
+ * an early error to escape — and the recorded failure is replayed as a
+ * rejection from every method this codebase calls. Callers already treat "no
+ * usable adapter" as a normal outcome, so it lands in error handling that
+ * exists.
  */
 
 import { createDebug } from '../../debug'
@@ -45,31 +47,6 @@ interface ErrorEmitter {
   off(event: 'error', listener: (err: unknown) => void): void
 }
 
-/**
- * Creates a node-ble session whose D-Bus connection can never raise an
- * unhandled `error` event, and whose pending operations never hang.
- *
- * Two failure modes have to be handled together:
- *
- * 1. `createBluetooth()` opens the system-bus connection eagerly and attaches
- *    no `error` listener. dbus-next reports transport failures by emitting
- *    `error` rather than by rejecting the pending call, so a missing or
- *    unreachable `/var/run/dbus/system_bus_socket` surfaces as an `error`
- *    event with no listener — which Node escalates into an uncaught
- *    exception. Because it arrives on the event emitter and not the promise
- *    chain, `await`ing inside `try/catch` never sees it.
- *
- * 2. Merely swallowing that event is not enough. dbus-next does not settle
- *    in-flight calls when the connection dies, so an operation issued before
- *    the failure stays pending forever and `await bluetooth.activeAdapters()`
- *    never returns — trading a crash for a hang, which is harder to diagnose.
- *
- * So the listener is attached synchronously (before the caller can await
- * anything, leaving no window for an early error to escape) and the recorded
- * failure is replayed as a rejection from every method this codebase calls.
- * Callers already treat "no usable adapter" as a normal outcome, so the
- * rejection lands in error handling that exists.
- */
 export function createBluetoothSafe(): BluetoothSession {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { createBluetooth } = require('@naugehyde/node-ble')

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -3,19 +3,8 @@ import { EventEmitter } from 'node:events'
 import Module from 'node:module'
 
 /**
- * Regression test for the BLE local provider taking the whole server down.
- *
- * `@naugehyde/node-ble`'s `createBluetooth()` opens a D-Bus system-bus
- * connection eagerly and hands it back without an `error` listener. dbus-next
- * reports transport failures by emitting `error` on that connection, so on a
- * host with no reachable `/var/run/dbus/system_bus_socket` (any container that
- * does not mount it) the failure arrives as an unhandled `error` event and
- * Node escalates it to an uncaught exception — several seconds after the
- * server has otherwise started cleanly. The `try/catch` around the awaited
- * calls cannot catch it because it never travels the promise path.
- *
- * `createBluetoothSafe()` attaches the listener synchronously, before the
- * caller can await anything, closing that window.
+ * Regression tests for the BLE local provider taking the whole server down.
+ * See `src/api/ble/safeBluetooth.ts` for the failure this guards against.
  */
 
 // Stand-in for the dbus-next connection: an emitter whose only interesting
@@ -93,8 +82,7 @@ describe('BLE D-Bus transport errors', () => {
       'expected an error listener to be attached synchronously'
     )
 
-    // The real failure: ENOENT on the system bus socket. Without a
-    // listener attached, this emit throws and takes the process down.
+    // The real failure: ENOENT on the system bus socket.
     const emit = () =>
       bus.emit(
         'error',
@@ -110,10 +98,6 @@ describe('BLE D-Bus transport errors', () => {
   })
 
   it('rejects a pending adapter call when the bus fails under it', async () => {
-    // Swallowing the 'error' event is not enough on its own: dbus-next does
-    // not settle in-flight calls when the connection dies, so an operation
-    // issued before the failure would otherwise stay pending forever and
-    // turn the crash into a hang.
     const { result: session, bus } = withStubbedNodeBle(() => {
       const { createBluetoothSafe: make } =
         // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -140,9 +124,6 @@ describe('BLE D-Bus transport errors', () => {
       'expected the pending call to reject once the bus failed'
     )
 
-    // The underlying op stays pending forever after a bus failure, so the
-    // listener has to come off on the rejection path too — nothing else
-    // will remove it.
     expect(bus.listenerCount('error')).to.equal(
       baseline,
       'expected the per-call listener to be removed on the bus-error path'
@@ -150,10 +131,6 @@ describe('BLE D-Bus transport errors', () => {
   })
 
   it('does not accumulate bus listeners across calls', async () => {
-    // guard() attaches an 'error' listener per call so a bus failure can
-    // reject the operation under way. Without removing it on settle, a
-    // long-lived session trips Node's max-listeners warning after ten
-    // operations and slowly leaks.
     const { result: session, bus } = withStubbedNodeBle(() => {
       const { createBluetoothSafe: make } =
         // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -36,7 +36,10 @@ interface PatchableModule {
 const patchable = Module as unknown as PatchableModule
 const requireStub: Requirer = patchable.prototype.require
 
-const withStubbedNodeBle = (fn: () => void) => {
+// Returns whatever the callback returns, and hands back the bus the stub
+// created so tests never read a stale one from an earlier case.
+const withStubbedNodeBle = <T>(fn: () => T): { result: T; bus: FakeBus } => {
+  lastBus = undefined
   patchable.prototype.require = function (
     this: unknown,
     id: string,
@@ -62,44 +65,48 @@ const withStubbedNodeBle = (fn: () => void) => {
     }
     return requireStub.call(this, id, ...rest)
   }
+  let result: T
   try {
-    fn()
+    result = fn()
   } finally {
     patchable.prototype.require = requireStub
   }
+  if (!lastBus) {
+    throw new Error('stub was never invoked — createBluetooth() not called')
+  }
+  return { result, bus: lastBus }
 }
 
 describe('BLE D-Bus transport errors', () => {
   it('does not let a system-bus error escape as an uncaught exception', () => {
-    withStubbedNodeBle(() => {
+    const { bus } = withStubbedNodeBle(() => {
       // Imported inside the stub so the wrapper picks up the fake module.
       const { createBluetoothSafe } =
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
 
-      createBluetoothSafe()
-      const bus = lastBus as FakeBus
+      return createBluetoothSafe()
+    })
 
-      expect(bus.listenerCount('error')).to.equal(
-        1,
-        'expected an error listener to be attached synchronously'
+    expect(bus.listenerCount('error')).to.equal(
+      1,
+      'expected an error listener to be attached synchronously'
+    )
+
+    // The real failure: ENOENT on the system bus socket. Without a
+    // listener attached, this emit throws and takes the process down.
+    const emit = () =>
+      bus.emit(
+        'error',
+        Object.assign(
+          new Error('connect ENOENT /var/run/dbus/system_bus_socket'),
+          {
+            code: 'ENOENT'
+          }
+        )
       )
 
-      // The real failure: ENOENT on the system bus socket. Without a
-      // listener attached, this emit throws and takes the process down.
-      const emit = () =>
-        bus.emit(
-          'error',
-          Object.assign(
-            new Error('connect ENOENT /var/run/dbus/system_bus_socket'),
-            {
-              code: 'ENOENT'
-            }
-          )
-        )
-
-      expect(emit).to.not.throw()
-    })
+    expect(emit).to.not.throw()
   })
 
   it('rejects a pending adapter call when the bus fails under it', async () => {
@@ -107,15 +114,12 @@ describe('BLE D-Bus transport errors', () => {
     // not settle in-flight calls when the connection dies, so an operation
     // issued before the failure would otherwise stay pending forever and
     // turn the crash into a hang.
-    let session!: { bluetooth: { activeAdapters(): Promise<unknown> } }
-
-    withStubbedNodeBle(() => {
+    const { result: session, bus } = withStubbedNodeBle(() => {
       const { createBluetoothSafe: make } =
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
-      session = make()
+      return make()
     })
-    const bus = lastBus as FakeBus
 
     // A call that never settles on its own, as the real one does not.
     const pending = session.bluetooth.activeAdapters()

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -22,6 +22,10 @@ import Module from 'node:module'
 // behaviour is that an unlistened 'error' throws, exactly as Node's does.
 class FakeBus extends EventEmitter {}
 
+// The wrapper returns its own bluetooth facade, so the stub records the bus
+// it handed out for the test to drive.
+let lastBus: FakeBus | undefined
+
 // Module.prototype.require is not in @types/node's public surface, so the
 // patch point is described structurally rather than reached through `any`.
 type Requirer = (this: unknown, id: string, ...rest: unknown[]) => unknown
@@ -42,7 +46,17 @@ const withStubbedNodeBle = (fn: () => void) => {
       return {
         createBluetooth: () => {
           const dbus = new FakeBus()
-          return { bluetooth: { dbus }, destroy: () => undefined }
+          lastBus = dbus
+          return {
+            bluetooth: {
+              dbus,
+              // Never settles on its own — mirrors dbus-next leaving calls
+              // in flight when the connection dies.
+              activeAdapters: () => new Promise(() => undefined),
+              getAdapter: () => new Promise(() => undefined)
+            },
+            destroy: () => undefined
+          }
         }
       }
     }
@@ -63,8 +77,8 @@ describe('BLE D-Bus transport errors', () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
 
-      const session = createBluetoothSafe()
-      const bus = (session.bluetooth as { dbus: FakeBus }).dbus
+      createBluetoothSafe()
+      const bus = lastBus as FakeBus
 
       expect(bus.listenerCount('error')).to.equal(
         1,
@@ -86,6 +100,39 @@ describe('BLE D-Bus transport errors', () => {
 
       expect(emit).to.not.throw()
     })
+  })
+
+  it('rejects a pending adapter call when the bus fails under it', async () => {
+    // Swallowing the 'error' event is not enough on its own: dbus-next does
+    // not settle in-flight calls when the connection dies, so an operation
+    // issued before the failure would otherwise stay pending forever and
+    // turn the crash into a hang.
+    let session!: { bluetooth: { activeAdapters(): Promise<unknown> } }
+
+    withStubbedNodeBle(() => {
+      const { createBluetoothSafe: make } =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
+      session = make()
+    })
+    const bus = lastBus as FakeBus
+
+    // A call that never settles on its own, as the real one does not.
+    const pending = session.bluetooth.activeAdapters()
+
+    bus.emit(
+      'error',
+      new Error('connect ENOENT /var/run/dbus/system_bus_socket')
+    )
+
+    let rejected = false
+    await pending.catch(() => {
+      rejected = true
+    })
+    expect(rejected).to.equal(
+      true,
+      'expected the pending call to reject once the bus failed'
+    )
   })
 
   it('still returns a usable session when the bus is healthy', () => {

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+import Module from 'node:module'
+
+/**
+ * Regression test for the BLE local provider taking the whole server down.
+ *
+ * `@naugehyde/node-ble`'s `createBluetooth()` opens a D-Bus system-bus
+ * connection eagerly and hands it back without an `error` listener. dbus-next
+ * reports transport failures by emitting `error` on that connection, so on a
+ * host with no reachable `/var/run/dbus/system_bus_socket` (any container that
+ * does not mount it) the failure arrives as an unhandled `error` event and
+ * Node escalates it to an uncaught exception — several seconds after the
+ * server has otherwise started cleanly. The `try/catch` around the awaited
+ * calls cannot catch it because it never travels the promise path.
+ *
+ * `createBluetoothSafe()` attaches the listener synchronously, before the
+ * caller can await anything, closing that window.
+ */
+
+// Stand-in for the dbus-next connection: an emitter whose only interesting
+// behaviour is that an unlistened 'error' throws, exactly as Node's does.
+class FakeBus extends EventEmitter {}
+
+// Module.prototype.require is not in @types/node's public surface, so the
+// patch point is described structurally rather than reached through `any`.
+type Requirer = (this: unknown, id: string, ...rest: unknown[]) => unknown
+interface PatchableModule {
+  prototype: { require: Requirer }
+}
+
+const patchable = Module as unknown as PatchableModule
+const requireStub: Requirer = patchable.prototype.require
+
+const withStubbedNodeBle = (fn: () => void) => {
+  patchable.prototype.require = function (
+    this: unknown,
+    id: string,
+    ...rest: unknown[]
+  ) {
+    if (id === '@naugehyde/node-ble') {
+      return {
+        createBluetooth: () => {
+          const dbus = new FakeBus()
+          return { bluetooth: { dbus }, destroy: () => undefined }
+        }
+      }
+    }
+    return requireStub.call(this, id, ...rest)
+  }
+  try {
+    fn()
+  } finally {
+    patchable.prototype.require = requireStub
+  }
+}
+
+describe('BLE D-Bus transport errors', () => {
+  it('does not let a system-bus error escape as an uncaught exception', () => {
+    withStubbedNodeBle(() => {
+      // Imported inside the stub so the wrapper picks up the fake module.
+      const { createBluetoothSafe } =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
+
+      const session = createBluetoothSafe()
+      const bus = (session.bluetooth as { dbus: FakeBus }).dbus
+
+      expect(bus.listenerCount('error')).to.equal(
+        1,
+        'expected an error listener to be attached synchronously'
+      )
+
+      // The real failure: ENOENT on the system bus socket. Without a
+      // listener attached, this emit throws and takes the process down.
+      const emit = () =>
+        bus.emit(
+          'error',
+          Object.assign(
+            new Error('connect ENOENT /var/run/dbus/system_bus_socket'),
+            {
+              code: 'ENOENT'
+            }
+          )
+        )
+
+      expect(emit).to.not.throw()
+    })
+  })
+
+  it('still returns a usable session when the bus is healthy', () => {
+    withStubbedNodeBle(() => {
+      const { createBluetoothSafe } =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
+
+      const session = createBluetoothSafe()
+      expect(session.bluetooth).to.be.an('object')
+      expect(session.destroy).to.be.a('function')
+    })
+  })
+})

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -56,7 +56,7 @@ const withStubbedNodeBle = <T>(fn: () => T): { result: T; bus: FakeBus } => {
               // Never settles on its own — mirrors dbus-next leaving calls
               // in flight when the connection dies.
               activeAdapters: () => new Promise(() => undefined),
-              getAdapter: () => new Promise(() => undefined)
+              getAdapter: () => Promise.resolve({})
             },
             destroy: () => undefined
           }
@@ -136,6 +136,28 @@ describe('BLE D-Bus transport errors', () => {
     expect(rejected).to.equal(
       true,
       'expected the pending call to reject once the bus failed'
+    )
+  })
+
+  it('does not accumulate bus listeners across calls', async () => {
+    // guard() attaches an 'error' listener per call so a bus failure can
+    // reject the operation under way. Without removing it on settle, a
+    // long-lived session trips Node's max-listeners warning after ten
+    // operations and slowly leaks.
+    const { result: session, bus } = withStubbedNodeBle(() => {
+      const { createBluetoothSafe: make } =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../src/api/ble/safeBluetooth') as typeof import('../src/api/ble/safeBluetooth')
+      return make()
+    })
+
+    const before = bus.listenerCount('error')
+    for (let i = 0; i < 12; i++) {
+      await session.bluetooth.getAdapter('hci0')
+    }
+    expect(bus.listenerCount('error')).to.equal(
+      before,
+      'expected per-call listeners to be removed once the call settled'
     )
   })
 

--- a/test/ble-dbus-error.ts
+++ b/test/ble-dbus-error.ts
@@ -121,6 +121,8 @@ describe('BLE D-Bus transport errors', () => {
       return make()
     })
 
+    const baseline = bus.listenerCount('error')
+
     // A call that never settles on its own, as the real one does not.
     const pending = session.bluetooth.activeAdapters()
 
@@ -136,6 +138,14 @@ describe('BLE D-Bus transport errors', () => {
     expect(rejected).to.equal(
       true,
       'expected the pending call to reject once the bus failed'
+    )
+
+    // The underlying op stays pending forever after a bus failure, so the
+    // listener has to come off on the rejection path too — nothing else
+    // will remove it.
+    expect(bus.listenerCount('error')).to.equal(
+      baseline,
+      'expected the per-call listener to be removed on the bus-error path'
     )
   })
 


### PR DESCRIPTION
## Problem

On any host with no reachable `/var/run/dbus/system_bus_socket`, the local BLE provider takes the whole server down a few seconds after startup:

```
signalk-server running at 0.0.0.0:80

Uncaught exception: Error: connect ENOENT /var/run/dbus/system_bus_socket
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1864:16) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'connect',
  address: '/var/run/dbus/system_bus_socket'
}
```

The server starts cleanly first — plugins load, the listener binds, `GET /signalk` serves 200s — and then exits. Under systemd `Restart=always` that becomes an endless crash-restart loop. On the install where I hit this, the restart counter reached 4450 and the journal held 8852 copies of the error.

No Bluetooth hardware is needed to reproduce it.

## Cause

Both call sites use `createBluetooth()` from `@naugehyde/node-ble`, which opens a dbus-next system-bus connection eagerly and returns synchronously without attaching an `error` listener. dbus-next reports transport failures by **emitting `'error'` on the connection**, not by rejecting the pending call.

Both sites already sit inside `try/catch`, but the catch never fires: the failure travels the event-emitter path, not the promise path. Node's default action for an unhandled `'error'` event is to throw, which kills the process.

Two details let this reach hosts with no interest in Bluetooth:

1. `getAvailableAdapters()` correctly checks `/sys/class/bluetooth` and returns `[]` when there is no hardware — but `initLocalProviders()` then falls back to `['hci0']` and dials the bus anyway.
2. `isLocalBLESupported()` gates only on `process.platform === 'linux'`, so every Linux host without a system bus is exposed.

This is the common case for containerized installs, which usually do not bind-mount the socket, and for stripped-down Linux hosts with no D-Bus daemon.

## Fix

Routes both call sites through `createBluetoothSafe()`, which attaches the `error` listener synchronously — before the caller can await anything, so there is no window for an early transport error to escape. The failure then stays on the promise path, where the existing `try/catch` already treats an unusable adapter as a normal outcome.

Also moves `destroy()` into a `finally` in `getAvailableAdapters()`: the probe leaked its D-Bus connection whenever `activeAdapters()` rejected, which is exactly the path a bus-less host takes.

The `hci0` fallback is deliberately left alone — adapters can appear after startup, and with a listener attached the attempt now fails harmlessly.

### Note on typing

`createBluetoothSafe()` declares a minimal local interface rather than using `@naugehyde/node-ble`'s shipped types. Those declarations are incomplete relative to the runtime: the declared `Bluetooth` interface exposes neither `dbus` (which the wrapper needs) nor `activeAdapters()` (already called by existing code), so adopting them fails to compile with `TS2339`.

## Plugin CI

The second commit closes the gap that let this class of bug through unnoticed.

The lifecycle check awaits `start()`, `stop()` and a restart inside `try/catch`, which catches anything rejecting on the promise path — and is structurally blind to the failures that actually take servers down: an unhandled `'error'` event, or a floating promise that rejects after `start()` has already resolved. A plugin can report start/stop/restart all clean and still terminate the process moments later.

This adds `uncaughtException` / `unhandledRejection` handlers around the lifecycle run and fails the job if either fires. Crashes are collected rather than fatal on arrival, so the run finishes and reports everything it found; duplicates are collapsed, since `start()` runs twice and one faulty path would otherwise report twice. A 1.5s drain before the verdict lets already-queued failures surface — sized for socket/D-Bus/DNS failures that land a second or so in, and well inside the step's 2-minute budget.

It is an error rather than a warning because the blast radius is not the plugin: the server does not sandbox plugins, so one bad handler makes the whole server unusable, and a crash-loop is hard for users to trace back to its cause.

`docs/develop/plugins/ci.md` documents the failure mode with good/bad patterns for both unhandled `'error'` events and floating promises.

## Tested

- Regression test `test/ble-dbus-error.ts` — verified it fails without the wrapper and passes with it
- Existing BLE suite — 10 passing
- `npm run build`, eslint, prettier — clean
- Plugin CI harness exercised against four fixtures: a plugin reproducing the bug (caught, exit 1), an equivalent that attaches an error listener (passes), a floating-promise rejection (caught), and a failure landing at 900 ms (caught — this is what sized the drain window). A clean run costs 1.5 s.

Not verified: the plugin-CI change has not run on GitHub Actions yet — it was exercised by extracting the generated script and running it locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents BLE crashes when the D-Bus system socket is unavailable.
- Adds `createBluetoothSafe()` with synchronous transport error handling.
- Rejects pending adapter calls after D-Bus transport failures.
- Removes per-call D-Bus error listeners after operations settle.
- Destroys adapter discovery connections in all cases.
- Detects and reports asynchronous plugin lifecycle failures during a 1.5-second drain window.
- Documents unhandled errors, floating promise rejections, and plugin error handling.
- Adds BLE D-Bus regression tests, including listener cleanup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->