### PR TITLE
fix(plugins): expose unregisterHistoryApiProvider to plugins

### DIFF
--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -967,6 +967,13 @@ module.exports = (theApp: any) => {
         historyApiRegistry.unregisterHistoryApiProvider(plugin.id)
       })
     }
+    // Stopping the plugin already unregisters it, but a plugin that loses its
+    // backing store may want to withdraw while staying loaded rather than
+    // answer queries it cannot serve. The registry ignores an unknown id, so
+    // the stop handler firing afterwards is a no-op.
+    appCopy.unregisterHistoryApiProvider = () => {
+      historyApiRegistry.unregisterHistoryApiProvider(plugin.id)
+    }
 
     const resourcesApi: ResourcesApi = app.resourcesApi
     appCopy.registerResourceProvider = (provider: ResourceProvider) => {

--- a/test/plugin-provider-registry.ts
+++ b/test/plugin-provider-registry.ts
@@ -13,6 +13,9 @@ interface PluginInfo {
   app: Record<string, any>
 }
 
+/** Booting a real server with its plugins is slow on a cold cache. */
+const TEST_TIMEOUT_MS = 30000
+
 const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
 const CONFIG_FILE = path.join(
   CONFIG_DIR,
@@ -34,7 +37,12 @@ const CONFIG_FILE = path.join(
  * rebuilt it would have passed either way.
  */
 describe('Plugin provider registries', () => {
+  let origConfigDir: string | undefined
+
   before(() => {
+    // Restored afterwards: mocha runs every test file in one process, so
+    // leaving this set would point whatever runs next at the plugin fixtures.
+    origConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
     process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
     fs.mkdirSync(path.join(CONFIG_DIR, 'plugin-config-data'), {
       recursive: true
@@ -47,10 +55,15 @@ describe('Plugin provider registries', () => {
 
   after(() => {
     if (fs.existsSync(CONFIG_FILE)) fs.unlinkSync(CONFIG_FILE)
+    if (origConfigDir === undefined) {
+      delete process.env.SIGNALK_NODE_CONFIG_DIR
+    } else {
+      process.env.SIGNALK_NODE_CONFIG_DIR = origConfigDir
+    }
   })
 
   it('gives a plugin both halves of the history provider registry', async function () {
-    this.timeout(30000)
+    this.timeout(TEST_TIMEOUT_MS)
     const port = await freeport()
     const server = new Server({ config: { settings: { port } } })
     await server.start()
@@ -76,7 +89,7 @@ describe('Plugin provider registries', () => {
   })
 
   it('withdraws a provider without stopping the plugin', async function () {
-    this.timeout(30000)
+    this.timeout(TEST_TIMEOUT_MS)
     const port = await freeport()
     const server = new Server({ config: { settings: { port } } })
     await server.start()

--- a/test/plugin-provider-registry.ts
+++ b/test/plugin-provider-registry.ts
@@ -1,0 +1,111 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Server = require('../dist/')
+
+interface PluginInfo {
+  id: string
+  // The app copy a plugin is handed, which is what these assertions are about.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app: Record<string, any>
+}
+
+const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
+const CONFIG_FILE = path.join(
+  CONFIG_DIR,
+  'plugin-config-data',
+  'testplugin.json'
+)
+
+/**
+ * The provider registries a plugin is handed.
+ *
+ * `HistoryProviderRegistry` declares both `registerHistoryApiProvider` and
+ * `unregisterHistoryApiProvider`, and `ServerAPI` extends it, so both are part
+ * of the typed surface a plugin sees and TypeScript accepts either call. The
+ * unregister half was declared but never assigned, which made it a runtime
+ * TypeError at a call site the compiler had approved.
+ *
+ * Asserted against the real `plugin.app` from a booted server rather than a
+ * reconstruction of the wiring: the defect was in the wiring, so a test that
+ * rebuilt it would have passed either way.
+ */
+describe('Plugin provider registries', () => {
+  before(() => {
+    process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
+    fs.mkdirSync(path.join(CONFIG_DIR, 'plugin-config-data'), {
+      recursive: true
+    })
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify({ enabled: true, configuration: {} })
+    )
+  })
+
+  after(() => {
+    if (fs.existsSync(CONFIG_FILE)) fs.unlinkSync(CONFIG_FILE)
+  })
+
+  it('gives a plugin both halves of the history provider registry', async function () {
+    this.timeout(30000)
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+    await server.start()
+    try {
+      const plugin = server.app.plugins.find(
+        (p: PluginInfo) => p.id === 'testplugin'
+      )
+      assert(plugin, 'testplugin should be loaded')
+
+      assert.strictEqual(
+        typeof plugin.app.registerHistoryApiProvider,
+        'function',
+        'registerHistoryApiProvider missing from the plugin app'
+      )
+      assert.strictEqual(
+        typeof plugin.app.unregisterHistoryApiProvider,
+        'function',
+        'unregisterHistoryApiProvider missing from the plugin app'
+      )
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('withdraws a provider without stopping the plugin', async function () {
+    this.timeout(30000)
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+    await server.start()
+    try {
+      const plugin = server.app.plugins.find(
+        (p: PluginInfo) => p.id === 'testplugin'
+      )
+      assert(plugin, 'testplugin should be loaded')
+
+      // Asserted against the registry rather than getHistoryApi(): other
+      // plugins in the test config register providers too, so the API still
+      // resolves through one of those and would hide whether this one left.
+      const providers = () => [
+        ...server.app.historyApiHttpRegistry.historyProviders.keys()
+      ]
+      assert(
+        providers().includes('testplugin'),
+        'testplugin registers a history provider at start'
+      )
+
+      plugin.app.unregisterHistoryApiProvider()
+
+      assert(
+        !providers().includes('testplugin'),
+        'the provider should be gone while the plugin stays loaded'
+      )
+      assert(plugin.started, 'the plugin itself should still be running')
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -40,6 +40,18 @@ describe('Demo plugin ', () => {
     const optionsTest = plugin.app.readPluginOptions()
     assert(optionsTest.configuration.testOption === 'testValue')
 
+    // Both halves of the provider registries the plugin API declares have to
+    // be present on the app a plugin is handed: the types permit the call, so
+    // a missing assignment is a runtime TypeError at a type-clean call site.
+    assert(
+      typeof plugin.app.registerHistoryApiProvider === 'function',
+      'registerHistoryApiProvider missing from the plugin app'
+    )
+    assert(
+      typeof plugin.app.unregisterHistoryApiProvider === 'function',
+      'unregisterHistoryApiProvider missing from the plugin app'
+    )
+
     assert(server.app.signalk.self.some.path.value === 'someValue')
 
     const outputValues = []

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -40,18 +40,6 @@ describe('Demo plugin ', () => {
     const optionsTest = plugin.app.readPluginOptions()
     assert(optionsTest.configuration.testOption === 'testValue')
 
-    // Both halves of the provider registries the plugin API declares have to
-    // be present on the app a plugin is handed: the types permit the call, so
-    // a missing assignment is a runtime TypeError at a type-clean call site.
-    assert(
-      typeof plugin.app.registerHistoryApiProvider === 'function',
-      'registerHistoryApiProvider missing from the plugin app'
-    )
-    assert(
-      typeof plugin.app.unregisterHistoryApiProvider === 'function',
-      'unregisterHistoryApiProvider missing from the plugin app'
-    )
-
     assert(server.app.signalk.self.some.path.value === 'someValue')
 
     const outputValues = []


### PR DESCRIPTION
Fixes #2996.

## The bug

`HistoryProviderRegistry` declares both halves:

```ts
export type HistoryProviderRegistry = {
  registerHistoryApiProvider(provider: HistoryProvider): void
  unregisterHistoryApiProvider(): void
}
```

`ServerAPI` extends it, so `unregisterHistoryApiProvider` is part of the typed surface a plugin sees and TypeScript accepts the call. But `doRegisterPlugin` only ever assigned the register half:

```ts
appCopy.registerHistoryApiProvider = (provider: HistoryProvider) => {
  historyApiRegistry.registerHistoryApiProvider(plugin.id, provider)
  onStopHandlers[plugin.id].push(() => {
    historyApiRegistry.unregisterHistoryApiProvider(plugin.id)
  })
}
```

The registry method exists and works; the only call to it was inside the plugin's own stop handler. A plugin calling it directly got a `TypeError` on `undefined` — at a call site the compiler had signed off on, which is the unpleasant part.

## Impact

Narrow. Stopping a plugin already unregisters its provider, so the common path was never affected and this has not bitten anyone. What was missing is withdrawing a provider **while staying loaded** — a plugin that has lost its database would rather deregister than answer queries it cannot serve.

## The fix

```ts
appCopy.unregisterHistoryApiProvider = () => {
  historyApiRegistry.unregisterHistoryApiProvider(plugin.id)
}
```

No `pluginId` argument, matching the declared signature — the server supplies it, as it does for register.

`unregisterHistoryApiProvider` in the registry returns early on an unknown id, so the stop handler firing after a manual unregister is a no-op and needs no guard.

## Scope

History is the only API affected. It is the only other provider registry that declares an unregister method at all — Weather, Resource, Autopilot and BLE declare register only. (The Track API in #2995 has both, having been written after this was found.)

## Tested

The demo plugin test now asserts both halves are present on `plugin.app`, the object a plugin actually receives — rather than on a reconstruction of the wiring, which would not have caught this.

Verified it catches the bug: with the fix reverted the test fails with `unregisterHistoryApiProvider missing from the plugin app`, and passes with it restored. `tsc`, `eslint` and the history suite clean (37 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR exposes `unregisterHistoryApiProvider()` on the plugin app API. The method uses the current plugin ID internally, so plugins can withdraw their history provider without stopping.

## Tests

- Verifies both provider methods on the real plugin app.
- Verifies provider removal while the plugin remains running.
- Restores `SIGNALK_NODE_CONFIG_DIR` after tests.
- History test suite passes 37 tests.
- TypeScript and ESLint checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->