### PR TITLE
Alerts subsystem 2/4: persistence and audit trail

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -23,7 +23,7 @@ You do not have to install Signal K Server yourself. Several commercially availa
 ## Prerequisites
 
 > [!NOTE]
-> Signal K server requires [NodeJS](https://nodejs.org) version >= 22 (version 24 recommended) be installed on the target system.
+> Signal K server requires [NodeJS](https://nodejs.org) `>=22.13 <23` or `>=23.4` (version 24 recommended) be installed on the target system. The alerts subsystem uses the built-in `node:sqlite` module, which needs a flag on 23.0 to 23.3, so those releases are not supported.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.13.0 <23 || >=23.4.0"
   },
   "workspaces": [
     "packages/server-admin-ui-dependencies",

--- a/src/api/alerts/alertManager.ts
+++ b/src/api/alerts/alertManager.ts
@@ -1,0 +1,1482 @@
+/**
+ * Alert manager.
+ *
+ * Owns the active alert set and drives every lifecycle operation, coordinating
+ * the state machine, the escalation timer, and the store. It is the
+ * authoritative record of alert state; the Signal K model tree is a mirror fed
+ * by the events emitted here.
+ */
+
+import { EventEmitter } from 'events'
+import type { Context, Path, SourceRef, Value } from '@signalk/server-api'
+import {
+  PRIORITY_RANK,
+  type Alert,
+  type AlertFilter,
+  type AlertPriority,
+  type AlertState,
+  type AlertTransition,
+  type HistoryEntry,
+  type HistoryEventType,
+  type IAlertStore
+} from './types'
+import {
+  AlertLimitReachedError,
+  AlertNotFoundError,
+  InvalidEscalationError,
+  InvalidSilenceDurationError
+} from './errors'
+import {
+  AlertStateMachine,
+  createAlert,
+  type CreateAlertParams,
+  type StateTransitionResult
+} from './alertStateMachine'
+import {
+  defaultTimerFunctions,
+  EscalationTimer,
+  type EscalationTimerConfig,
+  type TimerFunctions,
+  type TimerHandle
+} from './escalationTimer'
+
+const MILLISECONDS_PER_SECOND = 1000
+
+/**
+ * How often the audit trail is pruned while the server runs. Retention is also
+ * applied at startup, which is what actually bounds it on a device that reboots
+ * more often than this.
+ */
+const RETENTION_PRUNE_INTERVAL_MS = 24 * 60 * 60 * MILLISECONDS_PER_SECOND
+
+/**
+ * Retention applied when the configuration does not say. Unbounded is the
+ * wrong default on a device whose root filesystem is an SD card.
+ */
+const DEFAULT_RETENTION_DAYS = 90
+
+/**
+ * Active alerts allowed when the configuration does not say. High enough that
+ * no plausible vessel reaches it, low enough that a device raising a fresh
+ * alert per delta cannot exhaust memory.
+ */
+const DEFAULT_MAX_ACTIVE_ALERTS = 1000
+
+/**
+ * How long a delta source may stay quiet before its alerts are marked stale.
+ * A stale alert stays visible and actionable: silence is not evidence that the
+ * condition resolved.
+ */
+const DEFAULT_SOURCE_TIMEOUT_SECONDS = 60
+
+/**
+ * The cap to enforce, falling back to the default when the setting is not a
+ * usable count. A typo must not leave the subsystem unable to raise anything.
+ */
+function resolveMaxActiveAlerts(configured?: number): number {
+  if (configured === undefined) {
+    return DEFAULT_MAX_ACTIVE_ALERTS
+  }
+  if (!Number.isInteger(configured) || configured < 1) {
+    console.error(
+      `The active alert limit must be a whole number of at least 1, but is ` +
+        `${String(configured)}. Using ${String(DEFAULT_MAX_ACTIVE_ALERTS)}.`
+    )
+    return DEFAULT_MAX_ACTIVE_ALERTS
+  }
+  return configured
+}
+
+/**
+ * The liveness window to enforce, falling back to the default when the setting
+ * is not a usable number of seconds. A zero or a NaN would otherwise reach
+ * setTimeout and mark every re-emitting alert stale at once.
+ */
+function resolveSourceTimeoutSeconds(configured?: number): number {
+  if (configured === undefined) {
+    return DEFAULT_SOURCE_TIMEOUT_SECONDS
+  }
+  if (!Number.isFinite(configured) || configured <= 0) {
+    console.error(
+      `The alert source timeout must be a positive number of seconds, but is ` +
+        `${String(configured)}. Using ${String(DEFAULT_SOURCE_TIMEOUT_SECONDS)}.`
+    )
+    return DEFAULT_SOURCE_TIMEOUT_SECONDS
+  }
+  return configured
+}
+
+/**
+ * Whether two alerts carry the same description, ignoring the liveness fields
+ * a re-emission always moves.
+ */
+function sameDescription(before: Alert, after: Alert): boolean {
+  return (
+    before.$source === after.$source &&
+    JSON.stringify(before.source) === JSON.stringify(after.source) &&
+    before.group === after.group &&
+    before.latching === after.latching &&
+    JSON.stringify(before.references) === JSON.stringify(after.references) &&
+    JSON.stringify(before.data) === JSON.stringify(after.data)
+  )
+}
+
+/**
+ * What a source may refresh on an alert without re-announcing it.
+ *
+ * Priority and message are absent on purpose: those are what an operator
+ * reads, so a change to either is a fresh annunciation and belongs in
+ * raiseAlert.
+ */
+export interface AlertDescription {
+  $source?: SourceRef
+  source?: Record<string, unknown>
+  group?: string
+  latching?: boolean
+  references?: Path[]
+  data?: Record<string, Value>
+}
+
+/**
+ * Configuration for the AlertManager.
+ */
+export interface AlertManagerConfig {
+  /** Escalation settings for priority promotion */
+  escalation: EscalationTimerConfig
+  /** Silencing duration limits */
+  silencing: {
+    /** Longest a non-emergency alert may be silenced, in seconds */
+    defaultMaxSilenceSeconds: number
+    /** Longest an emergency may be silenced, in seconds */
+    emergencyMaxSilenceSeconds: number
+  }
+  /** Days to retain the audit trail. Defaults to 90. */
+  retentionDays?: number
+  /** Most alerts that may be active at once. Defaults to 1000. */
+  maxActiveAlerts?: number
+  /**
+   * Seconds a delta source may go quiet before its alerts are stale.
+   * Defaults to 60.
+   */
+  sourceTimeoutSeconds?: number
+}
+
+/**
+ * Event types emitted by the AlertManager.
+ */
+export type AlertEventType =
+  | 'raised'
+  | 'acknowledged'
+  | 'silenced'
+  | 'unsilenced'
+  | 'cleared'
+  | 'escalated'
+  | 'updated'
+
+/**
+ * Event emitted when an alert changes.
+ */
+export interface AlertEvent {
+  /** Type of event that occurred */
+  type: AlertEventType
+  /** The alert at the time of the event */
+  alert: Alert
+  /** The alert state before the event */
+  previousState?: AlertState
+}
+
+/**
+ * Event emitted when a store write fails.
+ *
+ * The lifecycle change it belongs to has already been applied and announced,
+ * so this reports lost durability, not a lost alert.
+ */
+export interface StoreFailureEvent {
+  /** Operation that failed */
+  operation: 'commit' | 'prune' | 'resync'
+  /** Alert the write belonged to, or null for store-wide operations */
+  alertId: string | null
+  /** The underlying error */
+  error: Error
+}
+
+/**
+ * Extra fields an audit entry carries beyond the alert's own identity.
+ */
+interface HistoryDetails {
+  /** Who caused this entry, when that is not the alert's own source */
+  $source?: SourceRef
+  userId?: string
+  previousState?: AlertState
+  newState?: AlertState
+  previousPriority?: AlertPriority
+  newPriority?: AlertPriority
+  details?: Record<string, unknown>
+}
+
+/**
+ * Alert manager.
+ *
+ * Manages the lifecycle of alerts including creation, acknowledgment,
+ * silencing, and clearing. Coordinates with the EscalationTimer for automatic
+ * priority promotion and optionally persists through an IAlertStore.
+ *
+ * Annunciation never waits on the store. Every lifecycle change is applied
+ * to the registry, announced, and only then committed, so a store that cannot
+ * be written costs durability across a restart rather than the alarm itself. A
+ * failed commit sets the degraded flag and emits `storeError`.
+ */
+export class AlertManager extends EventEmitter {
+  private config: AlertManagerConfig
+  private alerts = new Map<string, Alert>()
+  private stateMachine = new AlertStateMachine()
+  private escalationTimer: EscalationTimer
+  private store?: IAlertStore
+  private stopped = false
+  private storeDegraded = false
+  private resyncing = false
+  /** Bumped by every store failure, so a sweep can tell if one raced it. */
+  private storeFailures = 0
+  private timerFns: TimerFunctions
+  private readonly maxActiveAlerts: number
+  private readonly sourceTimeoutSeconds: number
+  /**
+   * One timer per alert whose source re-emits it, armed afresh on every
+   * re-emission. Only delta ingress enrols an alert here: re-emission is its
+   * heartbeat, and a REST or plugin alert raised once would go stale for no
+   * reason.
+   */
+  private livenessTimers = new Map<string, TimerHandle>()
+  /** Whether the full active set has already been reported. */
+  private limitReported = false
+  private retentionTimer?: TimerHandle
+
+  /**
+   * Index mapping path(+context) to alertId for duplicate detection.
+   */
+  private alertIndex = new Map<string, string>()
+
+  /**
+   * Timers for silence expiration.
+   */
+  private silenceTimers = new Map<string, TimerHandle>()
+
+  /**
+   * Removals the store rejected. Retried on the next successful write, since
+   * nothing else will ever name these alerts again.
+   */
+  private pendingRemovals = new Set<string>()
+
+  constructor(
+    config: AlertManagerConfig,
+    timerFunctions?: TimerFunctions,
+    store?: IAlertStore
+  ) {
+    super()
+    this.config = config
+    this.store = store
+    this.maxActiveAlerts = resolveMaxActiveAlerts(config.maxActiveAlerts)
+    this.sourceTimeoutSeconds = resolveSourceTimeoutSeconds(
+      config.sourceTimeoutSeconds
+    )
+    this.timerFns = timerFunctions ?? defaultTimerFunctions
+    this.escalationTimer = new EscalationTimer(
+      config.escalation,
+      (event) => {
+        this.handleEscalation(event.alertId)
+      },
+      timerFunctions
+    )
+  }
+
+  /**
+   * Whether the store currently disagrees with the registry.
+   *
+   * Set by a failed write and cleared once a later write succeeds and the
+   * active set has been re-committed. While it is true, alert state may not
+   * survive a restart; alerts themselves keep being raised and announced.
+   */
+  isStoreDegraded(): boolean {
+    return this.storeDegraded
+  }
+
+  /**
+   * Load alerts from the store into memory.
+   * Call this after construction to restore persisted alerts.
+   */
+  async loadFromStore(): Promise<void> {
+    const store = this.store
+    if (!store) {
+      return
+    }
+
+    let alerts: Alert[]
+    try {
+      alerts = await store.getAll()
+    } catch (err) {
+      // Fail loudly: an unreadable store must surface as a startup failure
+      // rather than silently presenting zero active alerts as truth.
+      console.error('Failed to load alerts from store:', err)
+      throw err
+    }
+
+    // Populate the whole registry before any side effect runs, so a failure
+    // while resuming one alert's timers cannot leave later alerts unloaded.
+    for (const alert of alerts) {
+      this.alerts.set(alert.id, alert)
+      this.alertIndex.set(this.getIndexKey(alert.path, alert.context), alert.id)
+    }
+
+    for (const stored of alerts) {
+      this.resumeEscalation(stored)
+      await this.resumeSilence(stored.id)
+    }
+
+    // Armed only once the load has succeeded, so a store this server has
+    // decided it cannot use is left alone and no timer outlives the abort.
+    this.startRetention()
+  }
+
+  /**
+   * Raise a new alert or update an existing one.
+   *
+   * If an active alert with the same path (and context) already exists, it is
+   * updated rather than duplicated. An omitted optional field leaves the
+   * existing value alone; a caller clears a field by sending it empty.
+   */
+  async raiseAlert(params: CreateAlertParams): Promise<Alert> {
+    const context = params.context || undefined
+    const existingId = this.alertIndex.get(
+      this.getIndexKey(params.path, context)
+    )
+
+    if (existingId) {
+      const existing = this.alerts.get(existingId)
+      if (existing) {
+        return this.updateExistingAlert(existing, params)
+      }
+    }
+
+    // Checked after the update branch: an alert that already exists keeps
+    // taking updates at the cap, and only genuinely new ones are refused. The
+    // cap lives here rather than at the REST boundary, so the delta and plugin
+    // surfaces that call the manager directly obey the same limit.
+    if (this.alerts.size >= this.maxActiveAlerts) {
+      await this.makeRoomFor(params.priority)
+
+      // That await is the only suspension point between reading the index and
+      // writing it, so a concurrent raise for this same path can have created
+      // the alert meanwhile. Overwriting the index key here would strand the
+      // first alert: still holding a slot and a timer, reachable by nobody.
+      const racedId = this.alertIndex.get(
+        this.getIndexKey(params.path, context)
+      )
+      const raced = racedId ? this.alerts.get(racedId) : undefined
+      if (raced) {
+        return this.updateExistingAlert(raced, params)
+      }
+    }
+
+    const alert = createAlert(params)
+
+    this.alerts.set(alert.id, alert)
+    this.alertIndex.set(this.getIndexKey(alert.path, alert.context), alert.id)
+
+    this.syncEscalationTimer(alert)
+    const history = [
+      this.historyEntry('raise', alert, { newState: alert.state })
+    ]
+    this.emitEvent('raised', alert)
+
+    await this.commit({ alertId: alert.id, alert, history })
+
+    return alert
+  }
+
+  /**
+   * Acknowledge an alert.
+   */
+  async acknowledgeAlert(
+    alertId: string,
+    userId?: string
+  ): Promise<StateTransitionResult> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    const result = this.stateMachine.acknowledge(alert, userId)
+
+    this.escalationTimer.cancelTimer(alertId)
+    if (result.alert) {
+      result.alert = this.clearSilencingIfSuperseded(alertId, result.alert)
+    }
+
+    if (result.cleared) {
+      const terminal = this.terminalAlert(alert)
+      this.removeFromRegistry(alertId, alert)
+      const history = [
+        this.historyEntry('clear', terminal, {
+          userId,
+          previousState: result.previousState,
+          newState: 'normal'
+        })
+      ]
+      this.emitEvent('cleared', terminal, result.previousState)
+      await this.commit({ alertId, alert: null, history })
+      return result
+    }
+
+    if (result.alert) {
+      const updated = result.alert
+      this.alerts.set(alertId, updated)
+      const history = [
+        this.historyEntry('acknowledge', updated, {
+          userId,
+          previousState: result.previousState,
+          newState: updated.state
+        })
+      ]
+      this.emitEvent('acknowledged', updated, result.previousState)
+      await this.commit({ alertId, alert: updated, history })
+    }
+
+    return result
+  }
+
+  /**
+   * Escalate an alert to a higher priority.
+   *
+   * Only escalation (raising priority) is supported — de-escalation is
+   * intentionally not allowed. If the condition has improved, the source
+   * should clear and re-raise at the lower priority instead.
+   */
+  async escalateAlert(
+    alertId: string,
+    newPriority: AlertPriority
+  ): Promise<Alert> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    if (PRIORITY_RANK[newPriority] <= PRIORITY_RANK[alert.priority]) {
+      throw new InvalidEscalationError(alert.priority, newPriority)
+    }
+
+    const previousPriority = alert.priority
+    const now = new Date().toISOString()
+    // lastSourceUpdate is not touched: it reports when the source last spoke,
+    // and this is the operator acting on an alert whose source may have gone
+    // quiet. Refreshing it here would report a silent source as live.
+    const priorityUpdated: Alert = {
+      ...alert,
+      priority: newPriority
+    }
+
+    // Escalation raises urgency; it does not claim that a condition which
+    // returned to normal came back. An alert whose condition is inactive keeps
+    // its state and its clearedAt, so acknowledging still resolves it.
+    const reAlerted = priorityUpdated.condition
+      ? this.stateMachine.reactivate(priorityUpdated).alert
+      : priorityUpdated
+
+    // Escalation is itself a state change (IEC 62923-1 6.4.2.2), so the
+    // escalated alert rises within its new priority group.
+    const updated: Alert = {
+      ...this.clearSilencingIfSuperseded(alertId, reAlerted),
+      stateChangedAt: now
+    }
+
+    this.alerts.set(alertId, updated)
+    this.syncEscalationTimer(updated)
+
+    const history = [
+      this.historyEntry('escalate', updated, {
+        previousState: alert.state,
+        newState: updated.state,
+        previousPriority,
+        newPriority
+      })
+    ]
+    this.emitEvent('escalated', updated, alert.state)
+
+    await this.commit({ alertId, alert: updated, history })
+
+    return updated
+  }
+
+  /**
+   * Silence an alert.
+   *
+   * @param alertId - The alert ID to silence
+   * @param durationMs - Duration in milliseconds, clamped to the configured
+   *   maximum for the alert's priority. Defaults to that maximum.
+   */
+  async silenceAlert(alertId: string, durationMs?: number): Promise<Alert> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    const duration = this.resolveSilenceDuration(alert.priority, durationMs)
+    const silenced = this.stateMachine.silence(
+      alert,
+      new Date(Date.now() + duration)
+    )
+    this.alerts.set(alertId, silenced)
+
+    this.startSilenceExpirationTimer(alertId, duration)
+    const history = [
+      this.historyEntry('silence', silenced, {
+        details: { silencedUntil: silenced.silencedUntil }
+      })
+    ]
+    this.emitEvent('silenced', silenced)
+
+    await this.commit({ alertId, alert: silenced, history })
+
+    return silenced
+  }
+
+  /**
+   * Unsilence an alert.
+   */
+  async unsilenceAlert(alertId: string): Promise<Alert> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    this.cancelSilenceExpirationTimer(alertId)
+
+    const unsilenced = this.stateMachine.unsilence(alert)
+    this.alerts.set(alertId, unsilenced)
+
+    const history = [this.historyEntry('unsilence', unsilenced)]
+    this.emitEvent('unsilenced', unsilenced)
+
+    await this.commit({ alertId, alert: unsilenced, history })
+
+    return unsilenced
+  }
+
+  /**
+   * Silence all unacknowledged alerts.
+   */
+  async silenceAll(): Promise<void> {
+    const candidateIds = Array.from(this.alerts.values())
+      .filter((a) => AlertStateMachine.isUnacknowledged(a) && !a.silenced)
+      .map((a) => a.id)
+
+    for (const alertId of candidateIds) {
+      // Re-read: an alert can be acknowledged or cleared while an earlier
+      // iteration awaits its write, and committing the stale snapshot would
+      // resurrect it.
+      const current = this.alerts.get(alertId)
+      if (
+        !current ||
+        !AlertStateMachine.isUnacknowledged(current) ||
+        current.silenced
+      ) {
+        continue
+      }
+
+      const duration = this.getMaxSilenceDuration(current.priority)
+      const silenced = this.stateMachine.silence(
+        current,
+        new Date(Date.now() + duration)
+      )
+      this.alerts.set(alertId, silenced)
+
+      this.startSilenceExpirationTimer(alertId, duration)
+      const history = [
+        this.historyEntry('silence', silenced, {
+          details: { silencedUntil: silenced.silencedUntil }
+        })
+      ]
+      this.emitEvent('silenced', silenced)
+
+      await this.commit({ alertId, alert: silenced, history })
+    }
+  }
+
+  /**
+   * Apply what a source says about an alert that is otherwise unchanged.
+   *
+   * A re-emission with the same priority and message is not news, so it must
+   * not travel through raiseAlert: that reactivates an acknowledged alert and
+   * strips its silencing. The descriptive fields still moved, though, and the
+   * model and the store should carry what the source last said.
+   */
+  async updateDescription(
+    alertId: string,
+    description: AlertDescription
+  ): Promise<Alert> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    // An omitted field means unchanged, as it does for a raise.
+    const updated: Alert = {
+      ...alert,
+      $source: description.$source ?? alert.$source,
+      source: description.source ?? alert.source,
+      group: description.group ?? alert.group,
+      latching: description.latching ?? alert.latching,
+      references: description.references ?? alert.references,
+      data: description.data ?? alert.data,
+      lastSourceUpdate: new Date().toISOString(),
+      sourceOnline: true,
+      stale: false
+    }
+
+    // A source that re-emits an identical alert is the common case, and it
+    // must stay free: no delta to every subscriber and no durable write for a
+    // message that says nothing new.
+    //
+    // A source that re-emits after going quiet is not that case. The alert is
+    // marked stale and its source offline, and saying so again is exactly what
+    // clears both, so that one is published and stored.
+    const wasOffline = alert.stale || !alert.sourceOnline
+    if (sameDescription(alert, updated) && !wasOffline) {
+      return alert
+    }
+
+    this.alerts.set(alertId, updated)
+    // No audit entry and no state change: nothing happened to the alert, the
+    // source merely said the same thing again with fresher detail.
+    this.emitEvent('updated', updated)
+
+    await this.commit({ alertId, alert: updated, history: [] })
+
+    return updated
+  }
+
+  /**
+   * Clear the condition for an alert.
+   */
+  async clearCondition(
+    alertId: string,
+    clearedBy?: SourceRef
+  ): Promise<StateTransitionResult> {
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      throw new AlertNotFoundError(alertId)
+    }
+
+    const result = this.stateMachine.clearCondition(alert)
+
+    if (result.cleared) {
+      const terminal = this.terminalAlert(alert)
+      this.removeFromRegistry(alertId, alert)
+      const history = [
+        this.historyEntry('clear', terminal, {
+          $source: clearedBy,
+          previousState: result.previousState,
+          newState: 'normal'
+        })
+      ]
+      this.emitEvent('cleared', terminal, result.previousState)
+      await this.commit({ alertId, alert: null, history })
+      return result
+    }
+
+    if (result.alert) {
+      const updated = result.alert
+      // A repeat clear on an already-cleared condition changes nothing.
+      // Logging and re-emitting it would flood the audit trail, because a
+      // delta source re-emits a null value as its liveness heartbeat.
+      const changed =
+        updated.state !== alert.state || updated.condition !== alert.condition
+
+      this.alerts.set(alertId, updated)
+      this.syncEscalationTimer(updated)
+
+      if (changed) {
+        const history = [
+          this.historyEntry('clear', updated, {
+            $source: clearedBy,
+            previousState: result.previousState,
+            newState: updated.state
+          })
+        ]
+        this.emitEvent('updated', updated, result.previousState)
+        await this.commit({ alertId, alert: updated, history })
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Get an alert by ID.
+   */
+  getAlert(alertId: string): Alert | null {
+    return this.alerts.get(alertId) ?? null
+  }
+
+  /**
+   * Get the active alert on a path (with optional context), if any.
+   *
+   * Delta and REST ingress resolve alerts through this index rather than
+   * keeping their own path-to-id maps, which would not survive a restart.
+   */
+  getAlertByPath(path: Path, context?: Context): Alert | null {
+    const alertId = this.alertIndex.get(this.getIndexKey(path, context))
+    return alertId ? (this.alerts.get(alertId) ?? null) : null
+  }
+
+  /**
+   * Get all alerts, optionally filtered.
+   */
+  getAlerts(filter?: AlertFilter): Alert[] {
+    let alerts = Array.from(this.alerts.values())
+
+    if (filter?.state) {
+      const states = new Set(
+        Array.isArray(filter.state) ? filter.state : [filter.state]
+      )
+      alerts = alerts.filter((a) => states.has(a.state))
+    }
+
+    if (filter?.priority) {
+      const priorities = new Set(
+        Array.isArray(filter.priority) ? filter.priority : [filter.priority]
+      )
+      alerts = alerts.filter((a) => priorities.has(a.priority))
+    }
+
+    if (filter?.group) {
+      alerts = alerts.filter((a) => a.group === filter.group)
+    }
+
+    if (filter?.stale !== undefined) {
+      alerts = alerts.filter((a) => a.stale === filter.stale)
+    }
+
+    return alerts
+  }
+
+  /**
+   * Get count of active alerts.
+   */
+  getActiveAlertCount(): number {
+    return this.alerts.size
+  }
+
+  /**
+   * Get count of unacknowledged alerts.
+   */
+  getUnacknowledgedCount(): number {
+    return this.getAlerts({ state: ['unacknowledged', 'rtn-unacknowledged'] })
+      .length
+  }
+
+  /**
+   * Record that an alert's source re-emitted it.
+   *
+   * Delta ingress calls this: re-emission of the alert value is the heartbeat
+   * (proposal §15). The raise itself already refreshed the timestamps, so this
+   * only enrols the alert in liveness checking.
+   */
+  noteSourceUpdate(alertId: string): void {
+    if (this.stopped) {
+      return
+    }
+
+    this.cancelLivenessTimer(alertId)
+    const timeoutMs = this.sourceTimeoutSeconds * MILLISECONDS_PER_SECOND
+    this.livenessTimers.set(
+      alertId,
+      this.timerFns.setTimeout(() => {
+        this.livenessTimers.delete(alertId)
+        void this.markStale(alertId)
+      }, timeoutMs)
+    )
+  }
+
+  /** The source stopped talking. The alert stays, and says so. */
+  private async markStale(alertId: string): Promise<void> {
+    const alert = this.alerts.get(alertId)
+    if (this.stopped || !alert || alert.stale) {
+      return
+    }
+
+    const stale: Alert = { ...alert, stale: true, sourceOnline: false }
+    this.alerts.set(alertId, stale)
+    this.emitEvent('updated', stale)
+    // No audit entry: staleness is a fact about the source, not something
+    // that happened to the alert.
+    await this.commit({ alertId, alert: stale, history: [] })
+  }
+
+  private cancelLivenessTimer(alertId: string): void {
+    const handle = this.livenessTimers.get(alertId)
+    if (handle !== undefined) {
+      this.timerFns.clearTimeout(handle)
+      this.livenessTimers.delete(alertId)
+    }
+  }
+
+  /**
+   * Stop the alert manager and clean up resources.
+   */
+  stop(): void {
+    this.stopped = true
+    this.escalationTimer.stop()
+
+    for (const alertId of Array.from(this.livenessTimers.keys())) {
+      this.cancelLivenessTimer(alertId)
+    }
+
+    for (const handle of this.silenceTimers.values()) {
+      this.timerFns.clearTimeout(handle)
+    }
+    this.silenceTimers.clear()
+
+    if (this.retentionTimer !== undefined) {
+      this.timerFns.clearTimeout(this.retentionTimer)
+      this.retentionTimer = undefined
+    }
+  }
+
+  /**
+   * Handle escalation timer callback.
+   */
+  private handleEscalation(alertId: string): void {
+    if (this.stopped) {
+      return
+    }
+
+    const alert = this.alerts.get(alertId)
+    if (!alert) {
+      return
+    }
+
+    const previousPriority = alert.priority
+
+    // Escalation is itself a state change (IEC 62923-1 6.4.2.2), so the alarm
+    // rises within its priority group. It supersedes silencing for the same
+    // reason the operator-driven path does — this timer fires precisely
+    // because nobody attended to the warning.
+    const escalated: Alert = {
+      ...this.clearSilencingIfSuperseded(alertId, alert),
+      priority: 'alarm',
+      stateChangedAt: new Date().toISOString()
+    }
+
+    this.alerts.set(alertId, escalated)
+    this.syncEscalationTimer(escalated)
+
+    const history = [
+      this.historyEntry('escalate', escalated, {
+        previousPriority,
+        newPriority: 'alarm'
+      })
+    ]
+    this.emitEvent('escalated', escalated, alert.state)
+
+    void this.commit({ alertId, alert: escalated, history })
+  }
+
+  /**
+   * Update an existing alert with new data.
+   * Priority can only be escalated (increased), not reduced.
+   * If the alert was acknowledged or returned-to-normal, reactivates it.
+   */
+  private async updateExistingAlert(
+    existing: Alert,
+    params: CreateAlertParams
+  ): Promise<Alert> {
+    const newPriority =
+      PRIORITY_RANK[params.priority] > PRIORITY_RANK[existing.priority]
+        ? params.priority
+        : existing.priority
+
+    // An omitted optional field means unchanged. A partial re-raise — a delta
+    // source's liveness heartbeat, for one — must not erase what an earlier
+    // raise described. Callers clear a field by sending it empty.
+    const dataUpdated: Alert = {
+      ...existing,
+      references: params.references ?? existing.references,
+      $source: params.$source,
+      source: params.source ?? existing.source,
+      priority: newPriority,
+      message: params.message,
+      group: params.group ?? existing.group,
+      latching: params.latching ?? existing.latching,
+      data: params.data ?? existing.data,
+      lastSourceUpdate: new Date().toISOString(),
+      sourceOnline: true,
+      // The source just spoke, so whatever the liveness check decided is over.
+      stale: false
+    }
+
+    const reactivation = this.stateMachine.reactivate(dataUpdated)
+    const updated = this.clearSilencingIfSuperseded(
+      existing.id,
+      reactivation.alert
+    )
+    const stateChanged = reactivation.previousState !== updated.state
+    const conditionReturned = !existing.condition && updated.condition
+    const reAnnounced = stateChanged || conditionReturned
+    const ownerChanged = params.$source !== existing.$source
+    const escalated =
+      PRIORITY_RANK[newPriority] > PRIORITY_RANK[existing.priority]
+
+    // Escalation is a state change, so it moves the alert to the front of its
+    // new priority group. `reactivate` leaves the timestamp alone for an alert
+    // that was already unacknowledged, so a source-driven escalation has to
+    // set it here — the timer and operator routes already do.
+    const announced: Alert = escalated
+      ? { ...updated, stateChangedAt: new Date().toISOString() }
+      : updated
+
+    this.alerts.set(existing.id, announced)
+
+    const history: Omit<HistoryEntry, 'id'>[] = []
+
+    if (newPriority !== existing.priority) {
+      history.push(
+        this.historyEntry('escalate', announced, {
+          previousPriority: existing.priority,
+          newPriority
+        })
+      )
+    }
+
+    // A re-annunciation restarts the escalation window; a plain update leaves
+    // the running one alone.
+    if (reAnnounced) {
+      this.escalationTimer.cancelTimer(existing.id)
+    }
+    this.syncEscalationTimer(announced)
+
+    // A source taking over an already-active alert belongs in the audit trail.
+    // A source re-emitting its own alert is a liveness heartbeat and would
+    // flood it.
+    if (reAnnounced || ownerChanged) {
+      history.push(
+        this.historyEntry('raise', announced, {
+          previousState: reactivation.previousState,
+          newState: announced.state,
+          details: ownerChanged
+            ? { previousSource: existing.$source }
+            : undefined
+        })
+      )
+    }
+
+    // A rise in priority is announced the same way the timer and the operator
+    // route announce it, so a listener that drives renewed annunciation from
+    // `escalated` cannot miss a source re-raising at a higher priority.
+    const eventType = reAnnounced
+      ? 'raised'
+      : escalated
+        ? 'escalated'
+        : 'updated'
+    this.emitEvent(
+      eventType,
+      announced,
+      reAnnounced || escalated ? reactivation.previousState : undefined
+    )
+
+    await this.commit({ alertId: existing.id, alert: announced, history })
+
+    return announced
+  }
+
+  /**
+   * Free a slot for an incoming alert, or refuse it.
+   *
+   * A device that mints a path per message would otherwise fill the set with
+   * trivia and lock out the emergency that matters. The least urgent alert
+   * gives way to a more urgent one; nothing gives way to an equal.
+   */
+  private async makeRoomFor(priority: AlertPriority): Promise<void> {
+    const victim = this.leastUrgentAlert()
+
+    if (!victim || PRIORITY_RANK[victim.priority] >= PRIORITY_RANK[priority]) {
+      if (!this.limitReported) {
+        this.limitReported = true
+        console.error(
+          `The alerts subsystem holds its maximum of ${String(this.maxActiveAlerts)} ` +
+            `active alerts and is refusing new ones. A source is probably raising ` +
+            `an alert per message.`
+        )
+      }
+      throw new AlertLimitReachedError(this.maxActiveAlerts)
+    }
+
+    console.error(
+      `The alerts subsystem is full, so the ${victim.priority} alert on ` +
+        `${victim.path} was dropped to make room for a ${priority} alert.`
+    )
+
+    const terminal = this.terminalAlert(victim)
+    this.removeFromRegistry(victim.id, victim)
+    this.emitEvent('cleared', terminal, victim.state)
+    await this.commit({
+      alertId: victim.id,
+      alert: null,
+      history: [
+        this.historyEntry('clear', terminal, {
+          previousState: victim.state,
+          newState: 'normal',
+          details: { reason: 'displaced', by: priority }
+        })
+      ]
+    })
+  }
+
+  /** The alert that gives way first: lowest priority, then least recent. */
+  private leastUrgentAlert(): Alert | undefined {
+    let victim: Alert | undefined
+    for (const alert of this.alerts.values()) {
+      if (
+        !victim ||
+        PRIORITY_RANK[alert.priority] < PRIORITY_RANK[victim.priority] ||
+        (PRIORITY_RANK[alert.priority] === PRIORITY_RANK[victim.priority] &&
+          alert.stateChangedAt < victim.stateChangedAt)
+      ) {
+        victim = alert
+      }
+    }
+    return victim
+  }
+
+  /**
+   * Build the terminal value of a resolved alert.
+   *
+   * Consumers publish this as the alert's last delta, so it has to say the
+   * alert is over rather than repeat the state it held before resolution.
+   */
+  private terminalAlert(alert: Alert): Alert {
+    const now = new Date().toISOString()
+    return {
+      ...alert,
+      state: 'normal',
+      condition: false,
+      clearedAt: alert.clearedAt ?? now,
+      stateChangedAt: now
+    }
+  }
+
+  /**
+   * Drop an alert from the registry and cancel its timers.
+   */
+  private removeFromRegistry(alertId: string, alert: Alert): void {
+    this.alerts.delete(alertId)
+    this.limitReported = false
+    this.cancelLivenessTimer(alertId)
+    this.alertIndex.delete(this.getIndexKey(alert.path, alert.context))
+    this.cancelSilenceExpirationTimer(alertId)
+    this.escalationTimer.cancelTimer(alertId)
+  }
+
+  /**
+   * Arm or cancel an alert's escalation timer to match its current state.
+   *
+   * Escalation applies to an unacknowledged warning whose condition is active.
+   * A latched warning whose condition returned to normal is not escalated: the
+   * condition is gone, and the alert waits for acknowledgment, not for urgency.
+   */
+  private syncEscalationTimer(alert: Alert, remainingMs?: number): void {
+    const eligible =
+      alert.state === 'unacknowledged' &&
+      alert.priority === 'warning' &&
+      alert.condition
+
+    if (!eligible) {
+      this.escalationTimer.cancelTimer(alert.id)
+      return
+    }
+
+    this.escalationTimer.startTimer(alert.id, alert.priority, remainingMs)
+  }
+
+  /**
+   * Resume an alert's escalation window after a restart.
+   */
+  private resumeEscalation(alert: Alert): void {
+    // The timer's own resolved window, not the raw setting: reading the
+    // setting here would bypass its fallback and put a NaN into setTimeout.
+    const timeoutMs = this.escalationTimer.getTimeoutMs()
+    const changedAtMs = new Date(alert.stateChangedAt).getTime()
+
+    // A stored timestamp ahead of the clock means the clock moved, not that the
+    // alert is overdue — a Raspberry Pi has no battery-backed clock and boots
+    // before NTP steps it. Clamping keeps that from escalating everything at
+    // startup, and keeps an absurd delay out of setTimeout's 32-bit range.
+    const remainingMs = Number.isFinite(changedAtMs)
+      ? Math.min(Math.max(timeoutMs - (Date.now() - changedAtMs), 0), timeoutMs)
+      : timeoutMs
+
+    this.syncEscalationTimer(alert, remainingMs)
+  }
+
+  /**
+   * Resume or expire an alert's silence after a restart.
+   */
+  private async resumeSilence(alertId: string): Promise<void> {
+    // Read the current value rather than the stored one: resuming escalation
+    // can already have escalated this alert, and the unsilenced copy has to
+    // build on that.
+    const alert = this.alerts.get(alertId)
+    if (!alert?.silenced || !alert.silencedUntil) {
+      return
+    }
+
+    const untilMs = new Date(alert.silencedUntil).getTime()
+    const maxMs = this.getMaxSilenceDuration(alert.priority)
+    const remainingMs = Number.isFinite(untilMs)
+      ? Math.min(Math.max(untilMs - Date.now(), 0), maxMs)
+      : 0
+
+    if (remainingMs > 0) {
+      this.startSilenceExpirationTimer(alertId, remainingMs)
+      return
+    }
+
+    const unsilenced = this.stateMachine.unsilence(alert)
+    this.alerts.set(alertId, unsilenced)
+    const history = [this.historyEntry('unsilence', unsilenced)]
+    this.emitEvent('unsilenced', unsilenced)
+
+    await this.commit({ alertId, alert: unsilenced, history })
+  }
+
+  private getIndexKey(path: Path, context?: Context): string {
+    // JSON-encoded rather than joined with a separator, so a path containing
+    // the separator cannot forge a context-scoped key.
+    return JSON.stringify([context ?? null, path])
+  }
+
+  /**
+   * Longest a given priority may be silenced.
+   */
+  private getMaxSilenceDuration(priority: AlertPriority): number {
+    if (priority === 'emergency') {
+      return (
+        this.config.silencing.emergencyMaxSilenceSeconds *
+        MILLISECONDS_PER_SECOND
+      )
+    }
+    return (
+      this.config.silencing.defaultMaxSilenceSeconds * MILLISECONDS_PER_SECOND
+    )
+  }
+
+  /**
+   * Resolve a requested silence duration against the configured maximum.
+   *
+   * The cap lives here rather than at the REST boundary, so the plugin and
+   * delta surfaces that call the manager directly obey the same limit.
+   */
+  private resolveSilenceDuration(
+    priority: AlertPriority,
+    requestedMs?: number
+  ): number {
+    const maxMs = this.getMaxSilenceDuration(priority)
+    if (requestedMs === undefined) {
+      return maxMs
+    }
+    if (!(requestedMs > 0)) {
+      throw new InvalidSilenceDurationError()
+    }
+    return Math.min(requestedMs, maxMs)
+  }
+
+  /**
+   * Commit one lifecycle transition.
+   *
+   * The change has already been applied and announced by the time this runs,
+   * so a failure degrades durability rather than the alert.
+   */
+  private async commit(transition: AlertTransition): Promise<void> {
+    const store = this.store
+    if (!store) {
+      return
+    }
+
+    try {
+      await store.commit(transition)
+    } catch (err) {
+      // A failed write is repaired by the alert's next transition. A failed
+      // removal is not, because no later transition names an alert that has
+      // left the registry, so it is remembered and retried.
+      if (!transition.alert) {
+        this.pendingRemovals.add(transition.alertId)
+      }
+      this.recordStoreFailure('commit', transition.alertId, err)
+      return
+    }
+
+    this.pendingRemovals.delete(transition.alertId)
+
+    if (this.storeDegraded) {
+      // Detached: the sweep writes every active alert, up to maxActiveAlerts
+      // durable writes, and no lifecycle call should wait behind that. It
+      // reports through `storeError` like the prune does.
+      void this.resync(store)
+    }
+  }
+
+  /**
+   * Bring the store back in line with the registry after a failed write.
+   *
+   * Runs on the first write that succeeds again, so a transient failure — a
+   * lock held by a backup, a moment of I/O trouble — heals itself instead of
+   * leaving the file permanently disagreeing with memory.
+   */
+  private async resync(store: IAlertStore): Promise<void> {
+    if (this.resyncing) {
+      return
+    }
+    this.resyncing = true
+    // Nothing serializes lifecycle writes against this sweep, so a commit can
+    // fail while it runs. Clearing the flag on the strength of the sweep alone
+    // would hide that failure, and with it any removal it queued: no later
+    // transition names a removed alert, so the row would survive to be
+    // restored as a phantom alert on the next start.
+    const failuresAtStart = this.storeFailures
+    try {
+      // The sweep is detached and outlives a stop, which closes the store
+      // under it. Every write it makes after that fails, and reports a
+      // degraded store for a manager that is no longer running.
+      for (const alertId of Array.from(this.pendingRemovals)) {
+        if (this.stopped) {
+          return
+        }
+        await store.commit({ alertId, alert: null, history: [] })
+        this.pendingRemovals.delete(alertId)
+      }
+      for (const alert of this.alerts.values()) {
+        if (this.stopped) {
+          return
+        }
+        await store.commit({ alertId: alert.id, alert, history: [] })
+      }
+    } catch (err) {
+      this.recordStoreFailure('resync', null, err)
+      return
+    } finally {
+      this.resyncing = false
+    }
+
+    if (
+      this.storeFailures === failuresAtStart &&
+      this.pendingRemovals.size === 0
+    ) {
+      this.storeDegraded = false
+    }
+  }
+
+  /**
+   * Start applying the retention window, now and daily.
+   */
+  private startRetention(): void {
+    const retentionDays = this.config.retentionDays ?? DEFAULT_RETENTION_DAYS
+
+    // A bad retention setting is a configuration error, not a durability
+    // failure, so it must not report the store as degraded.
+    if (!Number.isInteger(retentionDays) || retentionDays < 1) {
+      console.error(
+        `Alert history retention must be a whole number of days, at least 1, ` +
+          `but is ${String(retentionDays)}. The audit trail will not be pruned.`
+      )
+      return
+    }
+
+    this.applyRetention(retentionDays)
+    this.scheduleRetention(retentionDays)
+  }
+
+  /**
+   * Apply the retention window to the audit trail.
+   */
+  private applyRetention(retentionDays: number): void {
+    const store = this.store
+    if (!store) {
+      return
+    }
+
+    store.pruneHistory(retentionDays).catch((err: unknown) => {
+      // Reported, but not as degradation: the registry and the store still
+      // agree about every active alert. Only an unpruned trail is at stake,
+      // and marking the store degraded would trigger a full resync instead.
+      this.reportStoreFailure('prune', null, err)
+    })
+  }
+
+  /**
+   * Keep applying the retention window while the server runs, so an audit
+   * trail does not grow without bound between restarts.
+   */
+  private scheduleRetention(retentionDays: number): void {
+    if (this.stopped) {
+      return
+    }
+
+    if (this.retentionTimer !== undefined) {
+      this.timerFns.clearTimeout(this.retentionTimer)
+    }
+
+    this.retentionTimer = this.timerFns.setTimeout(() => {
+      this.applyRetention(retentionDays)
+      this.scheduleRetention(retentionDays)
+    }, RETENTION_PRUNE_INTERVAL_MS)
+  }
+
+  private recordStoreFailure(
+    operation: StoreFailureEvent['operation'],
+    alertId: string | null,
+    err: unknown
+  ): void {
+    this.storeDegraded = true
+    this.storeFailures++
+    this.reportStoreFailure(operation, alertId, err)
+  }
+
+  /**
+   * Log a store failure and announce it, without claiming the store and the
+   * registry disagree.
+   */
+  private reportStoreFailure(
+    operation: StoreFailureEvent['operation'],
+    alertId: string | null,
+    err: unknown
+  ): void {
+    const error = err instanceof Error ? err : new Error(String(err))
+    console.error(
+      `Alert store ${operation} failed${alertId ? ` for ${alertId}` : ''}:`,
+      error
+    )
+    const event: StoreFailureEvent = { operation, alertId, error }
+    this.emit('storeError', event)
+  }
+
+  /**
+   * Build an audit entry for a transition.
+   */
+  private historyEntry(
+    eventType: HistoryEventType,
+    alert: Alert,
+    extra?: HistoryDetails
+  ): Omit<HistoryEntry, 'id'> {
+    return {
+      alertId: alert.id,
+      path: alert.path,
+      context: alert.context,
+      priority: alert.priority,
+      message: alert.message,
+      $source: extra?.$source ?? alert.$source,
+      eventType,
+      timestamp: new Date().toISOString(),
+      userId: extra?.userId,
+      previousState: extra?.previousState,
+      newState: extra?.newState,
+      previousPriority: extra?.previousPriority,
+      newPriority: extra?.newPriority,
+      details: extra?.details
+    }
+  }
+
+  /**
+   * Emit an alert event.
+   */
+  private emitEvent(
+    type: AlertEventType,
+    alert: Alert,
+    previousState?: AlertState
+  ): void {
+    if (this.stopped) {
+      return
+    }
+
+    const event: AlertEvent = {
+      type,
+      alert,
+      previousState
+    }
+
+    this.emit('alert', event)
+  }
+
+  /**
+   * Clear silencing if the current operation supersedes it.
+   *
+   * Silencing suppresses audio — it is superseded when the operator has
+   * attended to the alert (acknowledge) or when the system demands renewed
+   * attention (reactivation, escalation). This is the single place that
+   * encodes that rule.
+   *
+   * Does not emit a separate 'unsilenced' event because the caller's own
+   * event (acknowledged, escalated, raised) already conveys that the
+   * operator's attention has been (re)demanded.
+   */
+  private clearSilencingIfSuperseded(alertId: string, alert: Alert): Alert {
+    if (!alert.silenced) {
+      return alert
+    }
+    this.cancelSilenceExpirationTimer(alertId)
+    return this.stateMachine.unsilence(alert)
+  }
+
+  /**
+   * Start a timer to automatically unsilence an alert after duration expires.
+   */
+  private startSilenceExpirationTimer(
+    alertId: string,
+    durationMs: number
+  ): void {
+    this.cancelSilenceExpirationTimer(alertId)
+
+    if (this.stopped) {
+      return
+    }
+
+    const handle = this.timerFns.setTimeout(() => {
+      this.handleSilenceExpiration(alertId)
+    }, durationMs)
+
+    this.silenceTimers.set(alertId, handle)
+  }
+
+  /**
+   * Cancel the silence expiration timer for an alert.
+   */
+  private cancelSilenceExpirationTimer(alertId: string): void {
+    const handle = this.silenceTimers.get(alertId)
+    if (handle !== undefined) {
+      this.timerFns.clearTimeout(handle)
+      this.silenceTimers.delete(alertId)
+    }
+  }
+
+  /**
+   * Handle silence expiration - automatically unsilence the alert.
+   */
+  private handleSilenceExpiration(alertId: string): void {
+    this.silenceTimers.delete(alertId)
+
+    if (this.stopped) {
+      return
+    }
+
+    const alert = this.alerts.get(alertId)
+    if (!alert?.silenced) {
+      return
+    }
+
+    const unsilenced = this.stateMachine.unsilence(alert)
+    this.alerts.set(alertId, unsilenced)
+
+    const history = [this.historyEntry('unsilence', unsilenced)]
+    this.emitEvent('unsilenced', unsilenced)
+
+    void this.commit({ alertId, alert: unsilenced, history })
+  }
+}

--- a/src/api/alerts/alertPath.ts
+++ b/src/api/alerts/alertPath.ts
@@ -1,0 +1,50 @@
+/**
+ * Validation of the path that identifies an alert.
+ *
+ * The path is the identity, and it arrives from REST, from deltas and from
+ * plugins, so every surface validates it the same way here rather than each
+ * trusting the others.
+ */
+
+import type { Path } from '@signalk/server-api'
+import { InvalidAlertPathError } from './errors'
+
+const MAX_PATH_LENGTH = 255
+
+const SEGMENT = /^[A-Za-z0-9_-]+$/
+
+/**
+ * Keys that would reach an object's prototype if a path segment were ever used
+ * to index one.
+ */
+const FORBIDDEN = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * The value as an alert path.
+ *
+ * @throws {InvalidAlertPathError} when it is not one.
+ */
+export function validateAlertPath(value: unknown): Path {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InvalidAlertPathError('the path must be a non-empty string')
+  }
+  if (value.length > MAX_PATH_LENGTH) {
+    throw new InvalidAlertPathError(
+      `the path must be at most ${String(MAX_PATH_LENGTH)} characters`
+    )
+  }
+
+  const segments = value.split('.')
+  for (const segment of segments) {
+    if (!SEGMENT.test(segment)) {
+      throw new InvalidAlertPathError(
+        `"${segment}" is not a usable path segment`
+      )
+    }
+    if (FORBIDDEN.has(segment)) {
+      throw new InvalidAlertPathError(`"${segment}" is not allowed in a path`)
+    }
+  }
+
+  return value as Path
+}

