### PR TITLE
docs(readme): restructure "How to get" install options, adding Universal Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,56 +80,46 @@ There is a [Signal K Server FAQ Frequently Asked Questions](https://github.com/S
 
 ## How to get Signal K Server?
 
-For the typical boater, not being a software developer nor electrical engineer, the best option is to get a (commercially available) product that already has Signal K Server inside. These are the currently available devices:
+Signal K Server is a server application written in Node.js. There are several methods to get it:
 
-- [HALPI2](https://shop.hatlabs.fi/products/halpi2-computer) by Hat Labs, a Raspberry Pi Compute Module 5 boat computer with Signal K Server preconfigured
-- [Cerbo GX](https://www.victronenergy.com/panel-systems-remote-monitoring/cerbo-gx) and other GX Devices by Victron Energy ([see Venus OS Large manual](https://www.victronenergy.com/live/venus-os:large))
-- [SmartBoat module](https://www.airmar.com/Catalog/SmartBoat-SmartFlex) by Airmar
+- npm install: install Node.js and install the server module from [npm](https://en.wikipedia.org/wiki/Npm)
+- container install: install Docker or Podman and Signal K server container
+- Linux image: download and install a Linux distro with preinstalled Signal K
+- commercial device: purchase a commercial device that has Signal K option
 
-For a more technical DIY oriented boater, a RaspberryPi based setup offers a very cost-attractive alternative.
-Read [this FAQ entry](https://github.com/SignalK/signalk-server/wiki/FAQ:-Frequently-Asked-Questions#how-do-i-integrate-with-nmea2000-can-bus) to learn how to connect a RaspberryPi to an NMEA2000 network.
+### npm install
 
-These prebuilt images for RaspberryPis take away most of the complexity involved from the software side:
+You will need to install or update Node.js and then the server itself from npm (Node package registry).
 
-- [Halos](https://docs.halos.fi/getting-started/choosing-an-image/) by Hat Labs, whose Marine images include Signal K Server
-- [BBN Marine OS](https://github.com/bareboat-necessities/lysmarine_gen#what-is-lysmarine-bbn-edition)
-- [OpenPlotter](https://openmarine.net/openplotter) by OpenMarine
-- [Venus OS for RaspberryPis](https://github.com/victronenergy/venus/wiki/raspberrypi-install-venus-image) by Victron Energy
-- [AvNav Headless/Touch](https://github.com/free-x/AvNav-Image)
+- One-liner: `sudo npm install -g signalk-server && sudo signalk-server-setup`
+- [Installation on a RaspberryPi](./docs/installation/raspberry_pi_installation.md) - with more details, applicable also to other Linux environments
+- [Windows installer](https://github.com/SignalK/signalk-server-windows)
 
-You can run Signal K Server in Docker:
+### Container install
+
+Signal K Server container images include everything needed for running the server. This makes updates easier as you can install a new server version in one go, without updating Node.js or the host operating system separately. On the other hand you need to have a container runtime, such as Docker or Podman. Container install allows also running easily additional services such as databases or data visualisation tools.
 
 - [Docker quickstart instructions](https://github.com/SignalK/signalk-server/blob/master/docker/README.md#quickstart)
-- For minimal deployments without the bundled webapps/plugins, see the [core image variant](https://github.com/SignalK/signalk-server/blob/master/docker/README.md#core-image-variant)
-
-Or in a Kubernetes cluster:
-
+- [Universal Installer](https://github.com/dirkwa/signalk-universal-installer#quick-start) - a single command, cross-platform installer to install Signal K Server with associated utility images
 - [Kubernetes quickstart instructions](https://github.com/SignalK/signalk-server/blob/master/kubernetes/README.md#quickstart)
 
-And an installer for Windows:
+### Linux image
 
-- [https://github.com/SignalK/signalk-server-windows](https://github.com/SignalK/signalk-server-windows)
+You can download and install these prebuilt Raspberry Pi images that include Signal K.
 
-Another level up, this document explains how to install Signal K Server, as well as its dependencies, on a RaspberryPi that is already running Raspberry Pi OS:
+- [HaLOS](https://docs.halos.fi/getting-started/choosing-an-image/) by Hat Labs, whose Marine images include Signal K Server
+- [BBN Marine OS](https://github.com/bareboat-necessities/lysmarine_gen#what-is-lysmarine-bbn-edition)
+- [OpenPlotter](https://openmarine.net/openplotter) by OpenMarine
+- [Venus OS for Raspberry Pis (large image)](https://github.com/victronenergy/venus/wiki/raspberrypi-install-venus-image) by Victron Energy
+- [AvNav Headless/Touch](https://github.com/free-x/AvNav-Image)
 
-- [Installation on a RaspberryPi](./docs/installation/raspberry_pi_installation.md)
+### Commercial device
 
-Last, here is how to install the Signal K Server application from NPM:
+There are several commercial devices for boat networking & interfacing with marine electronics that have a Signal K option:
 
-Prerequisites:
-
-- Node.js version 24 with latest npm installed
-
-  $ sudo npm install -g signalk-server
-
-Now you can start the server with sample data:
-
-- NMEA0183 sample data: `signalk-server --sample-nmea0183-data`
-- NMEA2000 sample data: `signalk-server --sample-n2k-data`
-
-To generate your own vessel settings file and configure the server to start automatically, run:
-
-    $ sudo signalk-server-setup
+- [HALPI2](https://shop.hatlabs.fi/products/halpi2-computer) by Hat Labs, a Raspberry Pi Compute Module 5 boat computer running HaLOS with Signal K Server preconfigured
+- Victron Energy [GX Devices](https://www.victronenergy.com/live/venus-os:start) that support [Venus OS Large image](https://www.victronenergy.com/live/venus-os:large)
+- [SmartBoat module](https://www.airmar.com/Catalog/SmartBoat-SmartFlex) by Airmar
 
 ## Configuration and use
 


### PR DESCRIPTION
## What problem does this solve?

This PR groups the installation options into npm, container, Linux image and commercial device categories, with a summary list up front, making it easier to understand the different options and follow them up.

Docker wording is changed to refer to 'container' and Podman mentioned as an alternative, as the container option is applicable with multiple different runtimes.

Additionally it adds Universal Installer as a new container option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restructures installation options into npm, container, Linux image, and commercial device categories.
- Adds a summary list, Universal Installer, container-runtime details, and prebuilt-image information.
- Uses container terminology, mentions Podman as an alternative runtime, and references devices that can run the large image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->