### PR TITLE
fix(admin-ui): forward a plugin's whole schema to the configuration form

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.tsx
@@ -450,10 +450,7 @@ export default function PluginConfigurationForm({
     }),
     properties: {
       configuration: {
-        // Spread the plugin's schema rather than copying named fields:
-        // cherry-picking `properties` silently dropped `dependencies`,
-        // `oneOf`, `allOf` and `required`, so a plugin that made a field
-        // conditional got a field that rendered in NO state at all.
+        // Spread rather than cherry-pick: forwards conditional keywords and `required`.
         ...(plugin.schema as RJSFSchema),
         type: 'object',
         title: ' ',

--- a/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.tsx
@@ -414,9 +414,14 @@ interface PluginData {
   [key: string]: unknown
 }
 
+// A plugin's schema is arbitrary JSON Schema. Only `description` and
+// `properties` are named because they are read directly below; everything
+// else — `dependencies`, `oneOf`, `allOf`, `required`, … — is forwarded
+// untouched, so plugins can use conditional schemas.
 interface PluginSchema {
   description?: string
   properties?: Record<string, unknown>
+  [key: string]: unknown
 }
 
 interface Plugin {
@@ -445,6 +450,11 @@ export default function PluginConfigurationForm({
     }),
     properties: {
       configuration: {
+        // Spread the plugin's schema rather than copying named fields:
+        // cherry-picking `properties` silently dropped `dependencies`,
+        // `oneOf`, `allOf` and `required`, so a plugin that made a field
+        // conditional got a field that rendered in NO state at all.
+        ...(plugin.schema as RJSFSchema),
         type: 'object',
         title: ' ',
         description: plugin.schema.description,


### PR DESCRIPTION
The plugin configuration form rebuilds its schema by copying two named fields off `plugin.schema` (`PluginConfigurationForm.tsx`):

```ts
properties: {
  configuration: {
    type: 'object',
    title: ' ',
    description: plugin.schema.description,
    properties: plugin.schema.properties as RJSFSchema['properties']
  }
}
```

Everything else is silently dropped — `dependencies`, `oneOf`, `allOf`, `required`. So a plugin cannot use a conditional schema: a field declared under `dependencies` reaches RJSF in **no** state at all, and the controlling field appears to do nothing.

## How it surfaced

`signalk-tailscale` 1.0.2 used `dependencies` to hide a "self-hosted server URL" field while the container is managed by `signalk-container` — the field does nothing in that mode and carries a "traffic leaves this host" warning that does not apply.

The field disappeared in **both** toggle positions instead, leaving the URL unconfigurable through the UI. That release was reverted.

## The change

Spread the plugin's schema rather than cherry-picking, keeping the explicit `type`/`title` the form needs. RJSF resolves a nested object field's `dependencies` against that object's own form data when it renders, so the conditional then behaves.

`PluginSchema` gains an index signature: a plugin's schema is arbitrary JSON Schema, and the two named members are only the ones read directly here.

## Verified

Resolving the real `signalk-tailscale` schema through `@rjsf/validator-ajv8` the way RJSF renders a nested object field:

| | `managedContainer: true` | `managedContainer: false` |
| --- | --- | --- |
| current | hidden | hidden |
| with this change | hidden | **shown** |

No behaviour change for plugins that do not use conditional schemas — the spread adds keys that were previously absent and overrides nothing the form sets itself.

Worth noting `retrieveSchema` at the top level does not recurse into sub-objects, so a probe there shows no difference; the resolution happens per-field at render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the admin UI plugin configuration form to preserve complete plugin JSON Schema definitions. It supports conditional keywords such as `dependencies`, `oneOf`, `allOf`, and `required`.

The form continues to override the nested schema `type` and `title`. `PluginSchema` now supports arbitrary JSON Schema fields through an index signature.

This enables conditional fields, such as the self-hosted server URL in `signalk-tailscale`, to render based on form data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->