--- a/src/api/alerts/alertStateMachine.ts
+++ b/src/api/alerts/alertStateMachine.ts
@@ -1,0 +1,344 @@
+/**
+ * Alert state machine.
+ *
+ * Implements the IEC 62682 alert lifecycle: which transitions each state
+ * allows, when a cleared condition resolves an alert, and when it leaves the
+ * alert waiting for acknowledgment.
+ */
+
+import type { Context, Path, SourceRef, Value } from '@signalk/server-api'
+import type { Alert, AlertPriority, AlertState } from './types'
+
+/**
+ * Parameters for creating a new alert.
+ *
+ * A raise carries the alert's whole description, but an omitted optional field
+ * means "unchanged" rather than "cleared" when it updates an existing alert.
+ * A caller clears a field by sending it empty. See AlertManager.raiseAlert.
+ */
+export interface CreateAlertParams {
+  /** Descriptive path naming the condition; identity together with `context` */
+  path: Path
+  /** Data paths the alert concerns; informational, never identity */
+  references?: Path[]
+  /** Signal K source reference (e.g., "n2k-on-ve.can-bus.115", "alertsApi") */
+  $source: SourceRef
+  /** Signal K structured source object, if available */
+  source?: Record<string, unknown>
+  /** Alert priority level */
+  priority: AlertPriority
+  /** Human-readable alert message */
+  message: string
+  /** Optional free-text UI grouping */
+  group?: string
+  /** Whether alert latches (stays active after condition clears) */
+  latching?: boolean
+  /** Additional context data */
+  data?: Record<string, Value>
+  /** Vessel context for multi-vessel deployments */
+  context?: Context
+}
+
+/**
+ * Result of a state transition operation.
+ */
+export interface StateTransitionResult {
+  /** The updated alert, or null if the alert was cleared */
+  alert: Alert | null
+  /** Whether the alert was cleared (removed from active alerts) */
+  cleared: boolean
+  /** The state before the transition */
+  previousState: AlertState
+}
+
+/**
+ * Result of a transition that can only keep the alert, never clear it.
+ */
+export interface KeepingTransitionResult extends StateTransitionResult {
+  alert: Alert
+  cleared: false
+}
+
+/**
+ * Create a new alert in the initial unacknowledged state.
+ */
+export function createAlert(params: CreateAlertParams): Alert {
+  const now = new Date().toISOString()
+
+  return {
+    id: crypto.randomUUID(),
+    path: params.path,
+    references: params.references,
+    $source: params.$source,
+    source: params.source,
+    priority: params.priority,
+    state: 'unacknowledged',
+    condition: true,
+    latching: params.latching ?? false,
+    silenced: false,
+    message: params.message,
+    group: params.group,
+    data: params.data,
+    raisedAt: now,
+    stateChangedAt: now,
+    sourceOnline: true,
+    lastSourceUpdate: now,
+    stale: false,
+    // An empty context is no context. Otherwise it would key the alert index
+    // differently from an absent one while meaning the same thing.
+    context: params.context || undefined
+  }
+}
+
+/**
+ * Alert state machine.
+ *
+ * Manages alert state transitions following the IEC 62682 model. All methods
+ * are pure functions that return new alert objects without mutating the input.
+ */
+export class AlertStateMachine {
+  /**
+   * Check if a priority level requires acknowledgment before clearing.
+   * Emergency, Alarm, and Warning require acknowledgment.
+   * Caution auto-clears without requiring acknowledgment.
+   */
+  static requiresAcknowledgment(priority: AlertPriority): boolean {
+    return priority !== 'caution'
+  }
+
+  /**
+   * Check if an alert is in an unacknowledged state.
+   * Both 'unacknowledged' and 'rtn-unacknowledged' count as unacknowledged.
+   */
+  static isUnacknowledged(alert: Alert): boolean {
+    return (
+      alert.state === 'unacknowledged' || alert.state === 'rtn-unacknowledged'
+    )
+  }
+
+  /**
+   * Acknowledge an alert.
+   *
+   * Transitions:
+   * - unacknowledged → acknowledged (if condition active)
+   * - unacknowledged → cleared (if condition cleared and latching)
+   * - rtn-unacknowledged → cleared
+   * - acknowledged → acknowledged (idempotent)
+   */
+  acknowledge(alert: Alert, userId?: string): StateTransitionResult {
+    const previousState = alert.state
+    const now = new Date().toISOString()
+
+    // RTN-unacknowledged: acknowledging clears the alert
+    if (alert.state === 'rtn-unacknowledged') {
+      return {
+        alert: null,
+        cleared: true,
+        previousState
+      }
+    }
+
+    // Latched alert with cleared condition: acknowledging clears it
+    if (
+      alert.state === 'unacknowledged' &&
+      alert.latching &&
+      !alert.condition
+    ) {
+      return {
+        alert: null,
+        cleared: true,
+        previousState
+      }
+    }
+
+    // Already acknowledged: idempotent
+    if (alert.state === 'acknowledged') {
+      return {
+        alert: { ...alert },
+        cleared: false,
+        previousState
+      }
+    }
+
+    // Normal transition: unacknowledged → acknowledged
+    return {
+      alert: {
+        ...alert,
+        state: 'acknowledged',
+        stateChangedAt: now,
+        acknowledgedAt: now,
+        acknowledgedBy: userId
+      },
+      cleared: false,
+      previousState
+    }
+  }
+
+  /**
+   * Clear the alert condition.
+   *
+   * Transitions (for ack-required priorities: emergency, alarm, warning):
+   * - unacknowledged → rtn-unacknowledged (unless latching)
+   * - unacknowledged + latching → unacknowledged (stays, but condition=false)
+   * - acknowledged → cleared
+   * - rtn-unacknowledged → rtn-unacknowledged (idempotent)
+   *
+   * For caution priority:
+   * - any state → cleared (auto-clears)
+   */
+  clearCondition(alert: Alert): StateTransitionResult {
+    const previousState = alert.state
+    const now = new Date().toISOString()
+
+    // Caution priority: auto-clears without requiring acknowledgment. Ahead of
+    // the idempotence check, so a caution never lingers on a cleared condition
+    // whatever state it arrived in.
+    if (!AlertStateMachine.requiresAcknowledgment(alert.priority)) {
+      return {
+        alert: null,
+        cleared: true,
+        previousState
+      }
+    }
+
+    // Already cleared condition: idempotent
+    if (!alert.condition) {
+      return {
+        alert: { ...alert },
+        cleared: false,
+        previousState
+      }
+    }
+
+    // Acknowledged state: clearing condition removes the alert
+    if (alert.state === 'acknowledged') {
+      return {
+        alert: null,
+        cleared: true,
+        previousState
+      }
+    }
+
+    // Latched alert: stays in unacknowledged but condition becomes false
+    if (alert.latching) {
+      return {
+        alert: {
+          ...alert,
+          condition: false,
+          clearedAt: now
+        },
+        cleared: false,
+        previousState
+      }
+    }
+
+    // Normal transition: unacknowledged → rtn-unacknowledged
+    return {
+      alert: {
+        ...alert,
+        state: 'rtn-unacknowledged',
+        stateChangedAt: now,
+        condition: false,
+        clearedAt: now
+      },
+      cleared: false,
+      previousState
+    }
+  }
+
+  /**
+   * Silence an alert.
+   *
+   * Silencing suppresses audible indicators without acknowledging.
+   * This does not affect the alert state.
+   */
+  silence(alert: Alert, until: Date): Alert {
+    return {
+      ...alert,
+      silenced: true,
+      silencedUntil: until.toISOString()
+    }
+  }
+
+  /**
+   * Reactivate an alert that has been acknowledged or returned-to-normal.
+   *
+   * Used when a source re-raises an alert for a condition that is still
+   * (or again) active. Transitions the alert back to unacknowledged so
+   * the operator is re-alerted.
+   *
+   * Silencing is NOT cleared here — that responsibility belongs to
+   * AlertManager, which also manages the silence expiration timers.
+   * See AlertManager.clearSilencingIfSuperseded().
+   *
+   * Transitions:
+   * - acknowledged → unacknowledged (resets ack fields)
+   * - rtn-unacknowledged → unacknowledged (resets clearedAt)
+   * - unacknowledged with an active condition → unchanged copy
+   * - unacknowledged with a cleared condition (a held latching alert) →
+   *   condition true, clearedAt reset, stateChangedAt bumped
+   */
+  reactivate(alert: Alert): KeepingTransitionResult {
+    const previousState = alert.state
+    const now = new Date().toISOString()
+
+    if (alert.state === 'acknowledged') {
+      return {
+        alert: {
+          ...alert,
+          state: 'unacknowledged',
+          stateChangedAt: now,
+          condition: true,
+          acknowledgedAt: undefined,
+          acknowledgedBy: undefined
+        },
+        cleared: false,
+        previousState
+      }
+    }
+
+    if (alert.state === 'rtn-unacknowledged') {
+      return {
+        alert: {
+          ...alert,
+          state: 'unacknowledged',
+          stateChangedAt: now,
+          condition: true,
+          clearedAt: undefined
+        },
+        cleared: false,
+        previousState
+      }
+    }
+
+    // A latched alert whose condition cleared waits here, still unacknowledged
+    // but with condition false and a clearedAt. The condition coming back is a
+    // fresh annunciation, so it resets clearedAt and counts as a state change.
+    if (!alert.condition) {
+      return {
+        alert: {
+          ...alert,
+          condition: true,
+          clearedAt: undefined,
+          stateChangedAt: now
+        },
+        cleared: false,
+        previousState
+      }
+    }
+
+    return {
+      alert: { ...alert },
+      cleared: false,
+      previousState
+    }
+  }
+
+  unsilence(alert: Alert): Alert {
+    return {
+      ...alert,
+      silenced: false,
+      silencedUntil: undefined
+    }
+  }
+}

--- a/src/api/alerts/alertStore.ts
+++ b/src/api/alerts/alertStore.ts
@@ -1,0 +1,609 @@
+/**
+ * SQLite storage for the alerts subsystem.
+ *
+ * Owns the single database file. The active set and the audit trail live in
+ * one file on one connection, so a lifecycle transition's row write and its
+ * audit appends commit as one transaction and no crash can leave the trail
+ * describing an alert the active set does not have.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import type { DatabaseSync, SQLInputValue, StatementSync } from 'node:sqlite'
+import type { Context, Path, SourceRef, Value } from '@signalk/server-api'
+import { HistoryStore } from './historyStore'
+import { asRecord, parseJson } from './jsonColumn'
+import { ALERT_PRIORITIES, ALERT_STATES } from './types'
+import type {
+  Alert,
+  AlertPriority,
+  AlertState,
+  AlertTransition,
+  HistoryEntry,
+  HistoryQuery,
+  IAlertStore
+} from './types'
+
+const SCHEMA_VERSION = 1
+
+/**
+ * How long SQLite retries a lock held by another connection before failing.
+ * WAL lets other processes open the file — a backup job, an operator running
+ * sqlite3 — and a moment's contention should not cost a lifecycle write.
+ */
+const BUSY_TIMEOUT_MS = 5000
+
+/**
+ * The audit trail records who acknowledged what, so it is not world-readable.
+ */
+const DATABASE_MODE = 0o600
+
+/** What `PRAGMA auto_vacuum` reports when the incremental mode is in force. */
+const AUTO_VACUUM_INCREMENTAL = 2
+
+/**
+ * Free pages one prune hands back at most.
+ *
+ * At the usual 4 KiB page size this is 8 MiB of reclaim per daily prune, which
+ * keeps the synchronous vacuum short enough not to be felt.
+ */
+export const MAX_VACUUM_PAGES_PER_PRUNE = 2000
+
+const KNOWN_PRIORITIES: ReadonlySet<string> = new Set(ALERT_PRIORITIES)
+
+const KNOWN_STATES: ReadonlySet<string> = new Set(ALERT_STATES)
+
+interface AlertRow {
+  id: string
+  path: string
+  context: string | null
+  references_json: string | null
+  source_ref: string
+  source_obj: string | null
+  priority: string
+  state: string
+  condition: number
+  latching: number
+  silenced: number
+  silenced_until: string | null
+  message: string
+  group_name: string | null
+  data: string | null
+  raised_at: string
+  state_changed_at: string
+  acknowledged_at: string | null
+  acknowledged_by: string | null
+  cleared_at: string | null
+  source_online: number
+  last_source_update: string
+  stale: number
+}
+
+/**
+ * Everything that exists only while the database is open. The fields are
+ * created together and released together, so they cannot disagree.
+ */
+interface OpenDatabase {
+  db: DatabaseSync
+  history: HistoryStore
+  writeAlert: StatementSync
+  removeAlert: StatementSync
+  journalMode: string
+  synchronous: number
+}
+
+/**
+ * The durability settings actually in force on the open connection.
+ *
+ * `synchronous` is per-connection state and is not recorded in the file, so
+ * this is the only place it can be observed.
+ */
+export interface Durability {
+  journalMode: string
+  synchronous: number
+}
+
+/**
+ * Resolve the `node:sqlite` builtin.
+ *
+ * The module is flagless from Node 22.13.0 and 23.4.0. On an older or flagged
+ * build the import would fail deep inside startup, so it is probed here and
+ * reported as the version requirement it actually is. `getBuiltinModule`
+ * itself only exists from 22.3.0, which is why its absence means the same
+ * thing.
+ */
+function loadSqlite(): typeof import('node:sqlite') {
+  const sqlite =
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule('node:sqlite')
+      : undefined
+  if (!sqlite) {
+    throw new Error(
+      'The alerts subsystem requires the node:sqlite module, which this Node ' +
+        'build does not provide. Node 22.13.0 or later, or 23.4.0 or later, ' +
+        'is required.'
+    )
+  }
+  return sqlite
+}
+
+export class AlertStore implements IAlertStore {
+  private open: OpenDatabase | null = null
+
+  constructor(private readonly dbPath: string) {}
+
+  /**
+   * Open the database, apply the durability pragmas and migrate the schema.
+   *
+   * Rejects when the file cannot be opened or migrated. That is deliberately
+   * fatal: a safety subsystem must not run on a store nobody can read, so the
+   * error names the file and the way out.
+   */
+  initialize(): Promise<void> {
+    if (this.open) {
+      return Promise.resolve()
+    }
+
+    // Probed before the try below, so a Node too old to provide the module is
+    // reported as that, not as a database this operator should move aside.
+    let sqlite: typeof import('node:sqlite')
+    try {
+      sqlite = loadSqlite()
+    } catch (error) {
+      return Promise.reject(asError(error))
+    }
+
+    let db: DatabaseSync | undefined
+    try {
+      fs.mkdirSync(path.dirname(this.dbPath), { recursive: true })
+
+      db = new sqlite.DatabaseSync(this.dbPath)
+      fs.chmodSync(this.dbPath, DATABASE_MODE)
+
+      db.exec(`PRAGMA busy_timeout = ${String(BUSY_TIMEOUT_MS)}`)
+
+      // Chosen before the journal mode, which writes the file header: after
+      // that the setting is fixed for the life of the file. Without it a
+      // pruned audit trail frees pages for reuse but never gives the bytes
+      // back, so the file keeps the high-water mark of its busiest day.
+      db.exec('PRAGMA auto_vacuum = INCREMENTAL')
+      const autoVacuum = Number(
+        (db.prepare('PRAGMA auto_vacuum').get() as { auto_vacuum?: number })
+          ?.auto_vacuum ?? -1
+      )
+      if (autoVacuum !== AUTO_VACUUM_INCREMENTAL) {
+        console.warn(
+          `The alerts database at ${this.dbPath} was created without incremental ` +
+            `auto-vacuum. Alerts remain durable; the file will not shrink when ` +
+            `history is pruned. Move it aside and restart to reclaim the space.`
+        )
+      }
+
+      // A pragma that cannot be applied reports the mode still in force in a
+      // result row rather than throwing, so the result has to be read.
+      const journalMode = String(
+        (
+          db.prepare('PRAGMA journal_mode = WAL').get() as {
+            journal_mode?: string
+          }
+        )?.journal_mode ?? 'unknown'
+      )
+      if (journalMode !== 'wal') {
+        console.warn(
+          `The alerts database at ${this.dbPath} could not use WAL journalling ` +
+            `(mode is ${journalMode}). Alerts remain durable; concurrent reads are slower.`
+        )
+      }
+
+      // One fsync per lifecycle transition. Alerts are human-scale events, a
+      // few writes per alarm, so the cost is negligible against an annunciated
+      // alarm disappearing in a power cut.
+      db.exec('PRAGMA synchronous = FULL')
+      const synchronous = Number(
+        (db.prepare('PRAGMA synchronous').get() as { synchronous?: number })
+          ?.synchronous ?? -1
+      )
+
+      migrate(db)
+
+      this.open = {
+        db,
+        history: new HistoryStore(db),
+        writeAlert: db.prepare(`
+          INSERT OR REPLACE INTO alerts (
+            id, path, context, references_json, source_ref, source_obj,
+            priority, state, condition, latching, silenced, silenced_until,
+            message, group_name, data, raised_at, state_changed_at,
+            acknowledged_at, acknowledged_by, cleared_at, source_online,
+            last_source_update, stale
+          ) VALUES (
+            $id, $path, $context, $references_json, $source_ref, $source_obj,
+            $priority, $state, $condition, $latching, $silenced,
+            $silenced_until, $message, $group_name, $data, $raised_at,
+            $state_changed_at, $acknowledged_at, $acknowledged_by, $cleared_at,
+            $source_online, $last_source_update, $stale
+          )
+        `),
+        removeAlert: db.prepare('DELETE FROM alerts WHERE id = ?'),
+        journalMode,
+        synchronous
+      }
+
+      return Promise.resolve()
+    } catch (error) {
+      // Close the half-open connection so a retry starts clean rather than
+      // reporting success from the guard above.
+      if (db) {
+        try {
+          db.close()
+        } catch {
+          // Nothing useful to do while unwinding a failed open.
+        }
+      }
+      this.open = null
+      return Promise.reject(openFailure(this.dbPath, error))
+    }
+  }
+
+  close(): Promise<void> {
+    const open = this.open
+    if (!open) {
+      return Promise.resolve()
+    }
+
+    try {
+      open.db.close()
+      return Promise.resolve()
+    } catch (error) {
+      return Promise.reject(asError(error))
+    } finally {
+      // Released even when the close itself failed, so a retry re-opens rather
+      // than reporting success on a connection nobody can use.
+      this.open = null
+    }
+  }
+
+  /**
+   * The durability settings in force on the open connection.
+   */
+  durability(): Durability {
+    const { journalMode, synchronous } = this.requireOpen()
+    return { journalMode, synchronous }
+  }
+
+  getAll(): Promise<Alert[]> {
+    try {
+      const rows = this.requireOpen()
+        .db.prepare('SELECT * FROM alerts')
+        .all() as unknown as AlertRow[]
+      return Promise.resolve(rows.map((row) => rowToAlert(row)))
+    } catch (error) {
+      return Promise.reject(asError(error))
+    }
+  }
+
+  /**
+   * Apply one lifecycle transition in a single transaction.
+   */
+  commit(transition: AlertTransition): Promise<void> {
+    try {
+      const open = this.requireOpen()
+
+      inTransaction(open.db, () => {
+        if (transition.alert) {
+          // Keyed by the transition's alertId, not the alert object's, so the
+          // row always lands where a later removal will look for it.
+          open.writeAlert.run(alertToRow(transition.alertId, transition.alert))
+        } else {
+          open.removeAlert.run(transition.alertId)
+        }
+        for (const entry of transition.history) {
+          open.history.append(entry)
+        }
+      })
+
+      return Promise.resolve()
+    } catch (error) {
+      return Promise.reject(asError(error))
+    }
+  }
+
+  queryHistory(
+    query: HistoryQuery
+  ): Promise<{ entries: HistoryEntry[]; total: number }> {
+    try {
+      return Promise.resolve(this.requireOpen().history.query(query))
+    } catch (error) {
+      return Promise.reject(asError(error))
+    }
+  }
+
+  pruneHistory(olderThanDays: number): Promise<number> {
+    try {
+      const open = this.requireOpen()
+      const removed = open.history.prune(olderThanDays)
+
+      // A delete only marks pages free; this hands them back to the
+      // filesystem, which is the point of pruning on a device that keeps the
+      // database on an SD card.
+      //
+      // Bounded, because node:sqlite is synchronous: reclaiming every free
+      // page of a long-neglected trail in one call would block the server,
+      // annunciation included. Run on every prune rather than only on one
+      // that deleted something, so the remainder comes back on later passes.
+      open.db.exec(
+        `PRAGMA incremental_vacuum(${String(MAX_VACUUM_PAGES_PER_PRUNE)})`
+      )
+      return Promise.resolve(removed)
+    } catch (error) {
+      return Promise.reject(asError(error))
+    }
+  }
+
+  private requireOpen(): OpenDatabase {
+    if (!this.open) {
+      throw new Error('AlertStore not initialized. Call initialize() first.')
+    }
+    return this.open
+  }
+}
+
+/**
+ * The part of a connection a transaction needs.
+ */
+export type TransactionalDatabase = Pick<DatabaseSync, 'exec'>
+
+/**
+ * Run `work` inside a transaction, committing it or rolling it back.
+ *
+ * SQLite rolls back by itself on a full disk or an I/O error — the failures
+ * this store exists to report — and the explicit ROLLBACK then fails with
+ * "cannot rollback - no transaction is active". Its complaint must not replace
+ * the failure the operator actually needs to see.
+ */
+export function inTransaction<T>(db: TransactionalDatabase, work: () => T): T {
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    const result = work()
+    db.exec('COMMIT')
+    return result
+  } catch (error) {
+    try {
+      db.exec('ROLLBACK')
+    } catch {
+      // Already rolled back by SQLite itself.
+    }
+    throw error
+  }
+}
+
+function openFailure(dbPath: string, error: unknown): Error {
+  const cause = asError(error)
+  return new Error(
+    `The alerts database at ${dbPath} could not be opened: ${cause.message}. ` +
+      'Move the file aside and restart to begin with an empty alert store.',
+    { cause }
+  )
+}
+
+export function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+/**
+ * Bring the schema up to SCHEMA_VERSION.
+ */
+function migrate(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )
+  `)
+
+  const row = db
+    .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
+    .get() as { version: number } | undefined
+  const current = row?.version ?? 0
+
+  // A file written by a later server must not be read with this version's
+  // assumptions: INSERT OR REPLACE rewrites whole rows, so a column this
+  // version does not know about would be erased on the first update.
+  if (current > SCHEMA_VERSION) {
+    throw new Error(
+      `it was written by a newer version of the alerts subsystem ` +
+        `(schema ${String(current)}, this version supports ${String(SCHEMA_VERSION)})`
+    )
+  }
+
+  if (current < 1) {
+    migrateToV1(db)
+  }
+}
+
+function migrateToV1(db: DatabaseSync): void {
+  inTransaction(db, () => {
+    // references, group and $source cannot be column names: the first two are
+    // SQLite keywords and the third is not a bare identifier.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS alerts (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        context TEXT,
+        references_json TEXT,
+        source_ref TEXT NOT NULL,
+        source_obj TEXT,
+        priority TEXT NOT NULL,
+        state TEXT NOT NULL,
+        condition INTEGER NOT NULL,
+        latching INTEGER NOT NULL,
+        silenced INTEGER NOT NULL,
+        silenced_until TEXT,
+        message TEXT NOT NULL,
+        group_name TEXT,
+        data TEXT,
+        raised_at TEXT NOT NULL,
+        state_changed_at TEXT NOT NULL,
+        acknowledged_at TEXT,
+        acknowledged_by TEXT,
+        cleared_at TEXT,
+        source_online INTEGER NOT NULL,
+        last_source_update TEXT NOT NULL,
+        stale INTEGER NOT NULL
+      )
+    `)
+    // At most one active alert per path(+context) is the subsystem's identity
+    // rule. Enforcing it here makes INSERT OR REPLACE self-healing: a raise on
+    // a path whose old row outlived a failed removal replaces it. ifnull is
+    // needed because SQLite treats NULLs in a unique index as distinct.
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_identity
+        ON alerts(path, ifnull(context, ''))
+    `)
+
+    // seq orders entries that share a millisecond timestamp — one transition
+    // legitimately appends several, and the audit trail has to report them in
+    // the order they happened.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS history (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL UNIQUE,
+        alert_id TEXT NOT NULL,
+        path TEXT NOT NULL,
+        context TEXT,
+        priority TEXT NOT NULL,
+        message TEXT NOT NULL,
+        source_ref TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        timestamp TEXT NOT NULL,
+        user_id TEXT,
+        previous_state TEXT,
+        new_state TEXT,
+        previous_priority TEXT,
+        new_priority TEXT,
+        details TEXT
+      )
+    `)
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_history_alert_id ON history(alert_id);
+      CREATE INDEX IF NOT EXISTS idx_history_path ON history(path);
+      CREATE INDEX IF NOT EXISTS idx_history_timestamp ON history(timestamp, seq);
+      CREATE INDEX IF NOT EXISTS idx_history_event_type ON history(event_type);
+    `)
+
+    db.prepare(
+      'INSERT INTO schema_version (version, applied_at) VALUES (?, ?)'
+    ).run(SCHEMA_VERSION, new Date().toISOString())
+  })
+}
+
+/**
+ * Map an alert onto its row.
+ *
+ * Named parameters rather than positional ones, so a column and its value
+ * cannot drift apart as the shape grows.
+ */
+function alertToRow(
+  alertId: string,
+  alert: Alert
+): Record<keyof AlertRow, SQLInputValue> {
+  const row: Record<keyof AlertRow, SQLInputValue> = {
+    id: alertId,
+    path: alert.path,
+    context: alert.context ?? null,
+    references_json: alert.references ? JSON.stringify(alert.references) : null,
+    source_ref: alert.$source,
+    source_obj: alert.source ? JSON.stringify(alert.source) : null,
+    priority: alert.priority,
+    state: alert.state,
+    condition: alert.condition ? 1 : 0,
+    latching: alert.latching ? 1 : 0,
+    silenced: alert.silenced ? 1 : 0,
+    silenced_until: alert.silencedUntil ?? null,
+    message: alert.message,
+    group_name: alert.group ?? null,
+    data: alert.data ? JSON.stringify(alert.data) : null,
+    raised_at: alert.raisedAt,
+    state_changed_at: alert.stateChangedAt,
+    acknowledged_at: alert.acknowledgedAt ?? null,
+    acknowledged_by: alert.acknowledgedBy ?? null,
+    cleared_at: alert.clearedAt ?? null,
+    source_online: alert.sourceOnline ? 1 : 0,
+    last_source_update: alert.lastSourceUpdate,
+    stale: alert.stale ? 1 : 0
+  }
+  return row
+}
+
+function rowToAlert(row: AlertRow): Alert {
+  // These two drive the state machine, so a value it cannot handle is a store
+  // this server must not run on rather than an alert to guess at.
+  if (!KNOWN_PRIORITIES.has(row.priority)) {
+    throw new Error(
+      `alert ${row.id} has an unknown priority ${JSON.stringify(row.priority)}`
+    )
+  }
+  if (!KNOWN_STATES.has(row.state)) {
+    throw new Error(
+      `alert ${row.id} has an unknown state ${JSON.stringify(row.state)}`
+    )
+  }
+
+  const alert: Alert = {
+    id: row.id,
+    path: row.path as Path,
+    $source: row.source_ref as SourceRef,
+    priority: row.priority as AlertPriority,
+    state: row.state as AlertState,
+    condition: row.condition === 1,
+    latching: row.latching === 1,
+    silenced: row.silenced === 1,
+    message: row.message,
+    raisedAt: row.raised_at,
+    stateChangedAt: row.state_changed_at,
+    sourceOnline: row.source_online === 1,
+    lastSourceUpdate: row.last_source_update,
+    stale: row.stale === 1
+  }
+
+  // Tested against null rather than truthiness: an empty string is how a
+  // caller clears one of these fields, and it has to survive a restart.
+  if (row.context !== null) {
+    alert.context = row.context as Context
+  }
+  if (row.references_json !== null) {
+    const parsed = parseJson(row.references_json)
+    if (Array.isArray(parsed)) {
+      alert.references = parsed as Path[]
+    }
+  }
+  if (row.source_obj !== null) {
+    const parsed = asRecord(parseJson(row.source_obj))
+    if (parsed) {
+      alert.source = parsed
+    }
+  }
+  if (row.silenced_until !== null) {
+    alert.silencedUntil = row.silenced_until
+  }
+  if (row.group_name !== null) {
+    alert.group = row.group_name
+  }
+  if (row.data !== null) {
+    const parsed = asRecord(parseJson(row.data))
+    if (parsed) {
+      alert.data = parsed as Record<string, Value>
+    }
+  }
+  if (row.acknowledged_at !== null) {
+    alert.acknowledgedAt = row.acknowledged_at
+  }
+  if (row.acknowledged_by !== null) {
+    alert.acknowledgedBy = row.acknowledged_by
+  }
+  if (row.cleared_at !== null) {
+    alert.clearedAt = row.cleared_at
+  }
+
+  return alert
+}

--- a/src/api/alerts/description.ts
+++ b/src/api/alerts/description.ts
@@ -1,0 +1,57 @@
+/**
+ * Bounds on what a caller may attach to an alert.
+ *
+ * An alert is held in memory, written to the database and republished to every
+ * subscriber, so an unbounded field is an unbounded cost three times over. The
+ * path is bounded in alertPath.ts; these are the rest.
+ */
+
+import type { Path, Value } from '@signalk/server-api'
+import { InvalidAlertDescriptionError } from './errors'
+
+export const MAX_MESSAGE_LENGTH = 1000
+
+export const MAX_GROUP_LENGTH = 100
+
+export const MAX_REFERENCES = 50
+
+export const MAX_DATA_BYTES = 4096
+
+/**
+ * The descriptive fields, bounded.
+ *
+ * @throws {InvalidAlertDescriptionError} when one is too large.
+ */
+export function checkDescriptionBounds(description: {
+  message: string
+  group?: string
+  references?: Path[]
+  data?: Record<string, Value>
+}): void {
+  if (description.message.length > MAX_MESSAGE_LENGTH) {
+    throw new InvalidAlertDescriptionError(
+      `the message must be at most ${String(MAX_MESSAGE_LENGTH)} characters`
+    )
+  }
+  if (description.group && description.group.length > MAX_GROUP_LENGTH) {
+    throw new InvalidAlertDescriptionError(
+      `the group must be at most ${String(MAX_GROUP_LENGTH)} characters`
+    )
+  }
+  if (
+    description.references &&
+    description.references.length > MAX_REFERENCES
+  ) {
+    throw new InvalidAlertDescriptionError(
+      `an alert may refer to at most ${String(MAX_REFERENCES)} paths`
+    )
+  }
+  if (
+    description.data &&
+    Buffer.byteLength(JSON.stringify(description.data), 'utf8') > MAX_DATA_BYTES
+  ) {
+    throw new InvalidAlertDescriptionError(
+      `the data must serialize to at most ${String(MAX_DATA_BYTES)} bytes`
+    )
+  }
+}

--- a/src/api/alerts/errors.ts
+++ b/src/api/alerts/errors.ts
@@ -1,0 +1,73 @@
+/**
+ * Errors the alert subsystem throws at its callers.
+ *
+ * Each carries a stable `code`, so the REST layer selects a status from the
+ * type rather than by matching message text. The shape follows
+ * `NotificationManagerDisabledError` in `packages/server-api`.
+ */
+
+/** No alert with the given id is in the active registry. */
+export class AlertNotFoundError extends Error {
+  readonly code = 'ALERT_NOT_FOUND'
+  constructor(alertId: string) {
+    super(`Alert not found: ${alertId}`)
+    this.name = 'AlertNotFoundError'
+  }
+}
+
+/** The requested priority is not above the alert's current one. */
+export class InvalidEscalationError extends Error {
+  readonly code = 'INVALID_ESCALATION'
+  constructor(from: string, to: string) {
+    super(`Cannot escalate from ${from} to ${to}: new priority must be higher`)
+    this.name = 'InvalidEscalationError'
+  }
+}
+
+/** The requested silence duration is not a positive number of milliseconds. */
+export class InvalidSilenceDurationError extends Error {
+  readonly code = 'INVALID_SILENCE_DURATION'
+  constructor() {
+    super('Silence duration must be a positive number of milliseconds')
+    this.name = 'InvalidSilenceDurationError'
+  }
+}
+
+/** The active set is full, so no further alert can be raised. */
+export class AlertLimitReachedError extends Error {
+  readonly code = 'ALERT_LIMIT_REACHED'
+  constructor(limit: number) {
+    super(
+      `The active alert limit of ${String(limit)} is reached. ` +
+        'Resolve alerts before raising new ones.'
+    )
+    this.name = 'AlertLimitReachedError'
+  }
+}
+
+/** The path that identifies an alert is not usable as one. */
+export class InvalidAlertPathError extends Error {
+  readonly code = 'INVALID_ALERT_PATH'
+  constructor(reason: string) {
+    super(`Invalid alert path: ${reason}.`)
+    this.name = 'InvalidAlertPathError'
+  }
+}
+
+/** The requested priority is not one the subsystem knows. */
+export class InvalidAlertPriorityError extends Error {
+  readonly code = 'INVALID_ALERT_PRIORITY'
+  constructor(priority: string) {
+    super(`Invalid alert priority: ${priority}.`)
+    this.name = 'InvalidAlertPriorityError'
+  }
+}
+
+/** A descriptive field is larger than the subsystem will carry. */
+export class InvalidAlertDescriptionError extends Error {
+  readonly code = 'INVALID_ALERT_DESCRIPTION'
+  constructor(reason: string) {
+    super(`Invalid alert description: ${reason}.`)
+    this.name = 'InvalidAlertDescriptionError'
+  }
+}

--- a/src/api/alerts/escalationTimer.ts
+++ b/src/api/alerts/escalationTimer.ts
@@ -1,0 +1,221 @@
+/**
+ * Escalation timer.
+ *
+ * Tracks unacknowledged warning alerts and escalates them to alarm priority
+ * after a configurable timeout.
+ */
+
+import type { AlertPriority } from './types'
+
+const MILLISECONDS_PER_SECOND = 1000
+
+const DEFAULT_ESCALATION_TIMEOUT_SECONDS = 300
+
+/**
+ * The escalation window to enforce, falling back to the default when the
+ * setting is not a usable number.
+ *
+ * Zero and negative values are kept: they mean a window already spent, which
+ * a restart produces legitimately. A NaN is not — it would reach setTimeout
+ * and escalate every warning on the next tick.
+ */
+function resolveTimeoutSeconds(configured: number): number {
+  if (Number.isFinite(configured)) {
+    return configured
+  }
+  console.error(
+    `The alert escalation timeout must be a number of seconds, but is ` +
+      `${String(configured)}. Using ${String(DEFAULT_ESCALATION_TIMEOUT_SECONDS)}.`
+  )
+  return DEFAULT_ESCALATION_TIMEOUT_SECONDS
+}
+
+/**
+ * Opaque handle for timer identification.
+ */
+export type TimerHandle = unknown
+
+/**
+ * Abstraction over timer functions to enable testing with fake timers.
+ */
+export interface TimerFunctions {
+  setTimeout(callback: () => void, ms: number): TimerHandle
+  clearTimeout(handle: TimerHandle): void
+}
+
+/**
+ * Configuration for the escalation timer.
+ */
+export interface EscalationTimerConfig {
+  /** Whether warning-to-alarm escalation is enabled */
+  enabled: boolean
+  /** Timeout in seconds before escalation */
+  timeoutSeconds: number
+}
+
+/**
+ * Event emitted when an alert is escalated.
+ */
+export interface EscalationEvent {
+  /** Alert ID that was escalated */
+  alertId: string
+  /** Priority before escalation */
+  fromPriority: AlertPriority
+  /** Priority after escalation */
+  toPriority: AlertPriority
+  /** ISO timestamp when escalation occurred */
+  timestamp: string
+}
+
+/**
+ * Callback invoked when escalation occurs.
+ */
+export type EscalationCallback = (event: EscalationEvent) => void
+
+/**
+ * Default timer functions using global setTimeout/clearTimeout.
+ */
+export const defaultTimerFunctions: TimerFunctions = {
+  setTimeout: (callback, ms) => setTimeout(callback, ms),
+  clearTimeout: (handle) => {
+    clearTimeout(handle as ReturnType<typeof setTimeout>)
+  }
+}
+
+/**
+ * Escalation timer.
+ *
+ * Manages escalation timers for unacknowledged warning alerts. When a warning
+ * alert remains unacknowledged for the configured timeout, it is escalated to
+ * alarm priority.
+ */
+export class EscalationTimer {
+  private config: EscalationTimerConfig
+  private onEscalate: EscalationCallback
+  private timerFns: TimerFunctions
+  private readonly timeoutSeconds: number
+  private activeTimers = new Map<string, TimerHandle>()
+  private stopped = false
+
+  constructor(
+    config: EscalationTimerConfig,
+    onEscalate: EscalationCallback,
+    timerFunctions?: TimerFunctions
+  ) {
+    this.config = config
+    this.timeoutSeconds = resolveTimeoutSeconds(config.timeoutSeconds)
+    this.onEscalate = onEscalate
+    this.timerFns = timerFunctions ?? defaultTimerFunctions
+  }
+
+  /**
+   * Start tracking an alert for potential escalation.
+   * Only starts a timer for warning priority alerts.
+   *
+   * @param alertId - The alert ID to track
+   * @param priority - The alert priority (only 'warning' will start a timer)
+   * @param remainingMs - Optional remaining time in ms (uses config timeout if not specified)
+   */
+  startTimer(
+    alertId: string,
+    priority: AlertPriority,
+    remainingMs?: number
+  ): void {
+    if (this.stopped) {
+      return
+    }
+
+    if (priority !== 'warning') {
+      return
+    }
+
+    if (!this.config.enabled) {
+      return
+    }
+
+    if (this.activeTimers.has(alertId)) {
+      return
+    }
+
+    const timeoutMs =
+      remainingMs ?? this.timeoutSeconds * MILLISECONDS_PER_SECOND
+
+    // A window that is already spent still escalates through a timer rather
+    // than inline. The caller is part-way through raising the alert and has
+    // neither announced nor stored it yet, so escalating within its call would
+    // put the escalation ahead of the raise in both the event stream and the
+    // store, and leave the raise to overwrite it.
+    const handle = this.timerFns.setTimeout(
+      () => {
+        this.handleEscalation(alertId)
+      },
+      Math.max(timeoutMs, 0)
+    )
+
+    this.activeTimers.set(alertId, handle)
+  }
+
+  /**
+   * Cancel escalation timer for an alert.
+   * Called when an alert is acknowledged or cleared.
+   */
+  cancelTimer(alertId: string): void {
+    const handle = this.activeTimers.get(alertId)
+    if (handle !== undefined) {
+      this.timerFns.clearTimeout(handle)
+      this.activeTimers.delete(alertId)
+    }
+  }
+
+  hasTimer(alertId: string): boolean {
+    return this.activeTimers.has(alertId)
+  }
+
+  /**
+   * The escalation window this timer enforces, for a caller resuming a window
+   * that a restart interrupted. Reading the setting directly there would skip
+   * the fallback and put a NaN into setTimeout.
+   */
+  getTimeoutMs(): number {
+    return this.timeoutSeconds * MILLISECONDS_PER_SECOND
+  }
+
+  getActiveTimerCount(): number {
+    return this.activeTimers.size
+  }
+
+  /**
+   * Stop all timers and clean up.
+   */
+  stop(): void {
+    this.stopped = true
+    this.cancelAllTimers()
+  }
+
+  private handleEscalation(alertId: string): void {
+    this.activeTimers.delete(alertId)
+
+    if (this.stopped) {
+      return
+    }
+
+    const event: EscalationEvent = {
+      alertId,
+      fromPriority: 'warning',
+      toPriority: 'alarm',
+      timestamp: new Date().toISOString()
+    }
+
+    this.onEscalate(event)
+  }
+
+  /**
+   * Cancel all active timers.
+   */
+  private cancelAllTimers(): void {
+    for (const handle of this.activeTimers.values()) {
+      this.timerFns.clearTimeout(handle)
+    }
+    this.activeTimers.clear()
+  }
+}

--- a/src/api/alerts/historyStore.ts
+++ b/src/api/alerts/historyStore.ts
@@ -1,0 +1,266 @@
+/**
+ * Audit trail storage.
+ *
+ * Shares the connection its owner opened, so an append can run inside the same
+ * transaction as the active-set write it belongs to. Every method is
+ * synchronous for that reason: an append that yielded could not be part of the
+ * caller's transaction.
+ */
+
+import type { DatabaseSync, StatementSync } from 'node:sqlite'
+import type { Context, Path, SourceRef } from '@signalk/server-api'
+import { asRecord, parseJson } from './jsonColumn'
+import type {
+  AlertPriority,
+  AlertState,
+  HistoryEntry,
+  HistoryEventType,
+  HistoryQuery
+} from './types'
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Largest page the audit trail will return.
+ *
+ * The cap lives here rather than at the REST boundary so every caller inherits
+ * it, and because the trail is the one table in this subsystem that grows.
+ */
+const MAX_PAGE_SIZE = 1000
+
+interface HistoryRow {
+  seq: number
+  id: string
+  alert_id: string
+  path: string
+  context: string | null
+  priority: string
+  message: string
+  source_ref: string
+  event_type: string
+  timestamp: string
+  user_id: string | null
+  previous_state: string | null
+  new_state: string | null
+  previous_priority: string | null
+  new_priority: string | null
+  details: string | null
+}
+
+export class HistoryStore {
+  private readonly appendStmt: StatementSync
+  private readonly pruneStmt: StatementSync
+
+  constructor(private readonly db: DatabaseSync) {
+    this.appendStmt = db.prepare(`
+      INSERT INTO history (
+        id, alert_id, path, context, priority, message, source_ref,
+        event_type, timestamp, user_id, previous_state, new_state,
+        previous_priority, new_priority, details
+      ) VALUES (
+        $id, $alert_id, $path, $context, $priority, $message, $source_ref,
+        $event_type, $timestamp, $user_id, $previous_state, $new_state,
+        $previous_priority, $new_priority, $details
+      )
+    `)
+    this.pruneStmt = db.prepare('DELETE FROM history WHERE timestamp < ?')
+  }
+
+  /**
+   * Append one audit entry. Runs in whatever transaction the caller opened.
+   */
+  append(entry: Omit<HistoryEntry, 'id'>): void {
+    this.appendStmt.run({
+      id: crypto.randomUUID(),
+      alert_id: entry.alertId,
+      path: entry.path,
+      context: entry.context ?? null,
+      priority: entry.priority,
+      message: entry.message,
+      source_ref: entry.$source,
+      event_type: entry.eventType,
+      // Stored in the one form the trail compares in. Normalizing only the
+      // query bounds would leave an offset or millisecond-less timestamp
+      // sorting wrongly, and no later read can repair the row.
+      timestamp: normalizeInstant('timestamp', entry.timestamp),
+      user_id: entry.userId ?? null,
+      previous_state: entry.previousState ?? null,
+      new_state: entry.newState ?? null,
+      previous_priority: entry.previousPriority ?? null,
+      new_priority: entry.newPriority ?? null,
+      details: entry.details ? JSON.stringify(entry.details) : null
+    })
+  }
+
+  /**
+   * Query the audit trail, newest first.
+   *
+   * `total` counts every matching entry, ignoring `limit` and `offset`.
+   *
+   * Ordered by `timestamp` descending, then by insertion sequence descending.
+   * Several entries appended by one transition share a millisecond, and the
+   * sequence keeps them in a defined order rather than an arbitrary one — the
+   * later of the two comes first, as newest-first ordering implies.
+   */
+  query(query: HistoryQuery): { entries: HistoryEntry[]; total: number } {
+    let where = 'WHERE 1=1'
+    const params: (string | number)[] = []
+
+    if (query.alertId) {
+      where += ' AND alert_id = ?'
+      params.push(query.alertId)
+    }
+    if (query.path) {
+      where += ' AND path = ?'
+      params.push(query.path)
+    }
+    if (query.context) {
+      where += ' AND context = ?'
+      params.push(query.context)
+    }
+    if (query.eventType) {
+      const types = Array.isArray(query.eventType)
+        ? query.eventType
+        : [query.eventType]
+      where += ` AND event_type IN (${types.map(() => '?').join(', ')})`
+      params.push(...types)
+    }
+    if (query.from !== undefined) {
+      where += ' AND timestamp >= ?'
+      params.push(normalizeBound('from', query.from))
+    }
+    if (query.to !== undefined) {
+      where += ' AND timestamp <= ?'
+      params.push(normalizeBound('to', query.to))
+    }
+
+    const countRow = this.db
+      .prepare(`SELECT COUNT(*) AS cnt FROM history ${where}`)
+      .get(...params) as { cnt: number }
+
+    const limit = resolveLimit(query.limit)
+    const offset = resolvePagingValue('offset', query.offset) ?? 0
+
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM history ${where} ORDER BY timestamp DESC, seq DESC LIMIT ? OFFSET ?`
+      )
+      .all(...params, limit, offset) as unknown as HistoryRow[]
+
+    return {
+      entries: rows.map((row) => rowToHistoryEntry(row)),
+      total: countRow.cnt
+    }
+  }
+
+  /**
+   * Delete entries older than the retention window.
+   *
+   * @returns how many entries were deleted
+   */
+  prune(olderThanDays: number): number {
+    if (!Number.isFinite(olderThanDays) || olderThanDays < 1) {
+      throw new Error(
+        `Alert history retention must be at least one day, got ${String(olderThanDays)}`
+      )
+    }
+
+    const cutoff = new Date(
+      Date.now() - olderThanDays * MILLISECONDS_PER_DAY
+    ).toISOString()
+
+    return Number(this.pruneStmt.run(cutoff).changes)
+  }
+}
+
+/**
+ * Accept any ISO 8601 instant and compare it in the form the trail stores.
+ *
+ * Entries are written as UTC ISO strings and compared lexicographically, so an
+ * offset form such as `+02:00` would otherwise sort as though it were UTC and
+ * silently return the wrong window.
+ */
+function normalizeBound(name: string, value: string): string {
+  return normalizeInstant(`${name} bound`, value)
+}
+
+/** The UTC ISO form every timestamp in the trail is written and compared in. */
+function normalizeInstant(name: string, value: string): string {
+  const parsed = new Date(value).getTime()
+  if (!Number.isFinite(parsed)) {
+    throw new Error(
+      `Alert history ${name} is not a valid date: ${JSON.stringify(value)}`
+    )
+  }
+  return new Date(parsed).toISOString()
+}
+
+function resolveLimit(limit: number | undefined): number {
+  const requested = resolvePagingValue('limit', limit)
+  if (requested === undefined) {
+    return MAX_PAGE_SIZE
+  }
+  return Math.min(requested, MAX_PAGE_SIZE)
+}
+
+/**
+ * SQLite reads a negative LIMIT as no limit at all, so the value that is meant
+ * to bound a response is also the one that removes the bound. Both paging
+ * values are checked rather than passed through.
+ */
+function resolvePagingValue(
+  name: string,
+  value: number | undefined
+): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `Alert history ${name} must be a non-negative integer, got ${String(value)}`
+    )
+  }
+  return value
+}
+
+function rowToHistoryEntry(row: HistoryRow): HistoryEntry {
+  const entry: HistoryEntry = {
+    id: row.id,
+    alertId: row.alert_id,
+    path: row.path as Path,
+    priority: row.priority as AlertPriority,
+    message: row.message,
+    $source: row.source_ref as SourceRef,
+    eventType: row.event_type as HistoryEventType,
+    timestamp: row.timestamp
+  }
+
+  // Tested against null rather than truthiness, so an empty string a caller
+  // stored comes back as the empty string it was.
+  if (row.context !== null) {
+    entry.context = row.context as Context
+  }
+  if (row.user_id !== null) {
+    entry.userId = row.user_id
+  }
+  if (row.previous_state !== null) {
+    entry.previousState = row.previous_state as AlertState
+  }
+  if (row.new_state !== null) {
+    entry.newState = row.new_state as AlertState
+  }
+  if (row.previous_priority !== null) {
+    entry.previousPriority = row.previous_priority as AlertPriority
+  }
+  if (row.new_priority !== null) {
+    entry.newPriority = row.new_priority as AlertPriority
+  }
+  if (row.details !== null) {
+    const parsed = asRecord(parseJson(row.details))
+    if (parsed) {
+      entry.details = parsed
+    }
+  }
+
+  return entry
+}

