### PR TITLE
feat(tracks): add a Track Query API with a provider registry

### DIFF
--- a/packages/server-api/package.json
+++ b/packages/server-api/package.json
@@ -33,12 +33,16 @@
   "exports": {
     ".": "./dist/index.js",
     "./history": "./dist/history.js",
+    "./tracks": "./dist/tracks.js",
     "./typebox": "./dist/typebox/index.js"
   },
   "typesVersions": {
     "*": {
       "history": [
         "dist/history.d.ts"
+      ],
+      "tracks": [
+        "dist/tracks.d.ts"
       ],
       "typebox": [
         "dist/typebox/index.d.ts"

--- a/packages/server-api/src/features.ts
+++ b/packages/server-api/src/features.ts
@@ -70,6 +70,7 @@ export type SignalKApiId =
   | 'course'
   | 'resources'
   | 'history'
+  | 'tracks'
   | 'autopilot'
   | 'anchor'
   | 'logbook'

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -17,6 +17,8 @@ export * from './streambundle'
 export * from './subscriptionmanager'
 /** @category History API */
 export * as history from './history'
+/** @category Track API */
+export * as tracks from './tracks'
 /**
  * TypeBox schemas — the source of truth for OpenAPI generation and
  * runtime validation across the v2 APIs.

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -14,6 +14,7 @@ import {
 import { RadarProviderRegistry, WithRadarApi } from './radarapi'
 import { CourseApi } from './course'
 import { HistoryProviderRegistry, WithHistoryApi } from './history'
+import { TrackProviderRegistry, WithTrackApi } from './tracks'
 import { StreamBundle } from './streambundle'
 import { SubscriptionManager } from './subscriptionmanager'
 import type { WebSocket } from 'ws'
@@ -85,6 +86,8 @@ export interface ServerAPI
     BLEProviderRegistry,
     WithHistoryApi,
     HistoryProviderRegistry,
+    TrackProviderRegistry,
+    WithTrackApi,
     WithFeatures,
     CourseApi,
     WithNotificationsApi,

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -118,6 +118,16 @@ export interface TrackProperties {
   isSelf: boolean
 
   /**
+   * Which registered provider answered for this track.
+   *
+   * Set by the server from the registry, so a provider neither has to name
+   * itself nor can name itself wrongly. Provenance only today, with a single
+   * provider answering any one query; it is what would let a client tell
+   * features apart if that ever changes.
+   */
+  providerId?: string
+
+  /**
    * Name of the vessel, aircraft or other context, when known.
    *
    * Not the name of the track: a track recorded from position data has no name

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -121,9 +121,9 @@ export interface TrackProperties {
    * Which registered provider answered for this track.
    *
    * Set by the server from the registry, so a provider neither has to name
-   * itself nor can name itself wrongly. Provenance only today, with a single
-   * provider answering any one query; it is what would let a client tell
-   * features apart if that ever changes.
+   * itself nor can name itself wrongly. Every registered provider is queried
+   * and their features concatenated, so a vessel recorded by two of them
+   * yields two features, and this is what tells them apart.
    */
   providerId?: string
 

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -81,7 +81,7 @@ export interface TracksRequest {
   /** Include the recording time of each point as `properties.coordTimes`. */
   times?: boolean
 
-  /** Return metadata only, omitting geometry. */
+  /** Include geometry. Defaults to true; set false to return metadata only. */
   geometry?: boolean
 }
 

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill'
-import { Context } from './deltas'
+import { Context, Path } from './deltas'
 
 /**
  * Track API — recorded vessel positions over time.
@@ -81,6 +81,22 @@ export interface TracksRequest {
   /** Include the recording time of each point as `properties.coordTimes`. */
   times?: boolean
 
+  /**
+   * Signal K paths to return alongside each position, as arrays nested to
+   * match `coordinates` in the same way `coordTimes` is.
+   *
+   * A client colouring a track by speed, or deriving a route from a recorded
+   * passage, otherwise has to query the History API for those paths and join
+   * the two responses by timestamp — the row-alignment problem `coordTimes`
+   * exists to remove, reintroduced one level down.
+   *
+   * Optional for a provider: one that cannot co-record other paths returns the
+   * geometry alone and omits them from
+   * {@link TrackProperties.appliedProperties}, so a client can tell what it
+   * actually received rather than inferring it from absent data.
+   */
+  properties?: Path[]
+
   /** Include geometry. Defaults to true; set false to return metadata only. */
   geometry?: boolean
 }
@@ -138,6 +154,25 @@ export interface TrackProperties {
    * LineString.
    */
   coordTimes?: string[][]
+
+  /**
+   * Which of the requested {@link TracksRequest.properties} the provider
+   * actually returned.
+   *
+   * Reported rather than inferred, for the same reason `resolution` and
+   * `epsilon` are: a client must be able to tell "this provider does not have
+   * that path" from "that path had no values in this window".
+   */
+  appliedProperties?: Path[]
+
+  /**
+   * Values for each requested path, keyed by path and nested to match
+   * `coordinates`: `values[path][i][j]` belongs with `coordinates[i][j]`.
+   *
+   * A position with no value for a path at that instant carries null rather
+   * than being omitted, so the arrays stay aligned.
+   */
+  values?: Record<string, (number | string | null)[][]>
 }
 
 /**

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -1,0 +1,229 @@
+import { Temporal } from '@js-temporal/polyfill'
+import { Context } from './deltas'
+
+/**
+ * Track API — recorded vessel positions over time.
+ *
+ * A track is what a vessel *did*: a recorded, time-ordered series of positions,
+ * queried by time window and optionally by area. That makes it different from
+ * `resources/routes`, which is what someone *intends*, authored and named, and
+ * from the History API, which answers questions about arbitrary paths rather
+ * than about where vessels have been.
+ *
+ * Discussed in https://github.com/SignalK/signalk-server/issues/2504
+ *
+ * @category Track API
+ */
+
+/**
+ * Bounding box as `[west, south, east, north]` — GeoJSON coordinate order,
+ * matching the Resources API.
+ *
+ * A box whose west edge is numerically greater than its east edge crosses the
+ * antimeridian and is read the short way round, so `[175, -10, -175, 10]` is a
+ * box near Fiji rather than a band across the rest of the globe.
+ *
+ * @category Track API
+ */
+export type TrackBoundingBox = [number, number, number, number]
+
+/** @category Track API */
+export interface TracksRequest {
+  /**
+   * Contexts to return tracks for. Defaults to the own vessel when neither
+   * `contexts` nor a bounding box is given.
+   *
+   * A bare id is qualified with `vessels.`; other prefixes are accepted so that
+   * aircraft — SAR aircraft appear in AIS — can be queried too.
+   */
+  contexts?: Context[]
+
+  /** Start of the window. */
+  from?: Temporal.Instant
+
+  /** End of the window. Defaults to now when `from` or `duration` is given. */
+  to?: Temporal.Instant
+
+  /** Window ending at `to`, as an alternative to giving `from`. */
+  duration?: Temporal.Duration
+
+  /**
+   * Only return tracks that pass through this box within the window.
+   *
+   * Intersection, not containment, and not "where the vessel is now": a vessel
+   * that crossed the box an hour ago and has since left still matches.
+   */
+  bbox?: TrackBoundingBox
+
+  /** Minimum spacing between returned points. */
+  resolution?: Temporal.Duration
+
+  /**
+   * Upper bound on the number of points returned per track.
+   *
+   * A budget rather than a fidelity contract, for clients that must bound
+   * transfer and rendering cost regardless of how convoluted a track is.
+   */
+  maxPoints?: number
+
+  /**
+   * Simplify the geometry, dropping points that do not change the line's shape
+   * beyond `epsilon`.
+   *
+   * With a bounding box and no explicit `epsilon`, an implementation should
+   * choose a tolerance suited to the size of the box.
+   */
+  simplify?: boolean
+
+  /** Douglas-Peucker tolerance in metres. Implies `simplify`. */
+  epsilon?: number
+
+  /** Include the recording time of each point as `properties.coordTimes`. */
+  times?: boolean
+
+  /** Return metadata only, omitting geometry. */
+  geometry?: boolean
+}
+
+/**
+ * Per-track metadata.
+ *
+ * The time range, point count and resolution describe what was *returned*
+ * rather than what was asked for, so a client can always tell whether it
+ * received a simplified track and ask again for more detail.
+ *
+ * @category Track API
+ */
+export interface TrackProperties {
+  /** The Signal K context this track belongs to. */
+  context: Context
+
+  /** Whether this is the own vessel's track. */
+  isSelf: boolean
+
+  /**
+   * Name of the vessel, aircraft or other context, when known.
+   *
+   * Not the name of the track: a track recorded from position data has no name
+   * of its own. Named tracks are `resources/tracks`.
+   */
+  contextName?: string
+
+  /** Time of the first returned point. */
+  from: string
+
+  /** Time of the last returned point. */
+  to: string
+
+  /** Bounding box of the returned geometry, `[west, south, east, north]`. */
+  bbox?: TrackBoundingBox
+
+  /** Number of points returned across all segments. */
+  pointCount: number
+
+  /** Spacing actually applied, as an ISO 8601 duration. */
+  resolution?: string
+
+  /** Simplification tolerance actually applied, in metres. */
+  epsilon?: number
+
+  /**
+   * Recording time of every point, ISO 8601 UTC, nested to match
+   * `geometry.coordinates`: `coordTimes[i][j]` is when `coordinates[i][j]` was
+   * recorded.
+   *
+   * Follows the `coordTimes` convention used by GPX-to-GeoJSON converters,
+   * which RFC 7946 permits as a foreign member of `properties`. The nesting for
+   * MultiLineString is specified here because the convention only covers
+   * LineString.
+   */
+  coordTimes?: string[][]
+}
+
+/**
+ * One vessel's track as a GeoJSON Feature.
+ *
+ * MultiLineString rather than LineString: a gap in recording — an overnight
+ * stop, a receiver out of range — starts a new segment, so the line is not
+ * drawn across a stretch the vessel did not travel.
+ *
+ * @category Track API
+ */
+export interface TrackFeature {
+  type: 'Feature'
+  geometry: {
+    type: 'MultiLineString'
+    /** `[longitude, latitude]` positions, per segment. */
+    coordinates: [number, number][][]
+  } | null
+  properties: TrackProperties
+}
+
+/** @category Track API */
+export interface TracksResponse {
+  type: 'FeatureCollection'
+  features: TrackFeature[]
+}
+
+/**
+ * Provider interface for the Track API.
+ *
+ * Plugins that record positions implement this and register it via
+ * {@link TrackProviderRegistry.registerTrackApiProvider}. How and where the
+ * positions are stored is entirely the provider's business.
+ *
+ * @category Track API
+ */
+export interface TrackApi {
+  /**
+   * Returns tracks matching the query.
+   *
+   * Implementations should return the full time range requested. Where the
+   * result would be too large, reduce the number of points and report what was
+   * applied in {@link TrackProperties.resolution} or
+   * {@link TrackProperties.epsilon} — never silently narrow the time range,
+   * since a long voyage viewed at low zoom is a legitimate query.
+   */
+  getTracks(query: TracksRequest): Promise<TracksResponse>
+
+  /**
+   * Lists contexts that have track data within the window, without returning
+   * geometry.
+   */
+  getTrackContexts(query: TracksRequest): Promise<Context[]>
+}
+
+/** @category Track API */
+export type TrackProvider = TrackApi
+
+/** @category Track API */
+export type TrackProviderRegistry = {
+  registerTrackApiProvider(provider: TrackProvider): void
+  unregisterTrackApiProvider(): void
+}
+
+/** @category Track API */
+export type WithTrackApi = {
+  /**
+   * Returns a promise for a Track API implementation, or rejects if none is
+   * available. Optional so that plugins can support older servers.
+   *
+   * @param providerId - Optional id of a specific track provider plugin. If omitted, returns the default provider.
+   */
+  getTrackApi?: (providerId?: string) => Promise<TrackApi>
+}
+
+/** @category Track API */
+export type TrackProviders = {
+  [providerId: string]: { isDefault: boolean }
+}
+
+export function isTrackProvider(obj: unknown): obj is TrackProvider {
+  if (typeof obj !== 'object' || obj === null) {
+    return false
+  }
+  return (
+    typeof (obj as TrackProvider).getTracks === 'function' &&
+    typeof (obj as TrackProvider).getTrackContexts === 'function'
+  )
+}

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -70,7 +70,8 @@ export interface TracksRequest {
    * reference date, since their length is timezone-dependent. Windows here are
    * absolute, so `P1D` means 24h and arrives as `PT24H`. Years and months are
    * rejected: a month is 744h from January and 672h from February, so it does
-   * not describe a spacing.
+   * not describe a spacing. So is anything below a millisecond, which is the
+   * finest granularity a timestamp carries.
    */
   resolution?: Temporal.Duration
 

--- a/packages/server-api/src/tracks.ts
+++ b/packages/server-api/src/tracks.ts
@@ -52,10 +52,26 @@ export interface TracksRequest {
    *
    * Intersection, not containment, and not "where the vessel is now": a vessel
    * that crossed the box an hour ago and has since left still matches.
+   *
+   * It selects tracks; it does not clip them. A matching track is returned
+   * whole, including the stretches outside the box, so a client gets the
+   * approach and the departure rather than a line that stops at an invisible
+   * edge. Providers must agree on this or the same query returns different
+   * geometry depending on which one answered.
    */
   bbox?: TrackBoundingBox
 
-  /** Minimum spacing between returned points. */
+  /**
+   * Minimum spacing between returned points.
+   *
+   * Normalised to hours and below before it reaches a provider, so
+   * `total({ unit: 'milliseconds' })` is always safe on it —
+   * `Temporal.Duration` refuses that for day-and-larger units without a
+   * reference date, since their length is timezone-dependent. Windows here are
+   * absolute, so `P1D` means 24h and arrives as `PT24H`. Years and months are
+   * rejected: a month is 744h from January and 672h from February, so it does
+   * not describe a spacing.
+   */
   resolution?: Temporal.Duration
 
   /**
@@ -94,6 +110,14 @@ export interface TracksRequest {
    * geometry alone and omits them from
    * {@link TrackProperties.appliedProperties}, so a client can tell what it
    * actually received rather than inferring it from absent data.
+   *
+   * Values are matched to the *nearest* sample of that path, not to one sharing
+   * the position's timestamp. Paths arrive from different talkers on their own
+   * cadences — position and speed over ground typically a couple of hundred
+   * milliseconds apart — so an equality join returns null for every point while
+   * `appliedProperties` still claims success. A provider that buckets should
+   * match within a tolerance of its bucket width; a value that genuinely has no
+   * nearby sample is null.
    */
   properties?: Path[]
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ import { AutopilotApi } from './autopilot'
 import { RadarApi } from './radar'
 import { BLEApi } from './ble'
 import { HistoryApiHttpRegistry, HistoryApplication } from './history'
+import { TrackApiHttpRegistry, TrackApplication } from './tracks'
 import { SignalKApiId, WithFeatures } from '@signalk/server-api'
 import { NotificationApi, NotificationApplication } from './notifications'
 import {
@@ -109,6 +110,11 @@ export const startApis = (
   ;(app as any).historyApiHttpRegistry = historyApiHttpRegistry
   apiList.push('history')
 
+  const trackApiHttpRegistry = new TrackApiHttpRegistry(app as TrackApplication)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(app as any).trackApiHttpRegistry = trackApiHttpRegistry
+  apiList.push('tracks')
+
   const notificationApi = new NotificationApi(app as NotificationApplication)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(app as any).notificationApi = notificationApi
@@ -133,6 +139,7 @@ export const startApis = (
     autopilotApi.start(),
     radarApi.start(),
     historyApiHttpRegistry.start(),
+    trackApiHttpRegistry.start(),
     notificationApi.start(),
     gnssOffsetCorrector.start(),
     sensorsApi.start(),

--- a/src/api/swagger.ts
+++ b/src/api/swagger.ts
@@ -13,6 +13,7 @@ import { discoveryApiRecord } from './discovery/openApi'
 import { weatherApiRecord } from './weather/openApi'
 import { appsApiRecord } from './apps/openApi'
 import { historyApiRecord } from './history/openApi'
+import { tracksApiRecord } from './tracks/openApi'
 import { radarApiRecord } from './radar/openApi'
 import { sensorsApiRecord } from './sensors/openApi'
 import { bleApiRecord } from './ble/openApi'
@@ -47,6 +48,7 @@ const apiDocs = [
   weatherApiRecord,
   securityApiRecord,
   historyApiRecord,
+  tracksApiRecord,
   radarApiRecord,
   sensorsApiRecord,
   bleApiRecord

--- a/src/api/tracks/index.ts
+++ b/src/api/tracks/index.ts
@@ -110,12 +110,24 @@ export class TrackApiHttpRegistry {
         return
       }
       debug.enabled && debug(JSON.stringify(request, null, 2))
+      // Selection stays inside respondWith's guard: naming a provider that does
+      // not exist throws, and that has to stay a 400 rather than escaping as an
+      // unhandled error. The chosen id is captured for provenance on the way
+      // through.
+      let selectedId: string | undefined
       void respondWith(
-        () => this.useProvider(req),
+        () => {
+          const selected = this.selectProvider(req)
+          selectedId = selected?.id
+          return selected?.provider
+        },
         // geometry=false is a listing rather than a different resource: the
         // provider still decides which contexts match, it just omits the
         // coordinates it would otherwise have to read and thin.
-        (provider) => provider.getTracks(request),
+        (provider) =>
+          provider
+            .getTracks(request)
+            .then((response) => stampProvider(response, selectedId)),
         res
       )
     })
@@ -145,16 +157,52 @@ export class TrackApiHttpRegistry {
   }
 
   private useProvider(req: Request): TrackProvider | undefined {
+    return this.selectProvider(req)?.provider
+  }
+
+  /**
+   * The provider that will answer, and the id it is registered under.
+   *
+   * The id comes from the registry rather than from the provider, so a
+   * provider never has to name itself and cannot name itself wrongly.
+   */
+  private selectProvider(
+    req: Request
+  ): { id: string; provider: TrackProvider } | undefined {
     if (req.query.provider) {
-      const provider = this.trackProviders.get(req.query.provider as string)
+      const id = req.query.provider as string
+      const provider = this.trackProviders.get(id)
       if (!provider) {
-        throw new Error(`Requested provider not found! (${req.query.provider})`)
+        throw new Error(`Requested provider not found! (${id})`)
       }
-      return provider
+      return { id, provider }
     }
-    return this.defaultProviderId
-      ? this.trackProviders.get(this.defaultProviderId)
-      : undefined
+    const id = this.defaultProviderId
+    const provider = id ? this.trackProviders.get(id) : undefined
+    return id && provider ? { id, provider } : undefined
+  }
+}
+
+/**
+ * Record which provider answered, on each feature.
+ *
+ * Costs nothing today with a single provider, and is what lets a client tell
+ * features apart if a query is ever answered by several. Stamped by the server
+ * rather than the provider so the id always matches the registry.
+ */
+function stampProvider(
+  response: TracksResponse,
+  providerId: string | undefined
+): TracksResponse {
+  if (providerId === undefined) {
+    return response
+  }
+  return {
+    ...response,
+    features: response.features.map((feature) => ({
+      ...feature,
+      properties: { ...feature.properties, providerId }
+    }))
   }
 }
 

--- a/src/api/tracks/index.ts
+++ b/src/api/tracks/index.ts
@@ -110,24 +110,17 @@ export class TrackApiHttpRegistry {
         return
       }
       debug.enabled && debug(JSON.stringify(request, null, 2))
-      // Selection stays inside respondWith's guard: naming a provider that does
-      // not exist throws, and that has to stay a 400 rather than escaping as an
-      // unhandled error. The chosen id is captured for provenance on the way
-      // through.
-      let selectedId: string | undefined
-      void respondWith(
-        () => {
-          const selected = this.selectProvider(req)
-          selectedId = selected?.id
-          return selected?.provider
-        },
+      void respondWithAll(
+        () => this.selectProviders(req),
         // geometry=false is a listing rather than a different resource: the
         // provider still decides which contexts match, it just omits the
         // coordinates it would otherwise have to read and thin.
-        (provider) =>
-          provider
-            .getTracks(request)
-            .then((response) => stampProvider(response, selectedId)),
+        ({ id, provider }) =>
+          provider.getTracks(request).then((r) => stampProvider(r, id)),
+        (responses) => ({
+          type: 'FeatureCollection' as const,
+          features: responses.flatMap((r) => r.features)
+        }),
         res
       )
     })
@@ -140,9 +133,14 @@ export class TrackApiHttpRegistry {
           res.status(400).json({ error: errors.join(', ') })
           return
         }
-        void respondWith(
-          () => this.useProvider(req),
-          (provider) => provider.getTrackContexts(request),
+        void respondWithAll(
+          () => this.selectProviders(req),
+          ({ provider }) => provider.getTrackContexts(request),
+          // Deduplicated: the same vessel may be recorded by more than one
+          // provider, and a listing of which contexts exist should name each
+          // once. The tracks themselves stay separate, since two providers
+          // genuinely hold two recordings.
+          (lists) => [...new Set(lists.flat())],
           res
         )
       }
@@ -156,30 +154,33 @@ export class TrackApiHttpRegistry {
     throw new Error('No track api provider configured')
   }
 
-  private useProvider(req: Request): TrackProvider | undefined {
-    return this.selectProvider(req)?.provider
-  }
-
   /**
-   * The provider that will answer, and the id it is registered under.
+   * The providers that will answer, and the ids they are registered under.
    *
-   * The id comes from the registry rather than from the provider, so a
-   * provider never has to name itself and cannot name itself wrongly.
+   * Every registered provider unless `?provider=` names one. Two providers can
+   * legitimately hold tracks for the same vessel — one recording AIS, another
+   * the own vessel, or the same passage imported twice — so their responses are
+   * concatenated rather than merged, and each feature carries the id of the
+   * provider that produced it.
+   *
+   * Ids come from the registry rather than from the providers, so a provider
+   * never has to name itself and cannot name itself wrongly.
    */
-  private selectProvider(
+  private selectProviders(
     req: Request
-  ): { id: string; provider: TrackProvider } | undefined {
+  ): { id: string; provider: TrackProvider }[] {
     if (req.query.provider) {
       const id = req.query.provider as string
       const provider = this.trackProviders.get(id)
       if (!provider) {
         throw new Error(`Requested provider not found! (${id})`)
       }
-      return { id, provider }
+      return [{ id, provider }]
     }
-    const id = this.defaultProviderId
-    const provider = id ? this.trackProviders.get(id) : undefined
-    return id && provider ? { id, provider } : undefined
+    return [...this.trackProviders.entries()].map(([id, provider]) => ({
+      id,
+      provider
+    }))
   }
 }
 
@@ -206,29 +207,40 @@ function stampProvider(
   }
 }
 
-async function respondWith<T>(
-  getProvider: () => TrackProvider | undefined,
-  handler: (provider: TrackProvider) => Promise<T> | undefined,
+/**
+ * Query every selected provider and combine what they return.
+ *
+ * Providers are queried concurrently: one being slow makes that provider slow,
+ * which is its own business, and serialising them would make the response as
+ * slow as the sum rather than the slowest.
+ *
+ * A provider that throws fails the request rather than being dropped from a
+ * partial answer, because a client cannot tell a provider that failed from one
+ * that simply had no data in the window.
+ */
+async function respondWithAll<T, R>(
+  select: () => { id: string; provider: TrackProvider }[],
+  query: (selected: { id: string; provider: TrackProvider }) => Promise<T>,
+  combine: (results: T[]) => R,
   res: Response
 ) {
-  // Provider selection and the provider call fail for different reasons and
-  // must not share a status. Naming a provider that does not exist is a client
-  // error; a provider throwing is a server fault, and its message can carry
-  // file paths, connection strings or SQL, so it is logged rather than
-  // returned.
-  let provider: TrackProvider | undefined
+  // Selection and the provider calls fail for different reasons and must not
+  // share a status: naming a provider that does not exist is a client error,
+  // while a provider throwing is a server fault whose message can carry file
+  // paths, connection strings or SQL.
+  let selected: { id: string; provider: TrackProvider }[]
   try {
-    provider = getProvider()
+    selected = select()
   } catch (error) {
     return res.status(400).json({
       error: error instanceof Error ? error.message : 'Invalid request'
     })
   }
-  if (!provider) {
+  if (selected.length === 0) {
     return res.status(501).json({ error: 'No track api provider configured' })
   }
   try {
-    res.json(await handler(provider))
+    res.json(combine(await Promise.all(selected.map(query))))
   } catch (error) {
     console.error('Track api provider failed:', error)
     res.status(500).json({ error: 'Track api provider failed' })

--- a/src/api/tracks/index.ts
+++ b/src/api/tracks/index.ts
@@ -67,19 +67,22 @@ export class TrackApiHttpRegistry {
     if (!isTrackProvider(provider)) {
       throw new Error('Invalid track api provider')
     }
-    if (!this.trackProviders.has(pluginId)) {
-      this.trackProviders.set(pluginId, provider)
-    }
-    debug(
-      `Registered track api provider ${pluginId}, total=${this.trackProviders.size}`
-    )
+    // Replace rather than keep the first: a plugin that re-registers after a
+    // restart or a config change means the new provider, and silently serving
+    // the stale one would be very hard to diagnose.
+    this.trackProviders.set(pluginId, provider)
+    debug.enabled &&
+      debug(
+        `Registered track api provider ${pluginId}, total=${this.trackProviders.size}`
+      )
   }
 
   unregisterTrackApiProvider(pluginId: string): void {
     this.trackProviders.delete(pluginId)
-    debug(
-      `Unregistered track api provider ${pluginId}, total=${this.trackProviders.size}`
-    )
+    debug.enabled &&
+      debug(
+        `Unregistered track api provider ${pluginId}, total=${this.trackProviders.size}`
+      )
   }
 
   async start() {
@@ -160,15 +163,26 @@ async function respondWith<T>(
   handler: (provider: TrackProvider) => Promise<T> | undefined,
   res: Response
 ) {
+  // Provider selection and the provider call fail for different reasons and
+  // must not share a status. Naming a provider that does not exist is a client
+  // error; a provider throwing is a server fault, and its message can carry
+  // file paths, connection strings or SQL, so it is logged rather than
+  // returned.
+  let provider: TrackProvider | undefined
   try {
-    const provider = getProvider()
-    if (!provider) {
-      return res.status(501).json({ error: 'No track api provider configured' })
-    }
-    res.json(await handler(provider))
+    provider = getProvider()
   } catch (error) {
-    res.status(400).json({
+    return res.status(400).json({
       error: error instanceof Error ? error.message : 'Invalid request'
     })
+  }
+  if (!provider) {
+    return res.status(501).json({ error: 'No track api provider configured' })
+  }
+  try {
+    res.json(await handler(provider))
+  } catch (error) {
+    console.error('Track api provider failed:', error)
+    res.status(500).json({ error: 'Track api provider failed' })
   }
 }

--- a/src/api/tracks/index.ts
+++ b/src/api/tracks/index.ts
@@ -1,0 +1,174 @@
+import {
+  isTrackProvider,
+  TrackApi,
+  TrackProvider,
+  TrackProviders,
+  TracksRequest,
+  TracksResponse,
+  WithTrackApi
+} from '@signalk/server-api/tracks'
+import { Context } from '@signalk/server-api'
+import { IRouter, Request, Response } from 'express'
+import { createDebug } from '../../debug'
+import { WithSecurityStrategy } from '../../security'
+import { ConfigApp } from '../../config/config'
+import { parseTracksQuery } from './query'
+
+const debug = createDebug('signalk-server:api:tracks')
+
+const TRACKS_API_PATH = `/signalk/v2/api/tracks`
+
+export interface TrackApplication
+  extends WithSecurityStrategy, IRouter, ConfigApp, WithTrackApi {}
+
+/**
+ * HTTP surface for the Track API.
+ *
+ * Follows the History API's registry pattern: plugins that record positions
+ * register as providers, and the server owns the route, the query contract and
+ * the response shape. Where the positions are actually kept — sqlite, a
+ * time-series database, parquet — is entirely the provider's business.
+ *
+ * Design discussion: https://github.com/SignalK/signalk-server/issues/2504
+ */
+export class TrackApiHttpRegistry {
+  private trackProviders: Map<string, TrackProvider> = new Map()
+  proxy: TrackApi
+
+  /** First registered provider, keeping the default independent of load order. */
+  private get defaultProviderId(): string | undefined {
+    return this.trackProviders.keys().next().value
+  }
+
+  constructor(private app: TrackApplication) {
+    this.proxy = {
+      getTracks: (query: TracksRequest): Promise<TracksResponse> =>
+        this.defaultProvider().getTracks(query),
+      getTrackContexts: (query: TracksRequest): Promise<Context[]> =>
+        this.defaultProvider().getTrackContexts(query)
+    }
+
+    app.getTrackApi = (providerId?: string) => {
+      if (providerId !== undefined) {
+        const provider = this.trackProviders.get(providerId)
+        return provider
+          ? Promise.resolve(provider)
+          : Promise.reject(
+              new Error(`Track api provider '${providerId}' not found`)
+            )
+      }
+      return this.defaultProviderId
+        ? Promise.resolve(this.proxy)
+        : Promise.reject(new Error('No track api provider configured'))
+    }
+  }
+
+  registerTrackApiProvider(pluginId: string, provider: TrackProvider): void {
+    if (!isTrackProvider(provider)) {
+      throw new Error('Invalid track api provider')
+    }
+    if (!this.trackProviders.has(pluginId)) {
+      this.trackProviders.set(pluginId, provider)
+    }
+    debug(
+      `Registered track api provider ${pluginId}, total=${this.trackProviders.size}`
+    )
+  }
+
+  unregisterTrackApiProvider(pluginId: string): void {
+    this.trackProviders.delete(pluginId)
+    debug(
+      `Unregistered track api provider ${pluginId}, total=${this.trackProviders.size}`
+    )
+  }
+
+  async start() {
+    this.initRoutes()
+    return Promise.resolve()
+  }
+
+  private initRoutes() {
+    this.app.get(`${TRACKS_API_PATH}/_providers`, (_req, res) => {
+      const providers: TrackProviders = {}
+      this.trackProviders.forEach((_v, id) => {
+        providers[id] = { isDefault: id === this.defaultProviderId }
+      })
+      res.json(providers)
+    })
+
+    // Query validation runs before the provider lookup on both routes: a
+    // malformed query is a client error whether or not a provider happens to
+    // be installed, and reporting 501 for it would send someone hunting for a
+    // missing plugin when the real problem is their query string.
+    this.app.get(TRACKS_API_PATH, (req: Request, res: Response) => {
+      const { request, errors } = parseTracksQuery(req.query)
+      if (errors.length > 0) {
+        res.status(400).json({ error: errors.join(', ') })
+        return
+      }
+      debug.enabled && debug(JSON.stringify(request, null, 2))
+      void respondWith(
+        () => this.useProvider(req),
+        // geometry=false is a listing rather than a different resource: the
+        // provider still decides which contexts match, it just omits the
+        // coordinates it would otherwise have to read and thin.
+        (provider) => provider.getTracks(request),
+        res
+      )
+    })
+
+    this.app.get(
+      `${TRACKS_API_PATH}/contexts`,
+      (req: Request, res: Response) => {
+        const { request, errors } = parseTracksQuery(req.query)
+        if (errors.length > 0) {
+          res.status(400).json({ error: errors.join(', ') })
+          return
+        }
+        void respondWith(
+          () => this.useProvider(req),
+          (provider) => provider.getTrackContexts(request),
+          res
+        )
+      }
+    )
+  }
+
+  private defaultProvider(): TrackProvider {
+    if (this.defaultProviderId) {
+      return this.trackProviders.get(this.defaultProviderId)!
+    }
+    throw new Error('No track api provider configured')
+  }
+
+  private useProvider(req: Request): TrackProvider | undefined {
+    if (req.query.provider) {
+      const provider = this.trackProviders.get(req.query.provider as string)
+      if (!provider) {
+        throw new Error(`Requested provider not found! (${req.query.provider})`)
+      }
+      return provider
+    }
+    return this.defaultProviderId
+      ? this.trackProviders.get(this.defaultProviderId)
+      : undefined
+  }
+}
+
+async function respondWith<T>(
+  getProvider: () => TrackProvider | undefined,
+  handler: (provider: TrackProvider) => Promise<T> | undefined,
+  res: Response
+) {
+  try {
+    const provider = getProvider()
+    if (!provider) {
+      return res.status(501).json({ error: 'No track api provider configured' })
+    }
+    res.json(await handler(provider))
+  } catch (error) {
+    res.status(400).json({
+      error: error instanceof Error ? error.message : 'Invalid request'
+    })
+  }
+}

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -1,0 +1,307 @@
+import { OpenApiDescription } from '../swagger'
+
+const tracksApiDoc = {
+  openapi: '3.0.0',
+  info: {
+    version: '0.0.1',
+    title: 'Signal K Track API',
+    description:
+      'API for querying recorded vessel tracks — where vessels have actually been, over time.\n\n' +
+      'A track is distinct from a route in `resources/routes`, which is a course someone authored and intends to follow, and from an uploaded GPX track in `resources/tracks`, which is a named document. A track here is recorded position data: unnamed, time-ordered, and queried by time window and area.\n\n' +
+      'Storage is not defined by this API. Providers are plugins that record positions and may keep them in SQLite, a time-series database, Parquet files, or anything else.\n\n' +
+      'The time range is given as **from**, **to** and **duration** in any workable combination; omitted **to** defaults to now. A time window is required unless a single **context** is requested, since an unbounded query across every recorded vessel can span years of data.\n\n' +
+      'The full time range asked for is always returned. Where a result would be too large, providers reduce the number of *points* — by resolution, point budget or simplification — and report what they applied in the response, rather than silently narrowing the time range.',
+    license: {
+      name: 'Apache 2.0',
+      url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+  },
+  servers: [{ url: '/signalk/v2/api/tracks' }],
+  components: {
+    schemas: {
+      TrackProperties: {
+        type: 'object',
+        required: ['context', 'isSelf', 'from', 'to', 'pointCount'],
+        properties: {
+          context: {
+            type: 'string',
+            description: 'Signal K context this track belongs to',
+            example: 'vessels.urn:mrn:imo:mmsi:123456789'
+          },
+          isSelf: {
+            type: 'boolean',
+            description: "Whether this is the own vessel's track"
+          },
+          contextName: {
+            type: 'string',
+            description:
+              'Name of the vessel, aircraft or other context, where known. Not a name for the track itself.',
+            example: 'Ariadne'
+          },
+          from: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Time of the first returned point'
+          },
+          to: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Time of the last returned point'
+          },
+          bbox: {
+            type: 'array',
+            items: { type: 'number' },
+            minItems: 4,
+            maxItems: 4,
+            description:
+              'Bounding box of the returned geometry as [west, south, east, north]'
+          },
+          pointCount: {
+            type: 'integer',
+            description: 'Number of points returned across all segments'
+          },
+          resolution: {
+            type: 'string',
+            format: 'duration',
+            description:
+              'Spacing actually applied. Present when the provider thinned the track, so a client can tell it did not receive full detail.',
+            example: 'PT1M'
+          },
+          epsilon: {
+            type: 'number',
+            description:
+              'Simplification tolerance actually applied, in metres. Present when the provider simplified the geometry.'
+          },
+          coordTimes: {
+            type: 'array',
+            description:
+              'Recording time of every point, ISO 8601 UTC, nested to match geometry.coordinates: coordTimes[i][j] is when coordinates[i][j] was recorded. Follows the coordTimes convention used by GPX to GeoJSON converters; the nesting for MultiLineString is specified here because the convention itself covers only LineString.',
+            items: {
+              type: 'array',
+              items: { type: 'string', format: 'date-time' }
+            }
+          }
+        }
+      },
+      TrackFeature: {
+        type: 'object',
+        required: ['type', 'geometry', 'properties'],
+        properties: {
+          type: { type: 'string', enum: ['Feature'] },
+          geometry: {
+            nullable: true,
+            description:
+              'MultiLineString, so that a gap in recording starts a new segment rather than drawing a line across a stretch the vessel did not travel. Null when geometry=false was requested.',
+            type: 'object',
+            properties: {
+              type: { type: 'string', enum: ['MultiLineString'] },
+              coordinates: {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: {
+                    type: 'array',
+                    items: { type: 'number' },
+                    minItems: 2,
+                    maxItems: 2
+                  }
+                }
+              }
+            }
+          },
+          properties: { $ref: '#/components/schemas/TrackProperties' }
+        }
+      },
+      TracksResponse: {
+        type: 'object',
+        required: ['type', 'features'],
+        properties: {
+          type: { type: 'string', enum: ['FeatureCollection'] },
+          features: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TrackFeature' }
+          }
+        }
+      }
+    },
+    parameters: {
+      Contexts: {
+        name: 'contexts',
+        in: 'query',
+        description:
+          "Comma-separated Signal K contexts. A bare id is qualified with 'vessels.'; other prefixes such as 'aircraft.' are accepted. Defaults to the own vessel. Also accepted as 'context'.",
+        schema: { type: 'string', example: 'self' }
+      },
+      From: {
+        name: 'from',
+        in: 'query',
+        description: 'Start of the time range, as an ISO 8601 timestamp',
+        schema: {
+          type: 'string',
+          format: 'date-time',
+          example: '2026-06-01T00:00:00Z'
+        }
+      },
+      To: {
+        name: 'to',
+        in: 'query',
+        description:
+          'End of the time range, as an ISO 8601 timestamp. Defaults to now.',
+        schema: { type: 'string', format: 'date-time' }
+      },
+      Duration: {
+        name: 'duration',
+        in: 'query',
+        description:
+          'Length of the time range, as an ISO 8601 duration string or an integer number of seconds. See https://datatracker.ietf.org/doc/html/rfc3339#appendix-A',
+        schema: {
+          oneOf: [
+            { type: 'integer', description: 'Duration in seconds' },
+            { type: 'string', format: 'duration', example: 'P7D' }
+          ]
+        }
+      },
+      Bbox: {
+        name: 'bbox',
+        in: 'query',
+        description:
+          "Only return tracks passing through this box, as west,south,east,north in GeoJSON coordinate order. Matching is intersection anywhere within the time window, not the vessel's current position: a vessel that crossed the box an hour ago and has since left still matches. A west edge numerically greater than the east edge describes a box crossing the antimeridian.",
+        schema: { type: 'string', example: '24.5,59.9,25.2,60.3' }
+      },
+      Resolution: {
+        name: 'resolution',
+        in: 'query',
+        description:
+          'Minimum spacing between returned points, as an ISO 8601 duration or seconds.',
+        schema: {
+          oneOf: [
+            { type: 'integer' },
+            { type: 'string', format: 'duration', example: 'PT1M' }
+          ]
+        }
+      },
+      MaxPoints: {
+        name: 'maxPoints',
+        in: 'query',
+        description:
+          'Upper bound on points returned per track. A budget rather than a fidelity contract, for clients that must bound transfer and rendering cost regardless of how convoluted a track is.',
+        schema: { type: 'integer', minimum: 1, example: 5000 }
+      },
+      Simplify: {
+        name: 'simplify',
+        in: 'query',
+        description:
+          'Simplify the geometry, dropping points that do not change the shape of the line. With a bounding box and no explicit epsilon, the provider chooses a tolerance suited to the size of the box.',
+        schema: { type: 'boolean' }
+      },
+      Epsilon: {
+        name: 'epsilon',
+        in: 'query',
+        description:
+          'Simplification tolerance in metres. Implies simplify=true.',
+        schema: { type: 'number', minimum: 0, example: 5 }
+      },
+      Times: {
+        name: 'times',
+        in: 'query',
+        description:
+          'Include the recording time of each point as properties.coordTimes.',
+        schema: { type: 'boolean' }
+      },
+      Geometry: {
+        name: 'geometry',
+        in: 'query',
+        description:
+          'Set to false to return metadata only, omitting coordinates. Useful for listing which tracks exist in an area or period before fetching any of them.',
+        schema: { type: 'boolean', default: true }
+      },
+      Provider: {
+        name: 'provider',
+        in: 'query',
+        description:
+          'Query a specific track provider rather than the default one.',
+        schema: { type: 'string' }
+      }
+    }
+  },
+  paths: {
+    '/': {
+      get: {
+        tags: ['tracks'],
+        summary: 'Retrieve recorded tracks',
+        description:
+          'Returns a GeoJSON FeatureCollection, one Feature per context.\n\n' +
+          'A time window is required unless a single context is given: `?context=self` with no window is a legitimate request for an entire recorded history, while the same query across every vessel a server has seen is not.',
+        parameters: [
+          { $ref: '#/components/parameters/Contexts' },
+          { $ref: '#/components/parameters/From' },
+          { $ref: '#/components/parameters/To' },
+          { $ref: '#/components/parameters/Duration' },
+          { $ref: '#/components/parameters/Bbox' },
+          { $ref: '#/components/parameters/Resolution' },
+          { $ref: '#/components/parameters/MaxPoints' },
+          { $ref: '#/components/parameters/Simplify' },
+          { $ref: '#/components/parameters/Epsilon' },
+          { $ref: '#/components/parameters/Times' },
+          { $ref: '#/components/parameters/Geometry' },
+          { $ref: '#/components/parameters/Provider' }
+        ],
+        responses: {
+          '200': {
+            description: 'Tracks matching the query',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/TracksResponse' }
+              }
+            }
+          },
+          '400': { description: 'Invalid query parameters' },
+          '501': { description: 'No track api provider configured' }
+        }
+      }
+    },
+    '/contexts': {
+      get: {
+        tags: ['tracks'],
+        summary: 'List contexts with track data in the window',
+        parameters: [
+          { $ref: '#/components/parameters/From' },
+          { $ref: '#/components/parameters/To' },
+          { $ref: '#/components/parameters/Duration' },
+          { $ref: '#/components/parameters/Bbox' },
+          { $ref: '#/components/parameters/Provider' }
+        ],
+        responses: {
+          '200': {
+            description: 'Contexts with recorded track data',
+            content: {
+              'application/json': {
+                schema: { type: 'array', items: { type: 'string' } }
+              }
+            }
+          },
+          '400': { description: 'Invalid query parameters' },
+          '501': { description: 'No track api provider configured' }
+        }
+      }
+    },
+    '/_providers': {
+      get: {
+        tags: ['provider'],
+        summary: 'List registered track providers',
+        responses: {
+          '200': {
+            description: 'Registered providers and which is the default',
+            content: { 'application/json': { schema: { type: 'object' } } }
+          }
+        }
+      }
+    }
+  }
+}
+
+export const tracksApiRecord = {
+  name: 'tracks',
+  path: '/signalk/v2/api/tracks',
+  apiDoc: tracksApiDoc as unknown as OpenApiDescription
+}

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -9,7 +9,7 @@ const tracksApiDoc = {
       'API for querying recorded vessel tracks — where vessels have actually been, over time.\n\n' +
       'A track is distinct from a route in `resources/routes`, which is a course someone authored and intends to follow, and from an uploaded GPX track in `resources/tracks`, which is a named document. A track here is recorded position data: unnamed, time-ordered, and queried by time window and area.\n\n' +
       'Storage is not defined by this API. Providers are plugins that record positions and may keep them in SQLite, a time-series database, Parquet files, or anything else.\n\n' +
-      'The time range is given as **from**, **to** and **duration** in any workable combination; omitted **to** defaults to now. A time window is required unless a single **context** is requested, since an unbounded query across every recorded vessel can span years of data.\n\n' +
+      'The time range is given as **from**, **to** and **duration** in any workable combination; an omitted **to** is resolved to now by the server, so every provider sees the same window. A time window is required unless a single **context** is requested, since an unbounded query across every recorded vessel can span years of data.\n\n' +
       'The full time range asked for is always returned. Where a result would be too large, providers reduce the number of *points* — by resolution, point budget or simplification — and report what they applied in the response, rather than silently narrowing the time range.',
     license: {
       name: 'Apache 2.0',
@@ -79,6 +79,27 @@ const tracksApiDoc = {
             items: {
               type: 'array',
               items: { type: 'string', format: 'date-time' }
+            }
+          },
+          appliedProperties: {
+            type: 'array',
+            description:
+              'Which of the requested properties the provider actually returned. Reported rather than inferred, for the same reason resolution and epsilon are: a client must be able to tell "this provider does not have that path" from "that path had no values in this window".',
+            items: { type: 'string' }
+          },
+          values: {
+            type: 'object',
+            description:
+              'Values for each requested path, keyed by path and nested to match geometry.coordinates: values[path][i][j] belongs with coordinates[i][j]. A position with no value for a path at that instant carries null rather than being omitted, so the arrays stay aligned.',
+            additionalProperties: {
+              type: 'array',
+              items: {
+                type: 'array',
+                items: {
+                  nullable: true,
+                  oneOf: [{ type: 'number' }, { type: 'string' }]
+                }
+              }
             }
           }
         }
@@ -216,6 +237,16 @@ const tracksApiDoc = {
           example: 5
         }
       },
+      Properties: {
+        name: 'properties',
+        in: 'query',
+        description:
+          'Comma-separated Signal K paths to return alongside each position, nested to match coordinates the way coordTimes is. Lets a client colour a track by speed, or derive a route from a recorded passage, without querying the History API separately and joining the two responses by timestamp. Provider-optional: what was actually returned is listed in properties.appliedProperties.',
+        schema: {
+          type: 'string',
+          example: 'navigation.speedOverGround,environment.wind.speedApparent'
+        }
+      },
       Times: {
         name: 'times',
         in: 'query',
@@ -258,6 +289,7 @@ const tracksApiDoc = {
           { $ref: '#/components/parameters/Simplify' },
           { $ref: '#/components/parameters/Epsilon' },
           { $ref: '#/components/parameters/Times' },
+          { $ref: '#/components/parameters/Properties' },
           { $ref: '#/components/parameters/Geometry' },
           { $ref: '#/components/parameters/Provider' }
         ],

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -199,7 +199,12 @@ const tracksApiDoc = {
         in: 'query',
         description:
           'Simplification tolerance in metres. Implies simplify=true.',
-        schema: { type: 'number', minimum: 0, example: 5 }
+        schema: {
+          type: 'number',
+          exclusiveMinimum: true,
+          minimum: 0,
+          example: 5
+        }
       },
       Times: {
         name: 'times',
@@ -264,7 +269,10 @@ const tracksApiDoc = {
       get: {
         tags: ['tracks'],
         summary: 'List contexts with track data in the window',
+        description:
+          'As with the tracks route, a time window is required unless a single context is given, so a bare request with no parameters returns 400.',
         parameters: [
+          { $ref: '#/components/parameters/Contexts' },
           { $ref: '#/components/parameters/From' },
           { $ref: '#/components/parameters/To' },
           { $ref: '#/components/parameters/Duration' },

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -32,6 +32,11 @@ const tracksApiDoc = {
             type: 'boolean',
             description: "Whether this is the own vessel's track"
           },
+          providerId: {
+            type: 'string',
+            description:
+              'Which registered provider answered for this track. Set by the server from its registry, so a provider neither has to name itself nor can name itself wrongly.'
+          },
           contextName: {
             type: 'string',
             description:

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -153,11 +153,16 @@ const tracksApiDoc = {
         name: 'duration',
         in: 'query',
         description:
-          'Length of the time range, as an ISO 8601 duration string or an integer number of seconds. See https://datatracker.ietf.org/doc/html/rfc3339#appendix-A',
+          'Length of the time range, as an ISO 8601 duration string or an integer number of seconds. Must be positive. See https://datatracker.ietf.org/doc/html/rfc3339#appendix-A',
         schema: {
           oneOf: [
-            { type: 'integer', description: 'Duration in seconds' },
-            { type: 'string', format: 'duration', example: 'P7D' }
+            { type: 'integer', minimum: 1, description: 'Duration in seconds' },
+            {
+              type: 'string',
+              format: 'duration',
+              description: 'Positive ISO 8601 duration',
+              example: 'P7D'
+            }
           ]
         }
       },
@@ -172,11 +177,16 @@ const tracksApiDoc = {
         name: 'resolution',
         in: 'query',
         description:
-          'Minimum spacing between returned points, as an ISO 8601 duration or seconds.',
+          'Minimum spacing between returned points, as an ISO 8601 duration or an integer number of seconds. Must be positive.',
         schema: {
           oneOf: [
-            { type: 'integer' },
-            { type: 'string', format: 'duration', example: 'PT1M' }
+            { type: 'integer', minimum: 1 },
+            {
+              type: 'string',
+              format: 'duration',
+              description: 'Positive ISO 8601 duration',
+              example: 'PT1M'
+            }
           ]
         }
       },

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -274,7 +274,7 @@ const tracksApiDoc = {
         name: 'provider',
         in: 'query',
         description:
-          'Query a specific track provider rather than the default one.',
+          'Query only this provider. Without it every registered provider is queried and their features concatenated, each carrying the providerId that produced it.',
         schema: { type: 'string' }
       }
     }
@@ -285,7 +285,8 @@ const tracksApiDoc = {
         tags: ['tracks'],
         summary: 'Retrieve recorded tracks',
         description:
-          'Returns a GeoJSON FeatureCollection, one Feature per context.\n\n' +
+          'Returns a GeoJSON FeatureCollection.\n\n' +
+          'Every registered provider is queried and their features concatenated verbatim, so two providers recording the same vessel yield two features for it rather than one merged track — they are two recordings, and each carries the providerId that produced it. Use the provider parameter to query one.\n\n' +
           'A time window is required unless a single context is given: `?context=self` with no window is a legitimate request for an entire recorded history, while the same query across every vessel a server has seen is not.',
         parameters: [
           { $ref: '#/components/parameters/Contexts' },

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -261,6 +261,7 @@ const tracksApiDoc = {
             }
           },
           '400': { description: 'Invalid query parameters' },
+          '500': { description: 'The track provider failed' },
           '501': { description: 'No track api provider configured' }
         }
       }
@@ -289,6 +290,7 @@ const tracksApiDoc = {
             }
           },
           '400': { description: 'Invalid query parameters' },
+          '500': { description: 'The track provider failed' },
           '501': { description: 'No track api provider configured' }
         }
       }

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -95,9 +95,13 @@ const tracksApiDoc = {
               type: 'array',
               items: {
                 type: 'array',
+                // nullable on a schema with oneOf but no same-level type is
+                // ambiguous in OpenAPI 3.0; put it on each member instead.
                 items: {
-                  nullable: true,
-                  oneOf: [{ type: 'number' }, { type: 'string' }]
+                  oneOf: [
+                    { type: 'number', nullable: true },
+                    { type: 'string', nullable: true }
+                  ]
                 }
               }
             }

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -207,7 +207,7 @@ const tracksApiDoc = {
         name: 'resolution',
         in: 'query',
         description:
-          'Minimum spacing between returned points, as an ISO 8601 duration or an integer number of seconds. Must be positive. Years and months are not accepted: their length depends on which month you count from, so they do not describe a spacing.',
+          'Minimum spacing between returned points, as an ISO 8601 duration or an integer number of seconds. Must be positive. Years and months are not accepted: their length depends on which month you count from, so they do not describe a spacing. Neither is anything below a millisecond, which is the finest granularity a timestamp carries.',
         schema: {
           oneOf: [
             { type: 'integer', minimum: 1 },

--- a/src/api/tracks/openApi.ts
+++ b/src/api/tracks/openApi.ts
@@ -200,14 +200,14 @@ const tracksApiDoc = {
         name: 'bbox',
         in: 'query',
         description:
-          "Only return tracks passing through this box, as west,south,east,north in GeoJSON coordinate order. Matching is intersection anywhere within the time window, not the vessel's current position: a vessel that crossed the box an hour ago and has since left still matches. A west edge numerically greater than the east edge describes a box crossing the antimeridian.",
+          "Only return tracks passing through this box, as west,south,east,north in GeoJSON coordinate order. Matching is intersection anywhere within the time window, not the vessel's current position: a vessel that crossed the box an hour ago and has since left still matches. Matching tracks are returned whole rather than clipped to the box, so a client gets the approach and the departure rather than a line stopping at an invisible edge. A west edge numerically greater than the east edge describes a box crossing the antimeridian.",
         schema: { type: 'string', example: '24.5,59.9,25.2,60.3' }
       },
       Resolution: {
         name: 'resolution',
         in: 'query',
         description:
-          'Minimum spacing between returned points, as an ISO 8601 duration or an integer number of seconds. Must be positive.',
+          'Minimum spacing between returned points, as an ISO 8601 duration or an integer number of seconds. Must be positive. Years and months are not accepted: their length depends on which month you count from, so they do not describe a spacing.',
         schema: {
           oneOf: [
             { type: 'integer', minimum: 1 },
@@ -250,7 +250,7 @@ const tracksApiDoc = {
         name: 'properties',
         in: 'query',
         description:
-          'Comma-separated Signal K paths to return alongside each position, nested to match coordinates the way coordTimes is. Lets a client colour a track by speed, or derive a route from a recorded passage, without querying the History API separately and joining the two responses by timestamp. Provider-optional: what was actually returned is listed in properties.appliedProperties.',
+          'Comma-separated Signal K paths to return alongside each position, nested to match coordinates the way coordTimes is. Lets a client colour a track by speed, or derive a route from a recorded passage, without querying the History API separately and joining the two responses by timestamp. Values are matched to the nearest sample of that path rather than one sharing the position timestamp, because paths arrive from different talkers on their own cadences. Provider-optional: what was actually returned is listed in properties.appliedProperties.',
         schema: {
           type: 'string',
           example: 'navigation.speedOverGround,environment.wind.speedApparent'

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -35,8 +35,16 @@ const parseDuration = (
   try {
     parsed = Temporal.Duration.from(value)
   } catch {
+    // The seconds fallback has to be guarded too: Temporal refuses a total
+    // above its safe range, so an absurd integer would throw out of the parser
+    // and surface as a 500 for what is really a bad query string.
     if (/^\d+$/.test(value)) {
-      parsed = Temporal.Duration.from({ seconds: Number(value) })
+      try {
+        parsed = Temporal.Duration.from({ seconds: Number(value) })
+      } catch {
+        errors.push(`${name} is out of range`)
+        return undefined
+      }
     } else {
       errors.push(
         `${name} must be an ISO 8601 duration string (e.g. 'PT15M') or an integer number of seconds`
@@ -211,7 +219,13 @@ export function parseTracksQuery(
 
   const simplify = readFlag(query, 'simplify', errors)
   if (simplify !== undefined) {
-    request.simplify = simplify
+    // epsilon sets simplify above, so an explicit simplify=false alongside it
+    // is a contradiction. Rejecting beats silently honouring one of the two.
+    if (simplify === false && request.epsilon !== undefined) {
+      errors.push('simplify=false cannot be combined with epsilon')
+    } else {
+      request.simplify = simplify
+    }
   }
 
   const times = readFlag(query, 'times', errors)

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -185,11 +185,18 @@ export function parseTracksQuery(
   if (contexts !== undefined && blank(contexts)) {
     errors.push('context must not be empty')
   } else if (contexts !== undefined) {
-    request.contexts = contexts
-      .split(',')
-      .map((c) => c.trim())
-      .filter((c) => c !== '')
-      .map(qualifyContext)
+    // Deduplicated: `contexts=self,self` would otherwise put the same vessel in
+    // the FeatureCollection twice, and after qualification `self` and the
+    // resolved id can arrive as the same context by two names.
+    request.contexts = [
+      ...new Set(
+        contexts
+          .split(',')
+          .map((c) => c.trim())
+          .filter((c) => c !== '')
+          .map(qualifyContext)
+      )
+    ]
     if (request.contexts.length === 0) {
       errors.push('context must not be empty')
     }

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -253,7 +253,10 @@ export function parseTracksQuery(
     // exponential (1e3 -> 1000) forms, so a typo becomes a silently different
     // budget. The History API's duration parsing guards the same way.
     const n = /^\d+$/.test(maxPoints.trim()) ? Number(maxPoints.trim()) : NaN
-    if (!Number.isInteger(n) || n <= 0) {
+    // isSafeInteger, not isInteger: above 2^53 Number() rounds, so
+    // 9007199254740993 would be accepted as a different value than was asked
+    // for. A point budget that large is meaningless anyway.
+    if (!Number.isSafeInteger(n) || n <= 0) {
       errors.push('maxPoints must be a positive integer')
     } else {
       request.maxPoints = n

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -14,10 +14,22 @@ export interface ParsedTracksQuery {
   errors: string[]
 }
 
+/**
+ * Extract a scalar query value; express repeats a key into an array.
+ *
+ * Returns undefined only when the parameter is genuinely absent. A present but
+ * empty value is returned as the empty string so callers can reject it —
+ * treating `?duration=` as omitted would quietly skip the window check rather
+ * than telling the client its query was malformed. `readFlag` is the one place
+ * an empty value legitimately means something.
+ */
 const first = (value: unknown): string | undefined => {
   const scalar = Array.isArray(value) ? (value as unknown[])[0] : value
-  return typeof scalar === 'string' && scalar.trim() !== '' ? scalar : undefined
+  return typeof scalar === 'string' ? scalar : undefined
 }
+
+/** A present-but-blank value, which every parameter except a flag rejects. */
+const blank = (value: string): boolean => value.trim() === ''
 
 /**
  * ISO 8601 duration, or a bare integer read as seconds.
@@ -75,6 +87,9 @@ const parseInstant = (
   }
 }
 
+const MAX_LONGITUDE = 180
+const MAX_LATITUDE = 90
+
 /**
  * `west,south,east,north` — GeoJSON coordinate order, as the Resources API
  * uses. A west edge numerically greater than the east edge is a box crossing
@@ -84,8 +99,17 @@ const parseBbox = (
   value: string,
   errors: string[]
 ): TrackBoundingBox | undefined => {
-  const parts = value.split(',').map((p) => Number(p.trim()))
-  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+  const raw = value.split(',')
+  // Number('') is 0, not NaN, so a blank component would pass the finite check
+  // and place an edge on the equator or the prime meridian rather than failing.
+  if (raw.length !== 4 || raw.some((p) => p.trim() === '')) {
+    errors.push(
+      'bbox must be four comma-separated numbers: west,south,east,north'
+    )
+    return undefined
+  }
+  const parts = raw.map((p) => Number(p.trim()))
+  if (parts.some((n) => !Number.isFinite(n))) {
     errors.push(
       'bbox must be four comma-separated numbers: west,south,east,north'
     )
@@ -98,11 +122,11 @@ const parseBbox = (
     )
     return undefined
   }
-  if ([west, east].some((n) => n < -180 || n > 180)) {
+  if ([west, east].some((n) => n < -MAX_LONGITUDE || n > MAX_LONGITUDE)) {
     errors.push('bbox longitudes must be between -180 and 180')
     return undefined
   }
-  if ([south, north].some((n) => n < -90 || n > 90)) {
+  if ([south, north].some((n) => n < -MAX_LATITUDE || n > MAX_LATITUDE)) {
     errors.push('bbox latitudes must be between -90 and 90')
     return undefined
   }
@@ -158,7 +182,9 @@ export function parseTracksQuery(
   const request: TracksRequest = {}
 
   const contexts = first(query.contexts) ?? first(query.context)
-  if (contexts !== undefined) {
+  if (contexts !== undefined && blank(contexts)) {
+    errors.push('context must not be empty')
+  } else if (contexts !== undefined) {
     request.contexts = contexts
       .split(',')
       .map((c) => c.trim())
@@ -171,32 +197,52 @@ export function parseTracksQuery(
 
   const from = first(query.from)
   if (from !== undefined) {
-    request.from = parseInstant(from, 'from', errors)
+    if (blank(from)) {
+      errors.push('from must not be empty')
+    } else {
+      request.from = parseInstant(from, 'from', errors)
+    }
   }
 
   const to = first(query.to)
   if (to !== undefined) {
-    request.to = parseInstant(to, 'to', errors)
+    if (blank(to)) {
+      errors.push('to must not be empty')
+    } else {
+      request.to = parseInstant(to, 'to', errors)
+    }
   }
 
   const duration = first(query.duration)
   if (duration !== undefined) {
-    request.duration = parseDuration(duration, 'duration', errors)
+    if (blank(duration)) {
+      errors.push('duration must not be empty')
+    } else {
+      request.duration = parseDuration(duration, 'duration', errors)
+    }
   }
 
   const bbox = first(query.bbox)
   if (bbox !== undefined) {
-    request.bbox = parseBbox(bbox, errors)
+    if (blank(bbox)) {
+      errors.push('bbox must not be empty')
+    } else {
+      request.bbox = parseBbox(bbox, errors)
+    }
   }
 
   const resolution = first(query.resolution)
   if (resolution !== undefined) {
-    request.resolution = parseDuration(resolution, 'resolution', errors)
+    if (blank(resolution)) {
+      errors.push('resolution must not be empty')
+    } else {
+      request.resolution = parseDuration(resolution, 'resolution', errors)
+    }
   }
 
   const maxPoints = first(query.maxPoints)
   if (maxPoints !== undefined) {
-    const n = Number(maxPoints)
+    const n = blank(maxPoints) ? NaN : Number(maxPoints)
     if (!Number.isInteger(n) || n <= 0) {
       errors.push('maxPoints must be a positive integer')
     } else {
@@ -206,7 +252,7 @@ export function parseTracksQuery(
 
   const epsilon = first(query.epsilon)
   if (epsilon !== undefined) {
-    const n = Number(epsilon)
+    const n = blank(epsilon) ? NaN : Number(epsilon)
     if (!Number.isFinite(n) || n <= 0) {
       errors.push('epsilon must be a positive number of metres')
     } else {

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -331,14 +331,6 @@ export function parseTracksQuery(
     request.geometry = geometry
   }
 
-  if (
-    request.from &&
-    request.to &&
-    Temporal.Instant.compare(request.from, request.to) >= 0
-  ) {
-    errors.push('from must be before to')
-  }
-
   // Resolved to a single `from`/`to` here rather than left to each provider.
   // Three fields describing one window is how two providers come to answer the
   // same query differently: given from+duration, one reads from..to and
@@ -366,6 +358,18 @@ export function parseTracksQuery(
           : request.from
       delete request.duration
     }
+  }
+
+  // Checked after the window is resolved, not before: `to` defaults to now, so
+  // a `from` in the future produces a backwards window that an earlier check
+  // would not have seen. Explicit bounds in the wrong order are caught here
+  // too, so one check covers both.
+  if (
+    request.from &&
+    request.to &&
+    Temporal.Instant.compare(request.from, request.to) >= 0
+  ) {
+    errors.push('from must be before to')
   }
 
   // An unbounded query is allowed for a single context — "my whole track since

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -31,17 +31,27 @@ const parseDuration = (
   name: string,
   errors: string[]
 ): Temporal.Duration | undefined => {
+  let parsed: Temporal.Duration
   try {
-    return Temporal.Duration.from(value)
+    parsed = Temporal.Duration.from(value)
   } catch {
     if (/^\d+$/.test(value)) {
-      return Temporal.Duration.from({ seconds: Number(value) })
+      parsed = Temporal.Duration.from({ seconds: Number(value) })
+    } else {
+      errors.push(
+        `${name} must be an ISO 8601 duration string (e.g. 'PT15M') or an integer number of seconds`
+      )
+      return undefined
     }
-    errors.push(
-      `${name} must be an ISO 8601 duration string (e.g. 'PT15M') or an integer number of seconds`
-    )
+  }
+  // Temporal accepts a leading minus, and zero parses fine, but neither
+  // describes a window or a spacing: a negative duration would ask for a range
+  // ending before it starts, and a zero resolution would thin nothing.
+  if (parsed.sign <= 0) {
+    errors.push(`${name} must be a positive duration`)
     return undefined
   }
+  return parsed
 }
 
 const parseInstant = (
@@ -95,20 +105,42 @@ const parseBbox = (
 const qualifyContext = (value: string): Context =>
   (value.includes('.') ? value : `vessels.${value}`) as Context
 
+/** A valueless parameter — `?times` — reads as true, as query strings spell flags. */
+const TRUE_FLAGS = new Set(['true', '1', 'yes', ''])
+const FALSE_FLAGS = new Set(['false', '0', 'no'])
+
 const parseFlag = (
   value: string,
   name: string,
   errors: string[]
 ): boolean | undefined => {
   const flag = value.trim().toLowerCase()
-  if (['true', '1', 'yes', ''].includes(flag)) {
+  if (TRUE_FLAGS.has(flag)) {
     return true
   }
-  if (['false', '0', 'no'].includes(flag)) {
+  if (FALSE_FLAGS.has(flag)) {
     return false
   }
   errors.push(`${name} must be true or false`)
   return undefined
+}
+
+/**
+ * Read a boolean parameter, honouring the valueless form.
+ *
+ * `first()` returns undefined for an empty string, so presence has to be
+ * tested on the raw query rather than on the extracted value; otherwise
+ * `?simplify` would be silently ignored while `?simplify=true` worked.
+ */
+const readFlag = (
+  query: Record<string, unknown>,
+  name: string,
+  errors: string[]
+): boolean | undefined => {
+  if (!Object.prototype.hasOwnProperty.call(query, name)) {
+    return undefined
+  }
+  return parseFlag(first(query[name]) ?? '', name, errors)
 }
 
 export function parseTracksQuery(
@@ -177,31 +209,19 @@ export function parseTracksQuery(
     }
   }
 
-  const simplify = first(query.simplify)
+  const simplify = readFlag(query, 'simplify', errors)
   if (simplify !== undefined) {
-    const flag = parseFlag(simplify, 'simplify', errors)
-    if (flag !== undefined) {
-      request.simplify = flag
-    }
+    request.simplify = simplify
   }
 
-  const times = first(query.times)
-  if (
-    times !== undefined ||
-    Object.prototype.hasOwnProperty.call(query, 'times')
-  ) {
-    const flag = parseFlag(times ?? '', 'times', errors)
-    if (flag !== undefined) {
-      request.times = flag
-    }
+  const times = readFlag(query, 'times', errors)
+  if (times !== undefined) {
+    request.times = times
   }
 
-  const geometry = first(query.geometry)
+  const geometry = readFlag(query, 'geometry', errors)
   if (geometry !== undefined) {
-    const flag = parseFlag(geometry, 'geometry', errors)
-    if (flag !== undefined) {
-      request.geometry = flag
-    }
+    request.geometry = geometry
   }
 
   if (

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -87,6 +87,13 @@ const parseInstant = (
   }
 }
 
+/**
+ * A Signal K path: dot-separated segments of letters, digits, dash and
+ * underscore. Validated rather than cast — these arrive from a client, and
+ * `Path` is a branded type whose guarantee would otherwise be hollow.
+ */
+const PATH_PATTERN = /^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*$/
+
 const MAX_LONGITUDE = 180
 const MAX_LATITUDE = 90
 
@@ -306,8 +313,13 @@ export function parseTracksQuery(
             .filter((p) => p !== '')
         )
       ]
+      const invalid = paths.filter((path) => !PATH_PATTERN.test(path))
       if (paths.length === 0) {
         errors.push('properties must not be empty')
+      } else if (invalid.length > 0) {
+        errors.push(
+          `properties contains invalid Signal K path(s): ${invalid.join(', ')}`
+        )
       } else {
         request.properties = paths as Path[]
       }
@@ -327,14 +339,33 @@ export function parseTracksQuery(
     errors.push('from must be before to')
   }
 
-  // Resolved here rather than left to each provider. The description has always
-  // said an omitted `to` means now, and leaving providers to apply that
-  // individually is how two of them come to answer the same query differently.
-  if (
-    request.to === undefined &&
-    (request.from !== undefined || request.duration !== undefined)
-  ) {
-    request.to = now
+  // Resolved to a single `from`/`to` here rather than left to each provider.
+  // Three fields describing one window is how two providers come to answer the
+  // same query differently: given from+duration, one reads from..to and
+  // another duration-before-to. `duration` measures back from the end of the
+  // window, which is what History's description says and what a client asking
+  // for "the last 7 days" means.
+  if (request.from !== undefined || request.duration !== undefined) {
+    if (request.to === undefined) {
+      request.to = now
+    }
+    if (request.duration !== undefined) {
+      // Via UTC rather than Instant.subtract, which refuses day-and-larger
+      // units because their length depends on a timezone. Windows here are
+      // absolute, so UTC is the right frame and `P7D` means 7 × 24h.
+      const start = request.to
+        .toZonedDateTimeISO('UTC')
+        .subtract(request.duration)
+        .toInstant()
+      // With both given, the later start wins: `from` is a floor the caller
+      // set deliberately, so `duration` must not reach back past it.
+      request.from =
+        request.from === undefined ||
+        Temporal.Instant.compare(start, request.from) > 0
+          ? start
+          : request.from
+      delete request.duration
+    }
   }
 
   // An unbounded query is allowed for a single context — "my whole track since

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill'
-import { Context } from '@signalk/server-api'
+import { Context, Path } from '@signalk/server-api'
 import { TrackBoundingBox, TracksRequest } from '@signalk/server-api/tracks'
 
 /**
@@ -176,7 +176,8 @@ const readFlag = (
 }
 
 export function parseTracksQuery(
-  query: Record<string, unknown>
+  query: Record<string, unknown>,
+  now: Temporal.Instant = Temporal.Now.instant()
 ): ParsedTracksQuery {
   const errors: string[] = []
   const request: TracksRequest = {}
@@ -292,6 +293,27 @@ export function parseTracksQuery(
     request.times = times
   }
 
+  const properties = first(query.properties)
+  if (properties !== undefined) {
+    if (blank(properties)) {
+      errors.push('properties must not be empty')
+    } else {
+      const paths = [
+        ...new Set(
+          properties
+            .split(',')
+            .map((p) => p.trim())
+            .filter((p) => p !== '')
+        )
+      ]
+      if (paths.length === 0) {
+        errors.push('properties must not be empty')
+      } else {
+        request.properties = paths as Path[]
+      }
+    }
+  }
+
   const geometry = readFlag(query, 'geometry', errors)
   if (geometry !== undefined) {
     request.geometry = geometry
@@ -303,6 +325,16 @@ export function parseTracksQuery(
     Temporal.Instant.compare(request.from, request.to) >= 0
   ) {
     errors.push('from must be before to')
+  }
+
+  // Resolved here rather than left to each provider. The description has always
+  // said an omitted `to` means now, and leaving providers to apply that
+  // individually is how two of them come to answer the same query differently.
+  if (
+    request.to === undefined &&
+    (request.from !== undefined || request.duration !== undefined)
+  ) {
+    request.to = now
   }
 
   // An unbounded query is allowed for a single context — "my whole track since

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -1,0 +1,228 @@
+import { Temporal } from '@js-temporal/polyfill'
+import { Context } from '@signalk/server-api'
+import { TrackBoundingBox, TracksRequest } from '@signalk/server-api/tracks'
+
+/**
+ * Query parsing for the Track API.
+ *
+ * Kept separate from the HTTP registry so the rules are testable without
+ * standing up express or a provider.
+ */
+
+export interface ParsedTracksQuery {
+  request: TracksRequest
+  errors: string[]
+}
+
+const first = (value: unknown): string | undefined => {
+  const scalar = Array.isArray(value) ? (value as unknown[])[0] : value
+  return typeof scalar === 'string' && scalar.trim() !== '' ? scalar : undefined
+}
+
+/**
+ * ISO 8601 duration, or a bare integer read as seconds.
+ *
+ * The integer form is not in the spec but the History API accepts it, and a
+ * client that has learned History's behaviour will reasonably expect the same
+ * here.
+ */
+const parseDuration = (
+  value: string,
+  name: string,
+  errors: string[]
+): Temporal.Duration | undefined => {
+  try {
+    return Temporal.Duration.from(value)
+  } catch {
+    if (/^\d+$/.test(value)) {
+      return Temporal.Duration.from({ seconds: Number(value) })
+    }
+    errors.push(
+      `${name} must be an ISO 8601 duration string (e.g. 'PT15M') or an integer number of seconds`
+    )
+    return undefined
+  }
+}
+
+const parseInstant = (
+  value: string,
+  name: string,
+  errors: string[]
+): Temporal.Instant | undefined => {
+  try {
+    return Temporal.Instant.from(value)
+  } catch {
+    errors.push(`${name} must be a valid ISO 8601 timestamp`)
+    return undefined
+  }
+}
+
+/**
+ * `west,south,east,north` — GeoJSON coordinate order, as the Resources API
+ * uses. A west edge numerically greater than the east edge is a box crossing
+ * the antimeridian, which is legal and left to the provider to interpret.
+ */
+const parseBbox = (
+  value: string,
+  errors: string[]
+): TrackBoundingBox | undefined => {
+  const parts = value.split(',').map((p) => Number(p.trim()))
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    errors.push(
+      'bbox must be four comma-separated numbers: west,south,east,north'
+    )
+    return undefined
+  }
+  const [west, south, east, north] = parts as [number, number, number, number]
+  if (south > north) {
+    errors.push(
+      `bbox south (${south}) must not be greater than north (${north})`
+    )
+    return undefined
+  }
+  if ([west, east].some((n) => n < -180 || n > 180)) {
+    errors.push('bbox longitudes must be between -180 and 180')
+    return undefined
+  }
+  if ([south, north].some((n) => n < -90 || n > 90)) {
+    errors.push('bbox latitudes must be between -90 and 90')
+    return undefined
+  }
+  return [west, south, east, north]
+}
+
+/** A bare id is qualified with `vessels.`; other prefixes pass through. */
+const qualifyContext = (value: string): Context =>
+  (value.includes('.') ? value : `vessels.${value}`) as Context
+
+const parseFlag = (
+  value: string,
+  name: string,
+  errors: string[]
+): boolean | undefined => {
+  const flag = value.trim().toLowerCase()
+  if (['true', '1', 'yes', ''].includes(flag)) {
+    return true
+  }
+  if (['false', '0', 'no'].includes(flag)) {
+    return false
+  }
+  errors.push(`${name} must be true or false`)
+  return undefined
+}
+
+export function parseTracksQuery(
+  query: Record<string, unknown>
+): ParsedTracksQuery {
+  const errors: string[] = []
+  const request: TracksRequest = {}
+
+  const contexts = first(query.contexts) ?? first(query.context)
+  if (contexts !== undefined) {
+    request.contexts = contexts
+      .split(',')
+      .map((c) => c.trim())
+      .filter((c) => c !== '')
+      .map(qualifyContext)
+    if (request.contexts.length === 0) {
+      errors.push('context must not be empty')
+    }
+  }
+
+  const from = first(query.from)
+  if (from !== undefined) {
+    request.from = parseInstant(from, 'from', errors)
+  }
+
+  const to = first(query.to)
+  if (to !== undefined) {
+    request.to = parseInstant(to, 'to', errors)
+  }
+
+  const duration = first(query.duration)
+  if (duration !== undefined) {
+    request.duration = parseDuration(duration, 'duration', errors)
+  }
+
+  const bbox = first(query.bbox)
+  if (bbox !== undefined) {
+    request.bbox = parseBbox(bbox, errors)
+  }
+
+  const resolution = first(query.resolution)
+  if (resolution !== undefined) {
+    request.resolution = parseDuration(resolution, 'resolution', errors)
+  }
+
+  const maxPoints = first(query.maxPoints)
+  if (maxPoints !== undefined) {
+    const n = Number(maxPoints)
+    if (!Number.isInteger(n) || n <= 0) {
+      errors.push('maxPoints must be a positive integer')
+    } else {
+      request.maxPoints = n
+    }
+  }
+
+  const epsilon = first(query.epsilon)
+  if (epsilon !== undefined) {
+    const n = Number(epsilon)
+    if (!Number.isFinite(n) || n <= 0) {
+      errors.push('epsilon must be a positive number of metres')
+    } else {
+      request.epsilon = n
+      // epsilon is meaningless without simplification, so asking for one is
+      // asking for the other.
+      request.simplify = true
+    }
+  }
+
+  const simplify = first(query.simplify)
+  if (simplify !== undefined) {
+    const flag = parseFlag(simplify, 'simplify', errors)
+    if (flag !== undefined) {
+      request.simplify = flag
+    }
+  }
+
+  const times = first(query.times)
+  if (
+    times !== undefined ||
+    Object.prototype.hasOwnProperty.call(query, 'times')
+  ) {
+    const flag = parseFlag(times ?? '', 'times', errors)
+    if (flag !== undefined) {
+      request.times = flag
+    }
+  }
+
+  const geometry = first(query.geometry)
+  if (geometry !== undefined) {
+    const flag = parseFlag(geometry, 'geometry', errors)
+    if (flag !== undefined) {
+      request.geometry = flag
+    }
+  }
+
+  if (
+    request.from &&
+    request.to &&
+    Temporal.Instant.compare(request.from, request.to) >= 0
+  ) {
+    errors.push('from must be before to')
+  }
+
+  // An unbounded query is allowed for a single context — "my whole track since
+  // I started recording" is the point of keeping own-vessel data forever — but
+  // not across every context the server has ever seen, which on a busy coast
+  // is years of data for hundreds of vessels.
+  const bounded = request.from !== undefined || request.duration !== undefined
+  const singleContext = request.contexts?.length === 1
+  if (!bounded && !singleContext) {
+    errors.push(
+      'a time window (from or duration) is required unless a single context is given'
+    )
+  }
+
+  return { request, errors }
+}

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -242,7 +242,10 @@ export function parseTracksQuery(
 
   const maxPoints = first(query.maxPoints)
   if (maxPoints !== undefined) {
-    const n = blank(maxPoints) ? NaN : Number(maxPoints)
+    // Decimal digits only. Number() would otherwise read hex (0x10 -> 16) and
+    // exponential (1e3 -> 1000) forms, so a typo becomes a silently different
+    // budget. The History API's duration parsing guards the same way.
+    const n = /^\d+$/.test(maxPoints.trim()) ? Number(maxPoints.trim()) : NaN
     if (!Number.isInteger(n) || n <= 0) {
       errors.push('maxPoints must be a positive integer')
     } else {

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -100,9 +100,18 @@ const normalizeDuration = (
   const anchor =
     Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO('UTC')
   try {
-    return anchor.until(anchor.add(duration), {
+    const normalized = anchor.until(anchor.add(duration), {
       largestUnit: 'hour'
     })
+    // A millisecond floor: timestamps carry no finer granularity, so a spacing
+    // below one cannot thin anything, and `PT0.0005S` is a request no store can
+    // act on. Rejected rather than rounded, because silently widening a
+    // client's spacing is worse than telling it the value was unusable.
+    if (normalized.total({ unit: 'milliseconds' }) < 1) {
+      errors.push(`${name} must be at least one millisecond`)
+      return undefined
+    }
+    return normalized
   } catch {
     // Temporal refuses a date beyond its supported range, so a duration large
     // enough to overshoot it throws here rather than parsing. That is a bad

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -99,9 +99,18 @@ const normalizeDuration = (
   }
   const anchor =
     Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO('UTC')
-  return anchor.until(anchor.add(duration), {
-    largestUnit: 'hour'
-  })
+  try {
+    return anchor.until(anchor.add(duration), {
+      largestUnit: 'hour'
+    })
+  } catch {
+    // Temporal refuses a date beyond its supported range, so a duration large
+    // enough to overshoot it throws here rather than parsing. That is a bad
+    // query string, not a server fault: guarded the same way parseDuration
+    // guards its own seconds fallback, so it surfaces as a 400.
+    errors.push(`${name} is out of range`)
+    return undefined
+  }
 }
 
 const parseInstant = (

--- a/src/api/tracks/query.ts
+++ b/src/api/tracks/query.ts
@@ -74,6 +74,36 @@ const parseDuration = (
   return parsed
 }
 
+/**
+ * Re-express a duration in hours and below, so a provider can call
+ * `total({ unit: 'milliseconds' })` on it without a reference date.
+ *
+ * Anchored to an arbitrary UTC instant: a spacing is a length, not a position,
+ * so the same query must resolve to the same number of milliseconds whenever it
+ * is asked. That fixes a day at 24h, which is what an absolute window means.
+ */
+const normalizeDuration = (
+  duration: Temporal.Duration,
+  name: string,
+  errors: string[]
+): Temporal.Duration | undefined => {
+  // Years and months have no fixed length — `P1M` is 744h measured from
+  // January and 672h from February — so they are rejected rather than silently
+  // resolved against an arbitrary anchor. A spacing is a length, not a
+  // position: the same query has to mean the same thing whenever it is asked.
+  if (duration.years !== 0 || duration.months !== 0) {
+    errors.push(
+      `${name} must not use years or months, which have no fixed length; use days or smaller`
+    )
+    return undefined
+  }
+  const anchor =
+    Temporal.Instant.fromEpochMilliseconds(0).toZonedDateTimeISO('UTC')
+  return anchor.until(anchor.add(duration), {
+    largestUnit: 'hour'
+  })
+}
+
 const parseInstant = (
   value: string,
   name: string,
@@ -251,7 +281,14 @@ export function parseTracksQuery(
     if (blank(resolution)) {
       errors.push('resolution must not be empty')
     } else {
-      request.resolution = parseDuration(resolution, 'resolution', errors)
+      const parsed = parseDuration(resolution, 'resolution', errors)
+      // Normalised to hours and below before a provider sees it: a provider
+      // needs this as a number of milliseconds, and Temporal.Duration.total()
+      // refuses day-and-larger units without a reference date because their
+      // length is timezone-dependent. Windows here are absolute, so P1D means
+      // 24h, exactly as it does for duration above.
+      request.resolution =
+        parsed && normalizeDuration(parsed, 'resolution', errors)
     }
   }
 

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -978,6 +978,9 @@ module.exports = (theApp: any) => {
         trackApiRegistry.unregisterTrackApiProvider(plugin.id)
       })
     }
+    appCopy.unregisterTrackApiProvider = () => {
+      trackApiRegistry.unregisterTrackApiProvider(plugin.id)
+    }
 
     const resourcesApi: ResourcesApi = app.resourcesApi
     appCopy.registerResourceProvider = (provider: ResourceProvider) => {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -88,6 +88,8 @@ import { queryRequest } from '../requestResponse'
 import { getMetadata } from '@signalk/path-metadata'
 import { HistoryProvider } from '@signalk/server-api/history'
 import { HistoryApiHttpRegistry } from '../api/history'
+import { TrackProvider } from '@signalk/server-api/tracks'
+import { TrackApiHttpRegistry } from '../api/tracks'
 import { derivePluginId } from '../pluginid'
 import { atomicWriteFileSync } from '../atomicWrite'
 import { writeBaseDeltasFile, ConfigApp } from '../config/config'
@@ -965,6 +967,15 @@ module.exports = (theApp: any) => {
       historyApiRegistry.registerHistoryApiProvider(plugin.id, provider)
       onStopHandlers[plugin.id].push(() => {
         historyApiRegistry.unregisterHistoryApiProvider(plugin.id)
+      })
+    }
+
+    const trackApiRegistry: TrackApiHttpRegistry = app.trackApiHttpRegistry
+    delete (appCopy as any).trackApiHttpRegistry // expose only the plugin-specific proxy
+    appCopy.registerTrackApiProvider = (provider: TrackProvider) => {
+      trackApiRegistry.registerTrackApiProvider(plugin.id, provider)
+      onStopHandlers[plugin.id].push(() => {
+        trackApiRegistry.unregisterTrackApiProvider(plugin.id)
       })
     }
 

--- a/test/tracks-provider-stamp.ts
+++ b/test/tracks-provider-stamp.ts
@@ -28,23 +28,27 @@ describe('Track API provider stamping', () => {
     }
   })
 
-  const provider = () => ({
+  const provider = (contexts: string[] = ['vessels.a']) => ({
     getTracks: () =>
       Promise.resolve({
         type: 'FeatureCollection' as const,
-        features: [track('vessels.a' as Context)]
+        features: contexts.map((c) => track(c as Context))
       }),
-    getTrackContexts: () => Promise.resolve([])
+    getTrackContexts: () => Promise.resolve(contexts.map((c) => c as Context))
   })
 
   let server: Server | undefined
   let base = ''
 
-  const serve = async () => {
+  const serve = async (
+    providers: Record<string, string[]> = { testprovider: ['vessels.a'] }
+  ) => {
     const app = express()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const registry = new TrackApiHttpRegistry(app as any)
-    registry.registerTrackApiProvider('testprovider', provider())
+    for (const [id, contexts] of Object.entries(providers)) {
+      registry.registerTrackApiProvider(id, provider(contexts))
+    }
     await registry.start()
     await new Promise<void>((resolve) => {
       server = app.listen(0, () => resolve())
@@ -101,5 +105,70 @@ describe('Track API provider stamping', () => {
     const body = (await res.json()) as { error: string }
 
     expect(body.error).to.match(/Requested provider not found/)
+  })
+
+  /**
+   * Fan-out across providers.
+   *
+   * Every registered provider answers and their features are concatenated
+   * verbatim rather than merged: two providers recording the same vessel hold
+   * two recordings, not one, and the server has no basis for reconciling them.
+   * Confirmed by @tkurki in the design discussion.
+   */
+  describe('Track API provider fan-out', () => {
+    const TWO = { alpha: ['vessels.a'], beta: ['vessels.b'] }
+
+    const tracksFrom = async (query = 'duration=PT1H') => {
+      const res = await fetch(`${base}/signalk/v2/api/tracks?${query}`)
+      expect(res.status).to.equal(200)
+      return (await res.json()) as {
+        features: { properties: { context: string; providerId?: string } }[]
+      }
+    }
+
+    it('concatenates features from every provider', async () => {
+      await serve(TWO)
+      const body = await tracksFrom()
+
+      expect(body.features).to.have.length(2)
+      expect(
+        body.features.map((f) => f.properties.providerId).sort()
+      ).to.deep.equal(['alpha', 'beta'])
+    })
+
+    it('keeps two recordings of one vessel separate', async () => {
+      // Not merged: the same passage imported twice, or one provider recording
+      // AIS while another records own vessel, are genuinely two recordings.
+      await serve({ alpha: ['vessels.a'], beta: ['vessels.a'] })
+      const body = await tracksFrom()
+
+      expect(body.features).to.have.length(2)
+      expect(
+        body.features.every((f) => f.properties.context === 'vessels.a')
+      ).to.equal(true)
+      expect(
+        body.features.map((f) => f.properties.providerId).sort()
+      ).to.deep.equal(['alpha', 'beta'])
+    })
+
+    it('queries only the named provider when one is given', async () => {
+      await serve(TWO)
+      const body = await tracksFrom('provider=alpha&duration=PT1H')
+
+      expect(body.features).to.have.length(1)
+      expect(body.features[0]?.properties.providerId).to.equal('alpha')
+    })
+
+    it('names each context once in the contexts listing', async () => {
+      // The tracks stay separate, but a listing of which contexts exist should
+      // not repeat a vessel because two providers both recorded it.
+      await serve({ alpha: ['vessels.a'], beta: ['vessels.a'] })
+      const res = await fetch(
+        `${base}/signalk/v2/api/tracks/contexts?duration=PT1H`
+      )
+      expect(res.status).to.equal(200)
+
+      expect(await res.json()).to.deep.equal(['vessels.a'])
+    })
   })
 })

--- a/test/tracks-provider-stamp.ts
+++ b/test/tracks-provider-stamp.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai'
+import express from 'express'
+import type { Server } from 'node:http'
+import { TrackApiHttpRegistry } from '../dist/api/tracks/index.js'
+import type { Context } from '@signalk/server-api'
+
+/**
+ * Provider selection on the tracks route.
+ *
+ * `providerId` is stamped by the server from its registry rather than by the
+ * provider, so it always matches what actually answered. Selection has to stay
+ * inside the error-handling path: naming a provider that does not exist throws,
+ * and that must surface as a 400 rather than an unhandled error page.
+ */
+describe('Track API provider stamping', () => {
+  const track = (context: Context) => ({
+    type: 'Feature' as const,
+    geometry: {
+      type: 'MultiLineString' as const,
+      coordinates: [[[24.9, 60.1] as [number, number]]]
+    },
+    properties: {
+      context,
+      isSelf: false,
+      from: '2026-08-01T00:00:00Z',
+      to: '2026-08-02T00:00:00Z',
+      pointCount: 1
+    }
+  })
+
+  const provider = () => ({
+    getTracks: () =>
+      Promise.resolve({
+        type: 'FeatureCollection' as const,
+        features: [track('vessels.a' as Context)]
+      }),
+    getTrackContexts: () => Promise.resolve([])
+  })
+
+  let server: Server | undefined
+  let base = ''
+
+  const serve = async () => {
+    const app = express()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const registry = new TrackApiHttpRegistry(app as any)
+    registry.registerTrackApiProvider('testprovider', provider())
+    await registry.start()
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve())
+    })
+    const address = server?.address()
+    base =
+      typeof address === 'object' && address
+        ? `http://localhost:${address.port}`
+        : ''
+  }
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      if (server) {
+        server.close(() => resolve())
+      } else {
+        resolve()
+      }
+    })
+    server = undefined
+  })
+
+  it('records which provider answered', async () => {
+    await serve()
+    const res = await fetch(`${base}/signalk/v2/api/tracks?duration=PT1H`)
+    expect(res.status).to.equal(200)
+    const body = (await res.json()) as {
+      features: { properties: { providerId?: string } }[]
+    }
+
+    expect(body.features[0]?.properties.providerId).to.equal('testprovider')
+  })
+
+  it('does not require the provider to name itself', async () => {
+    // The stub returns no providerId; the server supplies it from the registry.
+    await serve()
+    const res = await fetch(`${base}/signalk/v2/api/tracks?duration=PT1H`)
+    const body = (await res.json()) as {
+      features: { properties: { context: string; providerId?: string } }[]
+    }
+
+    expect(body.features[0]?.properties.context).to.equal('vessels.a')
+    expect(body.features[0]?.properties.providerId).to.equal('testprovider')
+  })
+
+  it('still reports an unknown provider as a client error', async () => {
+    // Selecting outside the guarded path turned this into an unhandled error
+    // page rather than a 400.
+    await serve()
+    const res = await fetch(
+      `${base}/signalk/v2/api/tracks?provider=nope&duration=PT1H`
+    )
+    expect(res.status).to.equal(400)
+    const body = (await res.json()) as { error: string }
+
+    expect(body.error).to.match(/Requested provider not found/)
+  })
+})

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -6,18 +6,30 @@ const parse = (query: Record<string, unknown>) => parseTracksQuery(query)
 const errorsFrom = (query: Record<string, unknown>) =>
   parse(query).errors.join('; ')
 
+const NOW_FIXED = Temporal.Instant.from('2026-08-31T12:00:00Z')
+
 describe('Track API query parsing', () => {
   describe('time window', () => {
+    // A duration is resolved into from/to rather than passed through, so these
+    // assert the window it produces rather than the parsed Duration itself.
+    const windowSeconds = (query: Record<string, unknown>) => {
+      const { request } = parseTracksQuery(query, NOW_FIXED)
+      return request.from && request.to
+        ? request.to.epochMilliseconds / 1000 -
+            request.from.epochMilliseconds / 1000
+        : undefined
+    }
+
     it('accepts an ISO 8601 duration', () => {
-      const { request, errors } = parse({ duration: 'PT2H' })
+      const { errors } = parseTracksQuery({ duration: 'PT2H' }, NOW_FIXED)
       expect(errors).to.be.empty
-      expect(request.duration?.toString()).to.equal('PT2H')
+      expect(windowSeconds({ duration: 'PT2H' })).to.equal(7200)
     })
 
     it('accepts a bare integer as seconds, as the History API does', () => {
-      const { request, errors } = parse({ duration: '900' })
+      const { errors } = parseTracksQuery({ duration: '900' }, NOW_FIXED)
       expect(errors).to.be.empty
-      expect(request.duration?.total({ unit: 'seconds' })).to.equal(900)
+      expect(windowSeconds({ duration: '900' })).to.equal(900)
     })
 
     it('rejects a duration that is neither', () => {
@@ -96,6 +108,46 @@ describe('Track API query parsing', () => {
         NOW
       )
       expect(request.to?.toString()).to.contain('2026-08-02')
+    })
+
+    it('handles day-and-larger durations without throwing', () => {
+      // Temporal.Instant.subtract refuses day units, since their length
+      // depends on a timezone. These windows are absolute, so UTC is the
+      // right frame — and P7D is the OpenAPI's own example.
+      for (const duration of ['P7D', 'P1M', 'P1Y']) {
+        const { errors } = parseTracksQuery({ duration }, NOW)
+        expect(errors, duration).to.be.empty
+      }
+      const { request } = parseTracksQuery({ duration: 'P7D' }, NOW)
+      expect(request.from?.toString()).to.contain('2026-08-24')
+    })
+
+    it('resolves duration into from, so providers see one window', () => {
+      // Three fields describing one window is how two providers answer the
+      // same query differently.
+      const { request } = parseTracksQuery({ duration: 'P7D' }, NOW)
+      expect(request.duration).to.equal(undefined)
+      expect(request.from?.toString()).to.contain('2026-08-24')
+      expect(request.to?.toString()).to.equal(NOW.toString())
+    })
+
+    it('keeps the later start when from and duration disagree', () => {
+      // `from` is a floor the caller set deliberately; a longer duration must
+      // not reach back past it.
+      const { request } = parseTracksQuery(
+        { from: '2026-08-29T00:00:00Z', duration: 'P30D' },
+        NOW
+      )
+      expect(request.from?.toString()).to.contain('2026-08-29')
+      expect(request.duration).to.equal(undefined)
+    })
+
+    it('lets a shorter duration narrow an earlier from', () => {
+      const { request } = parseTracksQuery(
+        { from: '2026-08-01T00:00:00Z', duration: 'P2D' },
+        NOW
+      )
+      expect(request.from?.toString()).to.contain('2026-08-29')
     })
 
     it('leaves to unset on an unbounded single-context query', () => {
@@ -303,6 +355,20 @@ describe('Track API query parsing', () => {
 
     it('is absent when not asked for', () => {
       expect(parse({ duration: 'PT1H' }).request.properties).to.equal(undefined)
+    })
+
+    it('rejects a path that is not a Signal K path', () => {
+      // These arrive from a client, and Path is a branded type whose guarantee
+      // would be hollow if anything were cast into it.
+      expect(
+        errorsFrom({
+          properties: 'navigation/speedOverGround',
+          duration: 'PT1H'
+        })
+      ).to.match(/invalid Signal K path/)
+      expect(errorsFrom({ properties: 'a..b', duration: 'PT1H' })).to.match(
+        /invalid Signal K path/
+      )
     })
 
     it('rejects a blank value', () => {

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -197,6 +197,14 @@ describe('Track API query parsing', () => {
       )
     })
 
+    it('rejects a maxPoints above the safe integer range', () => {
+      // Number() rounds above 2^53, so this would otherwise be accepted as
+      // 9007199254740992 — a different budget than the one requested.
+      expect(
+        errorsFrom({ maxPoints: '9007199254740993', duration: 'PT1H' })
+      ).to.match(/positive integer/)
+    })
+
     it('rejects a non-positive maxPoints', () => {
       expect(errorsFrom({ maxPoints: '0', duration: 'PT1H' })).to.match(
         /positive integer/

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -180,6 +180,17 @@ describe('Track API query parsing', () => {
       expect(request.maxPoints).to.equal(5000)
     })
 
+    it('rejects hex and exponential maxPoints', () => {
+      // Number() reads both, so a typo would silently become a different
+      // budget rather than an error.
+      expect(errorsFrom({ maxPoints: '0x10', duration: 'PT1H' })).to.match(
+        /positive integer/
+      )
+      expect(errorsFrom({ maxPoints: '1e3', duration: 'PT1H' })).to.match(
+        /positive integer/
+      )
+    })
+
     it('rejects a non-positive maxPoints', () => {
       expect(errorsFrom({ maxPoints: '0', duration: 'PT1H' })).to.match(
         /positive integer/

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -23,6 +23,29 @@ describe('Track API query parsing', () => {
       expect(errorsFrom({ duration: '2h' })).to.match(/ISO 8601 duration/)
     })
 
+    it('rejects a negative duration', () => {
+      // Temporal accepts a leading minus, but a negative window would end
+      // before it starts.
+      expect(errorsFrom({ duration: '-PT1H', context: 'self' })).to.match(
+        /must be a positive duration/
+      )
+    })
+
+    it('rejects a zero duration, in both forms', () => {
+      expect(errorsFrom({ duration: 'PT0S', context: 'self' })).to.match(
+        /must be a positive duration/
+      )
+      expect(errorsFrom({ duration: '0', context: 'self' })).to.match(
+        /must be a positive duration/
+      )
+    })
+
+    it('rejects a non-positive resolution', () => {
+      expect(errorsFrom({ resolution: 'PT0S', duration: 'PT1H' })).to.match(
+        /resolution must be a positive duration/
+      )
+    })
+
     it('accepts ISO 8601 instants for from and to', () => {
       const { request, errors } = parse({
         from: '2026-06-01T00:00:00Z',

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { Temporal } from '@js-temporal/polyfill'
 import { parseTracksQuery } from '../dist/api/tracks/query.js'
 
 const parse = (query: Record<string, unknown>) => parseTracksQuery(query)
@@ -68,6 +69,40 @@ describe('Track API query parsing', () => {
       expect(
         errorsFrom({ from: '2026-06-14T00:00:00Z', to: '2026-06-01T00:00:00Z' })
       ).to.match(/from must be before to/)
+    })
+  })
+
+  describe('to defaults to now', () => {
+    // The description always said so; leaving each provider to apply it
+    // independently is how two of them answer the same query differently.
+    const NOW = Temporal.Instant.from('2026-08-31T12:00:00Z')
+
+    it('resolves an omitted to when from is given', () => {
+      const { request } = parseTracksQuery(
+        { from: '2026-08-01T00:00:00Z' },
+        NOW
+      )
+      expect(request.to?.toString()).to.equal(NOW.toString())
+    })
+
+    it('resolves an omitted to when duration is given', () => {
+      const { request } = parseTracksQuery({ duration: 'P7D' }, NOW)
+      expect(request.to?.toString()).to.equal(NOW.toString())
+    })
+
+    it('leaves an explicit to alone', () => {
+      const { request } = parseTracksQuery(
+        { from: '2026-08-01T00:00:00Z', to: '2026-08-02T00:00:00Z' },
+        NOW
+      )
+      expect(request.to?.toString()).to.contain('2026-08-02')
+    })
+
+    it('leaves to unset on an unbounded single-context query', () => {
+      // No window was asked for, so inventing an end would silently bound it.
+      const { request, errors } = parseTracksQuery({ context: 'self' }, NOW)
+      expect(errors).to.be.empty
+      expect(request.to).to.equal(undefined)
     })
   })
 
@@ -242,6 +277,41 @@ describe('Track API query parsing', () => {
       })
       expect(errors).to.be.empty
       expect(request.resolution?.toString()).to.equal('PT1M')
+    })
+  })
+
+  describe('properties', () => {
+    it('splits a comma-separated list of paths', () => {
+      const { request, errors } = parse({
+        properties: 'navigation.speedOverGround,environment.wind.speedApparent',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.properties).to.deep.equal([
+        'navigation.speedOverGround',
+        'environment.wind.speedApparent'
+      ])
+    })
+
+    it('trims and deduplicates', () => {
+      const { request } = parse({
+        properties: ' navigation.speedOverGround , navigation.speedOverGround ',
+        duration: 'PT1H'
+      })
+      expect(request.properties).to.deep.equal(['navigation.speedOverGround'])
+    })
+
+    it('is absent when not asked for', () => {
+      expect(parse({ duration: 'PT1H' }).request.properties).to.equal(undefined)
+    })
+
+    it('rejects a blank value', () => {
+      expect(errorsFrom({ properties: '  ', duration: 'PT1H' })).to.match(
+        /properties must not be empty/
+      )
+      expect(errorsFrom({ properties: ' , ', duration: 'PT1H' })).to.match(
+        /properties must not be empty/
+      )
     })
   })
 

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -77,6 +77,26 @@ describe('Track API query parsing', () => {
       expect(request.to?.toString()).to.contain('2026-06-14')
     })
 
+    it('rejects a future from once to has defaulted to now', () => {
+      // `to` defaults to now, so a from in the future makes the window run
+      // backwards. Checking order before that default would not see it.
+      expect(errorsFrom({ from: '2027-01-01T00:00:00Z' })).to.match(
+        /from must be before to/
+      )
+      expect(
+        errorsFrom({ from: '2027-01-01T00:00:00Z', duration: 'P7D' })
+      ).to.match(/from must be before to/)
+    })
+
+    it('allows a window that lies entirely in the future', () => {
+      // Legitimate: an empty result, not a malformed query.
+      const { errors } = parseTracksQuery(
+        { from: '2027-01-01T00:00:00Z', to: '2027-02-01T00:00:00Z' },
+        NOW_FIXED
+      )
+      expect(errors).to.be.empty
+    })
+
     it('rejects from later than to', () => {
       expect(
         errorsFrom({ from: '2026-06-14T00:00:00Z', to: '2026-06-01T00:00:00Z' })

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -155,6 +155,17 @@ describe('Track API query parsing', () => {
       )
     })
 
+    it('rejects a blank component rather than reading it as zero', () => {
+      // Number('') is 0, not NaN, so a missing value would otherwise pass the
+      // finite check and silently place an edge on the equator.
+      expect(
+        errorsFrom({ bbox: '24.5,,25.2,60.3', duration: 'PT1H' })
+      ).to.match(/four comma-separated numbers/)
+      expect(
+        errorsFrom({ bbox: '24.5, ,25.2,60.3', duration: 'PT1H' })
+      ).to.match(/four comma-separated numbers/)
+    })
+
     it('rejects out-of-range coordinates', () => {
       expect(errorsFrom({ bbox: '24,60,25,120', duration: 'PT1H' })).to.match(
         /latitudes must be between/
@@ -229,6 +240,50 @@ describe('Track API query parsing', () => {
     it('reads geometry=false for a metadata-only listing', () => {
       const { request } = parse({ geometry: 'false', duration: 'PT1H' })
       expect(request.geometry).to.equal(false)
+    })
+  })
+
+  // A present-but-blank value is a malformed query, not an omitted parameter.
+  // Reading `?duration=` as absent would skip the time-window check instead of
+  // telling the client what was wrong.
+  describe('blank values', () => {
+    it('rejects a blank duration rather than treating it as omitted', () => {
+      expect(errorsFrom({ duration: '   ', context: 'self' })).to.match(
+        /duration must not be empty/
+      )
+    })
+
+    it('rejects a blank from and to', () => {
+      expect(errorsFrom({ from: '', duration: 'PT1H' })).to.match(
+        /from must not be empty/
+      )
+      expect(errorsFrom({ to: '', duration: 'PT1H' })).to.match(
+        /to must not be empty/
+      )
+    })
+
+    it('rejects a blank context', () => {
+      expect(errorsFrom({ context: '', duration: 'PT1H' })).to.match(
+        /context must not be empty/
+      )
+    })
+
+    it('rejects a blank bbox, maxPoints and epsilon', () => {
+      expect(errorsFrom({ bbox: '  ', duration: 'PT1H' })).to.match(
+        /bbox must not be empty/
+      )
+      expect(errorsFrom({ maxPoints: ' ', duration: 'PT1H' })).to.match(
+        /positive integer/
+      )
+      expect(errorsFrom({ epsilon: '', duration: 'PT1H' })).to.match(
+        /positive number of metres/
+      )
+    })
+
+    it('still treats an absent parameter as omitted', () => {
+      const { request, errors } = parse({ context: 'self' })
+      expect(errors).to.be.empty
+      expect(request.duration).to.equal(undefined)
     })
   })
 

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -40,6 +40,14 @@ describe('Track API query parsing', () => {
       )
     })
 
+    it('rejects an out-of-range duration rather than throwing', () => {
+      // Temporal refuses a total above its safe range, so the seconds fallback
+      // has to catch: otherwise a bad query string surfaces as a 500.
+      expect(
+        errorsFrom({ duration: '99999999999999999999', context: 'self' })
+      ).to.match(/out of range/)
+    })
+
     it('rejects a non-positive resolution', () => {
       expect(errorsFrom({ resolution: 'PT0S', duration: 'PT1H' })).to.match(
         /resolution must be a positive duration/
@@ -182,6 +190,13 @@ describe('Track API query parsing', () => {
       })
       expect(request.simplify).to.equal(true)
       expect(request.epsilon).to.equal(undefined)
+    })
+
+    it('rejects epsilon combined with simplify=false', () => {
+      // epsilon implies simplification, so asking for both is contradictory.
+      expect(
+        errorsFrom({ epsilon: '5', simplify: 'false', duration: 'PT1H' })
+      ).to.match(/cannot be combined with epsilon/)
     })
 
     it('accepts resolution as a duration', () => {

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -115,6 +115,12 @@ describe('Track API query parsing', () => {
       ])
     })
 
+    it('deduplicates repeated contexts', () => {
+      // Otherwise the same vessel appears twice in the FeatureCollection.
+      const { request } = parse({ contexts: 'self,self', duration: 'PT1H' })
+      expect(request.contexts).to.deep.equal(['vessels.self'])
+    })
+
     it('splits a comma-separated list', () => {
       const { request } = parse({
         contexts: 'self, vessels.a ',

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai'
+import { parseTracksQuery } from '../dist/api/tracks/query.js'
+
+const parse = (query: Record<string, unknown>) => parseTracksQuery(query)
+const errorsFrom = (query: Record<string, unknown>) =>
+  parse(query).errors.join('; ')
+
+describe('Track API query parsing', () => {
+  describe('time window', () => {
+    it('accepts an ISO 8601 duration', () => {
+      const { request, errors } = parse({ duration: 'PT2H' })
+      expect(errors).to.be.empty
+      expect(request.duration?.toString()).to.equal('PT2H')
+    })
+
+    it('accepts a bare integer as seconds, as the History API does', () => {
+      const { request, errors } = parse({ duration: '900' })
+      expect(errors).to.be.empty
+      expect(request.duration?.total({ unit: 'seconds' })).to.equal(900)
+    })
+
+    it('rejects a duration that is neither', () => {
+      expect(errorsFrom({ duration: '2h' })).to.match(/ISO 8601 duration/)
+    })
+
+    it('accepts ISO 8601 instants for from and to', () => {
+      const { request, errors } = parse({
+        from: '2026-06-01T00:00:00Z',
+        to: '2026-06-14T00:00:00Z'
+      })
+      expect(errors).to.be.empty
+      expect(request.from?.toString()).to.contain('2026-06-01')
+      expect(request.to?.toString()).to.contain('2026-06-14')
+    })
+
+    it('rejects from later than to', () => {
+      expect(
+        errorsFrom({ from: '2026-06-14T00:00:00Z', to: '2026-06-01T00:00:00Z' })
+      ).to.match(/from must be before to/)
+    })
+  })
+
+  describe('unbounded queries', () => {
+    // A single vessel over all time is the point of keeping own-vessel data
+    // forever; the same query across every context the server has seen is not.
+    it('allows no time window when a single context is given', () => {
+      const { errors } = parse({ context: 'self' })
+      expect(errors).to.be.empty
+    })
+
+    it('rejects no time window with no context', () => {
+      expect(errorsFrom({})).to.match(/time window .* is required/)
+    })
+
+    it('rejects no time window across several contexts', () => {
+      expect(errorsFrom({ contexts: 'vessels.a,vessels.b' })).to.match(
+        /time window .* is required/
+      )
+    })
+
+    it('allows several contexts when a window is given', () => {
+      const { errors } = parse({
+        contexts: 'vessels.a,vessels.b',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+    })
+  })
+
+  describe('context', () => {
+    it('qualifies a bare id with vessels.', () => {
+      const { request } = parse({ context: 'urn:mrn:imo:mmsi:123456789' })
+      expect(request.contexts).to.deep.equal([
+        'vessels.urn:mrn:imo:mmsi:123456789'
+      ])
+    })
+
+    it('leaves an explicit prefix alone, so aircraft can be queried', () => {
+      const { request } = parse({
+        context: 'aircraft.urn:mrn:imo:mmsi:111222333'
+      })
+      expect(request.contexts).to.deep.equal([
+        'aircraft.urn:mrn:imo:mmsi:111222333'
+      ])
+    })
+
+    it('splits a comma-separated list', () => {
+      const { request } = parse({
+        contexts: 'self, vessels.a ',
+        duration: 'PT1H'
+      })
+      expect(request.contexts).to.have.length(2)
+    })
+  })
+
+  describe('bbox', () => {
+    it('reads west,south,east,north in GeoJSON order', () => {
+      const { request, errors } = parse({
+        bbox: '24.5,59.9,25.2,60.3',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.bbox).to.deep.equal([24.5, 59.9, 25.2, 60.3])
+    })
+
+    it('accepts a box crossing the antimeridian, where west > east', () => {
+      const { request, errors } = parse({
+        bbox: '175,-10,-175,10',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.bbox).to.deep.equal([175, -10, -175, 10])
+    })
+
+    it('rejects south greater than north', () => {
+      expect(
+        errorsFrom({ bbox: '24,60.3,25,59.9', duration: 'PT1H' })
+      ).to.match(/south .* must not be greater than north/)
+    })
+
+    it('rejects the wrong number of values', () => {
+      expect(errorsFrom({ bbox: '24,60,25', duration: 'PT1H' })).to.match(
+        /four comma-separated numbers/
+      )
+    })
+
+    it('rejects out-of-range coordinates', () => {
+      expect(errorsFrom({ bbox: '24,60,25,120', duration: 'PT1H' })).to.match(
+        /latitudes must be between/
+      )
+    })
+  })
+
+  describe('thinning', () => {
+    it('accepts maxPoints as a point budget', () => {
+      const { request, errors } = parse({ maxPoints: '5000', duration: 'PT1H' })
+      expect(errors).to.be.empty
+      expect(request.maxPoints).to.equal(5000)
+    })
+
+    it('rejects a non-positive maxPoints', () => {
+      expect(errorsFrom({ maxPoints: '0', duration: 'PT1H' })).to.match(
+        /positive integer/
+      )
+    })
+
+    it('treats epsilon as implying simplify', () => {
+      const { request, errors } = parse({ epsilon: '5', duration: 'PT1H' })
+      expect(errors).to.be.empty
+      expect(request.epsilon).to.equal(5)
+      expect(request.simplify).to.equal(true)
+    })
+
+    it('accepts simplify on its own, leaving the tolerance to the provider', () => {
+      const { request } = parse({
+        simplify: 'true',
+        bbox: '24,59,25,61',
+        duration: 'PT1H'
+      })
+      expect(request.simplify).to.equal(true)
+      expect(request.epsilon).to.equal(undefined)
+    })
+
+    it('accepts resolution as a duration', () => {
+      const { request, errors } = parse({
+        resolution: 'PT1M',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.resolution?.toString()).to.equal('PT1M')
+    })
+  })
+
+  describe('flags', () => {
+    it('reads a valueless times as true', () => {
+      const { request } = parse({ times: '', duration: 'PT1H' })
+      expect(request.times).to.equal(true)
+    })
+
+    it('honours times=false', () => {
+      const { request } = parse({ times: 'false', duration: 'PT1H' })
+      expect(request.times).to.equal(false)
+    })
+
+    it('rejects an unparseable flag', () => {
+      expect(errorsFrom({ times: 'maybe', duration: 'PT1H' })).to.match(
+        /must be true or false/
+      )
+    })
+
+    it('reads geometry=false for a metadata-only listing', () => {
+      const { request } = parse({ geometry: 'false', duration: 'PT1H' })
+      expect(request.geometry).to.equal(false)
+    })
+  })
+
+  it('collects several errors rather than stopping at the first', () => {
+    const { errors } = parse({ duration: '2h', bbox: 'nope', maxPoints: '-1' })
+    expect(errors.length).to.be.greaterThan(1)
+  })
+})

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -415,6 +415,23 @@ describe('Track API query parsing', () => {
       expect(request.resolution?.toString()).to.equal('PT24000000H')
     })
 
+    // Timestamps carry milliseconds, so a finer spacing cannot thin anything.
+    // Accepting it meant handing a provider a value no store could act on.
+    it('rejects a resolution below one millisecond', () => {
+      expect(
+        errorsFrom({ resolution: 'PT0.0005S', duration: 'PT1H' })
+      ).to.match(/resolution must be at least one millisecond/)
+    })
+
+    it('accepts a resolution of exactly one millisecond', () => {
+      const { request, errors } = parse({
+        resolution: 'PT0.001S',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.resolution?.total({ unit: 'milliseconds' })).to.equal(1)
+    })
+
     // A month is 744h measured from January and 672h from February, so a
     // spacing expressed in one is ambiguous rather than merely awkward.
     it('rejects a resolution in years or months', () => {

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -350,6 +350,63 @@ describe('Track API query parsing', () => {
       expect(errors).to.be.empty
       expect(request.resolution?.toString()).to.equal('PT1M')
     })
+
+    // A provider needs this as a number of milliseconds, and
+    // `Temporal.Duration.total()` refuses day-and-larger units without a
+    // reference date. Both independent provider implementations tripped over
+    // it, so the parser hands over hours-and-below.
+    it('normalises a calendar-unit resolution to hours', () => {
+      for (const [given, expected] of [
+        ['P1D', 'PT24H'],
+        ['P7D', 'PT168H'],
+        ['P1W', 'PT168H']
+      ]) {
+        const { request, errors } = parse({
+          resolution: given,
+          duration: 'PT1H'
+        })
+        expect(errors, given).to.be.empty
+        expect(request.resolution?.toString(), given).to.equal(expected)
+      }
+    })
+
+    it('leaves a resolution that is already hours or below alone', () => {
+      for (const given of ['PT30S', 'PT5M', 'PT2H']) {
+        const { request } = parse({ resolution: given, duration: 'PT1H' })
+        expect(request.resolution?.toString(), given).to.equal(given)
+      }
+    })
+
+    // The property that matters: whatever the parser emits, a provider can call
+    // total() on it without a reference date.
+    it('emits a resolution every provider can total()', () => {
+      for (const given of ['PT30S', 'P1D', 'P7D', 'P1W', '3600']) {
+        const { request, errors } = parse({
+          resolution: given,
+          duration: 'PT1H'
+        })
+        // Asserted before the no-throw check: without these, a query that
+        // failed to parse would leave resolution undefined and the optional
+        // call would pass by doing nothing.
+        expect(errors, given).to.be.empty
+        expect(request.resolution, given).to.not.be.undefined
+        expect(
+          () => request.resolution!.total({ unit: 'milliseconds' }),
+          given
+        ).to.not.throw()
+      }
+    })
+
+    // A month is 744h measured from January and 672h from February, so a
+    // spacing expressed in one is ambiguous rather than merely awkward.
+    it('rejects a resolution in years or months', () => {
+      for (const given of ['P1M', 'P1Y', 'P2M']) {
+        expect(
+          errorsFrom({ resolution: given, duration: 'PT1H' }),
+          given
+        ).to.match(/must not use years or months/)
+      }
+    })
   })
 
   describe('properties', () => {

--- a/test/tracks-query.ts
+++ b/test/tracks-query.ts
@@ -397,6 +397,24 @@ describe('Track API query parsing', () => {
       }
     })
 
+    // Temporal refuses a date beyond its supported range, so normalising a
+    // duration large enough to overshoot it throws. That is a bad query string,
+    // and it has to surface as a 400 rather than escaping as a 500.
+    it('rejects a resolution too large to normalise', () => {
+      expect(
+        errorsFrom({ resolution: 'P100000001D', duration: 'PT1H' })
+      ).to.match(/resolution is out of range/)
+    })
+
+    it('still accepts a large but representable resolution', () => {
+      const { request, errors } = parse({
+        resolution: 'P1000000D',
+        duration: 'PT1H'
+      })
+      expect(errors).to.be.empty
+      expect(request.resolution?.toString()).to.equal('PT24000000H')
+    })
+
     // A month is 744h measured from January and 672h from February, so a
     // spacing expressed in one is ambiguous rather than merely awkward.
     it('rejects a resolution in years or months', () => {


### PR DESCRIPTION
Implements the Track query API discussed in #2504, as the "server PR with provider typings, API code and OpenApi description" suggested there.

Additive only — no existing behaviour changes.

## What a track is here

Recorded position data: unnamed, time-ordered, queried by time window and area. Distinct from `resources/routes`, which is a course someone authored and intends to follow. Whether an *uploaded* track belongs here too is a separate question — see the write RFC — and nothing in this PR decides it.

## Provider registry, not a mount point

Providers register the way history providers do:

```ts
app.registerTrackApiProvider({
  getTracks(query) { ... },
  getTrackContexts(query) { ... }
})
```

So nothing here decides where positions are stored. SQLite, a time-series database, downsampled Parquet and PostGIS are all equally valid behind the same interface, and a plugin needs no new v2 mount point to implement it.

## The API

```
GET /signalk/v2/api/tracks
GET /signalk/v2/api/tracks/contexts
GET /signalk/v2/api/tracks/_providers
```

All parameters are query parameters, following the History API rather than using path segments: `contexts` (or `context`, defaulting to self), `from`, `to`, `duration`, `bbox`, `resolution`, `maxPoints`, `simplify`, `epsilon`, `times`, `geometry`, `provider`.

Durations are ISO 8601, and — as `parseTimeRangeParams` already does — a bare integer is accepted as seconds, since clients will have learned that from History.

Response is a `FeatureCollection`, one `Feature` per context, `MultiLineString` geometry so a gap in recording starts a new segment. Metadata lives in `properties`: `context`, `isSelf`, `contextName`, `from`, `to`, `bbox`, `pointCount`, and the applied `resolution`/`epsilon`. Per-point times are `properties.coordTimes`, nested to match `coordinates` — the convention only covers LineString, so the MultiLineString nesting is pinned in the OpenAPI description.

## Two rules that shape the contract

**A time window is required unless a single context is requested.** `?context=self` with no window asks for one vessel's entire recorded history, which is the point of keeping own-vessel data forever. The same query with no context is years of data for every vessel the server has ever seen, and is refused with a 400.

**The time range asked for is always returned.** Where a result would be too large, providers reduce *points* and report what they applied. Silently narrowing the range would break the case the API exists for — drawing a whole voyage at low zoom.

`maxPoints` sits alongside `simplify`/`epsilon` because they are different contracts: epsilon bounds geometric error, `maxPoints` bounds transfer and rendering cost. The same epsilon yields wildly different point counts for a year at anchor versus a year of passages, which is why a low-powered client needs the budget form.

## Notes

- Query validation runs **before** the provider lookup, so a malformed query gets 400 rather than 501 — otherwise a typo sends someone hunting for a missing plugin.
- `bbox` is `west,south,east,north`, matching the Resources API, and means *intersects anywhere in the window* rather than "current position is inside": a vessel that crossed an hour ago and has since left still matches.
- `tracks` is added to `SignalKApiId` and appears in `/signalk/v2/features`.

## Tested

- 27 unit tests over the query contract (`test/tracks-query.ts`): durations both forms, bbox order and antimeridian, the unbounded rule in all four combinations, context qualification including non-vessel prefixes, thinning parameters, flags.
- Verified against a running server: routes mount, `_providers` lists, 501 with no provider, and 400 with the correct message for each malformed parameter.
- Full server suite passing; `tsc`, `eslint`, `prettier` clean.

Happy to adjust any of the shape — particularly `maxPoints`, which was the one open question in the thread.

---

**Scope note.** This PR is the **read** API only, as the maintainers asked. Write operations — importing a track, fetching and deleting one by id — are proposed separately so this can be released without waiting on that design.
