### PR TITLE
fix(ble): pass waitDevice timeouts in milliseconds so local BLE finds devices

### DIFF
--- a/src/api/ble/localProvider.ts
+++ b/src/api/ble/localProvider.ts
@@ -19,10 +19,11 @@ import {
 
 // How often to poll BlueZ for newly discovered devices
 const DEVICE_WATCH_INTERVAL_MS = 5000
-// waitDevice timeout when attaching a listener to an already-known device
-const DEVICE_ATTACH_TIMEOUT_S = 1
-// waitDevice timeout when establishing a GATT connection
-const GATT_CONNECT_TIMEOUT_S = 30
+// waitDevice timeouts. node-ble takes these in milliseconds and only checks
+// for the device once per second, so anything below that interval expires
+// before the first check and can never succeed.
+const DEVICE_ATTACH_TIMEOUT_MS = 5000
+const GATT_CONNECT_TIMEOUT_MS = 30000
 // GATT reconnect exponential backoff bounds
 const RECONNECT_BACKOFF_BASE_MS = 5000
 const RECONNECT_BACKOFF_MAX_MS = 60000
@@ -280,7 +281,10 @@ export class LocalBLEProvider {
     // iterations don't both kick off an attach for the same MAC.
     this.deviceListeners.set(mac, () => {})
     try {
-      const device = await this.adapter.waitDevice(mac, DEVICE_ATTACH_TIMEOUT_S)
+      const device = await this.adapter.waitDevice(
+        mac,
+        DEVICE_ATTACH_TIMEOUT_MS
+      )
       await device.helper._prepare()
       // Discovery may have been stopped while the awaits above ran —
       // registering now would repopulate the cleared listener table
@@ -483,7 +487,7 @@ export class LocalBLEProvider {
       debug.enabled && debug(`GATT connecting to ${mac}`)
 
       // 1. Find device
-      const device = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_S)
+      const device = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_MS)
       session.device = device
 
       // 2. Connect
@@ -709,7 +713,7 @@ export class LocalBLEProvider {
     let device: any
     try {
       device = await this.connectQueue.enqueue(async () => {
-        const dev = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_S)
+        const dev = await this.adapter.waitDevice(mac, GATT_CONNECT_TIMEOUT_MS)
         await dev.helper.callMethod('Connect')
         if (this.scanning) {
           try {

--- a/test/ble-local-provider.ts
+++ b/test/ble-local-provider.ts
@@ -1,0 +1,101 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+import { BLEAdvertisement } from '@signalk/server-api'
+import { LocalBLEProvider } from '../src/api/ble/localProvider'
+
+// node-ble's Adapter.waitDevice(uuid, timeout, discoveryInterval) takes the
+// timeout in milliseconds and only looks for the device once per interval,
+// so any timeout shorter than one interval expires before the first look.
+const NODE_BLE_POLL_INTERVAL_MS = 1000
+// Slack on top of one poll interval, so the attach has settled before asserting
+const SETTLE_MARGIN_MS = 250
+const MAX_GATT_SLOTS = 3
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+class FakeHelper extends EventEmitter {
+  async _prepare() {
+    // node-ble resolves the object's properties here; nothing to do for a fake
+  }
+  async callMethod(_name: string) {
+    // Connect / StopDiscovery / StartDiscovery all succeed silently
+  }
+}
+
+class FakeDevice extends EventEmitter {
+  helper = new FakeHelper()
+  _propsProxy = {
+    GetAll: async () => ({ Name: 'Sensor', RSSI: -64 })
+  }
+  async gatt() {
+    return {}
+  }
+  async disconnect() {}
+}
+
+/** The private watcher entry point the discovery test drives directly. */
+type DeviceWatcher = { startDeviceWatcher(): Promise<void> }
+
+/** Reproduces node-ble's waitDevice() race between poll and timeout. */
+class FakeAdapter {
+  helper = new FakeHelper()
+
+  private macs: string[]
+
+  constructor(macs: string[] = []) {
+    this.macs = macs
+  }
+
+  async devices() {
+    return this.macs
+  }
+
+  waitDevice(_mac: string, timeout: number): Promise<FakeDevice> {
+    return new Promise((resolve, reject) => {
+      const poll = setTimeout(() => {
+        clearTimeout(expiry)
+        resolve(new FakeDevice())
+      }, NODE_BLE_POLL_INTERVAL_MS)
+      const expiry = setTimeout(() => {
+        clearTimeout(poll)
+        reject(new Error('operation timed out'))
+      }, timeout)
+    })
+  }
+}
+
+const providerWithAdapter = (adapter: FakeAdapter, scanning = false) => {
+  const provider = new LocalBLEProvider('hci0', MAX_GATT_SLOTS)
+  Object.assign(provider, { adapter, adapterReady: true, scanning })
+  return provider
+}
+
+describe('LocalBLEProvider', () => {
+  it('emits an advertisement for a device BlueZ already knows about', async () => {
+    const adapter = new FakeAdapter(['AA:BB:CC:DD:EE:FF'])
+    const provider = providerWithAdapter(adapter, true)
+
+    const seen: BLEAdvertisement[] = []
+    provider.onAdvertisement((adv) => seen.push(adv))
+
+    await (provider as unknown as DeviceWatcher).startDeviceWatcher()
+    await delay(NODE_BLE_POLL_INTERVAL_MS + SETTLE_MARGIN_MS)
+    provider.shutdown()
+
+    expect(seen).to.have.lengthOf(1)
+    expect(seen[0].mac).to.equal('AA:BB:CC:DD:EE:FF')
+    expect(seen[0].rssi).to.equal(-64)
+    expect(seen[0].name).to.equal('Sensor')
+  })
+
+  it('establishes a GATT connection and claims a slot', async () => {
+    const adapter = new FakeAdapter()
+    const provider = providerWithAdapter(adapter)
+
+    const connection = await provider.connectGATT('aa:bb:cc:dd:ee:ff')
+    expect(connection).to.not.equal(undefined)
+    expect(provider.availableGATTSlots()).to.equal(MAX_GATT_SLOTS - 1)
+
+    provider.shutdown()
+  })
+})


### PR DESCRIPTION
`node-ble`'s `Adapter.waitDevice(uuid, timeout, discoveryInterval)` takes its timeout in **milliseconds** and only looks for the device once per `discoveryInterval` (1s by default). `localProvider.ts` passed second-valued constants — `DEVICE_ATTACH_TIMEOUT_S = 1` and `GATT_CONNECT_TIMEOUT_S = 30` — so both deadlines expired before the first look and every call rejected with `operation timed out`.

Two consequences, both silent because `attachDeviceListener()` swallows errors in a bare `catch`:

- No device listener ever attached, so no advertisement reached the BLE API. `GET /signalk/v2/api/vessels/self/ble/devices` stayed empty forever while the adapter reported `Discovering: true` and `adapterErrors: {}`, which makes it look like nothing is in range.
- Every GATT connection attempt failed.

Confirmed on a Raspberry Pi with 11 live-advertising devices, driving the provider's own code path inside the server container: with the shipped value 5/5 attaches failed and 0 advertisements arrived; with a millisecond value 5/5 attached and 207 `PropertiesChanged` events landed in 12s.

The constants are renamed to `_MS` and given millisecond values. `DEVICE_ATTACH_TIMEOUT_MS` is 5000 rather than 1000 so it does not race the 1s poll interval.

The added test fakes an adapter that reproduces node-ble's poll-vs-timeout race; it fails against the unfixed provider with the same two symptoms seen in production (empty advertisement list, `operation timed out`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes BLE device discovery and GATT connection timeouts by passing millisecond values to `node-ble`’s `Adapter.waitDevice()`.
- Sets the device attachment timeout to 5000 ms to avoid races with the adapter’s one-second discovery interval.
- Adds regression tests for advertisement delivery and successful GATT connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->