### PR TITLE
fix: report first TCP connection attempt as status, not error

### DIFF
--- a/packages/streams/src/tcp.ts
+++ b/packages/streams/src/tcp.ts
@@ -131,7 +131,11 @@ export default class TcpStream extends Transform {
       })
       .on('reconnect', (n: number, delay: number) => {
         const msg = `Reconnect ${this.options.host} ${this.options.port} retry ${n} delay ${delay}`
-        this.options.app.setProviderError(this.options.providerId, msg)
+        if (n === 0) {
+          this.options.app.setProviderStatus(this.options.providerId, msg)
+        } else {
+          this.options.app.setProviderError(this.options.providerId, msg)
+        }
         this.debug(msg)
       })
       .on('disconnect', () => {


### PR DESCRIPTION
Fixes #3023.

The TCP client provider's `reconnect` handler routes every scheduled attempt through `setProviderError`, including attempt 0, the initial connect. A data connection that connects cleanly on the first try therefore logs "Reconnect <host> <port> retry 0 delay 100" as a provider error at every server start, before the `connect` handler overwrites the status.

This change reports attempt 0 via `setProviderStatus` and leaves retries (n > 0), `disconnect` and `error` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the TCP client reconnect handler to report the initial connection attempt (`n === 0`) with `setProviderStatus`.

Retry attempts continue to use `setProviderError`. This prevents successful initial connections from creating misleading provider error entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->