--- a/src/api/alerts/jsonColumn.ts
+++ b/src/api/alerts/jsonColumn.ts
@@ -1,0 +1,28 @@
+/**
+ * Reading the JSON blob columns the alerts tables use for structured fields.
+ */
+
+/**
+ * A malformed blob costs the one field it holds, not the whole record.
+ * Dropping an active alarm because its detail JSON is unreadable would be
+ * worse than losing the detail.
+ */
+export function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Narrow a parsed blob to the object shape its field claims to hold.
+ *
+ * A stored `"text"`, `5` or `true` parses fine and would otherwise be handed
+ * to consumers typed as an object.
+ */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}

--- a/src/api/alerts/ordering.ts
+++ b/src/api/alerts/ordering.ts
@@ -1,0 +1,45 @@
+/**
+ * The order an operator reads the active alert list in.
+ *
+ * IMO MSC.302(87) 9.16 and IEC 62682 6.4.2.1: emergencies first, then whatever
+ * still needs an operator, most urgent and most recent first. Silencing is
+ * orthogonal to all of it and never moves an alert, which is why nothing here
+ * reads the silenced flag.
+ */
+
+import { PRIORITY_RANK, type Alert, type AlertState } from './types'
+
+const STATE_TIER: Record<AlertState, number> = {
+  unacknowledged: 0,
+  'rtn-unacknowledged': 1,
+  acknowledged: 2,
+  normal: 3
+}
+
+function compareForDisplay(a: Alert, b: Alert): number {
+  const emergency =
+    Number(b.priority === 'emergency') - Number(a.priority === 'emergency')
+  if (emergency !== 0) {
+    return emergency
+  }
+
+  const tier = STATE_TIER[a.state] - STATE_TIER[b.state]
+  if (tier !== 0) {
+    return tier
+  }
+
+  const priority = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority]
+  if (priority !== 0) {
+    return priority
+  }
+
+  // Both are `toISOString()` output, so byte order is chronological order.
+  if (b.stateChangedAt === a.stateChangedAt) {
+    return 0
+  }
+  return b.stateChangedAt > a.stateChangedAt ? 1 : -1
+}
+
+export function sortForDisplay(alerts: Alert[]): Alert[] {
+  return [...alerts].sort(compareForDisplay)
+}

--- a/src/api/alerts/types.ts
+++ b/src/api/alerts/types.ts
@@ -1,0 +1,355 @@
+/**
+ * Alerts subsystem type definitions.
+ *
+ * The model follows the alerts proposal in SignalK/signalk-server#1857, which is
+ * grounded in IMO MSC.302(87) bridge alert management and the IEC 62682 /
+ * IEC 62923-1 alarm lifecycle.
+ */
+
+import type { Context, Path, SourceRef, Value } from '@signalk/server-api'
+
+/**
+ * Alert priority levels following the IMO model.
+ *
+ * - emergency: Immediate danger to life or vessel; immediate action required
+ * - alarm: Conditions requiring immediate attention to maintain safe operation
+ * - warning: Conditions requiring attention for precautionary reasons
+ * - caution: Conditions requiring attention but not immediately hazardous
+ */
+export const ALERT_PRIORITIES = Object.freeze([
+  'emergency',
+  'alarm',
+  'warning',
+  'caution'
+] as const)
+
+export type AlertPriority = (typeof ALERT_PRIORITIES)[number]
+
+/**
+ * How urgent each priority is, as a number that sorts.
+ *
+ * Displacement at the active-set cap and the order an operator reads the list
+ * in must agree about which alert matters more, so both read this.
+ */
+export const PRIORITY_RANK: Readonly<Record<AlertPriority, number>> =
+  Object.freeze({
+    emergency: 3,
+    alarm: 2,
+    warning: 1,
+    caution: 0
+  })
+
+/**
+ * Alert states based on the IEC 62682 simplified model.
+ *
+ * - normal: No active alert condition (State A / cleared)
+ * - unacknowledged: Alert active, operator has not acknowledged (State B)
+ * - acknowledged: Alert active, operator has acknowledged (State C)
+ * - rtn-unacknowledged: Condition cleared before acknowledgment, awaiting ack (State D)
+ */
+export const ALERT_STATES = Object.freeze([
+  'normal',
+  'unacknowledged',
+  'acknowledged',
+  'rtn-unacknowledged'
+] as const)
+
+export type AlertState = (typeof ALERT_STATES)[number]
+
+/**
+ * Full alert instance representing an active or historical alert.
+ *
+ * Alerts are the core data structure tracking abnormal conditions that require
+ * operator attention. Each alert has a unique ID and tracks its full lifecycle.
+ */
+export interface Alert {
+  /** Unique alert instance ID (UUID) */
+  id: string
+
+  /**
+   * Descriptive path naming the condition this alert reports, for example
+   * `propulsion.port.oilPressureLow`. The path (with `context`) is the alert's
+   * identity: at most one alert is active per path, and a repeat raise on the
+   * same path updates that alert rather than creating a second one. It names
+   * the condition, not the measurement that triggered it — see `references`.
+   */
+  path: Path
+
+  /**
+   * Data paths this alert concerns, for example
+   * `propulsion.port.oilPressure`. Informational: consumers use them to link an
+   * alert to the values behind it. Never part of the alert's identity.
+   */
+  references?: Path[]
+
+  /** Signal K source reference (e.g., "n2k-on-ve.can-bus.115", "alertsApi") */
+  $source: SourceRef
+
+  /**
+   * Signal K structured source object, if available.
+   *
+   * Typed as an open record rather than the server-api `Source`, which is an
+   * alias for `any`.
+   */
+  source?: Record<string, unknown>
+
+  /** Alert priority level */
+  priority: AlertPriority
+
+  /** Current alert state in the IEC 62682 model */
+  state: AlertState
+
+  /** Whether the triggering condition is currently active */
+  condition: boolean
+
+  /** Whether alert latches (stays active after condition clears) */
+  latching: boolean
+
+  /** Whether audible indicators are silenced */
+  silenced: boolean
+
+  /** ISO timestamp when silence expires */
+  silencedUntil?: string
+
+  /** Human-readable alert message */
+  message: string
+
+  /** Optional free-text UI grouping (e.g., "engine", "navigation"); not the IEC alert category A/B/C */
+  group?: string
+
+  /** Additional context data */
+  data?: Record<string, Value>
+
+  /** ISO timestamp when alert was first raised */
+  raisedAt: string
+
+  /**
+   * ISO timestamp of the last lifecycle state change
+   * (raise/ack/clear/reactivate/escalate). A warning→alarm escalation bumps it,
+   * but a latching alarm whose condition clears does NOT (its state stays
+   * `unacknowledged`), and silence/unsilence never bump it. Used for
+   * IEC 62923-1 6.4.2.2 list ordering.
+   *
+   * The latching case is deliberately asymmetric. A condition going away is not
+   * a new annunciation, so a held alarm keeps its place in the list; the same
+   * condition coming back is, so it rises.
+   */
+  stateChangedAt: string
+
+  /** ISO timestamp when operator acknowledged */
+  acknowledgedAt?: string
+
+  /** User/client identifier that acknowledged */
+  acknowledgedBy?: string
+
+  /** ISO timestamp when condition cleared */
+  clearedAt?: string
+
+  /** Whether the source is currently reachable */
+  sourceOnline: boolean
+
+  /** ISO timestamp of last update from source */
+  lastSourceUpdate: string
+
+  /** Whether source went offline while alert was active */
+  stale: boolean
+
+  /** Vessel context for multi-vessel deployments */
+  context?: Context
+}
+
+/**
+ * Filter criteria for querying alerts.
+ */
+export interface AlertFilter {
+  /** Filter by alert state(s) */
+  state?: AlertState | AlertState[]
+
+  /** Filter by priority level(s) */
+  priority?: AlertPriority | AlertPriority[]
+
+  /** Filter by group */
+  group?: string
+
+  /** Filter by stale status */
+  stale?: boolean
+}
+
+/**
+ * Query parameters for retrieving alert history.
+ */
+export interface HistoryQuery {
+  /** Start of date range; any ISO 8601 instant, offsets included */
+  from?: string
+
+  /** End of date range; any ISO 8601 instant, offsets included */
+  to?: string
+
+  /** Filter by specific alert ID */
+  alertId?: string
+
+  /** Filter by the alert path the events concern */
+  path?: Path
+
+  /** Filter by the vessel context the events concern */
+  context?: Context
+
+  /** Filter by event type(s) */
+  eventType?: HistoryEventType | HistoryEventType[]
+
+  /**
+   * Maximum entries to return. A non-negative integer, capped by the store's
+   * own page size, which also applies when this is omitted.
+   */
+  limit?: number
+
+  /** Entries to skip, for paging. A non-negative integer. */
+  offset?: number
+}
+
+/**
+ * Types of events recorded in alert history.
+ */
+export const HISTORY_EVENT_TYPES = Object.freeze([
+  'raise',
+  'acknowledge',
+  'silence',
+  'unsilence',
+  'clear',
+  'escalate'
+] as const)
+
+export type HistoryEventType = (typeof HISTORY_EVENT_TYPES)[number]
+
+/**
+ * A single entry in the alert history log.
+ *
+ * History entries provide a complete audit trail of all alert lifecycle
+ * events for compliance and debugging purposes.
+ *
+ * The alert's identity is copied onto each entry rather than referenced by
+ * `alertId` alone. A cleared alert is deleted from the active set, and a new
+ * raise on the same path mints a new id, so `alertId` on its own cannot answer
+ * what a past event was about.
+ */
+export interface HistoryEntry {
+  /** Unique history entry ID */
+  id: string
+
+  /** ID of the alert this entry relates to */
+  alertId: string
+
+  /** Descriptive path of the alert this entry relates to */
+  path: Path
+
+  /** Vessel context of the alert, when it had one */
+  context?: Context
+
+  /** Priority the alert carried when the event occurred */
+  priority: AlertPriority
+
+  /** Message the alert carried when the event occurred */
+  message: string
+
+  /** Source that owned the alert when the event occurred */
+  $source: SourceRef
+
+  /** Type of event that occurred */
+  eventType: HistoryEventType
+
+  /** ISO timestamp when the event occurred */
+  timestamp: string
+
+  /** User/client that triggered the event (if applicable) */
+  userId?: string
+
+  /** Alert state before the event */
+  previousState?: AlertState
+
+  /** Alert state after the event */
+  newState?: AlertState
+
+  /** Priority before escalation (for escalate events) */
+  previousPriority?: AlertPriority
+
+  /** Priority after escalation (for escalate events) */
+  newPriority?: AlertPriority
+
+  /** Additional event-specific details */
+  details?: Record<string, unknown>
+}
+
+/**
+ * One lifecycle transition, as the store receives it.
+ *
+ * The active-set write and the audit appends belong to the same transition, so
+ * they are handed over together and commit together. A crash can therefore
+ * lose a transition whole, but never apply half of one. The audit trail
+ * outlives the alerts it describes by design: a clear removes the active alert
+ * and keeps its history.
+ */
+export interface AlertTransition {
+  /** The alert this transition applies to */
+  alertId: string
+
+  /** The alert's new value, or null when it leaves the active set */
+  alert: Alert | null
+
+  /** Audit entries this transition appends, in order */
+  history: Omit<HistoryEntry, 'id'>[]
+}
+
+/**
+ * Persistence for the alerts subsystem.
+ *
+ * The AlertManager runs in memory without one, or with one so that alerts
+ * survive a restart.
+ *
+ * Implementations must apply `commit` atomically, and must settle the promises
+ * they return without yielding to other manager operations. The manager
+ * applies each change to its registry before awaiting the write, and holds no
+ * per-alert lock, so an implementation that genuinely suspends would let two
+ * operations on one alert interleave. The `node:sqlite` implementation does
+ * its work synchronously and satisfies this.
+ */
+export interface IAlertStore {
+  /**
+   * Open the database and bring the schema up to date.
+   *
+   * Rejects when the database cannot be opened or migrated. That is a startup
+   * failure: a safety subsystem must not run on a store nobody can read.
+   */
+  initialize(): Promise<void>
+
+  /**
+   * Close the database and release resources.
+   */
+  close(): Promise<void>
+
+  /**
+   * Retrieve every active alert.
+   *
+   * The registry is the only reader, and it restores the whole set. Filtering
+   * belongs to AlertManager.getAlerts, which serves it from memory.
+   */
+  getAll(): Promise<Alert[]>
+
+  /**
+   * Apply one lifecycle transition.
+   */
+  commit(transition: AlertTransition): Promise<void>
+
+  /**
+   * Query the audit trail.
+   */
+  queryHistory(
+    query: HistoryQuery
+  ): Promise<{ entries: HistoryEntry[]; total: number }>
+
+  /**
+   * Delete audit entries older than the retention window.
+   *
+   * @returns how many entries were deleted
+   */
+  pruneHistory(olderThanDays: number): Promise<number>
+}

