### PR TITLE
fix(plugins): honour getOpenApi for signalKApiRoutes plugins

### DIFF
--- a/packages/server-api/src/plugin.ts
+++ b/packages/server-api/src/plugin.ts
@@ -189,6 +189,22 @@ export interface Plugin {
    */
   registerWithRouter?(router: PluginRouter): void
 
+  /**
+   * OpenAPI description of the routes this plugin serves.
+   *
+   * Honoured whichever way the routes are mounted — {@link registerWithRouter}
+   * under `/plugins/<pluginid>`, or {@link signalKApiRoutes} under
+   * `/signalk/v1/api`. The description is served at
+   * `/skServer/openapi/plugins/<pluginid>` and listed in the server's Swagger
+   * UI alongside the built-in APIs.
+   *
+   * The server fills in `servers` with `/plugins/<pluginid>` when the document
+   * does not declare it. A plugin mounting under `/signalk/v1/api` should
+   * therefore set `servers` itself, or its operations will be documented
+   * against the wrong base path.
+   *
+   * @category Rest API
+   */
   getOpenApi?: () => object
 
   statusMessage?: () => string | void

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -1286,14 +1286,19 @@ module.exports = (theApp: any) => {
 
     if (typeof plugin.registerWithRouter === 'function') {
       plugin.registerWithRouter(asPluginRouter(app, router, plugin.id))
-      if (typeof plugin.getOpenApi === 'function') {
-        app.setPluginOpenApi(plugin.id, plugin.getOpenApi())
-      }
     }
     app.use(backwardsCompat('/plugins/' + plugin.id), router)
 
     if (typeof plugin.signalKApiRoutes === 'function') {
       app.use('/signalk/v1/api', plugin.signalKApiRoutes(express.Router()))
+    }
+
+    // Registered for either way of mounting routes. It used to sit inside the
+    // registerWithRouter branch, so a plugin serving under /signalk/v1/api had
+    // its getOpenApi silently ignored — while the docs recommend implementing
+    // it to anyone who exposes an API, without distinguishing the two.
+    if (typeof plugin.getOpenApi === 'function') {
+      app.setPluginOpenApi(plugin.id, plugin.getOpenApi())
     }
   }
 }

