### PR TITLE
feat: add updateContract to the metadata editor

### DIFF
--- a/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.test.ts
@@ -86,6 +86,49 @@ describe('dataSlice', () => {
     })
   })
 
+  describe('removeMetaKeys', () => {
+    it('drops a key a merged delta would otherwise preserve', () => {
+      useStore.getState().updateMeta('vessels.self', 'navigation.state', {
+        description: 'Navigational state',
+        updateContract: 'event'
+      } as Partial<MetaData>)
+
+      useStore
+        .getState()
+        .removeMetaKeys('vessels.self', 'navigation.state', ['updateContract'])
+
+      const meta = useStore
+        .getState()
+        .getMeta('vessels.self', 'navigation.state')
+      expect(meta).toEqual({ description: 'Navigational state' })
+    })
+
+    it('leaves the entry alone when the key is not present', () => {
+      useStore
+        .getState()
+        .updateMeta('vessels.self', 'navigation.state', { units: 'm/s' })
+      const before = useStore
+        .getState()
+        .getMeta('vessels.self', 'navigation.state')
+
+      useStore
+        .getState()
+        .removeMetaKeys('vessels.self', 'navigation.state', ['updateContract'])
+
+      expect(
+        useStore.getState().getMeta('vessels.self', 'navigation.state')
+      ).toBe(before)
+    })
+
+    it('ignores a path it has no metadata for', () => {
+      expect(() =>
+        useStore
+          .getState()
+          .removeMetaKeys('vessels.self', 'navigation.unknown', ['units'])
+      ).not.toThrow()
+    })
+  })
+
   describe('updateMeta', () => {
     it('should add metadata for a path', () => {
       const metaData: MetaData = {

--- a/packages/server-admin-ui/src/store/slices/dataSlice.ts
+++ b/packages/server-admin-ui/src/store/slices/dataSlice.ts
@@ -64,6 +64,7 @@ export interface DataSliceActions {
     path: string,
     metaData: Partial<MetaData>
   ) => void
+  removeMetaKeys: (context: string, path: string, keys: string[]) => void
   getPathData: (context: string, path$SourceKey: string) => PathData | undefined
   getMeta: (context: string, path: string) => MetaData | undefined
   getPath$SourceKeys: (context: string) => string[]
@@ -146,6 +147,32 @@ export const createDataSlice: StateCreator<DataSlice, [], [], DataSlice> = (
         signalkMeta: {
           ...state.signalkMeta,
           [context]: newContextMeta
+        }
+      }
+    })
+  },
+
+  // Meta deltas are merged, because some carry only the field they change
+  // (registerPutHandler sends `{ supportsPut: true }`). A field the user
+  // cleared in the editor therefore survives the save it was removed in, so
+  // the editor drops it here explicitly.
+  removeMetaKeys: (context, path, keys) => {
+    set((state) => {
+      const existing = state.signalkMeta[context]?.[path]
+      if (!existing) return state
+      const remaining = { ...existing }
+      let changed = false
+      for (const key of keys) {
+        if (key in remaining) {
+          delete remaining[key as keyof MetaData]
+          changed = true
+        }
+      }
+      if (!changed) return state
+      return {
+        signalkMeta: {
+          ...state.signalkMeta,
+          [context]: { ...state.signalkMeta[context], [path]: remaining }
         }
       }
     })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { CategorySelect, Zones } from './Meta'
+import {
+  CategorySelect,
+  normalizeMetaForSave,
+  UpdateContractSelect,
+  Zones
+} from './Meta'
 import type { PresetDetails, UnitDefinitions } from '../../utils/unitConversion'
 
 const DEFINITIONS: UnitDefinitions = {
@@ -235,5 +240,92 @@ describe('Zones', () => {
   it('edits thresholds in the preset unit when there is no override', () => {
     renderZones()
     expect(screen.getByLabelText('Zone unit')).toHaveValue('kn')
+  })
+})
+
+describe('UpdateContractSelect', () => {
+  const renderContract = (
+    value: unknown,
+    setValue: (value: unknown) => void = () => {}
+  ) =>
+    render(
+      <UpdateContractSelect
+        disabled={false}
+        value={value}
+        setValue={setValue}
+        inputId="contract"
+      />
+    )
+
+  it('offers unset, periodic and event', () => {
+    renderContract(undefined)
+    const options = screen.getAllByRole('option').map((o) => o.textContent)
+    expect(options).to.deep.equal([
+      'Use the shipped classification',
+      'periodic: regular updates expected',
+      'event: emits only on change, never stale'
+    ])
+  })
+
+  it('shows the unset option when the path has no contract', () => {
+    renderContract(undefined)
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).to.equal(
+      ''
+    )
+  })
+
+  it('reflects a contract already set on the path', () => {
+    renderContract('event')
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).to.equal(
+      'event'
+    )
+  })
+
+  it('reports a chosen contract to the editor', () => {
+    const setValue = vi.fn()
+    renderContract(undefined, setValue)
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'event' }
+    })
+    expect(setValue).toHaveBeenCalledWith('event')
+  })
+
+  it('clears the field rather than storing an empty string', () => {
+    // An empty selection must remove the key so the shipped classification
+    // applies again, not persist '' as the contract.
+    const setValue = vi.fn()
+    renderContract('event', setValue)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } })
+    expect(setValue).toHaveBeenCalledWith(undefined)
+  })
+})
+
+describe('normalizeMetaForSave', () => {
+  it('drops a contract the user never chose', () => {
+    // Add Field seeds '' — saving without touching the select must not
+    // persist that as the contract.
+    expect(
+      normalizeMetaForSave({ description: 'x', updateContract: '' })
+    ).to.deep.equal({ description: 'x' })
+  })
+
+  it('keeps periodic and event', () => {
+    expect(normalizeMetaForSave({ updateContract: 'periodic' })).to.deep.equal({
+      updateContract: 'periodic'
+    })
+    expect(normalizeMetaForSave({ updateContract: 'event' })).to.deep.equal({
+      updateContract: 'event'
+    })
+  })
+
+  it('drops an unrecognised contract', () => {
+    expect(normalizeMetaForSave({ updateContract: 'sometimes' })).to.deep.equal(
+      {}
+    )
+  })
+
+  it('leaves metadata without a contract untouched', () => {
+    const meta = { description: 'x', timeout: 900 }
+    expect(normalizeMetaForSave(meta)).to.equal(meta)
   })
 })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import {
+import { useStore } from '../../store'
+import Meta, {
   CategorySelect,
   normalizeMetaForSave,
   UpdateContractSelect,
@@ -327,5 +328,67 @@ describe('normalizeMetaForSave', () => {
   it('leaves metadata without a contract untouched', () => {
     const meta = { description: 'x', timeout: 900 }
     expect(normalizeMetaForSave(meta)).to.equal(meta)
+  })
+})
+
+describe('Meta save clears removed fields', () => {
+  const path = 'navigation.state'
+  const meta = { description: 'Navigational state', updateContract: 'event' }
+
+  const renderMeta = () =>
+    render(<Meta meta={meta} path={path} context="vessels.self" />)
+
+  const openEditorAndDeleteContract = async () => {
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }))
+    const selects = screen
+      .getAllByRole('combobox')
+      .filter((s) =>
+        [...(s as HTMLSelectElement).options].some(
+          (o) => o.value === 'description'
+        )
+      )
+    const contractRow = selects.find(
+      (s) => (s as HTMLSelectElement).value === 'updateContract'
+    )
+    expect(contractRow).to.not.equal(undefined)
+    const trash = contractRow!
+      .closest('div')!
+      .parentElement!.querySelector('button')
+    fireEvent.click(trash!)
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    useStore.getState().clearData()
+  })
+
+  it('keeps the field locally when the save is rejected', async () => {
+    useStore.getState().updateMeta('vessels.self', path, meta)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    )
+
+    renderMeta()
+    await openEditorAndDeleteContract()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(
+      useStore.getState().getMeta('vessels.self', path)?.updateContract
+    ).to.equal('event')
+  })
+
+  it('drops the field locally once the save succeeds', async () => {
+    useStore.getState().updateMeta('vessels.self', path, meta)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }))
+
+    renderMeta()
+    await openEditorAndDeleteContract()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(
+      useStore.getState().getMeta('vessels.self', path)?.updateContract
+    ).to.equal(undefined)
   })
 })

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -708,13 +708,17 @@ export const normalizeMetaForSave = (meta: MetaData): MetaData => {
   return rest
 }
 
