### PR TITLE
Reset notification for any state change, not just coming from normal state

### DIFF
--- a/src/api/notifications/alarm.ts
+++ b/src/api/notifications/alarm.ts
@@ -100,10 +100,7 @@ export class Alarm {
 
     this.parseDelta(update, context)
 
-    if (
-      prevState === ALARM_STATE.normal &&
-      this.value.state !== ALARM_STATE.normal
-    ) {
+    if (prevState !== this.value.state){
       this.status.acknowledged = false
       delete this.status.acknowledgedAt
       this.status.silenced = false

--- a/src/api/notifications/alarm.ts
+++ b/src/api/notifications/alarm.ts
@@ -100,7 +100,8 @@ export class Alarm {
 
     this.parseDelta(update, context)
 
-    if (prevState !== this.value.state){
+    const weights = { normal: 0, alert: 1, warn: 2, alarm: 3, emergency: 4 };
+    if ((weights[this.value.state as keyof typeof weights] || 0) > (weights[prevState as keyof typeof weights] || 0)) {
       this.status.acknowledged = false
       delete this.status.acknowledgedAt
       this.status.silenced = false


### PR DESCRIPTION

Set status.acknowledge and status.silent to false whenever the notification state changes rather than only when it changes from normal state.

This is important so that higher level alarm state are not missed because lower levels were acknowledged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Resets notification acknowledgment and silence state when the alarm state escalates to a higher severity. This prevents higher-level alarm states from being missed after lower-level alarms are acknowledged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->