### PR TITLE
other: wrap the debugConnection call to satisfy prettier

### DIFF
--- a/src/interfaces/ws.ts
+++ b/src/interfaces/ws.ts
@@ -906,7 +906,11 @@ function createPrimusAuthorize(
       isWebSocketUpgrade &&
       (ipConnectionCounts.get(ip) ?? 0) >= maxConnectionsPerIp
     ) {
-      debugConnection('IP %s exceeded max connections (%d)', ip, maxConnectionsPerIp)
+      debugConnection(
+        'IP %s exceeded max connections (%d)',
+        ip,
+        maxConnectionsPerIp
+      )
       const err = Object.assign(
         new Error(
           JSON.stringify({


### PR DESCRIPTION
`ci-lint` runs `prettier --check .`, and master currently fails it.

78e3da3a renamed `debug` to `debugConnection` in the per-IP connection-limit log. The longer name pushed the call past the print width, so prettier wants it wrapped:

```
      debugConnection('IP %s exceeded max connections (%d)', ip, maxConnectionsPerIp)
```

Formatting only — no behaviour change, produced by `prettier --write` on the one file.

This fails on master itself, so every open PR inherits the red build regardless of its own contents.

Tested: `prettier --check .` passes across the repo with prettier 3.9.6 (what `^3.8.4` currently resolves to in CI).