-const saveMeta = (path: string, meta: MetaData) => {
-  fetch(`/signalk/v1/api/vessels/self/${pathToUrlSegments(path)}/meta`, {
-    method: 'PUT',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ value: normalizeMetaForSave(meta) })
-  })
+const saveMeta = async (path: string, meta: MetaData): Promise<boolean> => {
+  const res = await fetch(
+    `/signalk/v1/api/vessels/self/${pathToUrlSegments(path)}/meta`,
+    {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: normalizeMetaForSave(meta) })
+    }
+  ).catch(() => null)
+  return res?.ok ?? false
 }
 
 const Meta: React.FC<MetaProps> = ({ meta, path, context, showContext }) => {
@@ -776,7 +780,21 @@ const Meta: React.FC<MetaProps> = ({ meta, path, context, showContext }) => {
   }
 
   const handleSave = () => {
-    saveMeta(path, localMeta)
+    const saved = normalizeMetaForSave(localMeta)
+    const cleared = Object.keys(meta).filter((key) => !(key in saved))
+    saveMeta(path, localMeta).then((ok) => {
+      // The server drops a key the save omits, but its meta delta is merged
+      // into the store rather than replacing the entry, so a cleared field
+      // would linger in this session until a reload. Only drop it locally
+      // once the server has accepted the save, or the two would disagree.
+      if (ok && cleared.length > 0) {
+        // saveMeta always writes to vessels/self, and signalkMeta is keyed by
+        // the full context, so the local drop has to name the same entry.
+        useStore
+          .getState()
+          .removeMetaKeys(context || 'vessels.self', path, cleared)
+      }
+    })
     setIsEditing(false)
   }
 

--- a/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
+++ b/packages/server-admin-ui/src/views/DataBrowser/Meta.tsx
@@ -59,6 +59,7 @@ interface MetaData {
   longName?: string
   shortName?: string
   timeout?: number
+  updateContract?: string
   displayScale?: DisplayScaleValue
   displayUnits?: DisplayUnits
   zones?: Zone[]
@@ -145,6 +146,7 @@ const METAFIELDS = [
   'longName',
   'shortName',
   'timeout',
+  'updateContract',
   'displayScale',
   'displayUnits',
   'zones',
@@ -372,6 +374,35 @@ const UnitSelect: React.FC<ValueRenderProps> = ({
     {Object.entries(UNITS).map(([unit, description]) => (
       <option key={unit} value={unit}>
         {unit}:{description}
+      </option>
+    ))}
+  </Form.Select>
+)
+
+const UPDATE_CONTRACTS: Array<[string, string]> = [
+  ['', 'Use the shipped classification'],
+  ['periodic', 'periodic: regular updates expected'],
+  ['event', 'event: emits only on change, never stale']
+]
+
+export const UpdateContractSelect: React.FC<ValueRenderProps> = ({
+  disabled,
+  value,
+  setValue,
+  inputId
+}) => (
+  <Form.Select
+    id={inputId}
+    disabled={disabled}
+    value={(value as string) ?? ''}
+    size="sm"
+    onChange={(e) =>
+      setValue(e.target.value === '' ? undefined : e.target.value)
+    }
+  >
+    {UPDATE_CONTRACTS.map(([contract, label]) => (
+      <option key={contract || 'unset'} value={contract}>
+        {label}
       </option>
     ))}
   </Form.Select>
@@ -620,6 +651,13 @@ const METAFIELDRENDERERS: Record<
   longName: (props) => <MetaFormRow {...props} renderValue={Text} />,
   shortName: (props) => <MetaFormRow {...props} renderValue={Text} />,
   timeout: (props) => <MetaFormRow {...props} renderValue={NumberValue} />,
+  updateContract: (props) => (
+    <MetaFormRow
+      {...props}
+      renderValue={UpdateContractSelect}
+      description="Whether silence on this path means a failure (periodic) or simply no change (event)"
+    />
+  ),
   displayScale: (props) => (
     <MetaFormRow {...props} renderValue={DisplaySelect} />
   ),
@@ -657,12 +695,25 @@ const METAFIELDRENDERERS: Record<
   )
 }
 
+// `Add Field` seeds a new key with an empty string, so a contract the user
+// never chose would otherwise be persisted as `updateContract: ''`. Only the
+// two valid contracts are sent; anything else drops the key so the shipped
+// classification keeps applying.
+const UPDATE_CONTRACT_VALUES = ['periodic', 'event']
+
+export const normalizeMetaForSave = (meta: MetaData): MetaData => {
+  if (meta.updateContract === undefined) return meta
+  if (UPDATE_CONTRACT_VALUES.includes(meta.updateContract)) return meta
+  const { updateContract: _dropped, ...rest } = meta
+  return rest
+}
+
 const saveMeta = (path: string, meta: MetaData) => {
   fetch(`/signalk/v1/api/vessels/self/${pathToUrlSegments(path)}/meta`, {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ value: meta })
+    body: JSON.stringify({ value: normalizeMetaForSave(meta) })
   })
 }
 


### PR DESCRIPTION
The Stale Data Detection docs tell users to set `updateContract` to declare a path event-driven, but the Data Browser metadata editor offered no control for it — the only route was the meta API. This adds a select alongside `timeout`, with an unset option that leaves the server's shipped classification in place.

Three options: *Use the shipped classification* (unset), *periodic*, *event*.

While testing this I found that `Add Field` seeds a new key with an empty string, so saving without choosing a contract would persist `updateContract: ''`. That is an invalid enum in `baseDeltas.json`; the enforcer treats it as falsy and falls back to the shipped classification, so nothing breaks, but it should not be written. Any value that is not `periodic` or `event` is now dropped before the metadata PUT.

## Tested

- `npm run format`, `npm run build:all`, `npm test` — server 1276 passing, admin-ui 443 passing, workspaces green, ci-lint clean
- Nine new vitest cases: the three options and their labels, unset and preselected rendering, reporting a chosen contract, clearing to undefined rather than an empty string, and four covering the save-time normalisation
- Exercised in a browser against a real 2.32.0 server: added the field to `navigation.state`, confirmed the control renders and the options are correct
- Verified the empty-value defect on the wire before and after the fix. Before: `{"value":{"description":"...","updateContract":""}}`. After: `{"value":{"description":"..."}}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds an `updateContract` selector to the admin metadata editor.
- Supports unset, `periodic`, and `event` values.
- Removes invalid or empty values before saving metadata.
- Removes cleared metadata keys after a successful save.
- Prevents stale save callbacks from removing newer metadata.
- Adds an accessible name to the delete control.
- Adds tests for selector behavior, normalization, save handling, and local state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->