--- a/test/plugin-openapi-mounting.ts
+++ b/test/plugin-openapi-mounting.ts
@@ -1,0 +1,108 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { freeport } from './ts-servertestutilities'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Server = require('../dist/')
+
+interface PluginInfo {
+  id: string
+}
+
+const CONFIG_DIR = path.join(__dirname, 'plugin-test-config')
+const CONFIG_FILE = path.join(
+  CONFIG_DIR,
+  'plugin-config-data',
+  'skroutesplugin.json'
+)
+
+// Booting a real server under ts-node, twice, on a cold cache. The other
+// server-booting suites here use 60s for the same reason.
+const TEST_TIMEOUT_MS = 60000
+
+/**
+ * `getOpenApi` has to be honoured whichever way a plugin mounts its routes.
+ *
+ * It used to be called only inside the `registerWithRouter` branch, so a
+ * plugin serving under `/signalk/v1/api` had its description silently dropped
+ * — while the plugin docs recommend implementing it to anyone exposing an API,
+ * without distinguishing the two.
+ *
+ * The fixture `skroutesplugin` uses `signalKApiRoutes`; the demo `testplugin`
+ * covers the `registerWithRouter` side, so both paths are exercised.
+ */
+describe('Plugin OpenAPI registration', () => {
+  let origConfigDir: string | undefined
+
+  before(() => {
+    origConfigDir = process.env.SIGNALK_NODE_CONFIG_DIR
+    process.env.SIGNALK_NODE_CONFIG_DIR = CONFIG_DIR
+    fs.mkdirSync(path.join(CONFIG_DIR, 'plugin-config-data'), {
+      recursive: true
+    })
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify({ enabled: true, configuration: {} })
+    )
+  })
+
+  after(() => {
+    if (fs.existsSync(CONFIG_FILE)) fs.unlinkSync(CONFIG_FILE)
+    if (origConfigDir === undefined) {
+      delete process.env.SIGNALK_NODE_CONFIG_DIR
+    } else {
+      process.env.SIGNALK_NODE_CONFIG_DIR = origConfigDir
+    }
+  })
+
+  it('registers the description of a plugin mounting under /signalk/v1/api', async function () {
+    this.timeout(TEST_TIMEOUT_MS)
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+    await server.start()
+    try {
+      const plugin = server.app.plugins.find(
+        (p: PluginInfo) => p.id === 'skroutesplugin'
+      )
+      assert(plugin, 'skroutesplugin should be loaded')
+
+      const res = await fetch(
+        `http://localhost:${port}/skServer/openapi/plugins/skroutesplugin`
+      )
+      assert.strictEqual(
+        res.status,
+        200,
+        'the description should be served, not 404'
+      )
+      const doc = (await res.json()) as {
+        paths?: Record<string, unknown>
+        servers?: { url: string }[]
+      }
+      assert(
+        doc.paths?.['/skroutestest'],
+        'the documented path should be present'
+      )
+      // The plugin declares its own servers because it does not mount under
+      // /plugins/<id>; the server must not overwrite that.
+      assert.strictEqual(doc.servers?.[0]?.url, '/signalk/v1/api')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('still registers the description of a registerWithRouter plugin', async function () {
+    this.timeout(TEST_TIMEOUT_MS)
+    const port = await freeport()
+    const server = new Server({ config: { settings: { port } } })
+    await server.start()
+    try {
+      const res = await fetch(
+        `http://localhost:${port}/skServer/openapi/plugins/testplugin`
+      )
+      assert.strictEqual(res.status, 200)
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/test/plugin-test-config/node_modules/skroutesplugin/index.js
+++ b/test/plugin-test-config/node_modules/skroutesplugin/index.js
@@ -1,0 +1,20 @@
+// A plugin that serves its routes under /signalk/v1/api via signalKApiRoutes
+// rather than /plugins/<id> via registerWithRouter, and documents them with
+// getOpenApi. Both mounting styles must have their OpenAPI registered.
+module.exports = function (app) {
+  return {
+    id: 'skroutesplugin',
+    name: 'SK Routes Test Plugin',
+    description: 'Serves routes under /signalk/v1/api and documents them',
+    schema: () => ({ type: 'object', properties: {} }),
+    start: function () {
+      this.started = true
+    },
+    stop: function () {},
+    signalKApiRoutes: function (router) {
+      router.get('/skroutestest', (req, res) => res.json({ ok: true }))
+      return router
+    },
+    getOpenApi: () => require('./openApi.json')
+  }
+}

--- a/test/plugin-test-config/node_modules/skroutesplugin/openApi.json
+++ b/test/plugin-test-config/node_modules/skroutesplugin/openApi.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "SK Routes Test Plugin", "version": "1.0.0" },
+  "servers": [{ "url": "/signalk/v1/api" }],
+  "paths": {
+    "/skroutestest": {
+      "get": {
+        "summary": "A route mounted under /signalk/v1/api rather than /plugins",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/test/plugin-test-config/node_modules/skroutesplugin/package.json
+++ b/test/plugin-test-config/node_modules/skroutesplugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "skroutesplugin",
+  "version": "1.0.0",
+  "main": "index.js",
+  "keywords": ["signalk-node-server-plugin"]
+}


### PR DESCRIPTION
A plugin that serves its routes under `/signalk/v1/api` cannot publish an OpenAPI description today, because `getOpenApi` is only called for plugins that mount with `registerWithRouter`.

## The bug

```ts
if (typeof plugin.registerWithRouter === 'function') {
  plugin.registerWithRouter(asPluginRouter(app, router, plugin.id))
  if (typeof plugin.getOpenApi === 'function') {
    app.setPluginOpenApi(plugin.id, plugin.getOpenApi())   // <- inside the branch
  }
}
...
if (typeof plugin.signalKApiRoutes === 'function') {
  app.use('/signalk/v1/api', plugin.signalKApiRoutes(express.Router()))
}
```

A plugin implementing `signalKApiRoutes` + `getOpenApi` gets no error, no warning, no log — just a 404 at `/skServer/openapi/plugins/<id>` and nothing in the Swagger UI. It looks like the plugin's own bug.

Nothing in the API suggests the restriction. The `registerWithRouter` docs say that a plugin providing an API is "strongly recommended" to implement `getOpenApi`, without distinguishing the two ways of mounting routes.

## The fix

Registration moves out of the branch, so it happens for either mounting style. `setPluginOpenApi` only records the description against the plugin, so calling it outside the branch has no other effect.

## Also documented

`getOpenApi` had no doc comment. It now has one, including the part that is easy to get wrong: `getPluginOpenApi` fills in `servers` with `/plugins/<pluginid>` when the document does not declare it, so a plugin mounting under `/signalk/v1/api` must set `servers` itself or have its operations documented against the wrong base path.

## Tested

A new fixture, `skroutesplugin`, mounts with `signalKApiRoutes` and declares its own `servers` — no existing fixture used that path, which is why this went unnoticed.

Two tests: the description is served for the `signalKApiRoutes` plugin with its `servers` preserved, and the `registerWithRouter` case still works.

Verified the tests earn their place: reverting the change fails the first and leaves the second passing, so the fix is doing what it claims and the previously-working path is untouched.

`tsc`, `eslint`, `prettier` clean; `plugins.js` and `plugin-provider-registry.ts` pass unchanged.

## Context

Found while looking at SignalK/tracks#10, a 2021 WIP to add an OpenAPI description to the tracks plugin. That plugin serves under `/signalk/v1/api`, so the description could never have been published — which is probably why the PR stalled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR registers OpenAPI descriptions for plugins that use either `signalKApiRoutes` or `registerWithRouter`.

It documents `getOpenApi`, including the required `servers` value for plugins mounted under `/signalk/v1/api`.

It adds regression tests and a `skroutesplugin` fixture for both mounting styles.

## Testing

- TypeScript compilation
- ESLint
- Prettier
- OpenAPI mounting tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->