--- a/test/api/alerts/alertManager.test.ts
+++ b/test/api/alerts/alertManager.test.ts
@@ -1,0 +1,3787 @@
+import { expect } from 'chai'
+import {
+  AlertManager,
+  type AlertManagerConfig,
+  type AlertEvent,
+  type StoreFailureEvent
+} from '../../../src/api/alerts/alertManager'
+import {
+  AlertLimitReachedError,
+  AlertNotFoundError,
+  InvalidEscalationError,
+  InvalidSilenceDurationError
+} from '../../../src/api/alerts/errors'
+import type { AlertTransition } from '../../../src/api/alerts/types'
+import { FakeTimerFunctions } from './helpers/fakeTimerFunctions'
+import {
+  asContext,
+  asPath,
+  captureConsole,
+  FailingAlertStore,
+  MockAlertStore,
+  presentAlert,
+  raiseParams,
+  storedAlert
+} from './helpers/fixtures'
+
+/**
+ * Assert that a promise rejects with an error whose message contains `message`.
+ */
+async function expectRejection(promise: Promise<unknown>, message: string) {
+  try {
+    await promise
+  } catch (err) {
+    expect((err as Error).message).to.include(message)
+    return
+  }
+  expect.fail(`expected rejection containing "${message}"`)
+}
+
+/** The error a promise rejected with, for assertions about its type. */
+async function rejectionOf(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise
+  } catch (err) {
+    return err as Error
+  }
+  return expect.fail('expected a rejection, got a resolved promise')
+}
+
+/**
+ * Persistence that runs a hook inside its commit, so a test can act on the
+ * manager while a mutator is suspended on the store.
+ */
+class HookedAlertStore extends MockAlertStore {
+  onCommit?: (transition: AlertTransition) => Promise<void> | void
+
+  async commit(transition: AlertTransition): Promise<void> {
+    await super.commit(transition)
+    const hook = this.onCommit
+    if (hook) {
+      this.onCommit = undefined
+      await hook(transition)
+    }
+  }
+}
+
+/**
+ * Persistence whose commits fail on a schedule the test writes.
+ *
+ * Attempts are numbered from 1 in the order the manager makes them, and a
+ * resync's re-commits are attempts like any other, so a test can fail the
+ * recovery itself rather than only the write that triggered it.
+ */
+class ScriptedAlertStore extends MockAlertStore {
+  failAttempt: (attempt: number) => boolean = () => false
+  private attempts = 0
+
+  commit(transition: AlertTransition): Promise<void> {
+    this.attempts += 1
+    if (this.failAttempt(this.attempts)) {
+      return Promise.reject(new Error('SQLite disk I/O error'))
+    }
+    return super.commit(transition)
+  }
+}
+
+/**
+ * Persistence that lets a test run a lifecycle write while the resync sweep is
+ * suspended mid-way, which is the only way to reach the sweep's own race.
+ */
+class RacingAlertStore extends MockAlertStore {
+  failWhen: (transition: AlertTransition) => boolean = () => false
+  duringSweep?: () => Promise<void>
+  private raced = false
+
+  async commit(transition: AlertTransition): Promise<void> {
+    if (this.failWhen(transition)) {
+      return Promise.reject(new Error('SQLite disk I/O error'))
+    }
+    await super.commit(transition)
+    // A sweep re-commit carries no audit entries; a lifecycle write does.
+    if (transition.history.length === 0 && !this.raced && this.duringSweep) {
+      this.raced = true
+      await this.duringSweep()
+    }
+  }
+}
+
+const SILENCE_DURATION_ERROR =
+  'Silence duration must be a positive number of milliseconds'
+
+describe('AlertManager', () => {
+  let manager: AlertManager
+  let fakeTimers: FakeTimerFunctions
+  let events: AlertEvent[]
+  let defaultConfig: AlertManagerConfig
+
+  beforeEach(() => {
+    fakeTimers = new FakeTimerFunctions()
+    events = []
+    defaultConfig = {
+      escalation: {
+        enabled: true,
+        timeoutSeconds: 300
+      },
+      silencing: {
+        defaultMaxSilenceSeconds: 120,
+        emergencyMaxSilenceSeconds: 30
+      }
+    }
+    manager = new AlertManager(defaultConfig, fakeTimers)
+    manager.on('alert', (event: AlertEvent) => events.push(event))
+  })
+
+  afterEach(() => {
+    manager.stop()
+  })
+
+  describe('typed errors', () => {
+    it('rejects an unknown alert id with AlertNotFoundError everywhere', async () => {
+      const mutators: Array<() => Promise<unknown>> = [
+        () => manager.acknowledgeAlert('missing'),
+        () => manager.escalateAlert('missing', 'alarm'),
+        () => manager.silenceAlert('missing'),
+        () => manager.unsilenceAlert('missing'),
+        () => manager.clearCondition('missing')
+      ]
+
+      for (const mutate of mutators) {
+        const error = await rejectionOf(mutate())
+        expect(error).to.be.instanceOf(AlertNotFoundError)
+        expect((error as AlertNotFoundError).code).to.equal('ALERT_NOT_FOUND')
+        // The id belongs in the message: a REST layer selects on the code, an
+        // operator reading a log needs to know which alert.
+        expect(error.message).to.include('missing')
+      }
+    })
+
+    it('rejects a de-escalation with InvalidEscalationError', async () => {
+      const alert = await manager.raiseAlert(raiseParams({ priority: 'alarm' }))
+
+      const error = await rejectionOf(
+        manager.escalateAlert(alert.id, 'warning')
+      )
+
+      expect(error).to.be.instanceOf(InvalidEscalationError)
+      expect((error as InvalidEscalationError).code).to.equal(
+        'INVALID_ESCALATION'
+      )
+    })
+
+    it('rejects a silence duration that is not positive with InvalidSilenceDurationError', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const error = await rejectionOf(manager.silenceAlert(alert.id, 0))
+
+      expect(error).to.be.instanceOf(InvalidSilenceDurationError)
+      expect((error as InvalidSilenceDurationError).code).to.equal(
+        'INVALID_SILENCE_DURATION'
+      )
+    })
+  })
+
+  describe('active alert cap', () => {
+    beforeEach(() => {
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, maxActiveAlerts: 2 },
+        fakeTimers
+      )
+    })
+
+    async function raisePath(path: string) {
+      return manager.raiseAlert(raiseParams({ path }))
+    }
+
+    it('refuses a new alert past the cap and keeps the ones it has', async () => {
+      await raisePath('one')
+      await raisePath('two')
+
+      const { result: error } = await captureConsole(() =>
+        rejectionOf(raisePath('three'))
+      )
+
+      expect(error).to.be.instanceOf(AlertLimitReachedError)
+      expect((error as AlertLimitReachedError).code).to.equal(
+        'ALERT_LIMIT_REACHED'
+      )
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+    })
+
+    it('still updates an alert that already exists at the cap', async () => {
+      await raisePath('one')
+      const two = await raisePath('two')
+
+      const updated = await manager.raiseAlert(
+        raiseParams({ path: 'two', message: 'louder' })
+      )
+
+      expect(updated.id).to.equal(two.id)
+      expect(updated.message).to.equal('louder')
+    })
+
+    it('accepts a new alert again once one resolves', async () => {
+      const one = await raisePath('one')
+      await raisePath('two')
+      await manager.clearCondition(one.id)
+      await manager.acknowledgeAlert(one.id)
+
+      const three = await raisePath('three')
+
+      expect(three.path).to.equal('three')
+    })
+
+    it('logs the cap once, not once per refusal', async () => {
+      await raisePath('one')
+      await raisePath('two')
+
+      const { errors, warnings } = await captureConsole(async () => {
+        await rejectionOf(raisePath('three'))
+        await rejectionOf(raisePath('four'))
+      })
+
+      expect([...errors, ...warnings]).to.have.lengthOf(1)
+    })
+
+    it('lets a more urgent alert displace the least urgent one', async () => {
+      await manager.raiseAlert(
+        raiseParams({ path: 'one', priority: 'caution' })
+      )
+      await manager.raiseAlert(
+        raiseParams({ path: 'two', priority: 'caution' })
+      )
+      events = []
+
+      const emergency = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'flooding', priority: 'emergency' })
+        )
+      )
+
+      expect(emergency.result.priority).to.equal('emergency')
+      const active = manager.getAlerts().map((alert) => alert.path)
+      expect(active).to.include('flooding')
+      // Among equals the stalest gives way: the one whose state changed
+      // longest ago.
+      expect(active).to.deep.equal(['two', 'flooding'])
+    })
+
+    it('announces and records a displacement', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, maxActiveAlerts: 2 },
+        fakeTimers,
+        store
+      )
+      const seen: AlertEvent[] = []
+      manager.on('alert', (event: AlertEvent) => seen.push(event))
+      await manager.raiseAlert(
+        raiseParams({ path: 'one', priority: 'caution' })
+      )
+      await manager.raiseAlert(
+        raiseParams({ path: 'two', priority: 'caution' })
+      )
+      store.resetHistory()
+
+      await captureConsole(() =>
+        manager.raiseAlert(raiseParams({ path: 'flooding', priority: 'alarm' }))
+      )
+
+      // The mirror has to learn the displaced alert is gone.
+      expect(seen.map((e) => e.type)).to.include('cleared')
+      const displaced = store.history.find(
+        (entry) => entry.details?.reason === 'displaced'
+      )
+      expect(displaced?.eventType).to.equal('clear')
+    })
+
+    it('still refuses an alert no less urgent than everything active', async () => {
+      await manager.raiseAlert(raiseParams({ path: 'one', priority: 'alarm' }))
+      await manager.raiseAlert(raiseParams({ path: 'two', priority: 'alarm' }))
+
+      const { result: error } = await captureConsole(() =>
+        rejectionOf(
+          manager.raiseAlert(raiseParams({ path: 'three', priority: 'alarm' }))
+        )
+      )
+
+      expect(error).to.be.instanceOf(AlertLimitReachedError)
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+    })
+
+    it('reports the cap again after a later episode', async () => {
+      const one = await raisePath('one')
+      await raisePath('two')
+      await captureConsole(() => rejectionOf(raisePath('three')))
+      await manager.clearCondition(one.id)
+      await manager.acknowledgeAlert(one.id)
+      await raisePath('four')
+
+      const { errors } = await captureConsole(() =>
+        rejectionOf(raisePath('five'))
+      )
+
+      expect(errors).to.have.lengthOf(1)
+    })
+
+    it('falls back to the default when the configured cap is unusable', async () => {
+      for (const configured of [0, -1, 2.5, Number.NaN]) {
+        manager.stop()
+        const { result, errors } = await captureConsole(async () => {
+          manager = new AlertManager(
+            { ...defaultConfig, maxActiveAlerts: configured },
+            fakeTimers
+          )
+          return manager.raiseAlert(raiseParams())
+        })
+
+        expect(result.path).to.equal('test.alert')
+        expect(errors).to.have.lengthOf(1)
+      }
+    })
+
+    it('restores every persisted alert even past the cap', async () => {
+      const store = new MockAlertStore()
+      store.prePopulate([
+        storedAlert({ id: 'a', path: 'one' }),
+        storedAlert({ id: 'b', path: 'two' }),
+        storedAlert({ id: 'c', path: 'three' })
+      ])
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, maxActiveAlerts: 2 },
+        fakeTimers,
+        store
+      )
+
+      await manager.loadFromStore()
+
+      expect(manager.getAlerts()).to.have.lengthOf(3)
+    })
+
+    it('keeps one alert per path when two raises race at the cap', async () => {
+      const { errors } = await captureConsole(async () => {
+        await raisePath('one')
+        await raisePath('two')
+
+        // Displacing an alert awaits a store commit. The raise that suspends
+        // there resumes after the other has already created the alert and
+        // claimed the index key, so it must join that alert rather than mint a
+        // second one nothing can reach.
+        await Promise.all([
+          manager.raiseAlert(
+            raiseParams({ path: 'three', priority: 'emergency' })
+          ),
+          manager.raiseAlert(
+            raiseParams({ path: 'three', priority: 'emergency' })
+          )
+        ])
+      })
+
+      const onThree = manager
+        .getAlerts()
+        .filter((alert) => alert.path === asPath('three'))
+      expect(onThree).to.have.lengthOf(1)
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+      expect(manager.getAlertByPath(asPath('three'))?.id).to.equal(
+        onThree[0].id
+      )
+      expect(errors).to.have.lengthOf(1)
+    })
+  })
+
+  describe('raiseAlert', () => {
+    it('should create a new alert with correct initial state', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      expect(alert.id).to.not.be.undefined
+      expect(alert.$source).to.equal('test-source')
+      expect(alert.priority).to.equal('alarm')
+      expect(alert.state).to.equal('unacknowledged')
+      expect(alert.condition).to.equal(true)
+      expect(alert.message).to.equal('Test alert')
+      expect(alert.sourceOnline).to.equal(true)
+      expect(alert.stale).to.equal(false)
+    })
+
+    it('should emit alert-raised event', async () => {
+      await manager.raiseAlert(raiseParams())
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('raised')
+      expect(events[0].alert.message).to.equal('Test alert')
+    })
+
+    it('should store alert in internal collection', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const retrieved = manager.getAlert(alert.id)
+      expect(retrieved).to.deep.equal(alert)
+    })
+
+    it('should start escalation timer for warning priority', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      // Advance time to trigger escalation
+      fakeTimers.advanceTime(300 * 1000)
+
+      const updated = manager.getAlert(alert.id)
+      expect(updated?.priority).to.equal('alarm')
+    })
+
+    it('should not start escalation timer for alarm priority', async () => {
+      await manager.raiseAlert(raiseParams({ message: 'Test alarm' }))
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should support optional group and data', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          message: 'Engine alert',
+          group: 'engine',
+          data: { temperature: 95, threshold: 90 }
+        })
+      )
+
+      expect(alert.group).to.equal('engine')
+      expect(alert.data).to.deep.equal({ temperature: 95, threshold: 90 })
+    })
+
+    it('should support latching alerts', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ message: 'Latching alert', latching: true })
+      )
+
+      expect(alert.latching).to.equal(true)
+    })
+  })
+
+  describe('acknowledgeAlert', () => {
+    it('should transition unacknowledged to acknowledged', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const result = await manager.acknowledgeAlert(alert.id, 'user-1')
+
+      expect(result.alert?.state).to.equal('acknowledged')
+      expect(result.alert?.acknowledgedBy).to.equal('user-1')
+      expect(result.alert?.acknowledgedAt).to.not.be.undefined
+    })
+
+    it('should emit alert-acknowledged event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      events = [] // Clear raise event
+
+      await manager.acknowledgeAlert(alert.id)
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('acknowledged')
+    })
+
+    it('should cancel escalation timer on acknowledge', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.acknowledgeAlert(alert.id)
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should clear RTN-unacknowledged alert on acknowledge', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.clearCondition(alert.id)
+      const clearedAt = manager.getAlert(alert.id)?.clearedAt
+      events = []
+
+      const result = await manager.acknowledgeAlert(alert.id)
+
+      expect(result.cleared).to.equal(true)
+      expect(manager.getAlert(alert.id)).to.be.null
+
+      // The alert is announced with its terminal value, not the state it held
+      // before resolution.
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('cleared')
+      expect(events[0].alert.state).to.equal('normal')
+      expect(events[0].alert.condition).to.equal(false)
+      expect(events[0].alert.clearedAt).to.equal(clearedAt)
+      expect(Date.parse(events[0].alert.stateChangedAt)).to.be.at.least(
+        Date.parse(alert.stateChangedAt)
+      )
+    })
+
+    it('should throw for non-existent alert', async () => {
+      await expectRejection(
+        manager.acknowledgeAlert('non-existent'),
+        'Alert not found'
+      )
+    })
+  })
+
+  describe('silenceAlert', () => {
+    it('should set silenced flag and silencedUntil', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const silenced = await manager.silenceAlert(alert.id, 30000)
+
+      expect(silenced.silenced).to.equal(true)
+      expect(silenced.silencedUntil).to.not.be.undefined
+    })
+
+    it('should emit alert-silenced event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      events = []
+
+      await manager.silenceAlert(alert.id)
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('silenced')
+    })
+
+    it('should use default duration from config for alarm', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const silenced = await manager.silenceAlert(alert.id)
+
+      // Default is 120 seconds for alarm
+      if (silenced.silencedUntil === undefined) {
+        throw new Error('Expected silencedUntil to be defined')
+      }
+      const silencedUntil = new Date(silenced.silencedUntil).getTime()
+      const now = Date.now()
+      expect(silencedUntil - now).to.be.at.most(120000)
+      expect(silencedUntil - now).to.be.greaterThan(119000)
+    })
+
+    it('should use shorter duration for emergency', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'emergency', message: 'Test emergency' })
+      )
+
+      const silenced = await manager.silenceAlert(alert.id)
+
+      // Default is 30 seconds for emergency
+      if (silenced.silencedUntil === undefined) {
+        throw new Error('Expected silencedUntil to be defined')
+      }
+      const silencedUntil = new Date(silenced.silencedUntil).getTime()
+      const now = Date.now()
+      expect(silencedUntil - now).to.be.at.most(30000)
+      expect(silencedUntil - now).to.be.greaterThan(29000)
+    })
+
+    it('should clamp a duration longer than the configured maximum', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const silenced = await manager.silenceAlert(alert.id, 10 * 60 * 1000)
+
+      if (silenced.silencedUntil === undefined) {
+        throw new Error('Expected silencedUntil to be defined')
+      }
+      const silencedUntil = new Date(silenced.silencedUntil).getTime()
+      const now = Date.now()
+      expect(silencedUntil - now).to.be.at.most(120000)
+      expect(silencedUntil - now).to.be.greaterThan(119000)
+
+      // The expiration timer obeys the same cap.
+      fakeTimers.advanceTime(119000)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+      fakeTimers.advanceTime(2000)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(false)
+    })
+
+    it('should reject a zero, negative or NaN duration', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await expectRejection(
+        manager.silenceAlert(alert.id, 0),
+        SILENCE_DURATION_ERROR
+      )
+      await expectRejection(
+        manager.silenceAlert(alert.id, -1000),
+        SILENCE_DURATION_ERROR
+      )
+      await expectRejection(
+        manager.silenceAlert(alert.id, Number.NaN),
+        SILENCE_DURATION_ERROR
+      )
+
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(false)
+    })
+
+    it('should throw for non-existent alert', async () => {
+      await expectRejection(
+        manager.silenceAlert('non-existent'),
+        'Alert not found'
+      )
+    })
+  })
+
+  describe('clearCondition', () => {
+    it('should transition acknowledged alert to cleared', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id)
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(true)
+      expect(manager.getAlert(alert.id)).to.be.null
+    })
+
+    it('should transition unacknowledged to rtn-unacknowledged', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.alert?.state).to.equal('rtn-unacknowledged')
+    })
+
+    it('should auto-clear caution alerts', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'caution', message: 'Test caution' })
+      )
+
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(true)
+      expect(manager.getAlert(alert.id)).to.be.null
+    })
+
+    it('should emit alert-cleared event when removed', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.acknowledgeAlert(alert.id)
+      events = []
+
+      await manager.clearCondition(alert.id)
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('cleared')
+
+      // The event carries the terminal value of the resolved alert.
+      const cleared = events[0].alert
+      expect(cleared.id).to.equal(alert.id)
+      expect(cleared.state).to.equal('normal')
+      expect(cleared.condition).to.equal(false)
+      expect(cleared.clearedAt).to.equal(cleared.stateChangedAt)
+      expect(Date.parse(cleared.stateChangedAt)).to.be.at.least(
+        Date.parse(alert.stateChangedAt)
+      )
+    })
+
+    it('should not re-announce a repeat clear of an already-cleared condition', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.clearCondition(alert.id)
+      const commitsAfterFirstClear = store.commitCount
+      store.resetHistory()
+      events = []
+
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.alert?.state).to.equal('rtn-unacknowledged')
+      expect(events).to.have.lengthOf(0)
+      expect(store.history).to.have.lengthOf(0)
+      expect(store.commitCount).to.equal(commitsAfterFirstClear)
+    })
+
+    it('should cancel escalation timer when clearing warning', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.clearCondition(alert.id)
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should throw for non-existent alert', async () => {
+      await expectRejection(
+        manager.clearCondition('non-existent'),
+        'Alert not found'
+      )
+    })
+  })
+
+  describe('updateDescription', () => {
+    it('refreshes the descriptive fields without re-alerting', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ group: 'engine', data: { rpm: 1000 } })
+      )
+      await manager.acknowledgeAlert(alert.id, 'operator')
+      events.length = 0
+
+      const updated = await manager.updateDescription(alert.id, {
+        data: { rpm: 1200 },
+        references: [asPath('propulsion.port.revolutions')]
+      })
+
+      expect(updated.data).to.deep.equal({ rpm: 1200 })
+      expect(updated.references).to.deep.equal([
+        asPath('propulsion.port.revolutions')
+      ])
+      // The point of the method: an acknowledged alert stays acknowledged.
+      expect(updated.state).to.equal('acknowledged')
+      expect(updated.group).to.equal('engine')
+      expect(events.map((event) => event.type)).to.deep.equal(['updated'])
+    })
+
+    it('does nothing at all when the description is unchanged', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      const alert = await manager.raiseAlert(
+        raiseParams({ group: 'engine', data: { rpm: 1000 } })
+      )
+      const commitsAfterRaise = store.commitCount
+      events.length = 0
+
+      const same = await manager.updateDescription(alert.id, {
+        $source: alert.$source,
+        group: 'engine',
+        data: { rpm: 1000 }
+      })
+
+      // A source re-emitting an identical alert is the common case. It must
+      // cost neither a delta to every subscriber nor a durable write.
+      expect(same).to.equal(alert)
+      expect(events).to.have.lengthOf(0)
+      expect(store.commitCount).to.equal(commitsAfterRaise)
+    })
+
+    it('brings a stale alert back when its source speaks again', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, sourceTimeoutSeconds: 60 },
+        fakeTimers,
+        store
+      )
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      const alert = await manager.raiseAlert(
+        raiseParams({ data: { rpm: 1000 } })
+      )
+      manager.noteSourceUpdate(alert.id)
+      fakeTimers.advanceTime(60 * 1000)
+      expect(presentAlert(manager.getAlert(alert.id)).stale).to.equal(true)
+      events.length = 0
+
+      // The description has not moved, but the source coming back is the
+      // whole point of the message: staying stale would misreport a live
+      // source for as long as it keeps saying the same thing.
+      const recovered = await manager.updateDescription(alert.id, {
+        data: { rpm: 1000 }
+      })
+
+      expect(recovered.stale).to.equal(false)
+      expect(recovered.sourceOnline).to.equal(true)
+      expect(events.map((event) => event.type)).to.deep.equal(['updated'])
+      expect(store.getStoredAlert(alert.id)?.stale).to.equal(false)
+    })
+
+    it('publishes a changed structured source', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      events.length = 0
+
+      const updated = await manager.updateDescription(alert.id, {
+        source: { label: 'n2k', pgn: 127489 }
+      })
+
+      expect(updated.source).to.deep.equal({ label: 'n2k', pgn: 127489 })
+      expect(events.map((event) => event.type)).to.deep.equal(['updated'])
+    })
+
+    it('records nothing in the audit trail', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      const alert = await manager.raiseAlert(raiseParams())
+      store.resetHistory()
+
+      await manager.updateDescription(alert.id, { data: { rpm: 1200 } })
+
+      expect(store.eventTypes()).to.deep.equal([])
+      expect(store.getStoredAlert(alert.id)?.data).to.deep.equal({ rpm: 1200 })
+    })
+
+    it('rejects an unknown alert', async () => {
+      await expectRejection(
+        manager.updateDescription('non-existent', { data: {} }),
+        'Alert not found'
+      )
+    })
+  })
+
+  describe('escalation', () => {
+    it('does not report a silent source as live when an operator escalates', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      const reportedAt = alert.lastSourceUpdate
+
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      const escalated = await manager.escalateAlert(alert.id, 'alarm')
+
+      // lastSourceUpdate answers "when did the source last speak". The
+      // operator escalating is not the source speaking.
+      expect(escalated.lastSourceUpdate).to.equal(reportedAt)
+      expect(escalated.stateChangedAt).to.not.equal(alert.stateChangedAt)
+    })
+
+    it('announces a source re-raise at a higher priority as escalated', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      events.length = 0
+
+      const raised = await manager.raiseAlert(
+        raiseParams({ priority: 'emergency', message: 'Test warning' })
+      )
+
+      // The audit trail records this as an escalation, and a listener driving
+      // renewed annunciation reads the event stream, so the two must agree.
+      expect(raised.id).to.equal(alert.id)
+      expect(raised.priority).to.equal('emergency')
+      expect(events.map((event) => event.type)).to.deep.equal(['escalated'])
+      expect(events[0].previousState).to.equal('unacknowledged')
+    })
+
+    it('moves an escalated alert to the front of its new priority group', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      const escalated = await manager.raiseAlert(
+        raiseParams({ priority: 'alarm', message: 'Test warning' })
+      )
+
+      // Escalation is a state change, and display order reads stateChangedAt
+      // within a priority group. The timer and operator routes both bump it,
+      // so a source-driven escalation has to as well.
+      expect(escalated.priority).to.equal('alarm')
+      expect(escalated.stateChangedAt).to.not.equal(alert.stateChangedAt)
+    })
+
+    it('still announces an unchanged re-raise as updated', async () => {
+      await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      events.length = 0
+
+      await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      expect(events.map((event) => event.type)).to.deep.equal(['updated'])
+    })
+
+    it('should escalate warning to alarm after timeout', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      events = []
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      const updated = manager.getAlert(alert.id)
+      expect(updated?.priority).to.equal('alarm')
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('escalated')
+    })
+
+    it('advances stateChangedAt when the escalation timer fires', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      const before = alert.stateChangedAt
+      // Guarantee the wall clock advances past the raise timestamp.
+      await new Promise<void>((resolve) => setTimeout(resolve, 5))
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      const updated = manager.getAlert(alert.id)
+      expect(updated?.priority).to.equal('alarm')
+      expect((updated?.stateChangedAt ?? '') > before).to.equal(true)
+    })
+
+    it('should unsilence a warning the timer escalates', async () => {
+      // A silence that outlasts the escalation window is the only way to reach
+      // this: the timer fires precisely because nobody attended to the warning,
+      // so the alarm it produces must be audible.
+      manager.stop()
+      manager = new AlertManager(
+        {
+          ...defaultConfig,
+          silencing: {
+            defaultMaxSilenceSeconds: 600,
+            emergencyMaxSilenceSeconds: 30
+          }
+        },
+        fakeTimers
+      )
+      events = []
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      await manager.silenceAlert(alert.id)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+      events = []
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      const escalated = manager.getAlert(alert.id)
+      expect(escalated?.priority).to.equal('alarm')
+      expect(escalated?.silenced).to.equal(false)
+      expect(escalated?.silencedUntil).to.be.undefined
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('escalated')
+      expect(events[0].alert.silenced).to.equal(false)
+
+      // The pending unsilence timer went with it, so nothing fires later.
+      fakeTimers.advanceTime(600 * 1000)
+      expect(events).to.have.lengthOf(1)
+    })
+
+    it('should not escalate if acknowledged before timeout', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      await manager.acknowledgeAlert(alert.id)
+      fakeTimers.advanceTime(300 * 1000)
+
+      const updated = manager.getAlert(alert.id)
+      expect(updated?.priority).to.equal('warning')
+    })
+
+    it('should not escalate a latched warning whose condition cleared', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          priority: 'warning',
+          message: 'Test warning',
+          latching: true
+        })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.clearCondition(alert.id)
+      events = []
+
+      // Still unacknowledged and still a warning, but the condition is gone:
+      // the alert waits for acknowledgment, not for urgency.
+      expect(manager.getAlert(alert.id)?.state).to.equal('unacknowledged')
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      expect(manager.getAlert(alert.id)?.priority).to.equal('warning')
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(0)
+    })
+
+    it('should not escalate if disabled in config', async () => {
+      manager.stop()
+      manager = new AlertManager(
+        {
+          ...defaultConfig,
+          escalation: { enabled: false, timeoutSeconds: 300 }
+        },
+        fakeTimers
+      )
+
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      const updated = manager.getAlert(alert.id)
+      expect(updated?.priority).to.equal('warning')
+    })
+  })
+
+  describe('source liveness', () => {
+    /** Raise through the delta convention: re-emission is the heartbeat. */
+    async function raiseFromDelta(overrides = {}) {
+      const alert = await manager.raiseAlert(raiseParams(overrides))
+      manager.noteSourceUpdate(alert.id)
+      return alert
+    }
+
+    it('keeps an alert fresh while its source keeps re-emitting', async () => {
+      const alert = await raiseFromDelta()
+
+      for (let i = 0; i < 4; i++) {
+        fakeTimers.advanceTime(30 * 1000)
+        await raiseFromDelta()
+      }
+      fakeTimers.advanceTime(30 * 1000)
+
+      expect(manager.getAlert(alert.id)?.stale).to.equal(false)
+    })
+
+    it('marks an alert stale when its source goes quiet', async () => {
+      const alert = await raiseFromDelta()
+      events = []
+
+      fakeTimers.advanceTime(61 * 1000)
+      await Promise.resolve()
+
+      const stale = manager.getAlert(alert.id)
+      expect(stale?.stale).to.equal(true)
+      expect(stale?.sourceOnline).to.equal(false)
+      // The mirror has to learn about it, so the transition is announced.
+      expect(events.map((e) => e.type)).to.deep.equal(['updated'])
+    })
+
+    it('clears staleness when the source comes back', async () => {
+      const alert = await raiseFromDelta()
+      fakeTimers.advanceTime(61 * 1000)
+      await Promise.resolve()
+      expect(manager.getAlert(alert.id)?.stale).to.equal(true)
+
+      await raiseFromDelta()
+
+      const recovered = manager.getAlert(alert.id)
+      expect(recovered?.stale).to.equal(false)
+      expect(recovered?.sourceOnline).to.equal(true)
+    })
+
+    it('never marks a REST or plugin alert stale', async () => {
+      // Neither surface has a re-emission convention, so silence says nothing.
+      const alert = await manager.raiseAlert(raiseParams())
+
+      fakeTimers.advanceTime(600 * 1000)
+      await Promise.resolve()
+
+      expect(manager.getAlert(alert.id)?.stale).to.equal(false)
+    })
+
+    it('follows the source that owns the alert now', async () => {
+      const alert = await raiseFromDelta({ $source: 'source-a' })
+
+      for (let i = 0; i < 3; i++) {
+        fakeTimers.advanceTime(30 * 1000)
+        // Source B takes the path over and keeps it alive.
+        await raiseFromDelta({ $source: 'source-b' })
+      }
+      await Promise.resolve()
+
+      const current = manager.getAlert(alert.id)
+      expect(current?.$source).to.equal('source-b')
+      expect(current?.stale).to.equal(false)
+    })
+
+    it('does not touch lifecycle state, silencing or the condition', async () => {
+      const alert = await raiseFromDelta()
+      await manager.silenceAlert(alert.id, 300 * 1000)
+      const before = manager.getAlert(alert.id)
+
+      fakeTimers.advanceTime(61 * 1000)
+      await Promise.resolve()
+
+      const after = manager.getAlert(alert.id)
+      expect(after?.state).to.equal(before?.state)
+      expect(after?.silenced).to.equal(true)
+      expect(after?.condition).to.equal(true)
+      expect(after?.stale).to.equal(true)
+    })
+  })
+
+  describe('getAlerts', () => {
+    it('should return all active alerts', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          priority: 'warning',
+          message: 'Alert 2'
+        })
+      )
+
+      const alerts = manager.getAlerts()
+
+      expect(alerts).to.have.lengthOf(2)
+    })
+
+    it('should filter by state', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+
+      await manager.acknowledgeAlert(alert1.id)
+
+      const unacked = manager.getAlerts({ state: 'unacknowledged' })
+      const acked = manager.getAlerts({ state: 'acknowledged' })
+
+      expect(unacked).to.have.lengthOf(1)
+      expect(acked).to.have.lengthOf(1)
+    })
+
+    it('should filter by priority', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          priority: 'warning',
+          message: 'Alert 2'
+        })
+      )
+
+      const alarms = manager.getAlerts({ priority: 'alarm' })
+
+      expect(alarms).to.have.lengthOf(1)
+      expect(alarms[0].priority).to.equal('alarm')
+    })
+
+    it('should filter by group', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1',
+          group: 'engine'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2',
+          group: 'navigation'
+        })
+      )
+
+      const engineAlerts = manager.getAlerts({ group: 'engine' })
+
+      expect(engineAlerts).to.have.lengthOf(1)
+      expect(engineAlerts[0].group).to.equal('engine')
+    })
+
+    it('should filter by stale', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      const alert2 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+
+      // Only alert1 follows the delta convention, so only it can go stale.
+      manager.noteSourceUpdate(alert1.id)
+      fakeTimers.advanceTime(61 * 1000)
+      await Promise.resolve()
+
+      expect(manager.getAlerts({ stale: true }).map((a) => a.id)).to.deep.equal(
+        [alert1.id]
+      )
+      expect(
+        manager.getAlerts({ stale: false }).map((a) => a.id)
+      ).to.deep.equal([alert2.id])
+    })
+  })
+
+  describe('getAlertByPath', () => {
+    it('should resolve the active alert on a path', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(
+        manager.getAlertByPath(asPath('propulsion.port.oilPressureLow'))?.id
+      ).to.equal(alert.id)
+    })
+
+    it('should return null for a path with no active alert', () => {
+      expect(manager.getAlertByPath(asPath('propulsion.port.oilPressureLow')))
+        .to.be.null
+    })
+
+    it('should scope the lookup by context', async () => {
+      const context = 'vessels.urn:mrn:signalk:uuid:test'
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low',
+          context
+        })
+      )
+
+      expect(manager.getAlertByPath(asPath('propulsion.port.oilPressureLow')))
+        .to.be.null
+      expect(
+        manager.getAlertByPath(
+          asPath('propulsion.port.oilPressureLow'),
+          asContext(context)
+        )?.id
+      ).to.equal(alert.id)
+    })
+
+    it('should not let a path containing a separator collide with a context-scoped key', async () => {
+      const scoped = await manager.raiseAlert(
+        raiseParams({
+          path: 'oilPressureLow',
+          context: 'vessels.self',
+          message: 'Scoped'
+        })
+      )
+      const literal = await manager.raiseAlert(
+        raiseParams({
+          path: 'vessels.self::oilPressureLow',
+          message: 'Literal'
+        })
+      )
+
+      expect(literal.id).to.not.equal(scoped.id)
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+      expect(
+        manager.getAlertByPath(asPath('vessels.self::oilPressureLow'))?.id
+      ).to.equal(literal.id)
+      expect(
+        manager.getAlertByPath(
+          asPath('oilPressureLow'),
+          asContext('vessels.self')
+        )?.id
+      ).to.equal(scoped.id)
+    })
+
+    it('should treat an empty context as no context', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low',
+          context: ''
+        })
+      )
+
+      expect(alert.context).to.be.undefined
+      expect(
+        manager.getAlertByPath(asPath('propulsion.port.oilPressureLow'))?.id
+      ).to.equal(alert.id)
+
+      // The empty context keys the index the same way an absent one does, so
+      // neither a repeat empty-context raise nor a context-less one duplicates.
+      const reraisedEmpty = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low',
+          context: ''
+        })
+      )
+      expect(reraisedEmpty.id).to.equal(alert.id)
+
+      const reraisedWithout = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low'
+        })
+      )
+      expect(reraisedWithout.id).to.equal(alert.id)
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+    })
+
+    it('should return null once the alert is cleared', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          priority: 'caution',
+          message: 'Oil pressure low'
+        })
+      )
+
+      await manager.clearCondition(alert.id)
+
+      expect(manager.getAlertByPath(asPath('propulsion.port.oilPressureLow')))
+        .to.be.null
+    })
+
+    it('should resolve alerts restored from the store', async () => {
+      const store = new MockAlertStore()
+      store.prePopulate([
+        storedAlert({
+          id: 'restored-1',
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low'
+        })
+      ])
+
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      await manager.loadFromStore()
+
+      expect(
+        manager.getAlertByPath(asPath('propulsion.port.oilPressureLow'))?.id
+      ).to.equal('restored-1')
+    })
+  })
+
+  describe('duplicate handling', () => {
+    it('should update existing alert with same path', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', data: { value: 1 } })
+      )
+
+      const alert2 = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', data: { value: 2 } })
+      )
+
+      // Same alert ID - updated, not duplicated
+      expect(alert2.id).to.equal(alert1.id)
+      expect(alert2.data).to.deep.equal({ value: 2 })
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+    })
+
+    it('should create separate alerts for different paths', async () => {
+      await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.msg1', message: 'Alert 1' })
+      )
+
+      await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.msg2', message: 'Alert 2' })
+      )
+
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+    })
+
+    it('should emit alert-updated event for duplicate', async () => {
+      await manager.raiseAlert(raiseParams({ priority: 'warning' }))
+      events = []
+
+      await manager.raiseAlert(raiseParams({ priority: 'warning' }))
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('updated')
+    })
+
+    it('should dedup by path regardless of message', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.main.coolantTemperature',
+          priority: 'warning',
+          message: 'Coolant temp high'
+        })
+      )
+
+      const alert2 = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.main.coolantTemperature',
+          priority: 'warning',
+          message: 'Coolant temp very high'
+        })
+      )
+
+      expect(alert2.id).to.equal(alert1.id)
+      expect(alert2.message).to.equal('Coolant temp very high')
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+    })
+
+    it('should dedup by path across different sources', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.main.coolantTemperature',
+          $source: 'source-A',
+          priority: 'warning',
+          message: 'From source A'
+        })
+      )
+
+      const alert2 = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.main.coolantTemperature',
+          $source: 'source-B',
+          message: 'From source B'
+        })
+      )
+
+      expect(alert2.id).to.equal(alert1.id)
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+    })
+
+    it('should update message on re-raise', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'engine.overheating',
+          priority: 'warning',
+          message: 'Temperature 85°C'
+        })
+      )
+
+      const updated = await manager.raiseAlert(
+        raiseParams({
+          path: 'engine.overheating',
+          priority: 'warning',
+          message: 'Temperature 92°C'
+        })
+      )
+
+      expect(updated.message).to.equal('Temperature 92°C')
+      expect(manager.getAlert(updated.id)?.message).to.equal('Temperature 92°C')
+    })
+
+    it('should update group on re-raise', async () => {
+      const first = await manager.raiseAlert(raiseParams({ group: 'engine' }))
+
+      const updated = await manager.raiseAlert(
+        raiseParams({ group: 'navigation' })
+      )
+
+      expect(updated.id).to.equal(first.id)
+      expect(updated.group).to.equal('navigation')
+      expect(manager.getAlert(first.id)?.group).to.equal('navigation')
+    })
+
+    it('should update latching on re-raise', async () => {
+      const first = await manager.raiseAlert(raiseParams({ latching: false }))
+
+      const updated = await manager.raiseAlert(raiseParams({ latching: true }))
+
+      expect(updated.id).to.equal(first.id)
+      expect(updated.latching).to.equal(true)
+      expect(manager.getAlert(first.id)?.latching).to.equal(true)
+    })
+
+    it('should keep data when a re-raise omits it', async () => {
+      const first = await manager.raiseAlert(
+        raiseParams({ data: { temperature: 95 } })
+      )
+
+      const updated = await manager.raiseAlert(raiseParams())
+
+      expect(updated.id).to.equal(first.id)
+      expect(updated.data).to.deep.equal({ temperature: 95 })
+    })
+  })
+
+  describe('references', () => {
+    it('should store every reference given at raise', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: [
+            'propulsion.port.oilPressure',
+            'propulsion.port.revolutions'
+          ],
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(alert.references).to.deep.equal([
+        'propulsion.port.oilPressure',
+        'propulsion.port.revolutions'
+      ])
+    })
+
+    it('should leave references absent when none are given', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(alert.references).to.be.undefined
+    })
+
+    it('should not use references for dedup', async () => {
+      const first = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: ['propulsion.port.oilPressure'],
+          message: 'Oil pressure low'
+        })
+      )
+
+      const second = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: ['propulsion.port.oilPressure.secondary'],
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(second.id).to.equal(first.id)
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+      expect(second.references).to.deep.equal([
+        'propulsion.port.oilPressure.secondary'
+      ])
+    })
+
+    it('should keep alerts on distinct paths that share a reference separate', async () => {
+      const low = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: ['propulsion.port.oilPressure'],
+          priority: 'warning',
+          message: 'Oil pressure low'
+        })
+      )
+
+      const critical = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureCritical',
+          references: ['propulsion.port.oilPressure'],
+          message: 'Oil pressure critical'
+        })
+      )
+
+      expect(critical.id).to.not.equal(low.id)
+      expect(manager.getAlerts()).to.have.lengthOf(2)
+    })
+
+    it('should keep references when a re-raise omits them', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: ['propulsion.port.oilPressure'],
+          message: 'Oil pressure low'
+        })
+      )
+
+      const reraised = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(reraised.references).to.deep.equal(['propulsion.port.oilPressure'])
+    })
+
+    it('should clear references when a re-raise sends an empty list', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: ['propulsion.port.oilPressure'],
+          message: 'Oil pressure low'
+        })
+      )
+
+      const reraised = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          references: [],
+          message: 'Oil pressure low'
+        })
+      )
+
+      expect(reraised.references).to.deep.equal([])
+    })
+  })
+
+  describe('multiple sources on one path', () => {
+    it('should keep one alert and hand ownership to the later source', async () => {
+      const first = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-A',
+          message: 'From A'
+        })
+      )
+
+      const second = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-B',
+          message: 'From B'
+        })
+      )
+
+      expect(second.id).to.equal(first.id)
+      expect(manager.getAlerts()).to.have.lengthOf(1)
+      expect(second.$source).to.equal('source-B')
+    })
+
+    it('should record the ownership change in history', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-A',
+          message: 'From A'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-B',
+          message: 'From B'
+        })
+      )
+
+      const raises = store.entriesOfType('raise')
+      expect(raises).to.have.lengthOf(2)
+      expect(raises[1].path).to.equal('propulsion.port.oilPressureLow')
+      expect(raises[1].$source).to.equal('source-B')
+      expect(raises[1].priority).to.equal('alarm')
+      expect(raises[1].message).to.equal('From B')
+      expect(raises[1].details).to.deep.equal({ previousSource: 'source-A' })
+    })
+
+    it('should not record history when the same source re-raises', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-A',
+          message: 'From A'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-A',
+          message: 'From A again'
+        })
+      )
+
+      expect(store.entriesOfType('raise')).to.have.lengthOf(1)
+    })
+  })
+
+  describe('persistence', () => {
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+    })
+
+    it('should save alert to store on raise', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      expect(store.getStoredAlert(alert.id)).to.not.be.undefined
+      expect(store.getStoredAlert(alert.id)?.message).to.equal('Test alert')
+    })
+
+    it('should update store on acknowledge', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id)
+
+      expect(store.getStoredAlert(alert.id)?.state).to.equal('acknowledged')
+    })
+
+    it('should delete from store when alert is cleared', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id)
+      await manager.clearCondition(alert.id)
+
+      expect(store.getStoredAlert(alert.id)).to.be.undefined
+    })
+
+    it('should not report a degraded store before a write fails', async () => {
+      await manager.raiseAlert(raiseParams())
+
+      expect(manager.isStoreDegraded()).to.equal(false)
+    })
+
+    it('should raise, announce and escalate even when the store write fails', async () => {
+      manager.stop()
+      manager = new AlertManager(
+        defaultConfig,
+        fakeTimers,
+        new FailingAlertStore()
+      )
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      events = []
+
+      const { result: alert, errors } = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ priority: 'warning', message: 'Test warning' })
+        )
+      )
+
+      expect(alert.message).to.equal('Test warning')
+      expect(manager.getAlert(alert.id)?.message).to.equal('Test warning')
+      expect(events.filter((e) => e.type === 'raised')).to.have.lengthOf(1)
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+      expect(manager.isStoreDegraded()).to.equal(true)
+      expect(errors).to.have.lengthOf(1)
+    })
+
+    it('should emit storeError describing the failed write', async () => {
+      manager.stop()
+      manager = new AlertManager(
+        defaultConfig,
+        fakeTimers,
+        new FailingAlertStore()
+      )
+      const failures: StoreFailureEvent[] = []
+      manager.on('storeError', (event: StoreFailureEvent) =>
+        failures.push(event)
+      )
+
+      const { result: alert } = await captureConsole(() =>
+        manager.raiseAlert(raiseParams())
+      )
+
+      expect(failures).to.have.lengthOf(1)
+      expect(failures[0].operation).to.equal('commit')
+      expect(failures[0].alertId).to.equal(alert.id)
+      expect(failures[0].error.message).to.equal('SQLite disk I/O error')
+    })
+
+    it('should work without store (in-memory only)', async () => {
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers) // No store
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const kept = manager.getAlert(alert.id)
+      expect(kept).to.not.be.null
+      expect(kept?.message).to.equal('Test alert')
+    })
+  })
+
+  describe('store recovery', () => {
+    let store: ScriptedAlertStore
+    let failures: StoreFailureEvent[]
+
+    beforeEach(() => {
+      store = new ScriptedAlertStore()
+      failures = []
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      manager.on('storeError', (event: StoreFailureEvent) =>
+        failures.push(event)
+      )
+    })
+
+    it('should re-commit the active set once a write succeeds again', async () => {
+      // The first write fails, so its alert lives only in memory. The next
+      // write that lands has to carry it into the store with it.
+      store.failAttempt = (attempt) => attempt === 1
+
+      const { result: lost } = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'test.alert.1', message: 'Lost write' })
+        )
+      )
+
+      expect(manager.isStoreDegraded()).to.equal(true)
+      expect(store.getStoredAlert(lost.id)).to.be.undefined
+      expect(failures.map((f) => f.operation)).to.deep.equal(['commit'])
+
+      const written = await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.2', message: 'Good write' })
+      )
+
+      expect(store.getStoredAlertCount()).to.equal(2)
+      expect(store.getStoredAlert(lost.id)).to.deep.equal(
+        manager.getAlert(lost.id)
+      )
+      expect(store.getStoredAlert(written.id)).to.deep.equal(
+        manager.getAlert(written.id)
+      )
+      expect(manager.isStoreDegraded()).to.equal(false)
+    })
+
+    it('should re-commit a removal the store rejected', async () => {
+      const removed = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          priority: 'caution',
+          message: 'Goes away'
+        })
+      )
+      const kept = await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.2', message: 'Stays' })
+      )
+      expect(store.getStoredAlertCount()).to.equal(2)
+
+      // Only the removal fails. Its alert leaves the registry, so no later
+      // transition names it again and the row outlives the alert unless the
+      // resync repeats the removal.
+      store.failAttempt = (attempt) => attempt === 3
+      const { result } = await captureConsole(() =>
+        manager.clearCondition(removed.id)
+      )
+
+      expect(result.cleared).to.equal(true)
+      expect(manager.getAlert(removed.id)).to.be.null
+      expect(store.getStoredAlert(removed.id)?.message).to.equal('Goes away')
+      expect(manager.isStoreDegraded()).to.equal(true)
+
+      await manager.acknowledgeAlert(kept.id)
+
+      expect(store.getStoredAlert(removed.id)).to.be.undefined
+      expect(store.getStoredAlertCount()).to.equal(1)
+      expect(store.getStoredAlert(kept.id)?.state).to.equal('acknowledged')
+      expect(manager.isStoreDegraded()).to.equal(false)
+    })
+
+    it('stays degraded when a write fails while the resync sweep runs', async () => {
+      const racing = new RacingAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, racing)
+
+      racing.failWhen = (transition) =>
+        transition.history.some((entry) => entry.message === 'Lost write')
+      const lost = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'test.alert.1', message: 'Lost write' })
+        )
+      )
+      expect(manager.isStoreDegraded()).to.equal(true)
+
+      // The sweep is about to succeed. A lifecycle write fails while it is in
+      // flight, so the sweep must not report the store healthy on the strength
+      // of its own writes alone.
+      racing.failWhen = (transition) =>
+        transition.history.some((entry) => entry.eventType === 'acknowledge')
+      racing.duringSweep = async () => {
+        await captureConsole(() =>
+          manager.acknowledgeAlert(lost.result.id, 'operator')
+        )
+      }
+
+      await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.2', message: 'Good write' })
+      )
+      // The sweep is detached, so let it run to its end before asking.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(manager.isStoreDegraded()).to.equal(true)
+    })
+
+    it('abandons the resync sweep when the manager stops under it', async () => {
+      const racing = new RacingAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, racing)
+      const stopped: StoreFailureEvent[] = []
+      manager.on('storeError', (event: StoreFailureEvent) =>
+        stopped.push(event)
+      )
+
+      racing.failWhen = (transition) =>
+        transition.history.some((entry) => entry.message === 'Lost write')
+      await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'test.alert.1', message: 'Lost write' })
+        )
+      )
+      expect(manager.isStoreDegraded()).to.equal(true)
+
+      // A stop closes the store under the detached sweep, so every write it
+      // makes afterwards fails. Standing in for that: the store rejects
+      // everything from the moment the manager stops.
+      racing.duringSweep = () => {
+        manager.stop()
+        racing.failWhen = () => true
+        return Promise.resolve()
+      }
+      stopped.length = 0
+
+      await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.2', message: 'Good write' })
+      )
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(stopped.map((f) => f.operation)).to.deep.equal([])
+      expect(manager.isStoreDegraded()).to.equal(true)
+    })
+
+    it('should report a failed resync and stay degraded', async () => {
+      // The write that triggers the resync lands; the resync's own re-commit
+      // does not.
+      store.failAttempt = (attempt) => attempt === 1 || attempt >= 3
+
+      const { result: lost } = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'test.alert.1', message: 'Lost write' })
+        )
+      )
+      const { result: written } = await captureConsole(() =>
+        manager.raiseAlert(
+          raiseParams({ path: 'test.alert.2', message: 'Good write' })
+        )
+      )
+
+      expect(store.getStoredAlert(written.id)?.message).to.equal('Good write')
+      expect(store.getStoredAlert(lost.id)).to.be.undefined
+      expect(manager.isStoreDegraded()).to.equal(true)
+
+      expect(failures.map((f) => f.operation)).to.deep.equal([
+        'commit',
+        'resync'
+      ])
+      expect(failures[1].alertId).to.be.null
+      expect(failures[1].error.message).to.equal('SQLite disk I/O error')
+    })
+  })
+
+  describe('transition commits', () => {
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+    })
+
+    it('should commit a raise as one transition holding the alert and its raise entry', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      expect(store.commitCount).to.equal(1)
+      expect(store.getStoredAlert(alert.id)).to.deep.equal(alert)
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('raise')
+      expect(store.history[0].alertId).to.equal(alert.id)
+      expect(store.history[0].newState).to.equal('unacknowledged')
+    })
+
+    it('should commit a clear as one transition that drops the alert and holds its clear entry', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'caution' })
+      )
+      store.resetHistory()
+      const commitsAfterRaise = store.commitCount
+
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(true)
+      expect(store.commitCount).to.equal(commitsAfterRaise + 1)
+      // The mock only drops a row for a transition whose alert is null.
+      expect(store.getStoredAlert(alert.id)).to.be.undefined
+      expect(store.getStoredAlertCount()).to.equal(0)
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('clear')
+      expect(store.history[0].newState).to.equal('normal')
+    })
+
+    it('should commit an escalating owner change as one transition carrying both entries', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-A',
+          priority: 'warning',
+          message: 'From A'
+        })
+      )
+      store.resetHistory()
+      const commitsAfterRaise = store.commitCount
+
+      const updated = await manager.raiseAlert(
+        raiseParams({
+          path: 'propulsion.port.oilPressureLow',
+          $source: 'source-B',
+          priority: 'alarm',
+          message: 'From B'
+        })
+      )
+
+      expect(store.commitCount).to.equal(commitsAfterRaise + 1)
+      expect(store.eventTypes()).to.deep.equal(['escalate', 'raise'])
+      expect(store.history[0].previousPriority).to.equal('warning')
+      expect(store.history[0].newPriority).to.equal('alarm')
+      expect(store.history[1].$source).to.equal('source-B')
+      expect(store.history[1].details).to.deep.equal({
+        previousSource: 'source-A'
+      })
+      expect(store.getStoredAlert(updated.id)).to.deep.equal(updated)
+    })
+
+    it('should commit a stale mark as a transition with no audit entries', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      manager.noteSourceUpdate(alert.id)
+      store.resetHistory()
+      const commitsAfterRaise = store.commitCount
+
+      fakeTimers.advanceTime(61 * 1000)
+      await Promise.resolve()
+
+      expect(store.commitCount).to.equal(commitsAfterRaise + 1)
+      // Staleness is a fact about the source, not a lifecycle event.
+      expect(store.history).to.have.lengthOf(0)
+      expect(store.getStoredAlert(alert.id)?.stale).to.equal(true)
+    })
+  })
+
+  describe('stop', () => {
+    it('should cancel all escalation timers on stop', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          priority: 'warning',
+          message: 'Warning 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          priority: 'warning',
+          message: 'Warning 2'
+        })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(2)
+
+      manager.stop()
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should cancel silence expiration timers on stop', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.silenceAlert(alert.id, 5000)
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      manager.stop()
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should not emit events after stop', async () => {
+      await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      events = []
+
+      manager.stop()
+      fakeTimers.advanceTime(300 * 1000)
+
+      expect(events).to.have.lengthOf(0)
+    })
+  })
+
+  describe('silenceAll', () => {
+    it('should skip an alert acknowledged while an earlier write awaited', async () => {
+      // silenceAll snapshots its candidates, then awaits a store write per
+      // alert. An acknowledge landing in that window must not be overwritten by
+      // the stale snapshot.
+      const store = new HookedAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      events = []
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const first = await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.1', message: 'Alert 1' })
+      )
+      const second = await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.2', message: 'Alert 2' })
+      )
+
+      store.onCommit = async () => {
+        await manager.acknowledgeAlert(second.id, 'operator')
+      }
+
+      await manager.silenceAll()
+
+      expect(manager.getAlert(first.id)?.silenced).to.equal(true)
+      const secondAfter = manager.getAlert(second.id)
+      expect(secondAfter?.state).to.equal('acknowledged')
+      expect(secondAfter?.acknowledgedBy).to.equal('operator')
+      expect(secondAfter?.silenced).to.equal(false)
+    })
+
+    it('should silence all unacknowledged alerts', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      const alert2 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+
+      await manager.silenceAll()
+
+      expect(manager.getAlert(alert1.id)?.silenced).to.equal(true)
+      expect(manager.getAlert(alert2.id)?.silenced).to.equal(true)
+    })
+
+    it('should emit silenced events for each alert', async () => {
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+      events = []
+
+      await manager.silenceAll()
+
+      const silencedEvents = events.filter((e) => e.type === 'silenced')
+      expect(silencedEvents).to.have.lengthOf(2)
+    })
+
+    it('should not silence acknowledged alerts', async () => {
+      const acknowledged = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      const unacknowledged = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+      await manager.acknowledgeAlert(acknowledged.id)
+      events = []
+
+      await manager.silenceAll()
+
+      expect(manager.getAlert(acknowledged.id)?.silenced).to.equal(false)
+      expect(manager.getAlert(unacknowledged.id)?.silenced).to.equal(true)
+      expect(events.filter((e) => e.type === 'silenced')).to.have.lengthOf(1)
+    })
+
+    it('should not silence already silenced alerts', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id)
+      events = []
+
+      await manager.silenceAll()
+
+      expect(events.filter((e) => e.type === 'silenced')).to.have.lengthOf(0)
+    })
+  })
+
+  describe('getActiveAlertCount', () => {
+    it('should return count of active alerts', async () => {
+      expect(manager.getActiveAlertCount()).to.equal(0)
+
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+
+      expect(manager.getActiveAlertCount()).to.equal(1)
+
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+
+      expect(manager.getActiveAlertCount()).to.equal(2)
+    })
+  })
+
+  describe('getUnacknowledgedCount', () => {
+    it('should return count of unacknowledged alerts', async () => {
+      const alert1 = await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.1',
+          $source: 'source-1',
+          message: 'Alert 1'
+        })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          $source: 'source-2',
+          message: 'Alert 2'
+        })
+      )
+
+      expect(manager.getUnacknowledgedCount()).to.equal(2)
+
+      await manager.acknowledgeAlert(alert1.id)
+
+      expect(manager.getUnacknowledgedCount()).to.equal(1)
+    })
+  })
+
+  describe('unsilenceAlert', () => {
+    it('should remove silenced flag from alert', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+
+      const unsilenced = await manager.unsilenceAlert(alert.id)
+
+      expect(unsilenced.silenced).to.equal(false)
+      expect(unsilenced.silencedUntil).to.be.undefined
+    })
+
+    it('should emit unsilenced event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.silenceAlert(alert.id)
+      events = []
+
+      await manager.unsilenceAlert(alert.id)
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('unsilenced')
+    })
+
+    it('should throw for non-existent alert', async () => {
+      await expectRejection(
+        manager.unsilenceAlert('non-existent'),
+        'Alert not found'
+      )
+    })
+  })
+
+  describe('silence expiration', () => {
+    it('should automatically unsilence alert after duration', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id, 5000) // 5 second silence
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+
+      fakeTimers.advanceTime(5000)
+
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(false)
+    })
+
+    it('should emit unsilenced event on expiration', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id, 5000)
+      events = []
+
+      fakeTimers.advanceTime(5000)
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('unsilenced')
+    })
+
+    it('should cancel expiration timer when manually unsilenced', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id, 5000)
+      await manager.unsilenceAlert(alert.id)
+      events = []
+
+      fakeTimers.advanceTime(5000)
+
+      // Should not emit another unsilenced event
+      expect(events).to.have.lengthOf(0)
+    })
+
+    it('should cancel expiration timer when alert is cleared', async () => {
+      // Caution auto-clears, so the condition going away removes the alert
+      // outright. An acknowledge first would unsilence it and the removal
+      // would never have a silence timer left to cancel.
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'caution' })
+      )
+
+      await manager.silenceAlert(alert.id, 5000)
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      const result = await manager.clearCondition(alert.id)
+
+      expect(result.cleared).to.equal(true)
+      expect(manager.getAlert(alert.id)).to.be.null
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should cancel silence timer and clear flags on acknowledge', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id, 5000)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+
+      await manager.acknowledgeAlert(alert.id)
+
+      // Silence flags should be cleared immediately on acknowledge
+      const acknowledged = manager.getAlert(alert.id)
+      expect(acknowledged?.silenced).to.equal(false)
+      expect(acknowledged?.silencedUntil).to.be.undefined
+
+      // Advancing past silence duration should not emit unsilenced event
+      events = []
+      fakeTimers.advanceTime(5000)
+      expect(events.filter((e) => e.type === 'unsilenced')).to.have.lengthOf(0)
+    })
+
+    it('should clear silenced rtn-unacknowledged alert without emitting unsilenced event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      // Silence, then clear condition -> rtn-unacknowledged (still silenced)
+      await manager.silenceAlert(alert.id, 10000)
+      await manager.clearCondition(alert.id)
+      expect(manager.getAlert(alert.id)?.state).to.equal('rtn-unacknowledged')
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+      const clearedAt = manager.getAlert(alert.id)?.clearedAt
+
+      // Acknowledge clears the alert entirely (rtn-unacknowledged -> cleared)
+      events = []
+      await manager.acknowledgeAlert(alert.id)
+
+      // Should emit 'cleared' but NOT 'unsilenced'
+      const clearedEvents = events.filter((e) => e.type === 'cleared')
+      expect(clearedEvents).to.have.lengthOf(1)
+      expect(clearedEvents[0].alert.state).to.equal('normal')
+      expect(clearedEvents[0].alert.condition).to.equal(false)
+      expect(clearedEvents[0].alert.clearedAt).to.equal(clearedAt)
+      expect(events.filter((e) => e.type === 'unsilenced')).to.have.lengthOf(0)
+      expect(manager.getAlert(alert.id)).to.be.null
+
+      // Silence timer should not fire
+      fakeTimers.advanceTime(10000)
+      expect(events.filter((e) => e.type === 'unsilenced')).to.have.lengthOf(0)
+    })
+  })
+
+  describe('priority escalation on update', () => {
+    it('should allow source to escalate priority', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      const updated = await manager.raiseAlert(raiseParams())
+
+      expect(updated.id).to.equal(alert.id)
+      expect(updated.priority).to.equal('alarm')
+    })
+
+    it('should not allow priority reduction', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const updated = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      expect(updated.id).to.equal(alert.id)
+      expect(updated.priority).to.equal('alarm') // Stays at alarm
+    })
+
+    it('should cancel escalation timer when priority is escalated by source', async () => {
+      await manager.raiseAlert(raiseParams({ priority: 'warning' }))
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.raiseAlert(raiseParams())
+
+      // Escalation timer should be cancelled since priority was manually escalated
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should start escalation timer when a re-raise promotes caution to warning', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'caution' })
+      )
+
+      // Caution does not escalate
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+
+      const updated = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      expect(updated.id).to.equal(alert.id)
+      expect(updated.priority).to.equal('warning')
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      fakeTimers.advanceTime(300 * 1000)
+      expect(manager.getAlert(alert.id)?.priority).to.equal('alarm')
+    })
+  })
+
+  describe('explicit escalateAlert', () => {
+    it('should escalate from warning to alarm', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      const updated = await manager.escalateAlert(alert.id, 'alarm')
+      expect(updated.id).to.equal(alert.id)
+      expect(updated.priority).to.equal('alarm')
+    })
+
+    it('should reject escalation to same priority', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await expectRejection(
+        manager.escalateAlert(alert.id, 'alarm'),
+        'Cannot escalate'
+      )
+    })
+
+    it('should reject de-escalation', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await expectRejection(
+        manager.escalateAlert(alert.id, 'warning'),
+        'Cannot escalate'
+      )
+    })
+
+    it('should throw for non-existent alert', async () => {
+      await expectRejection(
+        manager.escalateAlert('non-existent', 'alarm'),
+        'Alert not found'
+      )
+    })
+
+    it('should cancel escalation timer on explicit escalation', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.escalateAlert(alert.id, 'alarm')
+
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should emit escalated event', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+      events = []
+
+      await manager.escalateAlert(alert.id, 'alarm')
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('escalated')
+      expect(events[0].alert.priority).to.equal('alarm')
+    })
+
+    it('should reactivate acknowledged alert on escalation', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      await manager.acknowledgeAlert(alert.id)
+      const acked = manager.getAlert(alert.id)
+      expect(acked?.state).to.equal('acknowledged')
+
+      const updated = await manager.escalateAlert(alert.id, 'alarm')
+      expect(updated.state).to.equal('unacknowledged')
+      expect(updated.priority).to.equal('alarm')
+    })
+
+    it('should clear silence when escalating a silenced alert', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning' })
+      )
+
+      await manager.silenceAlert(alert.id)
+      const silenced = manager.getAlert(alert.id)
+      expect(silenced?.silenced).to.equal(true)
+
+      const updated = await manager.escalateAlert(alert.id, 'alarm')
+      expect(updated.silenced).to.equal(false)
+      expect(updated.silencedUntil).to.be.undefined
+      expect(updated.priority).to.equal('alarm')
+    })
+
+    it('advances stateChangedAt when escalating an unacknowledged alert', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      const before = alert.stateChangedAt
+      // Guarantee the wall clock advances past the raise timestamp.
+      await new Promise<void>((resolve) => setTimeout(resolve, 5))
+
+      const updated = await manager.escalateAlert(alert.id, 'alarm')
+
+      expect(updated.state).to.equal('unacknowledged')
+      expect(updated.priority).to.equal('alarm')
+      expect(updated.stateChangedAt > before).to.equal(true)
+    })
+
+    it('should start escalation timer when escalating caution to warning', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'caution' })
+      )
+
+      // Caution does not start an escalation timer
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+
+      await manager.escalateAlert(alert.id, 'warning')
+
+      // Warning should start an escalation timer
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      // Advance time to trigger escalation to alarm
+      fakeTimers.advanceTime(300 * 1000)
+      expect(manager.getAlert(alert.id)?.priority).to.equal('alarm')
+    })
+  })
+
+  describe('escalation persistence', () => {
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+    })
+
+    it('should persist escalation to store', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      // Give async store.update a chance to complete
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(store.getStoredAlert(alert.id)?.priority).to.equal('alarm')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should not raise alerts after stop', async () => {
+      manager.stop()
+
+      const alert = await manager.raiseAlert(raiseParams())
+
+      // Alert is still created in memory but no events are emitted
+      expect(alert).to.not.be.undefined
+      expect(events.filter((e) => e.type === 'raised')).to.have.lengthOf(0)
+    })
+
+    it('should handle silencing an already silenced alert', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.silenceAlert(alert.id, 10000)
+      const firstSilencedUntil = manager.getAlert(alert.id)?.silencedUntil
+
+      await manager.silenceAlert(alert.id, 20000)
+      const secondSilencedUntil = manager.getAlert(alert.id)?.silencedUntil
+
+      // Second silence should update the silencedUntil
+      expect(secondSilencedUntil).to.not.equal(firstSilencedUntil)
+    })
+  })
+
+  describe('loadFromStore', () => {
+    const TIMEOUT_MS = 300 * 1000
+    // A load that succeeds arms the daily retention prune, so every pending
+    // count below is the timers under test plus that one.
+    const RETENTION_TIMERS = 1
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+    })
+
+    it('should load alerts from store into memory', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'stored-1',
+          path: 'stored.alert.1',
+          message: 'Alert 1'
+        }),
+        storedAlert({
+          id: 'stored-2',
+          path: 'stored.alert.2',
+          message: 'Alert 2'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(manager.getActiveAlertCount()).to.equal(2)
+      expect(manager.getAlert('stored-1')?.message).to.equal('Alert 1')
+      expect(manager.getAlert('stored-2')?.message).to.equal('Alert 2')
+    })
+
+    it('should rebuild alert index for duplicate detection', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'stored-1',
+          $source: 'test-source',
+          message: 'Test message'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Raising an alert with the same path should update the existing one
+      const updated = await manager.raiseAlert(
+        raiseParams({ path: 'stored.alert', message: 'Test message' })
+      )
+
+      // Should be the same alert, not a new one
+      expect(updated.id).to.equal('stored-1')
+      expect(manager.getActiveAlertCount()).to.equal(1)
+    })
+
+    it('should restart escalation timers for unacknowledged warnings', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'warning-1',
+          priority: 'warning',
+          state: 'unacknowledged'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should have started an escalation timer
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+      // Advance time to trigger escalation
+      fakeTimers.advanceTime(TIMEOUT_MS)
+
+      // Should have escalated to alarm
+      expect(manager.getAlert('warning-1')?.priority).to.equal('alarm')
+    })
+
+    it('should account for elapsed time when restarting escalation timers', async () => {
+      // A warning that last changed state 250 seconds ago (50 seconds
+      // remaining)
+      const pastTimestamp = new Date(Date.now() - 250 * 1000).toISOString()
+      store.prePopulate([
+        storedAlert({
+          id: 'old-warning',
+          priority: 'warning',
+          state: 'unacknowledged',
+          raisedAt: pastTimestamp,
+          stateChangedAt: pastTimestamp
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Timer should be set for remaining ~50 seconds, not full 300 seconds
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+      // Should NOT escalate after 40 seconds (still 10 seconds remaining)
+      fakeTimers.advanceTime(40 * 1000)
+      expect(manager.getAlert('old-warning')?.priority).to.equal('warning')
+
+      // Should escalate after another 20 seconds (total 60 seconds, past remaining 50)
+      fakeTimers.advanceTime(20 * 1000)
+      expect(manager.getAlert('old-warning')?.priority).to.equal('alarm')
+    })
+
+    it('should escalate warnings that have exceeded timeout on the next tick', async () => {
+      // A warning that last changed state 400 seconds ago (already past
+      // the 300s timeout)
+      const oldTimestamp = new Date(Date.now() - 400 * 1000).toISOString()
+      store.prePopulate([
+        storedAlert({
+          id: 'very-old-warning',
+          priority: 'warning',
+          state: 'unacknowledged',
+          raisedAt: oldTimestamp,
+          stateChangedAt: oldTimestamp
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // A spent window escalates through a zero-delay timer, so the restore
+      // finishes before the escalation rather than inside it.
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+      expect(manager.getAlert('very-old-warning')?.priority).to.equal('warning')
+
+      fakeTimers.advanceTime(0)
+
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+      expect(manager.getAlert('very-old-warning')?.priority).to.equal('alarm')
+    })
+
+    it('should give a full window to a stateChangedAt ahead of the clock', async () => {
+      // A Raspberry Pi boots before NTP steps its clock, so a stored timestamp
+      // can sit in the future. That must not read as an overdue escalation.
+      const futureTimestamp = new Date(Date.now() + 600 * 1000).toISOString()
+      store.prePopulate([
+        storedAlert({
+          id: 'future-warning',
+          priority: 'warning',
+          state: 'unacknowledged',
+          raisedAt: futureTimestamp,
+          stateChangedAt: futureTimestamp
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+      expect(manager.getAlert('future-warning')?.priority).to.equal('warning')
+
+      fakeTimers.advanceTime(TIMEOUT_MS - 2000)
+      expect(manager.getAlert('future-warning')?.priority).to.equal('warning')
+
+      fakeTimers.advanceTime(4000)
+      expect(manager.getAlert('future-warning')?.priority).to.equal('alarm')
+    })
+
+    it('should give a full window to a malformed stateChangedAt', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'malformed-warning',
+          priority: 'warning',
+          state: 'unacknowledged',
+          stateChangedAt: 'not-a-timestamp'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+      fakeTimers.advanceTime(TIMEOUT_MS - 2000)
+      expect(manager.getAlert('malformed-warning')?.priority).to.equal(
+        'warning'
+      )
+
+      fakeTimers.advanceTime(4000)
+      expect(manager.getAlert('malformed-warning')?.priority).to.equal('alarm')
+    })
+
+    it('should give a full window to an unusable configured timeout', async () => {
+      // resumeEscalation must read the window the timer resolved, not the raw
+      // setting: a NaN reaches setTimeout and escalates every restored warning
+      // on the next tick, which is the guard's whole purpose.
+      manager.stop()
+      manager = await captureConsole(() => {
+        const started = new AlertManager(
+          {
+            ...defaultConfig,
+            escalation: { enabled: true, timeoutSeconds: Number.NaN }
+          },
+          fakeTimers,
+          store
+        )
+        store.prePopulate([
+          storedAlert({
+            id: 'nan-timeout-warning',
+            priority: 'warning',
+            state: 'unacknowledged'
+          })
+        ])
+        return started.loadFromStore().then(() => started)
+      }).then((captured) => captured.result)
+
+      fakeTimers.advanceTime(0)
+      expect(manager.getAlert('nan-timeout-warning')?.priority).to.equal(
+        'warning'
+      )
+
+      fakeTimers.advanceTime(TIMEOUT_MS)
+      expect(manager.getAlert('nan-timeout-warning')?.priority).to.equal(
+        'alarm'
+      )
+    })
+
+    it('should not start escalation timers for caution priority', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'caution-1',
+          priority: 'caution',
+          state: 'unacknowledged'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Caution alerts don't escalate
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+    })
+
+    it('should not start escalation timers for rtn-unacknowledged state', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'rtn-warning',
+          priority: 'warning',
+          state: 'rtn-unacknowledged'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // RTN alerts have cleared condition, no need to escalate
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+    })
+
+    it('should not start escalation timers for acknowledged alerts', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'warning-1',
+          priority: 'warning',
+          state: 'acknowledged'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should not have started an escalation timer
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+    })
+
+    it('should not start escalation timers for a latched warning whose condition cleared', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'latched-warning',
+          priority: 'warning',
+          state: 'unacknowledged',
+          condition: false,
+          latching: true,
+          clearedAt: new Date().toISOString()
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+
+      fakeTimers.advanceTime(TIMEOUT_MS)
+      expect(manager.getAlert('latched-warning')?.priority).to.equal('warning')
+    })
+
+    it('should escalate a restored warning after its remaining time', async () => {
+      const stateChangedAt = new Date(Date.now() - 200_000).toISOString()
+      store.prePopulate([
+        storedAlert({
+          id: 'restored-warning',
+          path: 'propulsion.port.oilPressureLow',
+          priority: 'warning',
+          state: 'unacknowledged',
+          raisedAt: stateChangedAt,
+          stateChangedAt
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      fakeTimers.advanceTime(TIMEOUT_MS - 200_000 - 2_000)
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(4_000)
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(1)
+      expect(manager.getAlert('restored-warning')?.priority).to.equal('alarm')
+    })
+
+    it('should not escalate a warning that changed state just before the reload', async () => {
+      // Raised long ago, reactivated 5 s before the restart: escalation is
+      // owed from the reactivation, not from the original raise.
+      store.prePopulate([
+        storedAlert({
+          id: 'restored-warning',
+          path: 'propulsion.port.oilPressureLow',
+          priority: 'warning',
+          state: 'unacknowledged',
+          raisedAt: new Date(Date.now() - 10 * TIMEOUT_MS).toISOString(),
+          stateChangedAt: new Date(Date.now() - 5_000).toISOString()
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(0)
+      expect(manager.getAlert('restored-warning')?.priority).to.equal('warning')
+
+      fakeTimers.advanceTime(TIMEOUT_MS - 5_000 - 2_000)
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(4_000)
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(1)
+    })
+
+    it('should restart silence expiration timers for silenced alerts', async () => {
+      const futureTime = new Date(Date.now() + 15000).toISOString() // 15 seconds from now
+      store.prePopulate([
+        storedAlert({
+          id: 'silenced-1',
+          silenced: true,
+          silencedUntil: futureTime
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should have started a silence timer
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+      // Verify it unsilences when time expires
+      fakeTimers.advanceTime(16000)
+      expect(manager.getAlert('silenced-1')?.silenced).to.equal(false)
+    })
+
+    it('should clamp a resumed silence to the configured maximum', async () => {
+      // 10 minutes of silence remaining, against a 120 s alarm maximum.
+      store.prePopulate([
+        storedAlert({
+          id: 'over-silenced',
+          silenced: true,
+          silencedUntil: new Date(Date.now() + 10 * 60 * 1000).toISOString()
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+      fakeTimers.advanceTime(119_000)
+      expect(manager.getAlert('over-silenced')?.silenced).to.equal(true)
+
+      fakeTimers.advanceTime(2_000)
+      expect(manager.getAlert('over-silenced')?.silenced).to.equal(false)
+    })
+
+    it('should immediately unsilence alerts with expired silence time', async () => {
+      const pastTime = new Date(Date.now() - 1000).toISOString() // 1 second ago
+      store.prePopulate([
+        storedAlert({
+          id: 'expired-silenced',
+          silenced: true,
+          silencedUntil: pastTime
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should have immediately unsilenced
+      expect(manager.getAlert('expired-silenced')?.silenced).to.equal(false)
+    })
+
+    it('should immediately unsilence alerts with a malformed silencedUntil', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'malformed-silenced',
+          silenced: true,
+          silencedUntil: 'not-a-timestamp'
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      const loaded = manager.getAlert('malformed-silenced')
+      expect(loaded?.silenced).to.equal(false)
+      expect(loaded?.silencedUntil).to.be.undefined
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+    })
+
+    it('should emit unsilenced event for expired silences', async () => {
+      const pastTime = new Date(Date.now() - 1000).toISOString()
+      store.prePopulate([
+        storedAlert({
+          id: 'expired-with-event',
+          silenced: true,
+          silencedUntil: pastTime
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should have emitted unsilenced event
+      const unsilencedEvents = events.filter((e) => e.type === 'unsilenced')
+      expect(unsilencedEvents).to.have.lengthOf(1)
+      expect(unsilencedEvents[0].alert.id).to.equal('expired-with-event')
+    })
+
+    it('should escalate and unsilence an alert that is overdue for both', async () => {
+      // The registry is populated first and the timers resumed per alert
+      // afterwards, so the unsilence builds on the escalated value instead of
+      // reverting it.
+      store.prePopulate([
+        storedAlert({
+          id: 'overdue-both',
+          priority: 'warning',
+          state: 'unacknowledged',
+          condition: true,
+          stateChangedAt: new Date(Date.now() - 400 * 1000).toISOString(),
+          silenced: true,
+          silencedUntil: new Date(Date.now() - 1000).toISOString()
+        })
+      ])
+
+      await manager.loadFromStore()
+      fakeTimers.advanceTime(0)
+
+      const loaded = manager.getAlert('overdue-both')
+      expect(loaded?.priority).to.equal('alarm')
+      expect(loaded?.silenced).to.equal(false)
+      expect(loaded?.silencedUntil).to.be.undefined
+      expect(events.filter((e) => e.type === 'escalated')).to.have.lengthOf(1)
+    })
+
+    it('should leave silenced alerts without silencedUntil as silenced', async () => {
+      store.prePopulate([
+        storedAlert({
+          id: 'silenced-no-until',
+          silenced: true
+          // silencedUntil intentionally undefined
+        })
+      ])
+
+      await manager.loadFromStore()
+
+      // Should remain silenced (no timer started, no unsilencing)
+      expect(manager.getAlert('silenced-no-until')?.silenced).to.equal(true)
+      expect(fakeTimers.getPendingCount()).to.equal(RETENTION_TIMERS)
+    })
+
+    it('should handle empty store gracefully', async () => {
+      await manager.loadFromStore()
+
+      expect(manager.getActiveAlertCount()).to.equal(0)
+    })
+
+    it('should fail loudly when store.getAll() fails', async () => {
+      // Deliberate behavior: an unreadable store must surface as a startup
+      // failure rather than silently presenting an empty alert set.
+      store.getAll = () => Promise.reject(new Error('SQLite disk I/O error'))
+
+      const { errors } = await captureConsole(() =>
+        expectRejection(manager.loadFromStore(), 'SQLite disk I/O error')
+      )
+
+      expect(manager.getActiveAlertCount()).to.equal(0)
+      expect(errors).to.have.lengthOf(1)
+    })
+
+    it('should work without store configured', async () => {
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers) // No store
+
+      // Should not throw
+      await manager.loadFromStore()
+      expect(manager.getActiveAlertCount()).to.equal(0)
+    })
+
+    it('should preserve all alert fields when loading', async () => {
+      const fullAlert = storedAlert({
+        id: 'full-alert',
+        $source: 'source-123',
+        priority: 'emergency',
+        state: 'acknowledged',
+        condition: false,
+        latching: true,
+        silenced: false,
+        message: 'Full alert message',
+        group: 'engine',
+        data: { temperature: 95 },
+        acknowledgedAt: new Date().toISOString(),
+        acknowledgedBy: 'user-1',
+        context: 'vessels.self'
+      })
+      store.prePopulate([fullAlert])
+
+      await manager.loadFromStore()
+
+      const loaded = manager.getAlert('full-alert')
+      expect(loaded).to.deep.equal(fullAlert)
+    })
+
+    it('should survive manager restart with persisted alerts', async () => {
+      // Create an alert
+      const alert = await manager.raiseAlert(
+        raiseParams({ message: 'Persistent alert' })
+      )
+
+      // Stop and create a new manager with the same store
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+
+      // Load from store
+      await manager.loadFromStore()
+
+      // Alert should be restored
+      expect(manager.getActiveAlertCount()).to.equal(1)
+      expect(manager.getAlert(alert.id)?.message).to.equal('Persistent alert')
+    })
+  })
+
+  describe('history logging', () => {
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        store
+      )
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+    })
+
+    it('should log raise event', async () => {
+      const context = 'vessels.urn:mrn:signalk:uuid:test'
+      await manager.raiseAlert(raiseParams({ group: 'engine', context }))
+
+      expect(store.history).to.have.lengthOf(1)
+      const entry = store.history[0]
+      expect(entry.eventType).to.equal('raise')
+      expect(entry.newState).to.equal('unacknowledged')
+
+      // The alert's identity is copied onto the entry as first-class fields.
+      expect(entry.path).to.equal('test.alert')
+      expect(entry.context).to.equal(context)
+      expect(entry.priority).to.equal('alarm')
+      expect(entry.message).to.equal('Test alert')
+      expect(entry.$source).to.equal('test-source')
+      expect(entry.details).to.be.undefined
+    })
+
+    it('should log acknowledge event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      store.resetHistory()
+
+      await manager.acknowledgeAlert(alert.id, 'user-1')
+
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('acknowledge')
+      expect(store.history[0].userId).to.equal('user-1')
+      expect(store.history[0].previousState).to.equal('unacknowledged')
+      expect(store.history[0].newState).to.equal('acknowledged')
+    })
+
+    it('should log clear event with newState cleared when RTN alert is acknowledged', async () => {
+      const alert = await manager.raiseAlert(raiseParams({ group: 'engine' }))
+      await manager.clearCondition(alert.id)
+      store.resetHistory()
+
+      await manager.acknowledgeAlert(alert.id)
+
+      expect(store.history).to.have.lengthOf(1)
+      const entry = store.history[0]
+      expect(entry.eventType).to.equal('clear')
+      expect(entry.newState).to.equal('normal')
+      expect(entry.path).to.equal('test.alert')
+      expect(entry.priority).to.equal('alarm')
+      expect(entry.message).to.equal('Test alert')
+      expect(entry.$source).to.equal('test-source')
+      expect(entry.details).to.be.undefined
+    })
+
+    it('should log silence event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      store.resetHistory()
+
+      await manager.silenceAlert(alert.id, 30000)
+
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('silence')
+      expect(store.history[0].details).to.have.property('silencedUntil')
+    })
+
+    it('should log unsilence event', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.silenceAlert(alert.id, 30000)
+      store.resetHistory()
+
+      await manager.unsilenceAlert(alert.id)
+
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('unsilence')
+    })
+
+    it('should log clear event with newState cleared on clearCondition (when alert is removed)', async () => {
+      const alert = await manager.raiseAlert(raiseParams({ group: 'engine' }))
+      await manager.acknowledgeAlert(alert.id)
+      store.resetHistory()
+
+      await manager.clearCondition(alert.id)
+
+      expect(store.history).to.have.lengthOf(1)
+      const entry = store.history[0]
+      expect(entry.eventType).to.equal('clear')
+      expect(entry.newState).to.equal('normal')
+      expect(entry.path).to.equal('test.alert')
+      expect(entry.priority).to.equal('alarm')
+      expect(entry.message).to.equal('Test alert')
+      expect(entry.$source).to.equal('test-source')
+      expect(entry.details).to.be.undefined
+    })
+
+    it('should log clear event on clearCondition (RTN transition)', async () => {
+      const alert = await manager.raiseAlert(raiseParams({ group: 'engine' }))
+      store.resetHistory()
+
+      await manager.clearCondition(alert.id)
+
+      expect(store.history).to.have.lengthOf(1)
+      const entry = store.history[0]
+      expect(entry.eventType).to.equal('clear')
+      expect(entry.newState).to.equal('rtn-unacknowledged')
+      expect(entry.path).to.equal('test.alert')
+      expect(entry.priority).to.equal('alarm')
+      expect(entry.message).to.equal('Test alert')
+      expect(entry.$source).to.equal('test-source')
+      expect(entry.details).to.be.undefined
+    })
+
+    it('should log escalate event', async () => {
+      await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      store.resetHistory()
+
+      fakeTimers.advanceTime(300 * 1000)
+
+      // Give fire-and-forget a chance to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('escalate')
+      expect(store.history[0].previousPriority).to.equal('warning')
+      expect(store.history[0].newPriority).to.equal('alarm')
+    })
+
+    it('should log the state change an operator escalation causes', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+      await manager.acknowledgeAlert(alert.id)
+      store.resetHistory()
+
+      await manager.escalateAlert(alert.id, 'alarm')
+
+      expect(store.history).to.have.lengthOf(1)
+      const entry = store.history[0]
+      expect(entry.eventType).to.equal('escalate')
+      expect(entry.previousState).to.equal('acknowledged')
+      expect(entry.newState).to.equal('unacknowledged')
+      expect(entry.previousPriority).to.equal('warning')
+      expect(entry.newPriority).to.equal('alarm')
+    })
+
+    it('should log unsilence event on silence expiration', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.silenceAlert(alert.id, 5000)
+      store.resetHistory()
+
+      fakeTimers.advanceTime(5000)
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(store.history).to.have.lengthOf(1)
+      expect(store.history[0].eventType).to.equal('unsilence')
+    })
+
+    it('should log silence events for each alert in silenceAll', async () => {
+      await manager.raiseAlert(
+        raiseParams({ path: 'test.alert.1', message: 'Alert 1' })
+      )
+      await manager.raiseAlert(
+        raiseParams({
+          path: 'test.alert.2',
+          priority: 'warning',
+          message: 'Alert 2'
+        })
+      )
+      store.resetHistory()
+
+      await manager.silenceAll()
+
+      const silenceEntries = store.entriesOfType('silence')
+      expect(silenceEntries).to.have.lengthOf(2)
+      expect(silenceEntries.every((e) => e.details?.silencedUntil)).to.equal(
+        true
+      )
+    })
+
+    it('should log escalate event when re-raising with higher priority', async () => {
+      await manager.raiseAlert(raiseParams({ priority: 'warning' }))
+      store.resetHistory()
+
+      await manager.raiseAlert(raiseParams())
+
+      const escalateEntries = store.entriesOfType('escalate')
+      expect(escalateEntries).to.have.lengthOf(1)
+      expect(escalateEntries[0].previousPriority).to.equal('warning')
+      expect(escalateEntries[0].newPriority).to.equal('alarm')
+    })
+
+    it('should log unsilence event for expired silence on loadFromStore', async () => {
+      // Seed a silenced alert with expired silencedUntil directly into the store
+      store.prePopulate([
+        storedAlert({
+          id: 'expired-silence-1',
+          path: 'test.expired.silence',
+          $source: 'test-source',
+          silenced: true,
+          silencedUntil: new Date(Date.now() - 1000).toISOString(),
+          raisedAt: new Date(Date.now() - 60000).toISOString(),
+          stateChangedAt: new Date(Date.now() - 60000).toISOString()
+        })
+      ])
+      store.resetHistory()
+
+      // Create a new manager and load from store
+      const newManager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        store
+      )
+      await newManager.loadFromStore()
+
+      expect(store.entriesOfType('unsilence')).to.have.lengthOf(1)
+      newManager.stop()
+    })
+
+    it('should keep the alert when its transition fails to commit', async () => {
+      // The audit entries travel with the alert write, so a rejecting store
+      // loses both together — the alert itself survives in the registry.
+      manager.stop()
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        new FailingAlertStore()
+      )
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+      const failures: StoreFailureEvent[] = []
+      manager.on('storeError', (event: StoreFailureEvent) =>
+        failures.push(event)
+      )
+
+      const { result: alert, errors } = await captureConsole(() =>
+        manager.raiseAlert(raiseParams())
+      )
+
+      // The alert survives the failed commit, intact.
+      const kept = manager.getAlert(alert.id)
+      expect(kept).to.not.be.null
+      expect(kept?.message).to.equal('Test alert')
+
+      // The failure is recorded rather than swallowed silently.
+      expect(manager.isStoreDegraded()).to.equal(true)
+      expect(failures.map((f) => f.operation)).to.deep.equal(['commit'])
+      expect(failures[0].alertId).to.equal(alert.id)
+      expect(errors).to.have.lengthOf(1)
+    })
+
+    it('should prune history on loadFromStore', async () => {
+      await manager.loadFromStore()
+
+      // Give fire-and-forget a chance to resolve
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(store.pruneCalledWith).to.deep.equal([90])
+    })
+
+    it('should work without a store (no errors)', async () => {
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const alert = await manager.raiseAlert(raiseParams())
+
+      const kept = manager.getAlert(alert.id)
+      expect(kept).to.not.be.null
+      expect(kept?.message).to.equal('Test alert')
+    })
+  })
+
+  describe('history retention', () => {
+    const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000
+    const DEFAULT_RETENTION_DAYS = 90
+    let store: MockAlertStore
+
+    beforeEach(() => {
+      store = new MockAlertStore()
+      manager.stop()
+    })
+
+    it('should keep pruning every 24 hours after the initial load', async () => {
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        store
+      )
+
+      await manager.loadFromStore()
+
+      expect(store.pruneCalledWith).to.deep.equal([90])
+
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([90, 90])
+
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([90, 90, 90])
+    })
+
+    it('should stop the repeating prune when the manager stops', async () => {
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 90 },
+        fakeTimers,
+        store
+      )
+      await manager.loadFromStore()
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([90, 90])
+
+      manager.stop()
+
+      fakeTimers.advanceTime(3 * PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([90, 90])
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should apply the default window when none is configured', async () => {
+      // Unbounded is the wrong default on a device whose root filesystem is an
+      // SD card, so an absent setting means 90 days rather than never.
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+
+      await manager.loadFromStore()
+
+      expect(store.pruneCalledWith).to.deep.equal([DEFAULT_RETENTION_DAYS])
+
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([
+        DEFAULT_RETENTION_DAYS,
+        DEFAULT_RETENTION_DAYS
+      ])
+    })
+
+    it('should prefer a configured window over the default', async () => {
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 7 },
+        fakeTimers,
+        store
+      )
+
+      await manager.loadFromStore()
+
+      expect(store.pruneCalledWith).to.deep.equal([7])
+
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+      expect(store.pruneCalledWith).to.deep.equal([7, 7])
+    })
+
+    for (const retentionDays of [0, -1, 1.5, NaN]) {
+      it(`should refuse a retention window of ${String(retentionDays)} as a configuration error`, async () => {
+        manager = new AlertManager(
+          { ...defaultConfig, retentionDays },
+          fakeTimers,
+          store
+        )
+
+        const { errors } = await captureConsole(() => manager.loadFromStore())
+
+        expect(store.pruneCalledWith).to.deep.equal([])
+        expect(fakeTimers.getPendingCount()).to.equal(0)
+        // A bad setting is the operator's to fix, not lost durability.
+        expect(manager.isStoreDegraded()).to.equal(false)
+        expect(errors).to.have.lengthOf(1)
+        expect(String(errors[0][0])).to.include(
+          'must be a whole number of days'
+        )
+
+        fakeTimers.advanceTime(2 * PRUNE_INTERVAL_MS)
+        expect(store.pruneCalledWith).to.deep.equal([])
+      })
+    }
+
+    it('should not prune or schedule when the load fails', async () => {
+      // A store this server has decided it cannot use is left alone, and no
+      // timer outlives the aborted startup.
+      store.getAll = () => Promise.reject(new Error('SQLite disk I/O error'))
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 30 },
+        fakeTimers,
+        store
+      )
+
+      const { errors } = await captureConsole(() =>
+        expectRejection(manager.loadFromStore(), 'SQLite disk I/O error')
+      )
+
+      expect(store.pruneCalledWith).to.deep.equal([])
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+      expect(errors).to.have.lengthOf(1)
+    })
+
+    it('should keep one prune timer when the store is loaded twice', async () => {
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 30 },
+        fakeTimers,
+        store
+      )
+
+      await manager.loadFromStore()
+      await manager.loadFromStore()
+
+      expect(store.pruneCalledWith).to.deep.equal([30, 30])
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      fakeTimers.advanceTime(PRUNE_INTERVAL_MS)
+
+      expect(store.pruneCalledWith).to.deep.equal([30, 30, 30])
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+    })
+
+    it('should report a failed prune without preventing the load', async () => {
+      store.pruneHistory = () =>
+        Promise.reject(new Error('SQLite disk I/O error'))
+      store.prePopulate([storedAlert({ id: 'kept-1', message: 'Kept alert' })])
+      manager = new AlertManager(
+        { ...defaultConfig, retentionDays: 30 },
+        fakeTimers,
+        store
+      )
+      const failures: StoreFailureEvent[] = []
+      manager.on('storeError', (event: StoreFailureEvent) =>
+        failures.push(event)
+      )
+
+      const { errors } = await captureConsole(async () => {
+        await manager.loadFromStore()
+        // The prune is fire-and-forget; let its rejection settle.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(manager.getAlert('kept-1')?.message).to.equal('Kept alert')
+      // An unpruned trail is not a durability failure: the store and the
+      // registry still agree about every active alert.
+      expect(manager.isStoreDegraded()).to.equal(false)
+      expect(failures).to.have.lengthOf(1)
+      expect(failures[0].operation).to.equal('prune')
+      expect(failures[0].alertId).to.be.null
+      expect(errors).to.have.lengthOf(1)
+    })
+  })
+
+  describe('re-raise reactivation', () => {
+    it('should reactivate acknowledged alert to unacknowledged on re-raise', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id, 'user-1')
+      expect(manager.getAlert(alert.id)?.state).to.equal('acknowledged')
+
+      const reraised = await manager.raiseAlert(
+        raiseParams({ message: 'Test alert re-raised' })
+      )
+
+      expect(reraised.id).to.equal(alert.id)
+      expect(reraised.state).to.equal('unacknowledged')
+      expect(reraised.acknowledgedAt).to.be.undefined
+      expect(reraised.acknowledgedBy).to.be.undefined
+    })
+
+    it('should reactivate rtn-unacknowledged alert to unacknowledged on re-raise', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.clearCondition(alert.id)
+      expect(manager.getAlert(alert.id)?.state).to.equal('rtn-unacknowledged')
+
+      const reraised = await manager.raiseAlert(
+        raiseParams({ message: 'Test alert re-raised' })
+      )
+
+      expect(reraised.id).to.equal(alert.id)
+      expect(reraised.state).to.equal('unacknowledged')
+      expect(reraised.clearedAt).to.be.undefined
+    })
+
+    it('should emit raised event on reactivation (not updated)', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id)
+      events = []
+
+      await manager.raiseAlert(raiseParams({ message: 'Test alert re-raised' }))
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('raised')
+      expect(events[0].previousState).to.equal('acknowledged')
+    })
+
+    it('should emit updated event for unacknowledged re-raise (no state change)', async () => {
+      await manager.raiseAlert(raiseParams())
+      events = []
+
+      await manager.raiseAlert(raiseParams({ message: 'Test alert updated' }))
+
+      expect(events).to.have.lengthOf(1)
+      expect(events[0].type).to.equal('updated')
+    })
+
+    it('should restart escalation timer for reactivated warning', async () => {
+      const alert = await manager.raiseAlert(
+        raiseParams({ priority: 'warning', message: 'Test warning' })
+      )
+
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      await manager.acknowledgeAlert(alert.id)
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+
+      await manager.raiseAlert(
+        raiseParams({
+          priority: 'warning',
+          message: 'Test warning re-raised'
+        })
+      )
+
+      // Escalation timer should be restarted
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+
+      // Verify it fires
+      fakeTimers.advanceTime(300 * 1000)
+      expect(manager.getAlert(alert.id)?.priority).to.equal('alarm')
+    })
+
+    it('should un-silence and cancel silence timer on re-raise', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      await manager.acknowledgeAlert(alert.id)
+      // Silence the acknowledged alert
+      await manager.silenceAlert(alert.id, 30000)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+
+      await manager.raiseAlert(raiseParams({ message: 'Test alert re-raised' }))
+
+      const reactivated = manager.getAlert(alert.id)
+      expect(reactivated?.silenced).to.equal(false)
+      expect(reactivated?.silencedUntil).to.be.undefined
+
+      // Silence timer should not fire (was cancelled)
+      events = []
+      fakeTimers.advanceTime(30000)
+      expect(events.filter((e) => e.type === 'unsilenced')).to.have.lengthOf(0)
+    })
+
+    it('should un-silence on idempotent re-raise of unacknowledged alert', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+
+      // Silence without acknowledging first
+      await manager.silenceAlert(alert.id, 30000)
+      expect(manager.getAlert(alert.id)?.silenced).to.equal(true)
+      expect(manager.getAlert(alert.id)?.state).to.equal('unacknowledged')
+
+      // Re-raise the same alert (idempotent reactivation)
+      await manager.raiseAlert(raiseParams({ message: 'Test alert re-raised' }))
+
+      const reactivated = manager.getAlert(alert.id)
+      expect(reactivated?.state).to.equal('unacknowledged')
+      expect(reactivated?.silenced).to.equal(false)
+      expect(reactivated?.silencedUntil).to.be.undefined
+
+      // Silence timer should not fire (was cancelled)
+      events = []
+      fakeTimers.advanceTime(30000)
+      expect(events.filter((e) => e.type === 'unsilenced')).to.have.lengthOf(0)
+    })
+
+    it('should preserve raisedAt on reactivation', async () => {
+      const alert = await manager.raiseAlert(raiseParams())
+      const originalRaisedAt = alert.raisedAt
+
+      await manager.acknowledgeAlert(alert.id)
+
+      const reraised = await manager.raiseAlert(
+        raiseParams({ message: 'Test alert re-raised' })
+      )
+
+      expect(reraised.raisedAt).to.equal(originalRaisedAt)
+    })
+
+    it('should log raise history event on reactivation', async () => {
+      const store = new MockAlertStore()
+      manager.stop()
+      manager = new AlertManager(defaultConfig, fakeTimers, store)
+      manager.on('alert', (event: AlertEvent) => events.push(event))
+
+      const alert = await manager.raiseAlert(raiseParams())
+      await manager.acknowledgeAlert(alert.id)
+      store.resetHistory()
+
+      await manager.raiseAlert(raiseParams({ message: 'Test alert re-raised' }))
+
+      const raiseEntries = store.entriesOfType('raise')
+      expect(raiseEntries).to.have.lengthOf(1)
+      expect(raiseEntries[0].previousState).to.equal('acknowledged')
+      expect(raiseEntries[0].newState).to.equal('unacknowledged')
+    })
+  })
+})

--- a/test/api/alerts/alertPersistence.test.ts
+++ b/test/api/alerts/alertPersistence.test.ts
@@ -1,0 +1,492 @@
+/**
+ * The alert manager against real persistence.
+ *
+ * Every other alerts suite exercises one side of the seam: the manager tests
+ * run on an in-memory double, and the store tests run without a manager. These
+ * wire a real AlertStore on a temp file to a real AlertManager and restart the
+ * pair, which is the only way to see whether what one wrote is what the other
+ * reads back.
+ */
+
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  AlertManager,
+  type AlertEvent,
+  type AlertManagerConfig
+} from '../../../src/api/alerts/alertManager'
+import { AlertStore } from '../../../src/api/alerts/alertStore'
+import type { Alert } from '../../../src/api/alerts/types'
+import { FakeTimerFunctions } from './helpers/fakeTimerFunctions'
+import {
+  asPath,
+  asSourceRef,
+  captureConsole,
+  presentAlert,
+  raiseParams
+} from './helpers/fixtures'
+
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+const ESCALATION_TIMEOUT_MS = 300 * 1000
+
+/** The window `escalationTimer.ts` falls back to for an unusable setting. */
+const DEFAULT_ESCALATION_TIMEOUT_MS = 300 * 1000
+
+/**
+ * The daily retention prune a successful load arms, which every pending-timer
+ * count below carries on top of the timers under test.
+ */
+const RETENTION_TIMERS = 1
+
+/**
+ * Let a fire-and-forget store write settle before reading the file back.
+ */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('alerts persistence', () => {
+  let tempDir: string
+  let dbPath: string
+  let stores: AlertStore[]
+  let managers: AlertManager[]
+
+  const config: AlertManagerConfig = {
+    escalation: {
+      enabled: true,
+      timeoutSeconds: ESCALATION_TIMEOUT_MS / 1000
+    },
+    silencing: {
+      defaultMaxSilenceSeconds: 120,
+      emergencyMaxSilenceSeconds: 30
+    }
+  }
+
+  async function openStore(): Promise<AlertStore> {
+    const store = new AlertStore(dbPath)
+    stores.push(store)
+    await store.initialize()
+    return store
+  }
+
+  function openManager(
+    store: AlertStore,
+    timers: FakeTimerFunctions,
+    overrides: Partial<AlertManagerConfig> = {}
+  ): AlertManager {
+    const manager = new AlertManager({ ...config, ...overrides }, timers, store)
+    managers.push(manager)
+    return manager
+  }
+
+  /**
+   * Rewrite an alert's row as a restart would find it after downtime.
+   *
+   * Timestamps are the one part of a restart a test cannot produce by waiting,
+   * so the row the manager wrote is put back with the clock moved on.
+   */
+  function afterDowntime(
+    store: AlertStore,
+    alert: Alert,
+    changes: Partial<Alert>
+  ): Promise<void> {
+    return store.commit({
+      alertId: alert.id,
+      alert: { ...alert, ...changes },
+      history: []
+    })
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alerts-persistence-'))
+    dbPath = path.join(tempDir, 'alerts.db')
+    stores = []
+    managers = []
+  })
+
+  afterEach(async () => {
+    try {
+      for (const manager of managers) {
+        manager.stop()
+      }
+      for (const store of stores) {
+        await store.close()
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('restores an alert across a restart exactly as it was raised', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.oilPressureLow',
+        references: [
+          'propulsion.port.oilPressure',
+          'propulsion.port.revolutions'
+        ],
+        context: 'vessels.urn:mrn:imo:mmsi:230099999',
+        $source: 'n2k-on-ve.can-bus.115',
+        source: { label: 'n2k-on-ve.can-bus', pgn: 127489 },
+        priority: 'alarm',
+        message: 'Oil pressure low',
+        group: 'engine',
+        latching: true,
+        data: { pressure: 84000, threshold: 100000 }
+      })
+    )
+    const silenced = await firstManager.silenceAlert(raised.id, 60_000)
+
+    const other = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'electrical.batteries.house.lowVoltage',
+        references: ['electrical.batteries.house.voltage'],
+        context: 'vessels.urn:mrn:imo:mmsi:230099999',
+        $source: 'n2k-on-ve.can-bus.16',
+        source: { label: 'n2k-on-ve.can-bus', pgn: 127508 },
+        priority: 'warning',
+        message: 'House bank low',
+        group: 'electrical',
+        latching: false,
+        data: { voltage: 11.4 }
+      })
+    )
+    await firstManager.acknowledgeAlert(other.id, 'user-1')
+    const acknowledged = presentAlert(firstManager.getAlert(other.id))
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const secondManager = openManager(second, new FakeTimerFunctions())
+    await secondManager.loadFromStore()
+
+    expect(secondManager.getActiveAlertCount()).to.equal(2)
+    expect(presentAlert(secondManager.getAlert(raised.id))).to.deep.equal(
+      silenced
+    )
+    expect(presentAlert(secondManager.getAlert(other.id))).to.deep.equal(
+      acknowledged
+    )
+
+    // Spelled out as well as deep-compared, so a fixture that quietly stopped
+    // populating one of these cannot make the comparison vacuous.
+    const restored = presentAlert(secondManager.getAlert(raised.id))
+    expect(restored.state).to.equal('unacknowledged')
+    expect(restored.silenced).to.equal(true)
+    expect(restored.silencedUntil).to.equal(silenced.silencedUntil)
+    expect(restored.latching).to.equal(true)
+    expect(restored.group).to.equal('engine')
+    expect(restored.references).to.deep.equal([
+      'propulsion.port.oilPressure',
+      'propulsion.port.revolutions'
+    ])
+    expect(restored.context).to.equal('vessels.urn:mrn:imo:mmsi:230099999')
+    expect(restored.source).to.deep.equal({
+      label: 'n2k-on-ve.can-bus',
+      pgn: 127489
+    })
+    expect(restored.data).to.deep.equal({ pressure: 84000, threshold: 100000 })
+    expect(
+      presentAlert(secondManager.getAlert(other.id)).acknowledgedBy
+    ).to.equal('user-1')
+  })
+
+  it('unsilences a silence that ran out during the downtime and records it', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({ path: 'test.alert.silenced' })
+    )
+    const silenced = await firstManager.silenceAlert(raised.id, 60_000)
+    await afterDowntime(first, silenced, {
+      silencedUntil: new Date(Date.now() - 1000).toISOString()
+    })
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const secondManager = openManager(second, new FakeTimerFunctions())
+    const events: AlertEvent[] = []
+    secondManager.on('alert', (event: AlertEvent) => events.push(event))
+    await secondManager.loadFromStore()
+
+    const restored = presentAlert(secondManager.getAlert(raised.id))
+    expect(restored.silenced).to.equal(false)
+    expect(restored.silencedUntil).to.be.undefined
+    expect(events.map((event) => event.type)).to.deep.equal(['unsilenced'])
+
+    // The unsilence is a transition like any other, so it has to reach both
+    // the row and the audit trail rather than only the registry.
+    expect(
+      (await second.getAll()).map((alert) => alert.silenced)
+    ).to.deep.equal([false])
+    const { entries } = await second.queryHistory({ alertId: raised.id })
+    expect(entries.map((entry) => entry.eventType)).to.deep.equal([
+      'unsilence',
+      'silence',
+      'raise'
+    ])
+  })
+
+  it('re-arms a silence that is still running for the time it has left', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({ path: 'test.alert.silenced' })
+    )
+    const silenced = await firstManager.silenceAlert(raised.id, 60_000)
+    // Down for 45 of the 60 seconds.
+    await afterDowntime(first, silenced, {
+      silencedUntil: new Date(Date.now() + 15_000).toISOString()
+    })
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const timers = new FakeTimerFunctions()
+    const secondManager = openManager(second, timers)
+    await secondManager.loadFromStore()
+
+    expect(timers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+    expect(presentAlert(secondManager.getAlert(raised.id)).silenced).to.equal(
+      true
+    )
+
+    timers.advanceTime(14_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).silenced).to.equal(
+      true
+    )
+
+    timers.advanceTime(2_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).silenced).to.equal(
+      false
+    )
+  })
+
+  it('escalates a restored warning when the rest of its window runs out', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.coolantTemperatureHigh',
+        priority: 'warning',
+        message: 'Coolant temperature high'
+      })
+    )
+    // Down for 250 of the 300 second escalation window.
+    await afterDowntime(first, raised, {
+      stateChangedAt: new Date(Date.now() - 250_000).toISOString()
+    })
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const timers = new FakeTimerFunctions()
+    const secondManager = openManager(second, timers)
+    await secondManager.loadFromStore()
+
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'warning'
+    )
+
+    timers.advanceTime(40_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'warning'
+    )
+
+    timers.advanceTime(20_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'alarm'
+    )
+
+    await settle()
+    expect(
+      (await second.getAll()).map((alert) => alert.priority)
+    ).to.deep.equal(['alarm'])
+  })
+
+  it('resumes a restored warning on the fallback window when the configured one is unusable', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.coolantTemperatureHigh',
+        priority: 'warning',
+        message: 'Coolant temperature high'
+      })
+    )
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const timers = new FakeTimerFunctions()
+    const { result: secondManager } = await captureConsole(async () => {
+      const manager = openManager(second, timers, {
+        escalation: { enabled: true, timeoutSeconds: Number.NaN }
+      })
+      await manager.loadFromStore()
+      return manager
+    })
+
+    // An unresolved NaN reaches setTimeout through the resumed window and
+    // escalates every restored warning on the next tick.
+    timers.advanceTime(1)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'warning'
+    )
+
+    timers.advanceTime(DEFAULT_ESCALATION_TIMEOUT_MS)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'alarm'
+    )
+  })
+
+  it('gives a restored warning the window it has left rather than escalating it at once', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.coolantTemperatureHigh',
+        priority: 'warning',
+        message: 'Coolant temperature high'
+      })
+    )
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const timers = new FakeTimerFunctions()
+    const secondManager = openManager(second, timers)
+    const events: AlertEvent[] = []
+    secondManager.on('alert', (event: AlertEvent) => events.push(event))
+    await secondManager.loadFromStore()
+
+    expect(
+      events.filter((event) => event.type === 'escalated')
+    ).to.have.lengthOf(0)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'warning'
+    )
+    expect(timers.getPendingCount()).to.equal(RETENTION_TIMERS + 1)
+
+    timers.advanceTime(ESCALATION_TIMEOUT_MS - 5_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'warning'
+    )
+
+    timers.advanceTime(10_000)
+    expect(presentAlert(secondManager.getAlert(raised.id)).priority).to.equal(
+      'alarm'
+    )
+  })
+
+  it('reads the audit trail back in the order the transitions happened', async () => {
+    const first = await openStore()
+    const firstManager = openManager(first, new FakeTimerFunctions())
+
+    const raised = await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.oilPressureLow',
+        $source: 'source-A',
+        priority: 'warning',
+        message: 'From A'
+      })
+    )
+    await firstManager.silenceAlert(raised.id, 30_000)
+    // One transition, two entries: the priority rises and a second source
+    // takes the alert over.
+    await firstManager.raiseAlert(
+      raiseParams({
+        path: 'propulsion.port.oilPressureLow',
+        $source: 'source-B',
+        priority: 'alarm',
+        message: 'From B'
+      })
+    )
+    await firstManager.acknowledgeAlert(raised.id, 'user-1')
+    await firstManager.clearCondition(raised.id)
+
+    firstManager.stop()
+    await first.close()
+
+    const second = await openStore()
+    const { entries, total } = await second.queryHistory({ alertId: raised.id })
+
+    expect(total).to.equal(6)
+    // Newest first, and the two entries one transition appended keep the order
+    // they happened in even though they share a millisecond.
+    expect(entries.map((entry) => entry.eventType)).to.deep.equal([
+      'clear',
+      'acknowledge',
+      'raise',
+      'escalate',
+      'silence',
+      'raise'
+    ])
+    expect(entries[3].previousPriority).to.equal('warning')
+    expect(entries[3].newPriority).to.equal('alarm')
+    expect(entries[2].$source).to.equal('source-B')
+    expect(entries[2].details).to.deep.equal({ previousSource: 'source-A' })
+    expect(entries[5].$source).to.equal('source-A')
+    expect(entries[1].userId).to.equal('user-1')
+    expect(entries[0].newState).to.equal('normal')
+
+    // The alert resolved, so the trail is all that is left of it.
+    expect(await second.getAll()).to.deep.equal([])
+  })
+
+  it('prunes audit entries past the retention window on the daily timer', async () => {
+    const store = await openStore()
+    const timers = new FakeTimerFunctions()
+    const manager = openManager(store, timers, { retentionDays: 1 })
+    await manager.loadFromStore()
+
+    const raised = await manager.raiseAlert(
+      raiseParams({ path: 'test.alert.kept' })
+    )
+    // An entry from three days ago, as a server left running would hold.
+    await store.commit({
+      alertId: 'ancient-alert',
+      alert: null,
+      history: [
+        {
+          alertId: 'ancient-alert',
+          path: asPath('test.alert.ancient'),
+          priority: 'caution',
+          message: 'Ancient alert',
+          $source: asSourceRef('test-source'),
+          eventType: 'raise',
+          timestamp: new Date(
+            Date.now() - 3 * MILLISECONDS_PER_DAY
+          ).toISOString()
+        }
+      ]
+    })
+
+    expect((await store.queryHistory({})).total).to.equal(2)
+
+    timers.advanceTime(PRUNE_INTERVAL_MS)
+    await settle()
+
+    const { entries, total } = await store.queryHistory({})
+    expect(total).to.equal(1)
+    expect(entries.map((entry) => entry.alertId)).to.deep.equal([raised.id])
+  })
+})

