### PR TITLE
fix(docker): include Bluetooth dependencies in core image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,11 +22,11 @@ COPY --chown=node:node *.tgz .
 
 # EDITION selects the published variant: "full" bundles the optional webapps and
 # plugins; "core" installs the server with --omit=optional, leaving the server,
-# the admin UI, serialport, and required libraries. The admin UI ships in core
-# via its workspace tarball (kept in both editions below); serialport is an
-# external optional package, so core reinstalls it explicitly at the version the
-# server declares. Both stay in optionalDependencies but cannot be added back at
-# the .signalk layer, so the image must carry them.
+# the admin UI, serialport, local Bluetooth support, and required libraries.
+# The admin UI ships in core via its workspace tarball (kept in both editions
+# below); serialport and the Bluetooth packages are external optional packages,
+# so core reinstalls them explicitly at the versions the server declares. They
+# cannot be added back at the .signalk layer, so the image must carry them.
 ARG EDITION=full
 
 # npm 12 gates dependency install-time lifecycle scripts behind an allowlist
@@ -52,7 +52,9 @@ RUN case "$EDITION" in \
   && npm install "$server_tarball" --install-strategy=nested $npm_flags \
   && if [ "$EDITION" = core ]; then \
        serialport_spec=$(node -p "require('signalk-server/package.json').optionalDependencies.serialport") \
-       && npm install $npm_flags "serialport@$serialport_spec"; \
+       && node_ble_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@naugehyde/node-ble']") \
+       && dbus_next_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@jellybrick/dbus-next']") \
+       && npm install $npm_flags "serialport@$serialport_spec" "@naugehyde/node-ble@$node_ble_spec" "@jellybrick/dbus-next@$dbus_next_spec"; \
      fi \
   && if [ -d node_modules/@signalk ]; then \
        mkdir -p node_modules/signalk-server/node_modules/@signalk/ \

--- a/docker/Dockerfile_rel
+++ b/docker/Dockerfile_rel
@@ -20,12 +20,13 @@ ARG TAG
 
 # EDITION selects the published variant: "full" bundles the optional webapps
 # and plugins; "core" installs with --omit=optional, then reinstates the admin
-# UI and serialport. Those two stay in optionalDependencies (serialport is a
-# native module that must degrade gracefully on unsupported platforms), but
-# unlike the other optionals they cannot be added back at the .signalk layer —
-# the server serves the admin UI from a fixed path in its own install and
-# require()s serialport directly. Their versions are read from the installed
-# server's optionalDependencies so they cannot drift from the full image.
+# UI, serialport, and local Bluetooth support. These stay in optionalDependencies
+# (serialport is a native module that must degrade gracefully on unsupported
+# platforms), but unlike the other optionals they cannot be added back at the
+# .signalk layer — the server serves the admin UI from a fixed path in its own
+# install and require()s serialport, node-ble, and dbus-next directly. Their
+# versions are read from the installed server's optionalDependencies so they
+# cannot drift from the full image.
 ARG EDITION=full
 
 # npm 12 gates dependency install-time lifecycle scripts behind an allowlist
@@ -49,7 +50,9 @@ RUN case "$EDITION" in \
   && if [ "$EDITION" = core ]; then \
        adminui_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@signalk/server-admin-ui']") \
        && serialport_spec=$(node -p "require('signalk-server/package.json').optionalDependencies.serialport") \
-       && npm install $npm_flags "@signalk/server-admin-ui@$adminui_spec" "serialport@$serialport_spec"; \
+       && node_ble_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@naugehyde/node-ble']") \
+       && dbus_next_spec=$(node -p "require('signalk-server/package.json').optionalDependencies['@jellybrick/dbus-next']") \
+       && npm install $npm_flags "@signalk/server-admin-ui@$adminui_spec" "serialport@$serialport_spec" "@naugehyde/node-ble@$node_ble_spec" "@jellybrick/dbus-next@$dbus_next_spec"; \
      fi \
   && mkdir -p node_modules/signalk-server/node_modules/@signalk/ \
   && cp -rf node_modules/@signalk/* node_modules/signalk-server/node_modules/@signalk/ \

--- a/docker/Dockerfile_rel
+++ b/docker/Dockerfile_rel
@@ -25,8 +25,8 @@ ARG TAG
 # platforms), but unlike the other optionals they cannot be added back at the
 # .signalk layer — the server serves the admin UI from a fixed path in its own
 # install and require()s serialport, node-ble, and dbus-next directly. Their
-# versions are read from the installed server's optionalDependencies so they
-# cannot drift from the full image.
+# version ranges are read from the installed server's optionalDependencies, so
+# they stay aligned with the server's declared requirements.
 ARG EDITION=full
 
 # npm 12 gates dependency install-time lifecycle scripts behind an allowlist

