### PR TITLE
fix: time out string and boolean paths in stale data detection

### DIFF
--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -26,7 +26,12 @@ export * as typebox from './typebox'
 /** @category Notifications API */
 export * from './notificationsapi'
 export { FullSignalK, SourceMetaEntry } from './fullsignalk'
-export { getSourceId, fillIdentity, fillIdentityField } from './sourceutil'
+export {
+  getSourceId,
+  fillIdentity,
+  fillIdentityField,
+  isIdentityPath
+} from './sourceutil'
 
 /** @category  Server API */
 export interface Position {

--- a/packages/server-api/src/sourceutil.ts
+++ b/packages/server-api/src/sourceutil.ts
@@ -1,4 +1,4 @@
-import type { SourceRef } from './deltas'
+import type { Path, SourceRef } from './deltas'
 
 /**
  * Extract a normalised SourceRef string from a source object.
@@ -43,6 +43,27 @@ export function getSourceId(source: any): SourceRef {
 
 const MMSI_PREFIX = 'urn:mrn:imo:mmsi:'
 
+// Property names `fillIdentityField` writes onto a vessel context.
+const IDENTITY_FIELD_MMSI = 'mmsi'
+const IDENTITY_FIELD_UUID = 'uuid'
+const IDENTITY_FIELD_URL = 'url'
+
+// Vessel identity paths `fillIdentityField` may write as a bare primitive
+// rather than a value object.
+const IDENTITY_PATHS = new Set<string>([
+  IDENTITY_FIELD_MMSI,
+  IDENTITY_FIELD_UUID,
+  IDENTITY_FIELD_URL
+])
+
+/**
+ * True when `path` is a vessel identity path that `fillIdentityField`
+ * may write onto the vessel context as a bare primitive.
+ */
+export function isIdentityPath(path: Path): boolean {
+  return IDENTITY_PATHS.has(path)
+}
+
 /**
  * Set the identity field (mmsi, uuid, or url) on a vessel data object
  * based on the identity string format.
@@ -53,11 +74,11 @@ export function fillIdentityField(
   identity: string
 ): void {
   if (identity.startsWith(MMSI_PREFIX)) {
-    vesselData.mmsi = identity.substring(MMSI_PREFIX.length)
+    vesselData[IDENTITY_FIELD_MMSI] = identity.substring(MMSI_PREFIX.length)
   } else if (identity.startsWith('urn:mrn:signalk')) {
-    vesselData.uuid = identity
+    vesselData[IDENTITY_FIELD_UUID] = identity
   } else {
-    vesselData.url = identity
+    vesselData[IDENTITY_FIELD_URL] = identity
   }
 }
 

--- a/src/staleness.ts
+++ b/src/staleness.ts
@@ -22,6 +22,9 @@ const NOTIFICATIONS_ROOT = 'notifications'
 const DEFAULT_TIMEOUT_SECONDS = 60
 const DEFAULT_CHECK_INTERVAL_MS = 1000
 const NEVER_TIMEOUT = 0
+// Paths `fillIdentityField` may write to the vessel context as a bare
+// primitive rather than a value object; see checkLeafGroup.
+const IDENTITY_PATHS = new Set(['uuid', 'mmsi', 'url'])
 // `timeout: 'auto'` derives the effective timeout from observed delta
 // arrival rates. The constants below match the RFC v7 contract: a
 // warm-up window seeded with `defaultTimeout`, a sample ring of fixed
@@ -305,16 +308,15 @@ export class StalenessEnforcer {
       if (!isCacheLeafEntry(leaf)) continue
       if (leaf.isMeta) continue
       if (leaf.value === null) continue
-      // String and boolean leaves are by Signal K convention identity
-      // fields (uuid, mmsi, name, flag) or simple state flags — never
-      // periodic measurements. Emitting a null+timedOut delta for them
-      // also crashes FullSignalK.addValue when the path collides with a
-      // top-level identity scalar that fillIdentityField writes onto the
-      // vessel context (e.g. `vessels.<id>.uuid = '<id>'`): the value
-      // tree carries the identity as a primitive, so walking the path
-      // dereferences a string and addValue's leaf.meta assignment fails.
-      const valueType = typeof leaf.value
-      if (valueType === 'string' || valueType === 'boolean') continue
+      // `fillIdentityField` writes the vessel identity onto the context as a
+      // bare primitive (`vessels.<id>.uuid = '<id>'`), so for these paths the
+      // value tree holds a string where every other leaf holds an object.
+      // FullSignalK.addValue walks the path and assigns `leaf.value`, which
+      // throws on a primitive, so a timeout delta for them is dropped with a
+      // logged TypeError. Only the key matching the selfId form is ever a
+      // primitive, but all three are excluded: which one it is depends on how
+      // this vessel is identified.
+      if (IDENTITY_PATHS.has(path)) continue
       const key = makeKey(context, path, srcRef)
       // The base timeout depends on the source for `meta.timeout: 'auto'`
       // — different sources of the same path can have different update

--- a/src/staleness.ts
+++ b/src/staleness.ts
@@ -1,6 +1,7 @@
 import { getMetadata } from '@signalk/path-metadata'
 import {
   Context,
+  isIdentityPath,
   MetaValue,
   Path,
   PathValue,
@@ -22,9 +23,6 @@ const NOTIFICATIONS_ROOT = 'notifications'
 const DEFAULT_TIMEOUT_SECONDS = 60
 const DEFAULT_CHECK_INTERVAL_MS = 1000
 const NEVER_TIMEOUT = 0
-// Paths `fillIdentityField` may write to the vessel context as a bare
-// primitive rather than a value object; see checkLeafGroup.
-const IDENTITY_PATHS = new Set(['uuid', 'mmsi', 'url'])
 // `timeout: 'auto'` derives the effective timeout from observed delta
 // arrival rates. The constants below match the RFC v7 contract: a
 // warm-up window seeded with `defaultTimeout`, a sample ring of fixed
@@ -316,7 +314,7 @@ export class StalenessEnforcer {
       // logged TypeError. Only the key matching the selfId form is ever a
       // primitive, but all three are excluded: which one it is depends on how
       // this vessel is identified.
-      if (IDENTITY_PATHS.has(path)) continue
+      if (isIdentityPath(path as Path)) continue
       const key = makeKey(context, path, srcRef)
       // The base timeout depends on the source for `meta.timeout: 'auto'`
       // — different sources of the same path can have different update

--- a/test/staleness-strings-e2e.ts
+++ b/test/staleness-strings-e2e.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai'
+import { freeport } from './ts-servertestutilities'
+import { startServerP, sendDelta } from './servertestutilities'
+
+// The unit tests drive StalenessEnforcer against a mock app. This exercises
+// the real server end to end: once a string-valued path stops updating, the
+// REST snapshot must report `value: null` with `state.timedOut` set and the
+// last good reading preserved in `state.lastValue`.
+
+const SERVER_START_TIMEOUT_MS = 90000
+const TEST_TIMEOUT_MS = 30000
+const STALE_TIMEOUT_S = 1
+const SETTLE_MS = 3000
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('staleness on string-valued paths', function () {
+  let server: Awaited<ReturnType<typeof startServerP>>
+  let port: number
+
+  before(async function () {
+    this.timeout(SERVER_START_TIMEOUT_MS)
+    port = await freeport()
+    server = await startServerP(port, false, {
+      settings: {
+        enforceDataTimeouts: true,
+        defaultTimeout: STALE_TIMEOUT_S,
+        interfaces: { plugins: false }
+      }
+    })
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  it('emits null and state.timedOut for a stale string enum path', async function () {
+    this.timeout(TEST_TIMEOUT_MS)
+
+    await sendDelta(
+      {
+        context: `vessels.${server.app.selfId}`,
+        updates: [
+          {
+            source: { label: 'autostate-e2e' },
+            timestamp: new Date().toISOString(),
+            values: [{ path: 'navigation.state', value: 'moored' }]
+          }
+        ]
+      },
+      `http://localhost:${port}/signalk/v1/api/_test/delta`
+    )
+
+    // No further deltas: the enforcer must notice the silence. SETTLE_MS
+    // exceeds STALE_TIMEOUT_S plus one sweep interval.
+    await delay(SETTLE_MS)
+
+    const res = await fetch(
+      `http://localhost:${port}/signalk/v1/api/vessels/self/navigation/state`
+    )
+    expect(res.ok, `GET navigation/state returned ${res.status}`).to.equal(true)
+
+    const body: unknown = await res.json()
+    expect(body).to.be.an('object')
+    const entry = body as {
+      value?: unknown
+      state?: { timedOut?: unknown; lastValue?: { value?: unknown } }
+    }
+
+    expect(entry.value).to.equal(null)
+    expect(entry.state?.timedOut).to.equal(true)
+    expect(entry.state?.lastValue?.value).to.equal('moored')
+  })
+})

--- a/test/staleness-strings-e2e.ts
+++ b/test/staleness-strings-e2e.ts
@@ -15,7 +15,7 @@ const SETTLE_MS = 3000
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 describe('staleness on string-valued paths', function () {
-  let server: Awaited<ReturnType<typeof startServerP>>
+  let server: Awaited<ReturnType<typeof startServerP>> | undefined
   let port: number
 
   before(async function () {
@@ -31,7 +31,9 @@ describe('staleness on string-valued paths', function () {
   })
 
   after(async function () {
-    await server.stop()
+    // A rejected before hook leaves server undefined; Mocha still runs this,
+    // and an unguarded stop() would mask the real setup failure.
+    await server?.stop()
   })
 
   it('emits null and state.timedOut for a stale string enum path', async function () {

--- a/test/staleness.ts
+++ b/test/staleness.ts
@@ -442,7 +442,7 @@ describe('StalenessEnforcer', () => {
     })
   })
 
-  it('skips string-valued leaves (identity fields collide with FullSignalK)', () => {
+  it('skips the uuid identity path, which FullSignalK cannot represent', () => {
     const app = makeMockApp({ defaultTimeout: 60 })
     seedLeaf(
       app,
@@ -457,7 +457,7 @@ describe('StalenessEnforcer', () => {
     expect(app.captured).to.have.lengthOf(0)
   })
 
-  it('skips boolean-valued leaves (state flags, not measurements)', () => {
+  it('times out a boolean-valued leaf', () => {
     const app = makeMockApp({ defaultTimeout: 60 })
     seedLeaf(
       app,
@@ -469,7 +469,9 @@ describe('StalenessEnforcer', () => {
     )
     const enforcer = makeEnforcer(app)
     runTick(enforcer)
-    expect(app.captured).to.have.lengthOf(0)
+    expect(app.captured).to.have.lengthOf(1)
+    expect(app.captured[0].value).to.equal(null)
+    expect(app.captured[0].state?.lastValue?.value).to.equal(true)
   })
 
   describe('meta.timeout: "auto"', () => {
@@ -647,5 +649,64 @@ describe('StalenessEnforcer', () => {
       runTick(enforcer)
       expect(app.captured).to.have.lengthOf(0)
     })
+  })
+
+  it('times out a string enum path such as navigation.state', () => {
+    const app = makeMockApp({ defaultTimeout: 60 })
+    const ts = isoSecondsAgo(120)
+    seedLeaf(app, SELF_CONTEXT, 'navigation.state', 'autostate', ts, 'moored')
+    const enforcer = makeEnforcer(app)
+
+    runTick(enforcer)
+
+    expect(app.captured).to.have.lengthOf(1)
+    const [msg] = app.captured
+    expect(msg.providerId).to.equal(STALENESS_PLUGIN_ID)
+    expect(msg.path).to.equal('navigation.state')
+    expect(msg.value).to.equal(null)
+    expect(msg.state?.timedOut).to.equal(true)
+    expect(msg.state?.lastValue?.value).to.equal('moored')
+  })
+
+  it('honours a plugin-declared meta.timeout on a string path', () => {
+    // metaByPath models persisted baseDeltas meta, the only store the
+    // enforcer consults for a per-path timeout.
+    const app = makeMockApp({
+      defaultTimeout: 60,
+      metaByPath: { 'navigation.state': { timeout: 900 } }
+    })
+    seedLeaf(
+      app,
+      SELF_CONTEXT,
+      'navigation.state',
+      'autostate',
+      isoSecondsAgo(120),
+      'moored'
+    )
+    const enforcer = makeEnforcer(app)
+
+    runTick(enforcer)
+
+    expect(app.captured).to.be.empty
+  })
+
+  it('still times out a path whose last segment is an identity name', () => {
+    // The exclusion is on the whole path, not a trailing segment: a nested
+    // `...url` is an ordinary leaf and must not inherit the exemption.
+    const app = makeMockApp({ defaultTimeout: 60 })
+    seedLeaf(
+      app,
+      SELF_CONTEXT,
+      'network.services.signalk.url',
+      'srv.1',
+      isoSecondsAgo(120),
+      'http://example.com'
+    )
+    const enforcer = makeEnforcer(app)
+
+    runTick(enforcer)
+
+    expect(app.captured).to.have.lengthOf(1)
+    expect(app.captured[0].path).to.equal('network.services.signalk.url')
   })
 })


### PR DESCRIPTION
The staleness enforcer skipped every string- and boolean-valued leaf, so an enum observation such as `navigation.state`, a switch state, or an `armed`/`unarmed`/`latched` device state could never be reported stale however long its source had been silent. Those are arguably the paths where staleness matters most.

The code justified this two ways. Neither holds as stated:

- *"String and boolean leaves are by Signal K convention identity fields"* — the specification places no type restriction on `meta.timeout`: it is a plain number on the shared `meta` definition, and `navigation.state` is a string enum inheriting `commonValueFields` -> `meta` -> `timeout`. RFC #2350 does not restrict by value type either.
- *An `addValue` crash* — real, but far narrower. `fillIdentityField` writes the vessel identity onto the context as a bare primitive, so `FullSignalK.addValue` throws when it assigns `leaf.value` on it. Only `uuid`, `mmsi` and `url` can be written that way, and only whichever one matches the selfId form; the throw is caught by `handleMessage`, which logs it and drops that delta.

So this excludes those three paths by name and lets every other leaf time out normally. `value: null` plus the `state` container is unchanged, per RFC v7.

Recommend merging #3025 first: it documents how a plugin declares a longer timeout, which slow string-valued paths will want once they become eligible.

## Tested

- `npm run format`, `npm run build:all`, `npm test` — server 1280 passing, workspaces green, ci-lint clean
- Unit coverage for a string enum path, a boolean leaf, a plugin-declared `meta.timeout` on a string path, the three identity paths, and a nested path whose last segment is `url` (must still time out)
- New e2e `test/staleness-strings-e2e.ts` drives a real server: `navigation.state` stops updating and the REST snapshot reports `value: null`, `state.timedOut`, and the last good reading. Confirmed it fails without the fix (`expected 'moored' to equal null`)
- Measured the `addValue` behaviour directly: it throws for exactly one identity path per server depending on the selfId form, the other two accept null, and `navigation.state` accepts null cleanly with correct multi-source fanout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates stale-data detection so string and boolean leaves time out when their sources stop reporting.
- Excludes `uuid`, `mmsi`, and `url` identity paths from timeout processing.
- Exports the `isIdentityPath` helper from `server-api`.
- Preserves existing `value: null` and `state` container behavior.
- Adds coverage for enum strings, boolean leaves, plugin-defined timeouts, identity paths, nested `url` paths, and `navigation.state` end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->