--- a/test/api/alerts/alertStateMachine.test.ts
+++ b/test/api/alerts/alertStateMachine.test.ts
@@ -1,0 +1,634 @@
+import { expect } from 'chai'
+import {
+  AlertStateMachine,
+  createAlert
+} from '../../../src/api/alerts/alertStateMachine'
+import type { Alert, AlertPriority } from '../../../src/api/alerts/types'
+import {
+  presentAlert,
+  raiseParams,
+  type RaiseOverrides
+} from './helpers/fixtures'
+
+describe('AlertStateMachine', () => {
+  let stateMachine: AlertStateMachine
+
+  beforeEach(() => {
+    stateMachine = new AlertStateMachine()
+  })
+
+  function makeAlert(overrides: RaiseOverrides = {}): Alert {
+    return createAlert(raiseParams(overrides))
+  }
+
+  describe('createAlert', () => {
+    it('should create an alert in unacknowledged state', () => {
+      const alert = makeAlert()
+
+      expect(alert.state).to.equal('unacknowledged')
+      expect(alert.condition).to.equal(true)
+      expect(alert.silenced).to.equal(false)
+    })
+
+    it('should generate a unique ID', () => {
+      const alert1 = makeAlert()
+      const alert2 = makeAlert()
+
+      expect(alert1.id).to.not.be.undefined
+      expect(alert2.id).to.not.be.undefined
+      expect(alert1.id).to.not.equal(alert2.id)
+    })
+
+    it('should set raisedAt timestamp', () => {
+      const before = new Date().toISOString()
+      const alert = makeAlert()
+      const after = new Date().toISOString()
+
+      expect(alert.raisedAt).to.not.be.undefined
+      expect(alert.raisedAt >= before).to.equal(true)
+      expect(alert.raisedAt <= after).to.equal(true)
+    })
+
+    it('should default latching to false', () => {
+      const alert = makeAlert()
+      expect(alert.latching).to.equal(false)
+    })
+
+    it('should accept latching parameter', () => {
+      const alert = makeAlert({ latching: true })
+      expect(alert.latching).to.equal(true)
+    })
+
+    it('should set sourceOnline to true', () => {
+      const alert = makeAlert()
+      expect(alert.sourceOnline).to.equal(true)
+    })
+
+    it('should set stale to false', () => {
+      const alert = makeAlert()
+      expect(alert.stale).to.equal(false)
+    })
+
+    it('should normalise an empty context to undefined', () => {
+      // An empty context must key the alert index the same as an absent one
+      const alert = makeAlert({ context: '' })
+      expect(alert.context).to.be.undefined
+    })
+  })
+
+  describe('acknowledge', () => {
+    it('should transition from unacknowledged to acknowledged', () => {
+      const alert = makeAlert()
+
+      const result = stateMachine.acknowledge(alert)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.previousState).to.equal('unacknowledged')
+      expect(result.alert?.state).to.equal('acknowledged')
+    })
+
+    it('should set acknowledgedAt timestamp', () => {
+      const alert = makeAlert()
+
+      const result = stateMachine.acknowledge(alert)
+
+      expect(result.alert?.acknowledgedAt).to.not.be.undefined
+    })
+
+    it('should set acknowledgedBy when userId provided', () => {
+      const alert = makeAlert()
+
+      const result = stateMachine.acknowledge(alert, 'operator-1')
+
+      expect(result.alert?.acknowledgedBy).to.equal('operator-1')
+    })
+
+    it('should be idempotent on already-acknowledged alert', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+
+      const result = stateMachine.acknowledge(acked)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.alert?.state).to.equal('acknowledged')
+    })
+
+    it('should clear RTN-unacknowledged alert', () => {
+      const alert = makeAlert()
+      const rtnAlert: Alert = {
+        ...alert,
+        state: 'rtn-unacknowledged',
+        condition: false
+      }
+
+      const result = stateMachine.acknowledge(rtnAlert)
+
+      expect(result.cleared).to.equal(true)
+      expect(result.alert).to.be.null
+    })
+
+    it('should clear latched alert with cleared condition', () => {
+      const alert = makeAlert({ latching: true })
+      const latchedAlert: Alert = {
+        ...alert,
+        condition: false
+      }
+
+      const result = stateMachine.acknowledge(latchedAlert)
+
+      expect(result.cleared).to.equal(true)
+      expect(result.alert).to.be.null
+    })
+
+    it('should transition latched alert with active condition to acknowledged', () => {
+      const alert = makeAlert({ latching: true })
+
+      const result = stateMachine.acknowledge(alert)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.alert?.state).to.equal('acknowledged')
+    })
+  })
+
+  describe('clearCondition', () => {
+    describe('for ack-required priorities (emergency, alarm, warning)', () => {
+      const ackRequiredPriorities: AlertPriority[] = [
+        'emergency',
+        'alarm',
+        'warning'
+      ]
+
+      ackRequiredPriorities.forEach((priority) => {
+        it(`should transition ${priority} from unacknowledged to rtn-unacknowledged`, () => {
+          const alert = makeAlert({ priority })
+
+          const result = stateMachine.clearCondition(alert)
+
+          expect(result.cleared).to.equal(false)
+          expect(result.previousState).to.equal('unacknowledged')
+          expect(result.alert?.state).to.equal('rtn-unacknowledged')
+          expect(result.alert?.condition).to.equal(false)
+        })
+      })
+
+      it('should clear acknowledged alert when condition clears', () => {
+        const alert = makeAlert({ priority: 'alarm' })
+        const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+
+        const result = stateMachine.clearCondition(acked)
+
+        expect(result.cleared).to.equal(true)
+        expect(result.alert).to.be.null
+      })
+
+      it('should set clearedAt timestamp when transitioning to RTN', () => {
+        const alert = makeAlert({ priority: 'alarm' })
+
+        const result = stateMachine.clearCondition(alert)
+
+        expect(result.alert?.clearedAt).to.not.be.undefined
+      })
+    })
+
+    describe('for caution priority', () => {
+      it('should auto-clear caution alert without requiring ack', () => {
+        const alert = makeAlert({ priority: 'caution' })
+
+        const result = stateMachine.clearCondition(alert)
+
+        expect(result.cleared).to.equal(true)
+        expect(result.alert).to.be.null
+      })
+
+      it('should clear a caution whose condition is already false', () => {
+        // A caution never waits for an acknowledgment, so the auto-clear has
+        // to win over the idempotence check whatever state the alert is in.
+        const alert = makeAlert({ priority: 'caution' })
+        const held: Alert = { ...alert, condition: false }
+
+        const result = stateMachine.clearCondition(held)
+
+        expect(result.cleared).to.equal(true)
+        expect(result.alert).to.be.null
+      })
+
+      it('should clear acknowledged caution alert', () => {
+        const alert = makeAlert({ priority: 'caution' })
+        const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+
+        const result = stateMachine.clearCondition(acked)
+
+        expect(result.cleared).to.equal(true)
+        expect(result.alert).to.be.null
+      })
+    })
+
+    describe('for latched alerts', () => {
+      it('should keep latched alert in unacknowledged state when condition clears', () => {
+        const alert = makeAlert({ latching: true, priority: 'alarm' })
+
+        const result = stateMachine.clearCondition(alert)
+
+        expect(result.cleared).to.equal(false)
+        expect(result.alert?.state).to.equal('unacknowledged')
+        expect(result.alert?.condition).to.equal(false)
+      })
+
+      it('should clear acknowledged latched alert when condition clears', () => {
+        const alert = makeAlert({ latching: true, priority: 'alarm' })
+        const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+
+        const result = stateMachine.clearCondition(acked)
+
+        expect(result.cleared).to.equal(true)
+        expect(result.alert).to.be.null
+      })
+    })
+
+    it('should be idempotent on already-cleared condition', () => {
+      const alert = makeAlert({ priority: 'alarm' })
+      const rtn = presentAlert(stateMachine.clearCondition(alert).alert)
+
+      const result = stateMachine.clearCondition(rtn)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.alert?.state).to.equal('rtn-unacknowledged')
+    })
+  })
+
+  describe('silence', () => {
+    it('should set silenced to true', () => {
+      const alert = makeAlert()
+      const until = new Date(Date.now() + 30000)
+
+      const result = stateMachine.silence(alert, until)
+
+      expect(result.silenced).to.equal(true)
+    })
+
+    it('should set silencedUntil timestamp', () => {
+      const alert = makeAlert()
+      const until = new Date(Date.now() + 30000)
+
+      const result = stateMachine.silence(alert, until)
+
+      expect(result.silencedUntil).to.equal(until.toISOString())
+    })
+
+    it('should not change alert state', () => {
+      const alert = makeAlert()
+      const until = new Date(Date.now() + 30000)
+
+      const result = stateMachine.silence(alert, until)
+
+      expect(result.state).to.equal(alert.state)
+    })
+
+    it('should work on acknowledged alerts', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+      const until = new Date(Date.now() + 30000)
+
+      const result = stateMachine.silence(acked, until)
+
+      expect(result.silenced).to.equal(true)
+      expect(result.state).to.equal('acknowledged')
+    })
+  })
+
+  describe('unsilence', () => {
+    it('should set silenced to false', () => {
+      const alert = makeAlert()
+      const silenced = stateMachine.silence(alert, new Date(Date.now() + 30000))
+
+      const result = stateMachine.unsilence(silenced)
+
+      expect(result.silenced).to.equal(false)
+    })
+
+    it('should clear silencedUntil', () => {
+      const alert = makeAlert()
+      const silenced = stateMachine.silence(alert, new Date(Date.now() + 30000))
+
+      const result = stateMachine.unsilence(silenced)
+
+      expect(result.silencedUntil).to.be.undefined
+    })
+
+    it('should be idempotent on non-silenced alert', () => {
+      const alert = makeAlert()
+
+      const result = stateMachine.unsilence(alert)
+
+      expect(result.silenced).to.equal(false)
+    })
+  })
+
+  describe('requiresAcknowledgment', () => {
+    it('should return true for emergency priority', () => {
+      expect(AlertStateMachine.requiresAcknowledgment('emergency')).to.equal(
+        true
+      )
+    })
+
+    it('should return true for alarm priority', () => {
+      expect(AlertStateMachine.requiresAcknowledgment('alarm')).to.equal(true)
+    })
+
+    it('should return true for warning priority', () => {
+      expect(AlertStateMachine.requiresAcknowledgment('warning')).to.equal(true)
+    })
+
+    it('should return false for caution priority', () => {
+      expect(AlertStateMachine.requiresAcknowledgment('caution')).to.equal(
+        false
+      )
+    })
+  })
+
+  describe('isUnacknowledged', () => {
+    it('should return true for unacknowledged state', () => {
+      const alert = makeAlert()
+      expect(AlertStateMachine.isUnacknowledged(alert)).to.equal(true)
+    })
+
+    it('should return true for rtn-unacknowledged state', () => {
+      const alert = makeAlert()
+      const rtn = presentAlert(stateMachine.clearCondition(alert).alert)
+      expect(AlertStateMachine.isUnacknowledged(rtn)).to.equal(true)
+    })
+
+    it('should return false for acknowledged state', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+      expect(AlertStateMachine.isUnacknowledged(acked)).to.equal(false)
+    })
+  })
+
+  describe('immutability', () => {
+    it('should not mutate input alert on acknowledge', () => {
+      const alert = makeAlert()
+      const originalState = alert.state
+
+      stateMachine.acknowledge(alert)
+
+      expect(alert.state).to.equal(originalState)
+    })
+
+    it('should not mutate input alert on clearCondition', () => {
+      const alert = makeAlert()
+      const originalCondition = alert.condition
+
+      stateMachine.clearCondition(alert)
+
+      expect(alert.condition).to.equal(originalCondition)
+    })
+
+    it('should not mutate input alert on silence', () => {
+      const alert = makeAlert()
+      const originalSilenced = alert.silenced
+
+      stateMachine.silence(alert, new Date(Date.now() + 30000))
+
+      expect(alert.silenced).to.equal(originalSilenced)
+    })
+
+    it('should not mutate input alert on reactivate', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+      const originalState = acked.state
+
+      stateMachine.reactivate(acked)
+
+      expect(acked.state).to.equal(originalState)
+    })
+  })
+
+  describe('reactivate', () => {
+    const OLD = '2020-01-01T00:00:00.000Z'
+
+    it('should transition acknowledged to unacknowledged', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(
+        stateMachine.acknowledge(alert, 'user-1').alert
+      )
+
+      const result = stateMachine.reactivate(acked)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.previousState).to.equal('acknowledged')
+      expect(result.alert?.state).to.equal('unacknowledged')
+      expect(result.alert?.condition).to.equal(true)
+    })
+
+    it('should reset acknowledgedAt and acknowledgedBy on acknowledged → unacknowledged', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(
+        stateMachine.acknowledge(alert, 'user-1').alert
+      )
+      expect(acked.acknowledgedAt).to.not.be.undefined
+      expect(acked.acknowledgedBy).to.equal('user-1')
+
+      const result = stateMachine.reactivate(acked)
+
+      expect(result.alert?.acknowledgedAt).to.be.undefined
+      expect(result.alert?.acknowledgedBy).to.be.undefined
+    })
+
+    it('should transition rtn-unacknowledged to unacknowledged', () => {
+      const alert = makeAlert()
+      const rtn = presentAlert(stateMachine.clearCondition(alert).alert)
+      expect(rtn.state).to.equal('rtn-unacknowledged')
+
+      const result = stateMachine.reactivate(rtn)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.previousState).to.equal('rtn-unacknowledged')
+      expect(result.alert?.state).to.equal('unacknowledged')
+      expect(result.alert?.condition).to.equal(true)
+    })
+
+    it('should reset clearedAt on rtn-unacknowledged → unacknowledged', () => {
+      const alert = makeAlert()
+      const rtn = presentAlert(stateMachine.clearCondition(alert).alert)
+      expect(rtn.clearedAt).to.not.be.undefined
+
+      const result = stateMachine.reactivate(rtn)
+
+      expect(result.alert?.clearedAt).to.be.undefined
+    })
+
+    it('should be idempotent on unacknowledged alert', () => {
+      const alert = makeAlert()
+
+      const result = stateMachine.reactivate(alert)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.previousState).to.equal('unacknowledged')
+      expect(result.alert?.state).to.equal('unacknowledged')
+      expect(result.alert?.condition).to.equal(true)
+    })
+
+    it('should preserve silencing on reactivation (AlertManager clears it)', () => {
+      const alert = makeAlert()
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+      const silenced = stateMachine.silence(acked, new Date(Date.now() + 30000))
+
+      const result = stateMachine.reactivate(silenced)
+
+      // Silencing is NOT cleared by the state machine — that responsibility
+      // belongs to AlertManager.clearSilencingIfSuperseded(), which also
+      // manages the silence expiration timers.
+      expect(result.alert?.silenced).to.equal(true)
+      expect(result.alert?.silencedUntil).to.not.be.undefined
+    })
+
+    it('should transition latching acknowledged to unacknowledged', () => {
+      const alert = makeAlert({ latching: true })
+      const acked = presentAlert(
+        stateMachine.acknowledge(alert, 'user-1').alert
+      )
+
+      const result = stateMachine.reactivate(acked)
+
+      expect(result.cleared).to.equal(false)
+      expect(result.previousState).to.equal('acknowledged')
+      expect(result.alert?.state).to.equal('unacknowledged')
+      expect(result.alert?.condition).to.equal(true)
+      expect(result.alert?.latching).to.equal(true)
+    })
+
+    it('should reactivate a latched alert held with condition=false', () => {
+      const alert = makeAlert({ latching: true })
+      const cleared = presentAlert(stateMachine.clearCondition(alert).alert)
+      expect(cleared.state).to.equal('unacknowledged')
+      expect(cleared.condition).to.equal(false)
+
+      const result = stateMachine.reactivate(cleared)
+
+      expect(result.alert?.state).to.equal('unacknowledged')
+      expect(result.alert?.condition).to.equal(true)
+      expect(result.alert?.latching).to.equal(true)
+    })
+
+    it('should preserve raisedAt', () => {
+      const alert = makeAlert()
+      const originalRaisedAt = alert.raisedAt
+      const acked = presentAlert(stateMachine.acknowledge(alert).alert)
+
+      const result = stateMachine.reactivate(acked)
+
+      expect(result.alert?.raisedAt).to.equal(originalRaisedAt)
+    })
+
+    it('should reset clearedAt and bump stateChangedAt when a latched condition returns', () => {
+      const cleared = presentAlert(
+        stateMachine.clearCondition(makeAlert({ latching: true })).alert
+      )
+      const latched: Alert = { ...cleared, stateChangedAt: OLD }
+      expect(latched.state).to.equal('unacknowledged')
+      expect(latched.condition).to.equal(false)
+      expect(latched.clearedAt).to.be.a('string')
+      const before = new Date().toISOString()
+
+      const result = presentAlert(stateMachine.reactivate(latched).alert)
+
+      // The condition coming back is a fresh annunciation
+      expect(result.condition).to.equal(true)
+      expect(result.clearedAt).to.be.undefined
+      expect(result.stateChangedAt >= before).to.equal(true)
+    })
+
+    it('should keep stateChangedAt when the condition is already active', () => {
+      const alert: Alert = { ...makeAlert(), stateChangedAt: OLD }
+
+      const result = presentAlert(stateMachine.reactivate(alert).alert)
+
+      expect(result.state).to.equal('unacknowledged')
+      expect(result.condition).to.equal(true)
+      expect(result.stateChangedAt).to.equal(OLD)
+    })
+  })
+
+  describe('stateChangedAt tracking (IEC 62923-1 6.4.2.2)', () => {
+    const OLD = '2020-01-01T00:00:00.000Z'
+
+    it('sets stateChangedAt equal to raisedAt on creation', () => {
+      const alert = makeAlert()
+      expect(alert.stateChangedAt).to.equal(alert.raisedAt)
+    })
+
+    it('updates stateChangedAt when acknowledging', () => {
+      const alert = { ...makeAlert(), stateChangedAt: OLD }
+      const before = new Date().toISOString()
+      const result = presentAlert(stateMachine.acknowledge(alert).alert)
+
+      expect(result.state).to.equal('acknowledged')
+      expect(result.stateChangedAt >= before).to.equal(true)
+    })
+
+    it('updates stateChangedAt when the condition clears to rtn-unacknowledged', () => {
+      const alert = { ...makeAlert({ priority: 'alarm' }), stateChangedAt: OLD }
+      const before = new Date().toISOString()
+      const result = presentAlert(stateMachine.clearCondition(alert).alert)
+
+      expect(result.state).to.equal('rtn-unacknowledged')
+      expect(result.stateChangedAt >= before).to.equal(true)
+    })
+
+    it('does not change stateChangedAt when a latching alert keeps its state', () => {
+      const alert = {
+        ...makeAlert({ priority: 'alarm', latching: true }),
+        stateChangedAt: OLD
+      }
+      const result = presentAlert(stateMachine.clearCondition(alert).alert)
+
+      // Latched: stays unacknowledged, only the condition flag flips
+      expect(result.state).to.equal('unacknowledged')
+      expect(result.condition).to.equal(false)
+      expect(result.stateChangedAt).to.equal(OLD)
+    })
+
+    it('updates stateChangedAt when reactivating an acknowledged alert', () => {
+      const acked = {
+        ...presentAlert(stateMachine.acknowledge(makeAlert()).alert),
+        stateChangedAt: OLD
+      }
+      const before = new Date().toISOString()
+      const result = presentAlert(stateMachine.reactivate(acked).alert)
+
+      expect(result.state).to.equal('unacknowledged')
+      expect(result.stateChangedAt >= before).to.equal(true)
+    })
+
+    it('updates stateChangedAt when reactivating an rtn-unacknowledged alert', () => {
+      const rtn = {
+        ...makeAlert({ priority: 'alarm' }),
+        state: 'rtn-unacknowledged' as const,
+        condition: false,
+        stateChangedAt: OLD
+      }
+      const before = new Date().toISOString()
+      const result = presentAlert(stateMachine.reactivate(rtn).alert)
+
+      expect(result.state).to.equal('unacknowledged')
+      expect(result.stateChangedAt >= before).to.equal(true)
+    })
+
+    it('does not change stateChangedAt when silencing', () => {
+      const alert = { ...makeAlert(), stateChangedAt: OLD }
+      const result = stateMachine.silence(alert, new Date(Date.now() + 60000))
+
+      expect(result.silenced).to.equal(true)
+      expect(result.stateChangedAt).to.equal(OLD)
+    })
+
+    it('does not change stateChangedAt when unsilencing', () => {
+      const alert = { ...makeAlert(), silenced: true, stateChangedAt: OLD }
+      const result = stateMachine.unsilence(alert)
+
+      expect(result.silenced).to.equal(false)
+      expect(result.stateChangedAt).to.equal(OLD)
+    })
+  })
+})

