### PR TITLE
docs: document declaring stale data timeouts from a plugin

### DIFF
--- a/docs/develop/plugins/deltas.md
+++ b/docs/develop/plugins/deltas.md
@@ -318,6 +318,27 @@ The method is **idempotent**: on subsequent server starts, fields already persis
 
 The `displayUnits.category` is validated against the path's SI unit. If the category doesn't match, the method returns `false` and logs a debug message.
 
+### Declaring stale data behaviour
+
+The same method is how a plugin tells [Stale Data Detection](../../setup/staleness.md) how its paths behave. Declare it once at plugin start — metadata attached to individual deltas is not used to resolve timeouts, and repeating it on every delta would only add traffic.
+
+```javascript
+plugin.start = async (options) => {
+  // Republished every 10 minutes, so the 60s default would flag it as stale.
+  await app.setDefaultMetadata('navigation.state', { timeout: 900 })
+
+  // Emitted only when the value changes; silence means unchanged.
+  await app.setDefaultMetadata('propulsion.port.state', {
+    updateContract: 'event'
+  })
+
+  // Never meaningful to time out.
+  await app.setDefaultMetadata('design.airHeight', { timeout: 0 })
+}
+```
+
+Per-field merge applies here too: if the user has set a `timeout` for the path in the Data Browser, theirs wins and the plugin's suggestion is ignored.
+
 ## Correction and transform plugins
 
 There are essentially two strategies a plugin can employ to change a value for a path:

--- a/docs/develop/plugins/deltas.md
+++ b/docs/develop/plugins/deltas.md
@@ -327,6 +327,11 @@ plugin.start = async (options) => {
   // Republished every 10 minutes, so the 60s default would flag it as stale.
   await app.setDefaultMetadata('navigation.state', { timeout: 900 })
 
+  // Or let the server derive the timeout from the observed update rate.
+  await app.setDefaultMetadata('environment.inside.temperature', {
+    timeout: 'auto'
+  })
+
   // Emitted only when the value changes; silence means unchanged.
   await app.setDefaultMetadata('propulsion.port.state', {
     updateContract: 'event'

--- a/docs/setup/staleness.md
+++ b/docs/setup/staleness.md
@@ -47,6 +47,8 @@ Well-known event-driven paths are pre-classified by the server: notifications, n
 
 To classify a custom path, set `updateContract` in the path's metadata (Data Browser meta editor or the meta API). An explicit `updateContract` always wins over the shipped classification.
 
+A plugin can declare the contract for paths it publishes by calling `setDefaultMetadata()` once at start-up; see [Setting Default Metadata](../develop/plugins/deltas.md#setting-default-metadata). A value set by the user always takes precedence over the plugin's suggestion.
+
 ## Timeout Resolution
 
 For a `periodic` path, the effective timeout is resolved in this order:
@@ -57,6 +59,8 @@ For a `periodic` path, the effective timeout is resolved in this order:
 4. **Global default timeout** (`defaultTimeout`) when _Use default timeouts_ is enabled.
 
 If none of these produce a timeout, the path is not monitored.
+
+A plugin that publishes a path updating more slowly than the global default should declare its own `timeout` the same way, rather than relying on the user to adjust it.
 
 When [Source Priority](./source-priority.md) is active for a path, the effective timeout never undercuts the configured failover window, so staleness does not fire while a lower-priority source is still legitimately waiting to take over.
 

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -156,10 +156,12 @@ export interface ServerAPI
    *
    * This is also how a plugin declares how its paths behave for stale data
    * detection. Call it once at plugin start rather than attaching metadata
-   * to every delta: `timeout` (seconds) for a path that updates more slowly
-   * than the server default, `0` for a path that should never be considered
-   * stale, or `updateContract: 'event'` for a path that only emits on
-   * change. A value the user has set in the Data Browser always wins.
+   * to every delta: `timeout` for a path that updates more slowly than the
+   * server default — either a number of seconds or `'auto'` to let the
+   * server derive it from the observed update rate — `0` for a path that
+   * should never be considered stale, or `updateContract: 'event'` for a
+   * path that only emits on change. A value the user has set in the Data
+   * Browser always wins.
    *
    * @example
    * ```javascript

--- a/packages/server-api/src/serverapi.ts
+++ b/packages/server-api/src/serverapi.ts
@@ -154,10 +154,25 @@ export interface ServerAPI
    * Idempotent: on subsequent server starts, fields already persisted
    * from a previous call will not be overwritten.
    *
+   * This is also how a plugin declares how its paths behave for stale data
+   * detection. Call it once at plugin start rather than attaching metadata
+   * to every delta: `timeout` (seconds) for a path that updates more slowly
+   * than the server default, `0` for a path that should never be considered
+   * stale, or `updateContract: 'event'` for a path that only emits on
+   * change. A value the user has set in the Data Browser always wins.
+   *
    * @example
    * ```javascript
    * await app.setDefaultMetadata('electrical.batteries.house.energy', {
    *   displayUnits: { category: 'energy', targetUnit: 'Wh' }
+   * })
+   * ```
+   *
+   * @example Declaring staleness behaviour for a slow path
+   * ```javascript
+   * // This plugin republishes state every 10 minutes.
+   * await app.setDefaultMetadata('navigation.state', {
+   *   timeout: 900
    * })
    * ```
    *


### PR DESCRIPTION
`setDefaultMetadata()` is the supported way for a plugin to declare how its paths behave for stale data detection, but its documentation only covered display units, so the mechanism was effectively undiscoverable. A plugin publishing a path that updates more slowly than the global default had no evident way to say so, and metadata attached to individual deltas is not consulted when resolving a timeout.

This documents `timeout`, `timeout: 0` and `updateContract` on the API method and in the plugin developer guide, and points the Stale Data Detection page at it. It also notes that the call belongs in `plugin.start` rather than on every delta — repeating metadata per delta only adds traffic without affecting timeout resolution.

No code changes.

## Tested

- `npm run format`, `npm run build:all`, `npm test` — server 1276 passing, workspaces green, ci-lint clean
- Verified each documented declaration against the real `StalenessEnforcer` rather than only asserting it: `timeout: 900` resolves to 900000 ms, `updateContract: 'event'` resolves to `event`, `timeout: 0` resolves to never, and a path with no metadata falls back to the 60 s default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Documents how plugins use `setDefaultMetadata()` to declare stale-data behavior.
- Covers numeric timeouts, `timeout: 'auto'`, `timeout: 0`, and `updateContract: 'event'`.
- Explains that plugins configure metadata once in `plugin.start`.
- Explains that user-configured values take precedence over plugin defaults.
- Updates the API reference, plugin developer guide, and Stale Data Detection guide.
- Includes no code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->