### PR TITLE
docs(radar): subscribe to spokes only while displaying the radar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ nul
 # debug artefacts
 *.sln
 test/server-test-config/debug
+# Per-developer local Makefile (deploy shortcuts, scratch targets)
+Makefile.local

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -1000,7 +1000,7 @@ The URL is constructed by convention from the host serving the radar list:
 
 ### Connection Logic
 
-This a Javascript example how to set up the connection to receive spokes. It returns the
+This is a JavaScript example of how to set up the connection to receive spokes. It returns the
 socket so the caller can close it when the radar is no longer displayed (see
 [Subscribe only while displaying](#subscribe-only-while-displaying)):
 

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -83,6 +83,12 @@ Different manufacturers have vastly different hardware capabilities, control set
 1. **Capabilities** — hardware capabilities (Doppler, dual-range, no-transmit zones, supported ranges)
 2. **Controls** — schema for each control (type, valid values, modes, read-only status)
 
+A provider also treats the spoke stream's subscribers as the measure of whether anyone is
+watching a radar, and may let an unwatched radar stand down. A plugin that relays spokes from
+another provider — a proxy in front of mayara-server, say — must therefore hold its own
+upstream subscription only while it has subscribers of its own; see
+[Subscribe only while displaying](#subscribe-only-while-displaying).
+
 ## Control Categories
 
 | Category       | Description                  | Examples                                           |
@@ -1021,6 +1027,28 @@ async function connectToSpokes() {
   }
 }
 ```
+
+### Subscribe only while displaying
+
+An open spoke stream tells the provider that someone is watching the radar. A provider may
+use that to stop holding an unwatched radar up: mayara-server, for instance, lets a radar
+stand down once nobody has subscribed to its spokes for the period set by its `autoStandby`
+control (a minute by default), so that a headless installation does not keep the magnetron
+transmitting for nobody. Control PUTs and REST reads do not count as watching — only the
+spoke stream does.
+
+So a client must open the spoke stream only while it is actually displaying the radar, and
+close it as soon as it stops — when the radar view is hidden, not merely when the page is
+closed. A subscription held open "just in case" keeps the radar transmitting.
+
+The same rule applies one level up. A provider plugin that relays spokes from another
+source (the mayara-server plugin, or an app-specific bridge such as an ORCA emulator)
+must hold its upstream subscription only while it has subscribers itself, and close it
+when the last one leaves. On the server side `app.binaryStreamManager.getClientCount('radars/{id}')`
+gives the number of clients currently subscribed to a radar's spoke stream; poll it and
+connect on the first subscriber, disconnect after the last. A relay that stays subscribed
+around the clock hides every downstream client from the provider, and the radar never
+stands down.
 
 ### Spoke content and the legend
 

--- a/docs/develop/rest-api/radar_api.md
+++ b/docs/develop/rest-api/radar_api.md
@@ -1000,7 +1000,9 @@ The URL is constructed by convention from the host serving the radar list:
 
 ### Connection Logic
 
-This a Javascript example how to set up the connection to receive spokes:
+This a Javascript example how to set up the connection to receive spokes. It returns the
+socket so the caller can close it when the radar is no longer displayed (see
+[Subscribe only while displaying](#subscribe-only-while-displaying)):
 
 ```javascript
 async function connectToSpokes() {
@@ -1025,7 +1027,11 @@ async function connectToSpokes() {
     const spokeData = new Uint8Array(event.data)
     // Process binary spoke data...
   }
+  return socket
 }
+
+// When the radar view is hidden or unmounted:
+//   socket.close()
 ```
 
 ### Subscribe only while displaying
@@ -1044,11 +1050,11 @@ closed. A subscription held open "just in case" keeps the radar transmitting.
 The same rule applies one level up. A provider plugin that relays spokes from another
 source (the mayara-server plugin, or an app-specific bridge such as an ORCA emulator)
 must hold its upstream subscription only while it has subscribers itself, and close it
-when the last one leaves. On the server side `app.binaryStreamManager.getClientCount('radars/{id}')`
-gives the number of clients currently subscribed to a radar's spoke stream; poll it and
-connect on the first subscriber, disconnect after the last. A relay that stays subscribed
-around the clock hides every downstream client from the provider, and the radar never
-stands down.
+when the last one leaves. On the server side `app.binaryStreamManager.getClientCount(streamId)`,
+with `streamId` being `` `radars/${radarId}` ``, gives the number of clients currently
+subscribed to that radar's spoke stream, so a relay can connect on the first subscriber and
+disconnect after the last. A relay that stays subscribed around the clock hides every
+downstream client from the provider, and the radar never stands down.
 
 ### Spoke content and the legend
 


### PR DESCRIPTION
A radar provider uses the spoke stream's subscribers as its measure of whether anyone is watching a radar, and may let an unwatched radar stand down — mayara-server now does so (MarineYachtRadar/mayara-server#663), so a headless installation stops holding the magnetron up for nobody. That only works if clients and relays are honest about it: a spoke subscription held open "just in case" keeps the radar transmitting, and a relaying plugin that stays subscribed upstream around the clock hides every downstream client from the provider.

This spells out the contract in the Radar API docs: clients open the spoke stream only while displaying the radar and close it when the view is hidden; a provider that relays spokes holds its upstream subscription only while it has subscribers of its own, using `binaryStreamManager.getClientCount('radars/{id}')` — which the server already exposes. The mayara plugin (MarineYachtRadar/mayara-server-signalk-plugin#120) and the beluga ORCA bridge now follow this.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VvpP3eXB2WhgD8bwyDWoU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates Radar API documentation to define spoke subscription behavior. Clients subscribe only while displaying radar data and close the spoke stream when the view is hidden. Relay providers maintain upstream subscriptions only while downstream subscribers exist and use `binaryStreamManager.getClientCount('radars/{id}')` to check the count. Providers may reduce radar operation when no clients are watching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->