--- a/test/api/alerts/alertStore.test.ts
+++ b/test/api/alerts/alertStore.test.ts
@@ -1,0 +1,712 @@
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { DatabaseSync, type SQLOutputValue } from 'node:sqlite'
+import { AlertStore, inTransaction } from '../../../src/api/alerts/alertStore'
+import type {
+  Alert,
+  AlertTransition,
+  HistoryEntry
+} from '../../../src/api/alerts/types'
+import { asPath, asSourceRef, storedAlert } from './helpers/fixtures'
+
+/** The mode the store must give the database file. */
+const DATABASE_MODE = 0o600
+
+/**
+ * Assert that a promise rejects with an error whose message contains `message`.
+ */
+async function expectRejection(promise: Promise<unknown>, message: string) {
+  try {
+    await promise
+  } catch (err) {
+    expect((err as Error).message).to.include(message)
+    return
+  }
+  expect.fail(`expected rejection containing "${message}"`)
+}
+
+/**
+ * Assert that a promise rejects with an error whose message does NOT contain
+ * `message`.
+ */
+async function expectRejectionWithout(
+  promise: Promise<unknown>,
+  message: string
+) {
+  try {
+    await promise
+  } catch (err) {
+    expect((err as Error).message).to.not.include(message)
+    return
+  }
+  expect.fail(`expected a rejection, got a resolved promise`)
+}
+
+function historyEntry(
+  overrides: Partial<Omit<HistoryEntry, 'id'>> = {}
+): Omit<HistoryEntry, 'id'> {
+  return {
+    alertId: 'alert-1',
+    path: asPath('test.alert'),
+    priority: 'alarm',
+    message: 'Test alert',
+    $source: asSourceRef('test-source'),
+    eventType: 'raise',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function write(
+  alert: Alert,
+  history: Omit<HistoryEntry, 'id'>[] = []
+): AlertTransition {
+  return { alertId: alert.id, alert, history }
+}
+
+function remove(
+  alertId: string,
+  history: Omit<HistoryEntry, 'id'>[] = []
+): AlertTransition {
+  return { alertId, alert: null, history }
+}
+
+function ids(alerts: Alert[]): string[] {
+  return alerts.map((alert) => alert.id).sort()
+}
+
+function only(alerts: Alert[], id: string): Alert {
+  const matching = alerts.filter((alert) => alert.id === id)
+  expect(matching).to.have.lengthOf(1)
+  return matching[0]
+}
+
+function pragma(db: DatabaseSync, name: string): SQLOutputValue {
+  const row = db.prepare(`PRAGMA ${name}`).get()
+  if (!row) {
+    throw new Error(`PRAGMA ${name} returned no row`)
+  }
+  return row[name]
+}
+
+/** Swap `process.getBuiltinModule` for the duration of `run`. */
+async function withBuiltinModule(
+  replacement: typeof process.getBuiltinModule | undefined,
+  run: () => Promise<void>
+): Promise<void> {
+  const host = process as { getBuiltinModule?: typeof process.getBuiltinModule }
+  const original = process.getBuiltinModule
+  host.getBuiltinModule = replacement
+  try {
+    await run()
+  } finally {
+    host.getBuiltinModule = original
+  }
+}
+
+/** Collect what `run` writes to console.warn. */
+async function captureWarnings(run: () => Promise<void>): Promise<string[]> {
+  const warnings: string[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(' '))
+  }
+  try {
+    await run()
+  } finally {
+    console.warn = original
+  }
+  return warnings
+}
+
+describe('AlertStore', () => {
+  let tempDir: string
+  let dbPath: string
+  let store: AlertStore
+  let extraStores: AlertStore[]
+
+  /** Run `use` against a second connection to the database under test. */
+  function withConnection<T>(use: (db: DatabaseSync) => T): T {
+    const db = new DatabaseSync(dbPath)
+    try {
+      return use(db)
+    } finally {
+      db.close()
+    }
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alerts-'))
+    dbPath = path.join(tempDir, 'alerts.db')
+    store = new AlertStore(dbPath)
+    extraStores = []
+  })
+
+  afterEach(async () => {
+    for (const open of [store, ...extraStores]) {
+      await open.close()
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe('initialize', () => {
+    it('opens the database in WAL mode with synchronous FULL', async () => {
+      await store.initialize()
+
+      // WAL is recorded in the file header, so any connection sees it.
+      expect(withConnection((db) => pragma(db, 'journal_mode'))).to.equal('wal')
+      // synchronous is per-connection state no other connection can report.
+      expect(store.durability()).to.deep.equal({
+        journalMode: 'wal',
+        synchronous: 2
+      })
+    })
+
+    it('creates the database with incremental auto-vacuum', async () => {
+      await store.initialize()
+
+      // auto_vacuum is recorded in the file header, so any connection sees it,
+      // and 2 is INCREMENTAL. The choice is only available while the file is
+      // being created, which is why it is asserted on a fresh store.
+      expect(withConnection((db) => pragma(db, 'auto_vacuum'))).to.equal(2)
+    })
+
+    it('warns when the file predates auto-vacuum and stays usable', async () => {
+      // A database whose header already exists cannot change the setting.
+      withConnection((db) => db.exec('CREATE TABLE placeholder (a)'))
+
+      const warnings = await captureWarnings(() => store.initialize())
+
+      expect(warnings.join('\n')).to.include(dbPath)
+      expect(warnings.join('\n')).to.include('auto-vacuum')
+      await store.commit(write(storedAlert({ id: 'still-writable' })))
+      expect((await store.getAll()).map((alert) => alert.id)).to.deep.equal([
+        'still-writable'
+      ])
+    })
+
+    it('creates the parent directory of the database file', async () => {
+      const nested = path.join(tempDir, 'serverState', 'alerts', 'alerts.db')
+      expect(fs.existsSync(path.dirname(nested))).to.equal(false)
+      const nestedStore = new AlertStore(nested)
+      extraStores.push(nestedStore)
+
+      await nestedStore.initialize()
+
+      expect(fs.existsSync(nested)).to.equal(true)
+    })
+
+    it('gives the database file owner-only permissions', async () => {
+      await store.initialize()
+
+      expect(fs.statSync(dbPath).mode & 0o777).to.equal(DATABASE_MODE)
+    })
+
+    it('creates the alerts, history and schema_version tables at version 1', async () => {
+      await store.initialize()
+
+      const tables = withConnection((db) =>
+        db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+          .all()
+          .map((row) => row.name)
+      )
+      expect(tables).to.include.members(['alerts', 'history', 'schema_version'])
+
+      const versions = withConnection((db) =>
+        db
+          .prepare('SELECT version FROM schema_version ORDER BY version')
+          .all()
+          .map((row) => row.version)
+      )
+      expect(versions).to.deep.equal([1])
+    })
+
+    it('opens an existing database at the current version without re-migrating', async () => {
+      await store.initialize()
+      const alert = storedAlert({ id: 'survivor' })
+      await store.commit(write(alert, [historyEntry({ alertId: alert.id })]))
+      await store.close()
+
+      const reopened = new AlertStore(dbPath)
+      extraStores.push(reopened)
+      await reopened.initialize()
+
+      expect(await reopened.getAll()).to.deep.equal([alert])
+      expect((await reopened.queryHistory({})).total).to.equal(1)
+
+      const versions = withConnection((db) =>
+        db
+          .prepare('SELECT version FROM schema_version ORDER BY version')
+          .all()
+          .map((row) => row.version)
+      )
+      expect(versions).to.deep.equal([1])
+    })
+
+    it('is a no-op the second time, keeping the connection and the data', async () => {
+      await store.initialize()
+      const alert = storedAlert({ id: 'kept' })
+      await store.commit(write(alert))
+      const durability = store.durability()
+
+      await store.initialize()
+
+      expect(store.durability()).to.deep.equal(durability)
+      expect(await store.getAll()).to.deep.equal([alert])
+    })
+
+    it('rejects naming the file when it is not a SQLite database', async () => {
+      fs.writeFileSync(dbPath, 'this is not a SQLite database file '.repeat(8))
+
+      await expectRejection(store.initialize(), dbPath)
+      await expectRejection(store.initialize(), 'Move the file aside')
+    })
+
+    it('rejects naming the file when the schema is newer than this version', async () => {
+      await store.initialize()
+      await store.close()
+      withConnection((db) => {
+        db.prepare(
+          'INSERT INTO schema_version (version, applied_at) VALUES (?, ?)'
+        ).run(2, new Date().toISOString())
+      })
+
+      const newer = new AlertStore(dbPath)
+      extraStores.push(newer)
+
+      await expectRejection(newer.initialize(), dbPath)
+      await expectRejection(newer.initialize(), 'schema 2')
+    })
+
+    it('rejects naming the Node version when node:sqlite is unavailable', async () => {
+      const original = process.getBuiltinModule
+      const withoutSqlite = ((id: string) =>
+        id === 'node:sqlite'
+          ? undefined
+          : original.call(process, id)) as typeof process.getBuiltinModule
+
+      await withBuiltinModule(withoutSqlite, async () => {
+        await expectRejection(store.initialize(), 'node:sqlite')
+        await expectRejection(store.initialize(), '22.13.0')
+        await expectRejection(store.initialize(), '23.4.0')
+        // A Node that cannot provide the module is not a database the
+        // operator should be told to move aside.
+        await expectRejectionWithout(store.initialize(), 'Move the file aside')
+      })
+    })
+
+    it('rejects naming the Node version when getBuiltinModule is absent', async () => {
+      await withBuiltinModule(undefined, async () => {
+        await expectRejection(store.initialize(), 'node:sqlite')
+        await expectRejection(store.initialize(), '22.13.0')
+        await expectRejection(store.initialize(), '23.4.0')
+        await expectRejectionWithout(store.initialize(), 'Move the file aside')
+      })
+    })
+  })
+
+  describe('commit', () => {
+    beforeEach(async () => {
+      await store.initialize()
+    })
+
+    it('keys the row by the transition id, so a removal finds it', async () => {
+      // The two ids agree for every manager-built transition. Keying the write
+      // by the transition's id keeps them from ever disagreeing on disk.
+      const alert = storedAlert({ id: 'other-id' })
+      await store.commit({ alertId: 'transition-id', alert, history: [] })
+
+      const stored = await store.getAll()
+      expect(stored).to.have.lengthOf(1)
+      expect(stored[0].id).to.equal('transition-id')
+
+      await store.commit({ alertId: 'transition-id', alert: null, history: [] })
+      expect(await store.getAll()).to.have.lengthOf(0)
+    })
+
+    it('round-trips every field of an alert', async () => {
+      const alert = storedAlert({
+        id: 'full-1',
+        path: 'propulsion.port.oilPressureLow',
+        references: [
+          'propulsion.port.oilPressure',
+          'propulsion.port.revolutions'
+        ],
+        context: 'vessels.urn:mrn:imo:mmsi:200000000',
+        $source: 'n2k-on-ve.can-bus.115',
+        source: {
+          label: 'n2k-on-ve',
+          type: 'NMEA2000',
+          pgn: 127489,
+          src: '115'
+        },
+        priority: 'emergency',
+        state: 'acknowledged',
+        condition: true,
+        latching: true,
+        silenced: true,
+        silencedUntil: '2026-01-01T00:05:00.000Z',
+        message: 'Oil pressure low',
+        group: 'engine',
+        data: { pressure: 120000, threshold: 200000, unit: 'Pa' },
+        raisedAt: '2026-01-01T00:00:00.000Z',
+        stateChangedAt: '2026-01-01T00:01:00.000Z',
+        acknowledgedAt: '2026-01-01T00:02:00.000Z',
+        acknowledgedBy: 'user-1',
+        clearedAt: '2026-01-01T00:03:00.000Z',
+        sourceOnline: true,
+        lastSourceUpdate: '2026-01-01T00:04:00.000Z',
+        stale: true
+      })
+
+      await store.commit(write(alert))
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      expect(alerts[0]).to.deep.equal(alert)
+    })
+
+    it('round-trips the flags as booleans in both directions', async () => {
+      const raised = storedAlert({
+        id: 'flags-true',
+        path: 'stored.flagsTrue',
+        condition: true,
+        latching: true,
+        silenced: true,
+        sourceOnline: true,
+        stale: true
+      })
+      const settled = storedAlert({
+        id: 'flags-false',
+        path: 'stored.flagsFalse',
+        condition: false,
+        latching: false,
+        silenced: false,
+        sourceOnline: false,
+        stale: false
+      })
+
+      await store.commit(write(raised))
+      await store.commit(write(settled))
+
+      const alerts = await store.getAll()
+      expect(only(alerts, 'flags-true')).to.deep.equal(raised)
+      expect(only(alerts, 'flags-false')).to.deep.equal(settled)
+      // deep.equal is strict, but spell out the 0/1 trap the mapping avoids.
+      expect(only(alerts, 'flags-false').stale).to.equal(false)
+      expect(only(alerts, 'flags-true').stale).to.equal(true)
+    })
+
+    it('leaves the optional fields absent when the alert has none', async () => {
+      const alert = storedAlert({ id: 'minimal' })
+
+      await store.commit(write(alert))
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      const stored = alerts[0]
+      expect(stored).to.deep.equal(alert)
+      for (const field of [
+        'references',
+        'context',
+        'source',
+        'silencedUntil',
+        'group',
+        'data',
+        'acknowledgedAt',
+        'acknowledgedBy',
+        'clearedAt'
+      ]) {
+        expect(stored).to.not.have.property(field)
+      }
+    })
+
+    it('round-trips an empty string rather than dropping the field', async () => {
+      // An empty string is how a caller clears one of these fields, and it has
+      // to survive the round trip as the empty string it is.
+      const alert = storedAlert({
+        id: 'emptied',
+        group: '',
+        acknowledgedBy: ''
+      })
+
+      await store.commit(write(alert))
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      expect(alerts[0]).to.have.property('group', '')
+      expect(alerts[0]).to.have.property('acknowledgedBy', '')
+      expect(alerts[0]).to.deep.equal(alert)
+    })
+
+    it('removes the row when the transition carries no alert', async () => {
+      const alert = storedAlert({ id: 'departing', path: 'stored.departing' })
+      const other = storedAlert({ id: 'staying', path: 'stored.staying' })
+      await store.commit(write(alert))
+      await store.commit(write(other))
+
+      await store.commit(
+        remove(alert.id, [historyEntry({ alertId: alert.id })])
+      )
+
+      expect(ids(await store.getAll())).to.deep.equal(['staying'])
+      // The audit entry outlives the alert it describes.
+      expect((await store.queryHistory({})).total).to.equal(1)
+    })
+
+    it('replaces an existing row rather than duplicating it', async () => {
+      const alert = storedAlert({ id: 'replaced', state: 'unacknowledged' })
+      await store.commit(write(alert))
+
+      const acknowledged: Alert = {
+        ...alert,
+        state: 'acknowledged',
+        acknowledgedAt: '2026-01-01T00:02:00.000Z',
+        acknowledgedBy: 'user-1'
+      }
+      await store.commit(write(acknowledged))
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      expect(alerts[0]).to.deep.equal(acknowledged)
+    })
+
+    it('replaces a stale row holding the same path, keeping one alert per identity', async () => {
+      // At most one alert is active per path(+context). A raise on a path whose
+      // previous row outlived a failed removal has to take it over rather than
+      // leave the active set with two.
+      const first = storedAlert({ id: 'identity-a', path: 'stored.identity' })
+      const second = storedAlert({ id: 'identity-b', path: 'stored.identity' })
+
+      await store.commit(write(first))
+      await store.commit(write(second))
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      expect(alerts[0]).to.deep.equal(second)
+    })
+  })
+
+  describe('inTransaction', () => {
+    /** Record the statements a transaction issues, failing the chosen ones. */
+    function recorder(failOn: Set<string>) {
+      const issued: string[] = []
+      return {
+        issued,
+        exec(sql: string): void {
+          issued.push(sql)
+          if (failOn.has(sql)) {
+            throw new Error(`${sql} refused`)
+          }
+        }
+      }
+    }
+
+    it('commits the work it was given', () => {
+      const db = recorder(new Set())
+
+      const result = inTransaction(db, () => 'done')
+
+      expect(result).to.equal('done')
+      expect(db.issued).to.deep.equal(['BEGIN IMMEDIATE', 'COMMIT'])
+    })
+
+    it('rolls back when the work throws and reports its error', () => {
+      const db = recorder(new Set())
+
+      expect(() =>
+        inTransaction(db, () => {
+          throw new Error('disk is full')
+        })
+      ).to.throw('disk is full')
+
+      expect(db.issued).to.deep.equal(['BEGIN IMMEDIATE', 'ROLLBACK'])
+    })
+
+    it('reports the original error when the rollback itself fails', () => {
+      // SQLite rolls back by itself on a full disk, so the explicit ROLLBACK
+      // fails with 'no transaction is active'. That must not be the message
+      // the operator is left with.
+      const db = recorder(new Set(['ROLLBACK']))
+
+      expect(() =>
+        inTransaction(db, () => {
+          throw new Error('database or disk is full')
+        })
+      ).to.throw('database or disk is full')
+    })
+
+    it('rolls back when the commit fails', () => {
+      const db = recorder(new Set(['COMMIT']))
+
+      expect(() => inTransaction(db, () => undefined)).to.throw(
+        'COMMIT refused'
+      )
+
+      expect(db.issued).to.deep.equal(['BEGIN IMMEDIATE', 'COMMIT', 'ROLLBACK'])
+    })
+  })
+
+  describe('transaction atomicity', () => {
+    beforeEach(async () => {
+      await store.initialize()
+    })
+
+    it('rolls the alert row back when an audit append fails', async () => {
+      const alert = storedAlert({ id: 'atomic-1' })
+      const invalid = {
+        ...historyEntry({ alertId: alert.id }),
+        path: null
+      } as unknown as Omit<HistoryEntry, 'id'>
+
+      await expectRejection(
+        store.commit(
+          write(alert, [historyEntry({ alertId: alert.id }), invalid])
+        ),
+        'NOT NULL constraint failed: history.path'
+      )
+
+      expect(await store.getAll()).to.deep.equal([])
+      expect((await store.queryHistory({})).total).to.equal(0)
+
+      // The rollback left the connection usable.
+      const next = storedAlert({ id: 'atomic-2' })
+      await store.commit(write(next, [historyEntry({ alertId: next.id })]))
+      expect(ids(await store.getAll())).to.deep.equal(['atomic-2'])
+      expect((await store.queryHistory({})).total).to.equal(1)
+    })
+
+    it('rolls a removal back when an audit append fails', async () => {
+      const alert = storedAlert({ id: 'atomic-3' })
+      await store.commit(write(alert))
+      const invalid = {
+        ...historyEntry({ alertId: alert.id }),
+        path: null
+      } as unknown as Omit<HistoryEntry, 'id'>
+
+      await expectRejection(
+        store.commit(remove(alert.id, [invalid])),
+        'NOT NULL constraint failed: history.path'
+      )
+
+      expect(await store.getAll()).to.deep.equal([alert])
+    })
+  })
+
+  describe('malformed blobs', () => {
+    beforeEach(async () => {
+      await store.initialize()
+    })
+
+    it('drops an unreadable detail field rather than the alert', async () => {
+      const alert = storedAlert({
+        id: 'malformed-1',
+        references: ['propulsion.port.oilPressure'],
+        source: { label: 'n2k-on-ve' },
+        data: { pressure: 120000 }
+      })
+      await store.commit(write(alert))
+
+      withConnection((db) => {
+        db.prepare(
+          'UPDATE alerts SET references_json = ?, source_obj = ?, data = ? WHERE id = ?'
+        ).run('[not json', '{not json', '{not json', alert.id)
+      })
+
+      const alerts = await store.getAll()
+      expect(alerts).to.have.lengthOf(1)
+      const stored = alerts[0]
+      expect(stored.id).to.equal('malformed-1')
+      expect(stored.message).to.equal(alert.message)
+      expect(stored.priority).to.equal(alert.priority)
+      expect(stored).to.not.have.property('references')
+      expect(stored).to.not.have.property('source')
+      expect(stored).to.not.have.property('data')
+    })
+
+    it('drops a blob that parses to something other than an object', async () => {
+      const alert = storedAlert({
+        id: 'malformed-2',
+        source: { label: 'n2k-on-ve' },
+        data: { pressure: 120000 }
+      })
+      await store.commit(write(alert))
+
+      for (const blob of ['"text"', '5', 'true']) {
+        withConnection((db) => {
+          db.prepare(
+            'UPDATE alerts SET source_obj = ?, data = ? WHERE id = ?'
+          ).run(blob, blob, alert.id)
+        })
+
+        const alerts = await store.getAll()
+        expect(alerts).to.have.lengthOf(1)
+        expect(alerts[0].message).to.equal(alert.message)
+        expect(alerts[0], `blob ${blob}`).to.not.have.property('data')
+        expect(alerts[0], `blob ${blob}`).to.not.have.property('source')
+      }
+    })
+
+    it('rejects an unknown state rather than guessing at it', async () => {
+      const alert = storedAlert({ id: 'bad-state' })
+      await store.commit(write(alert))
+
+      withConnection((db) => {
+        db.prepare('UPDATE alerts SET state = ? WHERE id = ?').run(
+          'sideways',
+          alert.id
+        )
+      })
+
+      await expectRejection(store.getAll(), 'sideways')
+      await expectRejection(store.getAll(), 'unknown state')
+    })
+
+    it('rejects an unknown priority rather than guessing at it', async () => {
+      const alert = storedAlert({ id: 'bad-priority' })
+      await store.commit(write(alert))
+
+      withConnection((db) => {
+        db.prepare('UPDATE alerts SET priority = ? WHERE id = ?').run(
+          'catastrophic',
+          alert.id
+        )
+      })
+
+      await expectRejection(store.getAll(), 'catastrophic')
+      await expectRejection(store.getAll(), 'unknown priority')
+    })
+  })
+
+  describe('before initialize', () => {
+    it('rejects every operation with a not initialized error', async () => {
+      await expectRejection(store.getAll(), 'not initialized')
+      await expectRejection(
+        store.commit(write(storedAlert({ id: 'never-written' }))),
+        'not initialized'
+      )
+      await expectRejection(store.queryHistory({}), 'not initialized')
+      await expectRejection(store.pruneHistory(30), 'not initialized')
+    })
+  })
+
+  describe('after close', () => {
+    it('rejects every operation with a not initialized error', async () => {
+      await store.initialize()
+      await store.commit(write(storedAlert({ id: 'before-close' })))
+
+      await store.close()
+
+      await expectRejection(store.getAll(), 'not initialized')
+      await expectRejection(
+        store.commit(write(storedAlert({ id: 'after-close' }))),
+        'not initialized'
+      )
+      await expectRejection(store.queryHistory({}), 'not initialized')
+      await expectRejection(store.pruneHistory(30), 'not initialized')
+    })
+  })
+})

--- a/test/api/alerts/description.test.ts
+++ b/test/api/alerts/description.test.ts
@@ -1,0 +1,87 @@
+import { expect } from 'chai'
+import type { Path, Value } from '@signalk/server-api'
+import {
+  checkDescriptionBounds,
+  MAX_DATA_BYTES,
+  MAX_GROUP_LENGTH,
+  MAX_MESSAGE_LENGTH,
+  MAX_REFERENCES
+} from '../../../src/api/alerts/description'
+import { InvalidAlertDescriptionError } from '../../../src/api/alerts/errors'
+
+function rejectionMessage(description: {
+  message: string
+  group?: string
+  references?: Path[]
+  data?: Record<string, Value>
+}): string {
+  try {
+    checkDescriptionBounds(description)
+  } catch (error) {
+    expect(error).to.be.instanceOf(InvalidAlertDescriptionError)
+    return (error as InvalidAlertDescriptionError).message
+  }
+  expect.fail('expected the description to be refused')
+}
+
+describe('alert description bounds', () => {
+  it('accepts a description within every bound', () => {
+    expect(() => {
+      checkDescriptionBounds({
+        message: 'x'.repeat(MAX_MESSAGE_LENGTH),
+        group: 'g'.repeat(MAX_GROUP_LENGTH),
+        references: Array.from(
+          { length: MAX_REFERENCES },
+          (_unused, index) => `a.b${String(index)}` as Path
+        )
+      })
+    }).to.not.throw()
+  })
+
+  it('refuses an oversized message, group and reference list', () => {
+    expect(
+      rejectionMessage({ message: 'x'.repeat(MAX_MESSAGE_LENGTH + 1) })
+    ).to.contain('message')
+    expect(
+      rejectionMessage({
+        message: 'ok',
+        group: 'g'.repeat(MAX_GROUP_LENGTH + 1)
+      })
+    ).to.contain('group')
+    expect(
+      rejectionMessage({
+        message: 'ok',
+        references: Array.from(
+          { length: MAX_REFERENCES + 1 },
+          (_unused, index) => `a.b${String(index)}` as Path
+        )
+      })
+    ).to.contain('paths')
+  })
+
+  it('measures the data payload in serialized bytes, not code units', () => {
+    // Each of these is one UTF-16 code unit and three UTF-8 bytes, so a
+    // length-based check would admit roughly three times the stated bound.
+    const multiByte = '€'.repeat(MAX_DATA_BYTES / 2)
+    const data: Record<string, Value> = { note: multiByte }
+
+    expect(JSON.stringify(data).length).to.be.below(MAX_DATA_BYTES)
+    expect(Buffer.byteLength(JSON.stringify(data), 'utf8')).to.be.above(
+      MAX_DATA_BYTES
+    )
+    expect(rejectionMessage({ message: 'ok', data })).to.contain('bytes')
+  })
+
+  it('accepts a data payload just inside the byte bound', () => {
+    const data: Record<string, Value> = {
+      note: 'a'.repeat(MAX_DATA_BYTES - 20)
+    }
+
+    expect(Buffer.byteLength(JSON.stringify(data), 'utf8')).to.be.at.most(
+      MAX_DATA_BYTES
+    )
+    expect(() => {
+      checkDescriptionBounds({ message: 'ok', data })
+    }).to.not.throw()
+  })
+})

--- a/test/api/alerts/escalationTimer.test.ts
+++ b/test/api/alerts/escalationTimer.test.ts
@@ -1,0 +1,555 @@
+import { expect } from 'chai'
+import {
+  EscalationTimer,
+  type EscalationEvent,
+  type EscalationTimerConfig
+} from '../../../src/api/alerts/escalationTimer'
+import { FakeTimerFunctions } from './helpers/fakeTimerFunctions'
+
+const MILLISECONDS_PER_SECOND = 1000
+
+/** The window every test in this suite escalates after, unless it says otherwise. */
+const DEFAULT_TIMEOUT_SECONDS = 300
+const DEFAULT_TIMEOUT_MS = DEFAULT_TIMEOUT_SECONDS * MILLISECONDS_PER_SECOND
+
+describe('EscalationTimer', () => {
+  let timer: EscalationTimer
+  let fakeTimers: FakeTimerFunctions
+  let escalationEvents: EscalationEvent[]
+  let defaultConfig: EscalationTimerConfig
+
+  beforeEach(() => {
+    fakeTimers = new FakeTimerFunctions()
+    escalationEvents = []
+    defaultConfig = { enabled: true, timeoutSeconds: DEFAULT_TIMEOUT_SECONDS }
+    timer = new EscalationTimer(
+      defaultConfig,
+      (event) => escalationEvents.push(event),
+      fakeTimers
+    )
+  })
+
+  afterEach(() => {
+    timer.stop()
+  })
+
+  describe('startTimer', () => {
+    it('should start timer for warning priority', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.hasTimer('alert-1')).to.equal(true)
+      expect(timer.getActiveTimerCount()).to.equal(1)
+    })
+
+    it('should not start timer for alarm priority', () => {
+      timer.startTimer('alert-1', 'alarm')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should not start timer for emergency priority', () => {
+      timer.startTimer('alert-1', 'emergency')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should not start timer for caution priority', () => {
+      timer.startTimer('alert-1', 'caution')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should not start timer when escalation is disabled', () => {
+      timer = new EscalationTimer(
+        { enabled: false, timeoutSeconds: DEFAULT_TIMEOUT_SECONDS },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should be idempotent - starting timer twice does not create duplicate', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.getActiveTimerCount()).to.equal(1)
+      expect(fakeTimers.getPendingCount()).to.equal(1)
+    })
+
+    it('should track multiple alerts independently', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.startTimer('alert-2', 'warning')
+      timer.startTimer('alert-3', 'warning')
+
+      expect(timer.getActiveTimerCount()).to.equal(3)
+      expect(timer.hasTimer('alert-1')).to.equal(true)
+      expect(timer.hasTimer('alert-2')).to.equal(true)
+      expect(timer.hasTimer('alert-3')).to.equal(true)
+    })
+  })
+
+  it('should fire at a resumed remaining window, not the configured one', () => {
+    // What a restart uses: an alert part-way through its escalation window
+    // gets the remainder, not a fresh 300 s.
+    timer.startTimer('alert-1', 'warning', 30 * 1000)
+
+    fakeTimers.advanceTime(29 * 1000)
+    expect(escalationEvents).to.have.lengthOf(0)
+
+    fakeTimers.advanceTime(1000)
+    expect(escalationEvents).to.have.lengthOf(1)
+    expect(timer.getActiveTimerCount()).to.equal(0)
+  })
+
+  describe('escalation callback', () => {
+    it('should fire escalation callback after timeout', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      expect(escalationEvents).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(escalationEvents).to.have.lengthOf(1)
+      expect(escalationEvents[0].alertId).to.equal('alert-1')
+      expect(escalationEvents[0].fromPriority).to.equal('warning')
+      expect(escalationEvents[0].toPriority).to.equal('alarm')
+    })
+
+    it('should include timestamp in escalation event', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      const { timestamp } = escalationEvents[0]
+      expect(timestamp).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      )
+      expect(Number.isFinite(Date.parse(timestamp))).to.equal(true)
+    })
+
+    it('should remove timer after escalation fires', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should not fire callback before timeout', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(299 * 1000) // 1 second before timeout
+
+      expect(escalationEvents).to.have.lengthOf(0)
+      expect(timer.hasTimer('alert-1')).to.equal(true)
+    })
+
+    it('should use configured timeout duration', () => {
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: 60 },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(59 * 1000)
+      expect(escalationEvents).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(1 * 1000) // Now at 60 seconds
+      expect(escalationEvents).to.have.lengthOf(1)
+    })
+
+    it('should escalate multiple alerts independently', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(100 * 1000)
+      timer.startTimer('alert-2', 'warning')
+
+      fakeTimers.advanceTime(200 * 1000) // 300s for alert-1, 200s for alert-2
+      expect(escalationEvents).to.have.lengthOf(1)
+      expect(escalationEvents[0].alertId).to.equal('alert-1')
+
+      fakeTimers.advanceTime(100 * 1000) // 300s for alert-2
+      expect(escalationEvents).to.have.lengthOf(2)
+      expect(escalationEvents[1].alertId).to.equal('alert-2')
+    })
+  })
+
+  describe('cancelTimer', () => {
+    it('should prevent escalation callback when cancelled', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.cancelTimer('alert-1')
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(escalationEvents).to.have.lengthOf(0)
+    })
+
+    it('should remove timer from tracking', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.hasTimer('alert-1')).to.equal(true)
+
+      timer.cancelTimer('alert-1')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should be idempotent - cancelling non-existent timer is safe', () => {
+      expect(() => {
+        timer.cancelTimer('non-existent')
+      }).to.not.throw()
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should only cancel the specified timer', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.startTimer('alert-2', 'warning')
+
+      timer.cancelTimer('alert-1')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.hasTimer('alert-2')).to.equal(true)
+      expect(timer.getActiveTimerCount()).to.equal(1)
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(escalationEvents).to.have.lengthOf(1)
+      expect(escalationEvents[0].alertId).to.equal('alert-2')
+    })
+  })
+
+  describe('stop', () => {
+    it('should cancel all active timers', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.startTimer('alert-2', 'warning')
+      timer.startTimer('alert-3', 'warning')
+
+      timer.stop()
+
+      expect(timer.getActiveTimerCount()).to.equal(0)
+      expect(fakeTimers.getPendingCount()).to.equal(0)
+    })
+
+    it('should not fire callbacks after stop', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      timer.stop()
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(escalationEvents).to.have.lengthOf(0)
+    })
+
+    it('should prevent new timers from starting after stop', () => {
+      timer.stop()
+
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should be idempotent - multiple stop calls are safe', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      expect(() => {
+        timer.stop()
+        timer.stop()
+        timer.stop()
+      }).to.not.throw()
+    })
+  })
+
+  describe('hasTimer', () => {
+    it('should return true for active timer', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      expect(timer.hasTimer('alert-1')).to.equal(true)
+    })
+
+    it('should return false for non-existent timer', () => {
+      expect(timer.hasTimer('non-existent')).to.equal(false)
+    })
+
+    it('should return false after timer fires', () => {
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+    })
+
+    it('should return false after timer is cancelled', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.cancelTimer('alert-1')
+
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+    })
+  })
+
+  describe('getActiveTimerCount', () => {
+    it('should return 0 when no timers active', () => {
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should return correct count of active timers', () => {
+      timer.startTimer('alert-1', 'warning')
+      expect(timer.getActiveTimerCount()).to.equal(1)
+
+      timer.startTimer('alert-2', 'warning')
+      expect(timer.getActiveTimerCount()).to.equal(2)
+
+      timer.cancelTimer('alert-1')
+      expect(timer.getActiveTimerCount()).to.equal(1)
+    })
+
+    it('should decrease when timer fires', () => {
+      timer.startTimer('alert-1', 'warning')
+      timer.startTimer('alert-2', 'warning')
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('falls back to the default window when the timeout is not a number', () => {
+      const logged = console.error
+      console.error = () => {}
+      try {
+        timer = new EscalationTimer(
+          { enabled: true, timeoutSeconds: Number.NaN },
+          (event) => escalationEvents.push(event),
+          fakeTimers
+        )
+      } finally {
+        console.error = logged
+      }
+
+      timer.startTimer('alert-1', 'warning')
+
+      // Unvalidated, NaN reaches setTimeout and fires on the next tick, which
+      // would escalate every warning the moment it is raised.
+      fakeTimers.advanceTime(0)
+      expect(escalationEvents).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+      expect(escalationEvents).to.have.lengthOf(1)
+    })
+
+    it('should escalate a zero timeout through a timer, not inline', () => {
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: 0 },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      // The caller must be able to finish raising the alert first, so a spent
+      // window escalates on the next tick rather than within startTimer.
+      expect(escalationEvents).to.have.lengthOf(0)
+      expect(timer.getActiveTimerCount()).to.equal(1)
+
+      fakeTimers.advanceTime(0)
+
+      expect(escalationEvents).to.have.lengthOf(1)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should handle very large timeout values', () => {
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: 86400 }, // 24 hours
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      fakeTimers.advanceTime(86400 * 1000)
+
+      expect(escalationEvents).to.have.lengthOf(1)
+    })
+
+    it('should treat a negative timeout as a spent window', () => {
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: -10 },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      expect(escalationEvents).to.have.lengthOf(0)
+
+      fakeTimers.advanceTime(0)
+
+      expect(escalationEvents).to.have.lengthOf(1)
+      expect(timer.getActiveTimerCount()).to.equal(0)
+    })
+
+    it('should let a spent window be cancelled before it fires', () => {
+      timer = new EscalationTimer(
+        { enabled: true, timeoutSeconds: 0 },
+        (event) => escalationEvents.push(event),
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+      timer.cancelTimer('alert-1')
+
+      fakeTimers.advanceTime(0)
+
+      expect(escalationEvents).to.have.lengthOf(0)
+    })
+
+    it('should use default timer functions when not provided', () => {
+      const timerWithDefaults = new EscalationTimer(defaultConfig, (event) =>
+        escalationEvents.push(event)
+      )
+
+      expect(() => {
+        timerWithDefaults.stop()
+      }).to.not.throw()
+    })
+
+    it('should propagate callback exceptions to caller', () => {
+      const error = new Error('Callback failed')
+      timer = new EscalationTimer(
+        defaultConfig,
+        () => {
+          throw error
+        },
+        fakeTimers
+      )
+
+      timer.startTimer('alert-1', 'warning')
+
+      // Exception should propagate - caller is responsible for handling
+      expect(() => {
+        fakeTimers.advanceTime(DEFAULT_TIMEOUT_MS)
+      }).to.throw(error)
+
+      // Timer should still be removed from tracking (cleanup happens before callback)
+      expect(timer.hasTimer('alert-1')).to.equal(false)
+    })
+  })
+})
+
+describe('FakeTimerFunctions', () => {
+  let fakeTimers: FakeTimerFunctions
+
+  beforeEach(() => {
+    fakeTimers = new FakeTimerFunctions()
+  })
+
+  it('should track pending timers', () => {
+    const noop = (): void => {
+      /* no-op for testing */
+    }
+    fakeTimers.setTimeout(noop, 1000)
+    fakeTimers.setTimeout(noop, 2000)
+
+    expect(fakeTimers.getPendingCount()).to.equal(2)
+  })
+
+  it('should fire timers in order of expiration', () => {
+    const order: number[] = []
+
+    fakeTimers.setTimeout(() => order.push(2), 2000)
+    fakeTimers.setTimeout(() => order.push(1), 1000)
+    fakeTimers.setTimeout(() => order.push(3), 3000)
+
+    fakeTimers.advanceTime(3000)
+
+    expect(order).to.deep.equal([1, 2, 3])
+  })
+
+  it('should allow clearing timers', () => {
+    let called = false
+    const handle = fakeTimers.setTimeout(() => {
+      called = true
+    }, 1000)
+
+    fakeTimers.clearTimeout(handle)
+    fakeTimers.advanceTime(1000)
+
+    expect(called).to.equal(false)
+    expect(fakeTimers.getPendingCount()).to.equal(0)
+  })
+
+  it('should not fire a timer cancelled by an earlier callback', () => {
+    let secondFired = false
+
+    const second = fakeTimers.setTimeout(() => {
+      secondFired = true
+    }, 2000)
+    fakeTimers.setTimeout(() => fakeTimers.clearTimeout(second), 1000)
+
+    fakeTimers.advanceTime(2000)
+
+    expect(secondFired).to.equal(false)
+  })
+
+  it('should give a nested timer the delay it asked for', () => {
+    let nestedAt: number | undefined
+
+    fakeTimers.setTimeout(() => {
+      fakeTimers.setTimeout(() => {
+        nestedAt = fakeTimers.getCurrentTime()
+      }, 1000)
+    }, 1000)
+
+    fakeTimers.advanceTime(2000)
+
+    // The outer timer runs at 1000, so the inner one is due at 2000. Moving
+    // straight to the target before firing would have made it due at 3000.
+    expect(nestedAt).to.equal(2000)
+  })
+
+  it('should run a callback at its own expiry, not at the target', () => {
+    let ranAt: number | undefined
+
+    fakeTimers.setTimeout(() => {
+      ranAt = fakeTimers.getCurrentTime()
+    }, 1000)
+
+    fakeTimers.advanceTime(5000)
+
+    expect(ranAt).to.equal(1000)
+    expect(fakeTimers.getCurrentTime()).to.equal(5000)
+  })
+
+  it('should track current time', () => {
+    expect(fakeTimers.getCurrentTime()).to.equal(0)
+
+    fakeTimers.advanceTime(1000)
+    expect(fakeTimers.getCurrentTime()).to.equal(1000)
+
+    fakeTimers.advanceTime(500)
+    expect(fakeTimers.getCurrentTime()).to.equal(1500)
+  })
+
+  it('should reset all state', () => {
+    fakeTimers.setTimeout(() => {
+      /* no-op for testing */
+    }, 1000)
+    fakeTimers.advanceTime(500)
+
+    fakeTimers.reset()
+
+    expect(fakeTimers.getPendingCount()).to.equal(0)
+    expect(fakeTimers.getCurrentTime()).to.equal(0)
+  })
+})