--- a/docker/README.md
+++ b/docker/README.md
@@ -149,7 +149,7 @@ Both patterns install into the persisted config directory (`/home/node/.signalk`
 
 ### Behavioral change for non-Docker consumers
 
-The bundled webapps, plugins, the admin UI, `serialport`, and local Bluetooth support are all declared in `optionalDependencies`, not `dependencies`. **Default `npm install` is unaffected** because npm installs optional deps by default — the full Docker image and direct-from-npm installs ship them all. A consumer passing `npm install signalk-server --omit=optional` (CI pipelines, security-conscious deployments, distros) gets a minimal headless server: no admin UI, no serial-port or local Bluetooth support, and none of the bundled webapps or plugins. The core Docker image starts from that minimal set and adds back the admin UI, `serialport`, and the Bluetooth packages — the packages that can't be installed later at the config-directory layer. To get everything, drop the `--omit=optional` flag.
+The bundled webapps, plugins, the admin UI, `serialport`, and local Bluetooth support are all declared in `optionalDependencies`, not `dependencies`. Standard npm installations include optional dependencies, as do the full Docker images. Installations configured to omit them are minimal headless servers: they have no admin UI, serial-port or local Bluetooth support, bundled webapps, or plugins. The core Docker image restores the admin UI, `serialport`, and the Bluetooth packages because they cannot be added at the config-directory layer.
 
 ## Development images
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -119,9 +119,9 @@ The core image omits these packages — all declared in `package.json` `optional
 - Webapps: `@signalk/freeboard-sk`, `@signalk/instrumentpanel`, `@mxtommy/kip`, `@signalk/app-dock`
 - Plugins and bridges: `@signalk/set-system-time`, `@signalk/signalk-to-nmea0183`, `@signalk/udp-nmea-plugin`, `signalk-n2kais-to-nmea0183`, `signalk-to-nmea2000`
 
-What the core image ships: the Signal K server, the admin UI (`@signalk/server-admin-ui`) and its app store, serial-port support (`serialport`), `@signalk/server-api`, `@signalk/streams`, `@signalk/signalk-schema`, `@signalk/course-provider`, `@signalk/resources-provider`, and the NMEA0183 / NMEA2000 parser libraries (`@signalk/nmea0183-signalk`, `@signalk/n2k-signalk`).
+What the core image ships: the Signal K server, the admin UI (`@signalk/server-admin-ui`) and its app store, serial-port support (`serialport`), local Bluetooth support (`@naugehyde/node-ble`, `@jellybrick/dbus-next`), `@signalk/server-api`, `@signalk/streams`, `@signalk/signalk-schema`, `@signalk/course-provider`, `@signalk/resources-provider`, and the NMEA0183 / NMEA2000 parser libraries (`@signalk/nmea0183-signalk`, `@signalk/n2k-signalk`).
 
-The admin UI and `serialport` are themselves declared `optionalDependencies`, so `--omit=optional` strips them too — but the core image **reinstates** them, because neither can be added back at the config-directory layer: the server serves the admin UI from a fixed path inside its own install, and it `require`s `serialport` directly. (`serialport` stays optional rather than a hard dependency so direct npm installs degrade gracefully on platforms without prebuilt bindings.)
+The admin UI, `serialport`, and the Bluetooth packages are themselves declared `optionalDependencies`, so `--omit=optional` strips them too — but the core image **reinstates** them, because they cannot be added back at the config-directory layer: the server serves the admin UI from a fixed path inside its own install and it `require`s `serialport`, `node-ble`, and `dbus-next` directly. (`serialport` stays optional rather than a hard dependency so direct npm installs degrade gracefully on unsupported platforms.)
 
 ### App store and plugin installation
 
@@ -149,7 +149,7 @@ Both patterns install into the persisted config directory (`/home/node/.signalk`
 
 ### Behavioral change for non-Docker consumers
 
-The bundled webapps, plugins, the admin UI, and `serialport` are all declared in `optionalDependencies`, not `dependencies`. **Default `npm install` is unaffected** because npm installs optional deps by default — the full Docker image and direct-from-npm installs ship them all. A consumer passing `npm install signalk-server --omit=optional` (CI pipelines, security-conscious deployments, distros) gets a minimal headless server: no admin UI, no serial-port support, and none of the bundled webapps or plugins. The core Docker image starts from that minimal set and adds back the admin UI and `serialport` — the two that can't be installed later at the config-directory layer. To get everything, drop the `--omit=optional` flag.
+The bundled webapps, plugins, the admin UI, `serialport`, and local Bluetooth support are all declared in `optionalDependencies`, not `dependencies`. **Default `npm install` is unaffected** because npm installs optional deps by default — the full Docker image and direct-from-npm installs ship them all. A consumer passing `npm install signalk-server --omit=optional` (CI pipelines, security-conscious deployments, distros) gets a minimal headless server: no admin UI, no serial-port or local Bluetooth support, and none of the bundled webapps or plugins. The core Docker image starts from that minimal set and adds back the admin UI, `serialport`, and the Bluetooth packages — the packages that can't be installed later at the config-directory layer. To get everything, drop the `--omit=optional` flag.
 
 ## Development images
 


### PR DESCRIPTION
## Summary
- reinstall `@naugehyde/node-ble` and `@jellybrick/dbus-next` in the core Docker image
- read their versions from the server package metadata, as for `serialport`
- document that local Bluetooth support is available in the core variant

`localProvider` requires both packages directly. `--omit=optional` removed them from `latest-core`, causing the managed Bluetooth provider to report `Cannot find module @naugehyde/node-ble`.

## Verification
- `git diff --check`
- `prettier --check docker/README.md`
- installed both packages with `npm install --omit=optional` in the published `latest-core` image and resolved both modules

A complete Bluetooth connection test needs an available BlueZ D-Bus system socket and an adapter, which are not present in the build environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR restores `@naugehyde/node-ble` and `@jellybrick/dbus-next` in core Docker images at the versions declared by the server package. It enables managed local Bluetooth support when optional dependencies are omitted during installation.

It updates both Dockerfiles and documents the restored Bluetooth dependencies in `docker/README.md`.

## Verification

- `git diff --check`
- Prettier validation for `docker/README.md`
- Package resolution in the published `latest-core` image

Full Bluetooth connection testing is not performed because the build environment lacks a BlueZ D-Bus socket and adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->