--- a/test/api/alerts/helpers/fakeTimerFunctions.ts
+++ b/test/api/alerts/helpers/fakeTimerFunctions.ts
@@ -1,0 +1,91 @@
+/**
+ * Fake timer functions for the alerts suites.
+ *
+ * Lets a test advance simulated time and observe which timers fired, without
+ * waiting on wall-clock time.
+ */
+
+import type {
+  TimerFunctions,
+  TimerHandle
+} from '../../../../src/api/alerts/escalationTimer'
+
+interface PendingTimer {
+  callback: () => void
+  expiresAt: number
+}
+
+export class FakeTimerFunctions implements TimerFunctions {
+  private nextId = 1
+  private timers = new Map<number, PendingTimer>()
+  private currentTime = 0
+
+  setTimeout(callback: () => void, ms: number): TimerHandle {
+    const id = this.nextId++
+    this.timers.set(id, { callback, expiresAt: this.currentTime + ms })
+    return id
+  }
+
+  clearTimeout(handle: TimerHandle): void {
+    this.timers.delete(handle as number)
+  }
+
+  /**
+   * Advance time by the specified milliseconds and fire expired timers.
+   *
+   * Time moves to each timer's own expiry before that timer runs, never
+   * straight to the target. A callback that schedules another timer then gets
+   * the delay it asked for measured from when it actually ran, as it would
+   * with real timers.
+   */
+  advanceTime(ms: number): void {
+    const target = this.currentTime + ms
+
+    for (;;) {
+      const next = this.nextExpiryUpTo(target)
+      if (next === undefined) {
+        break
+      }
+      this.currentTime = Math.max(this.currentTime, next.timer.expiresAt)
+      // Deleted before the callback runs, so a callback that reschedules the
+      // same alert does not have its new timer removed by this iteration.
+      this.timers.delete(next.id)
+      next.timer.callback()
+    }
+
+    this.currentTime = target
+  }
+
+  /** The earliest timer due at or before `limit`, if any is still pending. */
+  private nextExpiryUpTo(
+    limit: number
+  ): { id: number; timer: PendingTimer } | undefined {
+    let earliest: { id: number; timer: PendingTimer } | undefined
+    for (const [id, timer] of this.timers) {
+      if (timer.expiresAt > limit) {
+        continue
+      }
+      if (
+        earliest === undefined ||
+        timer.expiresAt < earliest.timer.expiresAt
+      ) {
+        earliest = { id, timer }
+      }
+    }
+    return earliest
+  }
+
+  getPendingCount(): number {
+    return this.timers.size
+  }
+
+  getCurrentTime(): number {
+    return this.currentTime
+  }
+
+  reset(): void {
+    this.timers.clear()
+    this.currentTime = 0
+    this.nextId = 1
+  }
+}

--- a/test/api/alerts/helpers/fixtures.ts
+++ b/test/api/alerts/helpers/fixtures.ts
@@ -1,0 +1,233 @@
+/**
+ * Shared fixtures for the alerts suites.
+ *
+ * The Signal K identity types are opaque brands over string, so tests build
+ * alerts and raise parameters through these builders and speak in plain
+ * strings.
+ */
+
+import type { Context, Path, SourceRef } from '@signalk/server-api'
+import type { CreateAlertParams } from '../../../../src/api/alerts/alertStateMachine'
+import type {
+  Alert,
+  AlertTransition,
+  HistoryEntry,
+  HistoryEventType,
+  HistoryQuery,
+  IAlertStore
+} from '../../../../src/api/alerts/types'
+
+export const asPath = (value: string): Path => value as Path
+export const asSourceRef = (value: string): SourceRef => value as SourceRef
+export const asContext = (value: string): Context => value as Context
+
+export const DEFAULT_PATH = 'test.alert'
+export const DEFAULT_SOURCE = 'test-source'
+export const DEFAULT_MESSAGE = 'Test alert'
+
+export interface RaiseOverrides extends Partial<
+  Omit<CreateAlertParams, 'path' | '$source' | 'context' | 'references'>
+> {
+  path?: string
+  $source?: string
+  context?: string
+  references?: string[]
+}
+
+/**
+ * Assert an optional alert is present and hand it back narrowed.
+ */
+export function presentAlert(alert: Alert | null | undefined): Alert {
+  if (!alert) {
+    throw new Error('Expected the alert to be present')
+  }
+  return alert
+}
+
+/**
+ * Build raise parameters, defaulting every field a test does not care about.
+ */
+export function raiseParams(overrides: RaiseOverrides = {}): CreateAlertParams {
+  const { path, $source, context, references, ...rest } = overrides
+  return {
+    path: asPath(path ?? DEFAULT_PATH),
+    $source: asSourceRef($source ?? DEFAULT_SOURCE),
+    priority: 'alarm',
+    message: DEFAULT_MESSAGE,
+    ...rest,
+    ...(context === undefined ? {} : { context: asContext(context) }),
+    ...(references === undefined ? {} : { references: references.map(asPath) })
+  }
+}
+
+export interface StoredAlertOverrides extends Partial<
+  Omit<Alert, 'path' | '$source' | 'context' | 'references'>
+> {
+  path?: string
+  $source?: string
+  context?: string
+  references?: string[]
+}
+
+let storedAlertCounter = 0
+
+/**
+ * Build a whole Alert as persistence would hand it back after a restart.
+ */
+export function storedAlert(overrides: StoredAlertOverrides = {}): Alert {
+  const { path, $source, context, references, ...rest } = overrides
+  const now = new Date().toISOString()
+  return {
+    id: `stored-${String(++storedAlertCounter)}`,
+    path: asPath(path ?? 'stored.alert'),
+    $source: asSourceRef($source ?? 'stored-source'),
+    priority: 'alarm',
+    state: 'unacknowledged',
+    condition: true,
+    latching: false,
+    silenced: false,
+    message: 'Stored alert',
+    raisedAt: now,
+    stateChangedAt: now,
+    sourceOnline: true,
+    lastSourceUpdate: now,
+    stale: false,
+    ...rest,
+    ...(context === undefined ? {} : { context: asContext(context) }),
+    ...(references === undefined ? {} : { references: references.map(asPath) })
+  }
+}
+
+/**
+ * In-memory persistence that records what it was asked to commit.
+ */
+export class MockAlertStore implements IAlertStore {
+  private alerts = new Map<string, Alert>()
+
+  /** Every audit entry committed, in order */
+  history: Omit<HistoryEntry, 'id'>[] = []
+  /** Retention windows pruneHistory was called with */
+  pruneCalledWith: number[] = []
+  /** How many transitions were committed */
+  commitCount = 0
+
+  initialize(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  getAll(): Promise<Alert[]> {
+    return Promise.resolve(Array.from(this.alerts.values()))
+  }
+
+  commit(transition: AlertTransition): Promise<void> {
+    this.commitCount++
+    if (transition.alert) {
+      this.alerts.set(transition.alertId, { ...transition.alert })
+    } else {
+      this.alerts.delete(transition.alertId)
+    }
+    this.history.push(...transition.history)
+    return Promise.resolve()
+  }
+
+  queryHistory(
+    query: HistoryQuery
+  ): Promise<{ entries: HistoryEntry[]; total: number }> {
+    // Only `alertId` is implemented, because that is all any suite asks for.
+    // Anything else is refused rather than quietly ignored: a filter this mock
+    // dropped would let an assertion pass against the wrong entries.
+    const unsupported = Object.keys(query).filter((key) => key !== 'alertId')
+    if (unsupported.length > 0) {
+      return Promise.reject(
+        new Error(
+          `MockAlertStore.queryHistory does not implement ${unsupported.join(', ')}.`
+        )
+      )
+    }
+
+    // Serves what commit recorded, newest first as AlertStore does, so an
+    // assertion on audit order written against this holds against the real
+    // store. An `alertId` of '' is a filter for an alert that cannot exist,
+    // not an absent filter: `historyQuery` passes through any string.
+    const matching = this.history
+      .filter(
+        (entry) =>
+          query.alertId === undefined || entry.alertId === query.alertId
+      )
+      .map((entry, index) => ({
+        ...entry,
+        id: `mock-history-${String(index)}`
+      }))
+      .reverse()
+    return Promise.resolve({ entries: matching, total: matching.length })
+  }
+
+  pruneHistory(olderThanDays: number): Promise<number> {
+    this.pruneCalledWith.push(olderThanDays)
+    return Promise.resolve(0)
+  }
+
+  getStoredAlert(id: string): Alert | undefined {
+    return this.alerts.get(id)
+  }
+
+  getStoredAlertCount(): number {
+    return this.alerts.size
+  }
+
+  prePopulate(alerts: Alert[]): void {
+    for (const alert of alerts) {
+      this.alerts.set(alert.id, { ...alert })
+    }
+  }
+
+  eventTypes(): HistoryEventType[] {
+    return this.history.map((e) => e.eventType)
+  }
+
+  entriesOfType(eventType: HistoryEventType): Omit<HistoryEntry, 'id'>[] {
+    return this.history.filter((e) => e.eventType === eventType)
+  }
+
+  resetHistory(): void {
+    this.history = []
+  }
+}
+
+/**
+ * Persistence whose commits reject, for exercising degraded-store behaviour.
+ */
+export class FailingAlertStore extends MockAlertStore {
+  constructor(private readonly message = 'SQLite disk I/O error') {
+    super()
+  }
+
+  commit(_transition: AlertTransition): Promise<void> {
+    return Promise.reject(new Error(this.message))
+  }
+}
+
+/**
+ * Capture console.error / console.warn for the duration of a call.
+ */
+export async function captureConsole<T>(
+  run: () => Promise<T> | T
+): Promise<{ result: T; errors: unknown[][]; warnings: unknown[][] }> {
+  const errors: unknown[][] = []
+  const warnings: unknown[][] = []
+  const originalError = console.error
+  const originalWarn = console.warn
+  console.error = (...args: unknown[]) => errors.push(args)
+  console.warn = (...args: unknown[]) => warnings.push(args)
+  try {
+    const result = await run()
+    return { result, errors, warnings }
+  } finally {
+    console.error = originalError
+    console.warn = originalWarn
+  }
+}

--- a/test/api/alerts/historyStore.test.ts
+++ b/test/api/alerts/historyStore.test.ts
@@ -1,0 +1,606 @@
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { DatabaseSync, type SQLOutputValue } from 'node:sqlite'
+import {
+  AlertStore,
+  MAX_VACUUM_PAGES_PER_PRUNE
+} from '../../../src/api/alerts/alertStore'
+import type { HistoryEntry } from '../../../src/api/alerts/types'
+import { asContext, asPath, asSourceRef, storedAlert } from './helpers/fixtures'
+
+/**
+ * The audit trail is reached through AlertStore, which owns the connection the
+ * HistoryStore writes on, so these tests exercise the wiring the server uses.
+ */
+
+/** Largest page the audit trail returns, whatever the caller asks for. */
+const MAX_PAGE_SIZE = 1000
+
+/**
+ * Assert that a promise rejects with an error whose message contains `message`.
+ */
+async function expectRejection(promise: Promise<unknown>, message: string) {
+  try {
+    await promise
+  } catch (err) {
+    expect((err as Error).message).to.include(message)
+    return
+  }
+  expect.fail(`expected rejection containing "${message}"`)
+}
+
+function historyEntry(
+  overrides: Partial<Omit<HistoryEntry, 'id'>> = {}
+): Omit<HistoryEntry, 'id'> {
+  return {
+    alertId: 'alert-1',
+    path: asPath('test.alert'),
+    priority: 'alarm',
+    message: 'Test alert',
+    $source: asSourceRef('test-source'),
+    eventType: 'raise',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+/** Payload per fixture row, big enough that row overhead does not dominate. */
+const ROW_PAYLOAD_BYTES = 2000
+
+/** Pages beyond the vacuum bound the fixture frees, so one pass cannot finish. */
+const VACUUM_PASS_MARGIN_PAGES = 200
+
+const APPEND_BATCH = 500
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+/** The `message` of each entry, used as a per-fixture tag. */
+function tags(entries: HistoryEntry[]): string[] {
+  return entries.map((entry) => entry.message)
+}
+
+function pragma(db: DatabaseSync, name: string): SQLOutputValue {
+  const row = db.prepare(`PRAGMA ${name}`).get()
+  if (!row) {
+    throw new Error(`PRAGMA ${name} returned no row`)
+  }
+  return row[name]
+}
+
+describe('alert history', () => {
+  let tempDir: string
+  let dbPath: string
+  let store: AlertStore
+
+  /**
+   * Append entries through a transition. The audit trail is the subject here,
+   * so the transitions carry no alert; the delete they imply is a no-op.
+   */
+  async function append(...entries: Omit<HistoryEntry, 'id'>[]): Promise<void> {
+    await store.commit({
+      alertId: entries[0].alertId,
+      alert: null,
+      history: entries
+    })
+  }
+
+  /** Every byte the database occupies, including its WAL sidecars. */
+  function bytesOnDisk(): number {
+    return ['', '-wal', '-shm']
+      .map((suffix) => dbPath + suffix)
+      .filter((file) => fs.existsSync(file))
+      .reduce((total, file) => total + fs.statSync(file).size, 0)
+  }
+
+  function withConnection<T>(use: (db: DatabaseSync) => T): T {
+    const db = new DatabaseSync(dbPath)
+    try {
+      return use(db)
+    } finally {
+      db.close()
+    }
+  }
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alerts-'))
+    dbPath = path.join(tempDir, 'alerts.db')
+    store = new AlertStore(dbPath)
+    await store.initialize()
+  })
+
+  afterEach(async () => {
+    await store.close()
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe('append', () => {
+    it('round-trips every field of an entry', async () => {
+      const alert = storedAlert({ id: 'alert-42' })
+      const entry: Omit<HistoryEntry, 'id'> = {
+        alertId: alert.id,
+        path: asPath('propulsion.port.oilPressureLow'),
+        context: asContext('vessels.urn:mrn:imo:mmsi:200000000'),
+        priority: 'alarm',
+        message: 'Oil pressure low',
+        $source: asSourceRef('n2k-on-ve.can-bus.115'),
+        eventType: 'escalate',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        userId: 'user-1',
+        previousState: 'unacknowledged',
+        newState: 'acknowledged',
+        previousPriority: 'warning',
+        newPriority: 'alarm',
+        details: { reason: 'timeout', thresholds: { warn: 1, alarm: 2 } }
+      }
+
+      await store.commit({
+        alertId: alert.id,
+        alert,
+        history: [entry]
+      })
+
+      const { entries, total } = await store.queryHistory({})
+      expect(total).to.equal(1)
+      expect(entries).to.have.lengthOf(1)
+      const stored = entries[0]
+      expect(stored.id).to.be.a('string')
+      expect(stored.id.length).to.be.greaterThan(0)
+      expect(stored).to.deep.equal({ ...entry, id: stored.id })
+    })
+
+    it('leaves the optional fields absent when the entry has none', async () => {
+      await append(historyEntry())
+
+      const { entries } = await store.queryHistory({})
+      expect(entries).to.have.lengthOf(1)
+      const stored = entries[0]
+      for (const field of [
+        'context',
+        'userId',
+        'previousState',
+        'newState',
+        'previousPriority',
+        'newPriority',
+        'details'
+      ]) {
+        expect(stored).to.not.have.property(field)
+      }
+    })
+
+    it('orders the entries of one transition by when they happened', async () => {
+      // An escalating re-raise appends both entries under one timestamp, and
+      // the trail has to report them in a stable order rather than an
+      // arbitrary one.
+      const shared = '2026-03-01T00:00:00.000Z'
+      await append(
+        historyEntry({
+          message: 'escalated',
+          eventType: 'escalate',
+          timestamp: shared,
+          previousPriority: 'warning',
+          newPriority: 'alarm'
+        }),
+        historyEntry({
+          message: 're-raised',
+          eventType: 'raise',
+          timestamp: shared
+        })
+      )
+
+      const { entries } = await store.queryHistory({})
+      // Newest first, so the raise appended after the escalate leads.
+      expect(tags(entries)).to.deep.equal(['re-raised', 'escalated'])
+      expect(entries.map((entry) => entry.eventType)).to.deep.equal([
+        'raise',
+        'escalate'
+      ])
+    })
+  })
+
+  describe('query', () => {
+    beforeEach(async () => {
+      await append(
+        historyEntry({
+          message: 'e1',
+          alertId: 'a1',
+          path: asPath('p1'),
+          eventType: 'raise',
+          timestamp: '2026-01-01T00:00:00.000Z'
+        })
+      )
+      await append(
+        historyEntry({
+          message: 'e2',
+          alertId: 'a1',
+          path: asPath('p1'),
+          eventType: 'acknowledge',
+          timestamp: '2026-01-02T00:00:00.000Z'
+        })
+      )
+      await append(
+        historyEntry({
+          message: 'e3',
+          alertId: 'a2',
+          path: asPath('p2'),
+          eventType: 'raise',
+          timestamp: '2026-01-03T00:00:00.000Z'
+        })
+      )
+      await append(
+        historyEntry({
+          message: 'e4',
+          alertId: 'a2',
+          path: asPath('p2'),
+          eventType: 'clear',
+          timestamp: '2026-01-04T00:00:00.000Z'
+        })
+      )
+      await append(
+        historyEntry({
+          message: 'e5',
+          alertId: 'a3',
+          path: asPath('p1'),
+          eventType: 'escalate',
+          timestamp: '2026-01-05T00:00:00.000Z'
+        })
+      )
+    })
+
+    it('orders entries newest first', async () => {
+      const { entries, total } = await store.queryHistory({})
+      expect(tags(entries)).to.deep.equal(['e5', 'e4', 'e3', 'e2', 'e1'])
+      expect(total).to.equal(5)
+    })
+
+    it('filters by alertId', async () => {
+      const { entries, total } = await store.queryHistory({ alertId: 'a1' })
+      expect(tags(entries)).to.deep.equal(['e2', 'e1'])
+      expect(total).to.equal(2)
+    })
+
+    it('filters by path', async () => {
+      const { entries, total } = await store.queryHistory({
+        path: asPath('p1')
+      })
+      expect(tags(entries)).to.deep.equal(['e5', 'e2', 'e1'])
+      expect(total).to.equal(3)
+    })
+
+    it('filters by a single eventType', async () => {
+      const { entries, total } = await store.queryHistory({
+        eventType: 'raise'
+      })
+      expect(tags(entries)).to.deep.equal(['e3', 'e1'])
+      expect(total).to.equal(2)
+    })
+
+    it('filters by an array of eventTypes', async () => {
+      const { entries, total } = await store.queryHistory({
+        eventType: ['raise', 'clear']
+      })
+      expect(tags(entries)).to.deep.equal(['e4', 'e3', 'e1'])
+      expect(total).to.equal(3)
+    })
+
+    it('filters by from, inclusive of the boundary', async () => {
+      const { entries, total } = await store.queryHistory({
+        from: '2026-01-03T00:00:00.000Z'
+      })
+      expect(tags(entries)).to.deep.equal(['e5', 'e4', 'e3'])
+      expect(total).to.equal(3)
+    })
+
+    it('filters by to, inclusive of the boundary', async () => {
+      const { entries, total } = await store.queryHistory({
+        to: '2026-01-03T00:00:00.000Z'
+      })
+      expect(tags(entries)).to.deep.equal(['e3', 'e2', 'e1'])
+      expect(total).to.equal(3)
+    })
+
+    it('selects the same window from a bound given in another offset', async () => {
+      // Entries are stored as UTC and compared as text, so an offset form has
+      // to be normalised or it selects the wrong window.
+      const offsetBound = await store.queryHistory({
+        from: '2026-01-03T02:00:00.000+02:00'
+      })
+      expect(tags(offsetBound.entries)).to.deep.equal(['e5', 'e4', 'e3'])
+      expect(offsetBound.total).to.equal(3)
+
+      const offsetTo = await store.queryHistory({
+        to: '2026-01-02T20:00:00.000-04:00'
+      })
+      expect(tags(offsetTo.entries)).to.deep.equal(['e3', 'e2', 'e1'])
+      expect(offsetTo.total).to.equal(3)
+    })
+
+    it('rejects a bound that is not a date', async () => {
+      await expectRejection(
+        store.queryHistory({ from: 'the day before yesterday' }),
+        'Alert history from bound is not a valid date'
+      )
+      await expectRejection(
+        store.queryHistory({ to: '2026-13-45T00:00:00.000Z' }),
+        'Alert history to bound is not a valid date'
+      )
+    })
+
+    it('combines a date range with the other filters', async () => {
+      const { entries, total } = await store.queryHistory({
+        from: '2026-01-02T00:00:00.000Z',
+        to: '2026-01-04T00:00:00.000Z',
+        path: asPath('p2'),
+        eventType: ['raise', 'clear']
+      })
+      expect(tags(entries)).to.deep.equal(['e4', 'e3'])
+      expect(total).to.equal(2)
+    })
+
+    it('counts every match in total while limit and offset shape entries', async () => {
+      const firstPage = await store.queryHistory({ limit: 2 })
+      expect(tags(firstPage.entries)).to.deep.equal(['e5', 'e4'])
+      expect(firstPage.total).to.equal(5)
+
+      const secondPage = await store.queryHistory({ limit: 2, offset: 2 })
+      expect(tags(secondPage.entries)).to.deep.equal(['e3', 'e2'])
+      expect(secondPage.total).to.equal(5)
+
+      const filtered = await store.queryHistory({ alertId: 'a1', limit: 1 })
+      expect(tags(filtered.entries)).to.deep.equal(['e2'])
+      expect(filtered.total).to.equal(2)
+    })
+
+    it('applies offset when no limit is given', async () => {
+      const { entries, total } = await store.queryHistory({ offset: 2 })
+      expect(tags(entries)).to.deep.equal(['e3', 'e2', 'e1'])
+      expect(total).to.equal(5)
+    })
+
+    it('returns an empty page for a zero limit and the full one for a zero offset', async () => {
+      const none = await store.queryHistory({ limit: 0 })
+      expect(none.entries).to.have.lengthOf(0)
+      expect(none.total).to.equal(5)
+
+      const all = await store.queryHistory({ offset: 0 })
+      expect(tags(all.entries)).to.deep.equal(['e5', 'e4', 'e3', 'e2', 'e1'])
+      expect(all.total).to.equal(5)
+    })
+
+    it('rejects a limit or offset that is not a non-negative integer', async () => {
+      // SQLite reads a negative LIMIT as no limit at all, so the value meant to
+      // bound the response is the one that would remove the bound.
+      for (const value of [-1, 1.5, Number.NaN]) {
+        await expectRejection(
+          store.queryHistory({ limit: value }),
+          `Alert history limit must be a non-negative integer, got ${String(value)}`
+        )
+        await expectRejection(
+          store.queryHistory({ offset: value }),
+          `Alert history offset must be a non-negative integer, got ${String(value)}`
+        )
+      }
+    })
+
+    it('stores an offset timestamp in the form it compares in', async () => {
+      // 12:00+02:00 is 10:00Z. Stored verbatim it would sort after an entry
+      // written at 11:00Z, and fall outside a window that ends at 11:00Z,
+      // because the trail compares these strings byte by byte.
+      await append(
+        historyEntry({
+          message: 'offset',
+          timestamp: '2026-03-01T12:00:00+02:00'
+        }),
+        historyEntry({ message: 'utc', timestamp: '2026-03-01T11:00:00.000Z' })
+      )
+
+      const { entries } = await store.queryHistory({
+        from: '2026-03-01T00:00:00.000Z',
+        to: '2026-03-01T11:30:00.000Z'
+      })
+
+      expect(tags(entries)).to.deep.equal(['utc', 'offset'])
+      expect(entries[1].timestamp).to.equal('2026-03-01T10:00:00.000Z')
+    })
+
+    it('refuses an entry whose timestamp is not a date', async () => {
+      await expectRejection(
+        append(historyEntry({ timestamp: 'the day before yesterday' })),
+        'Alert history timestamp is not a valid date'
+      )
+    })
+
+    it('matches nothing for an empty event type list', async () => {
+      const result = await store.queryHistory({ eventType: [] })
+      expect(result.entries).to.have.lengthOf(0)
+      expect(result.total).to.equal(0)
+    })
+  })
+
+  describe('context filter', () => {
+    const alpha = asContext('vessels.urn:mrn:imo:mmsi:200000000')
+    const beta = asContext('vessels.urn:mrn:imo:mmsi:200000001')
+
+    beforeEach(async () => {
+      await append(historyEntry({ message: 'alpha-1', context: alpha }))
+      await append(historyEntry({ message: 'beta-1', context: beta }))
+      await append(historyEntry({ message: 'own-vessel' }))
+    })
+
+    it('selects only the entries of that context', async () => {
+      const { entries, total } = await store.queryHistory({ context: alpha })
+      expect(tags(entries)).to.deep.equal(['alpha-1'])
+      expect(total).to.equal(1)
+
+      const other = await store.queryHistory({ context: beta })
+      expect(tags(other.entries)).to.deep.equal(['beta-1'])
+      expect(other.total).to.equal(1)
+
+      expect((await store.queryHistory({})).total).to.equal(3)
+    })
+  })
+
+  describe('page size cap', () => {
+    it('caps a page at 1000 entries while total reports the true count', async () => {
+      const overCap = MAX_PAGE_SIZE + 1
+      const bulk = Array.from({ length: overCap }, (_unused, index) =>
+        historyEntry({
+          message: `bulk-${String(index)}`,
+          timestamp: new Date(Date.UTC(2026, 0, 1) + index * 1000).toISOString()
+        })
+      )
+      await append(...bulk)
+
+      const unlimited = await store.queryHistory({})
+      expect(unlimited.total).to.equal(overCap)
+      expect(unlimited.entries).to.have.lengthOf(MAX_PAGE_SIZE)
+      // Newest first, so the single entry left out is the oldest.
+      expect(tags(unlimited.entries)[0]).to.equal(`bulk-${String(overCap - 1)}`)
+      expect(tags(unlimited.entries)).to.not.include('bulk-0')
+
+      const asked = await store.queryHistory({ limit: overCap })
+      expect(asked.entries).to.have.lengthOf(MAX_PAGE_SIZE)
+      expect(asked.total).to.equal(overCap)
+    })
+  })
+
+  describe('query paging over a shared timestamp', () => {
+    it('neither repeats nor skips an entry', async () => {
+      const shared = '2026-02-01T00:00:00.000Z'
+      for (let index = 0; index < 5; index++) {
+        await append(
+          historyEntry({
+            message: `shared-${String(index)}`,
+            timestamp: shared
+          })
+        )
+      }
+
+      const all = await store.queryHistory({})
+      expect(all.total).to.equal(5)
+
+      const paged: HistoryEntry[] = []
+      for (const offset of [0, 2, 4]) {
+        const page = await store.queryHistory({ limit: 2, offset })
+        expect(page.total).to.equal(5)
+        paged.push(...page.entries)
+      }
+
+      expect(paged.map((entry) => entry.id)).to.deep.equal(
+        all.entries.map((entry) => entry.id)
+      )
+      expect(new Set(paged.map((entry) => entry.id)).size).to.equal(5)
+    })
+  })
+
+  describe('prune', () => {
+    it('deletes entries older than the window and reports the count', async () => {
+      await append(historyEntry({ message: 'old-1', timestamp: daysAgo(100) }))
+      await append(historyEntry({ message: 'old-2', timestamp: daysAgo(91) }))
+      await append(historyEntry({ message: 'recent', timestamp: daysAgo(1) }))
+
+      expect(await store.pruneHistory(90)).to.equal(2)
+
+      const { entries, total } = await store.queryHistory({})
+      expect(tags(entries)).to.deep.equal(['recent'])
+      expect(total).to.equal(1)
+    })
+
+    it('returns the pages it frees to the filesystem', async () => {
+      // Sized from the page size this build actually uses, so the fixture
+      // frees more than one vacuum pass can reclaim whatever that size is.
+      const pageSize = Number(withConnection((db) => pragma(db, 'page_size')))
+      const bulky = 'x'.repeat(ROW_PAYLOAD_BYTES)
+      const rows = Math.ceil(
+        ((MAX_VACUUM_PAGES_PER_PRUNE + VACUUM_PASS_MARGIN_PAGES) * pageSize) /
+          ROW_PAYLOAD_BYTES
+      )
+      for (let written = 0; written < rows; written += APPEND_BATCH) {
+        await append(
+          ...Array.from(
+            { length: Math.min(APPEND_BATCH, rows - written) },
+            (_unused, index) =>
+              historyEntry({
+                message: `${bulky}-${String(written + index)}`,
+                timestamp: daysAgo(100)
+              })
+          )
+        )
+      }
+      const bytesBefore = bytesOnDisk()
+      const pagesBefore = withConnection((db) => pragma(db, 'page_count'))
+
+      expect(await store.pruneHistory(90)).to.equal(rows)
+
+      // One prune reclaims at most MAX_VACUUM_PAGES_PER_PRUNE pages, so a
+      // trail this size comes back over more than one pass rather than
+      // blocking the server for the whole of it at once.
+      let passes = 1
+      while (withConnection((db) => pragma(db, 'freelist_count')) !== 0) {
+        expect(await store.pruneHistory(90)).to.equal(0)
+        passes++
+        expect(passes).to.be.below(10)
+      }
+
+      expect(passes).to.be.above(1)
+      expect(withConnection((db) => pragma(db, 'page_count'))).to.be.below(
+        Number(pagesBefore) / 10
+      )
+      // The bytes are what the SD card cares about, and the WAL is folded back
+      // into the file on close.
+      await store.close()
+      expect(bytesOnDisk()).to.be.below(bytesBefore / 10)
+    })
+
+    it('deletes nothing when every entry is inside the window', async () => {
+      await append(historyEntry({ message: 'recent', timestamp: daysAgo(1) }))
+
+      expect(await store.pruneHistory(90)).to.equal(0)
+      expect((await store.queryHistory({})).total).to.equal(1)
+    })
+
+    it('rejects a window that is not at least one day and keeps the entries', async () => {
+      await append(historyEntry({ message: 'kept', timestamp: daysAgo(400) }))
+
+      for (const window of [
+        0,
+        -5,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY
+      ]) {
+        await expectRejection(
+          store.pruneHistory(window),
+          'Alert history retention must be at least one day'
+        )
+      }
+
+      expect((await store.queryHistory({})).total).to.equal(1)
+    })
+  })
+
+  describe('malformed blobs', () => {
+    it('drops unreadable details rather than the entry', async () => {
+      await append(
+        historyEntry({ message: 'malformed', details: { reason: 'timeout' } })
+      )
+
+      withConnection((db) => {
+        db.prepare('UPDATE history SET details = ? WHERE message = ?').run(
+          '{not json',
+          'malformed'
+        )
+      })
+
+      const { entries } = await store.queryHistory({})
+      expect(entries).to.have.lengthOf(1)
+      const stored = entries[0]
+      expect(stored.message).to.equal('malformed')
+      expect(stored.eventType).to.equal('raise')
+      expect(stored).to.not.have.property('details')
+    })
+  })
+})


### PR DESCRIPTION
## What problem does this solve?

An alarm system that forgets everything on restart is not an alarm system. An unacknowledged alarm has to still be unacknowledged after a power cycle, and reviewing an incident afterwards means knowing when an alert was raised, when it was acknowledged and by whom. The lifecycle engine declares a store interface and works without one; this supplies the implementation.

Two tables in SQLite: the active set, reloaded at startup so alerts survive a restart with their acknowledgment state intact, and an append-only history of every transition. History is pruned against a retention window, 90 days by default, with `auto_vacuum = INCREMENTAL` so the file returns space instead of growing without bound. WAL journalling with `synchronous = FULL` keeps a committed write durable across the power cut that is the failure mode worth designing for on a boat. Annunciation never waits on the store: a lifecycle change is applied and announced first and committed after, so a database that cannot be written degrades the audit trail rather than the alarm.

Nothing wires the store into the server yet — that is 3/4.

## How was this tested?

65 store and history tests: schema round-trips, restoration of the active set across a restart, retention pruning, transaction rollback, and the degraded path where the database cannot be opened. The full suite passes at 1626, and `npm run build` and `npm run ci-lint` are clean on this branch.

## The stack

Four pull requests, each branch based on the one before it. GitHub does not accept a base branch that lives in a fork, so all four target `master` and the diffs of 2/4, 3/4 and 4/4 repeat the commits below them. The Commits tab separates what is new.

**New in this pull request:** the top commit only, `feat(alerts): persist alerts and their audit trail`.

- 1/4 https://github.com/SignalK/signalk-server/pull/3009 — lifecycle engine
- 2/4 https://github.com/SignalK/signalk-server/pull/3010 — persistence and audit trail
- 3/4 https://github.com/SignalK/signalk-server/pull/3011 — delta surface, REST API, server wiring
- 4/4 https://github.com/SignalK/signalk-server/pull/3012 — plugin surface

They are meant to land in that order.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmEL91uGc7sNotczyGihFx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds the alert lifecycle engine and SQLite persistence layer.

- Defines alert states, priorities, transitions, validation, bounds, ordering, and stable error types.
- Adds `AlertManager` for lifecycle operations, escalation, silencing, source liveness, alert limits, and degraded store failures.
- Adds `AlertStore` and `HistoryStore` for durable active alerts and append-only audit history.
- Restores alerts after restart, including silence and escalation timers.
- Uses WAL journaling, `synchronous = FULL`, transactions, configurable 90-day history retention, and incremental auto-vacuum.
- Updates supported Node.js versions for built-in `node:sqlite`.
- Adds comprehensive lifecycle, persistence, history, timer, and failure-path tests.

The server does not wire the alert store yet. That integration is planned for a subsequent change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->