### PR TITLE
feat: report the resolved updateContract in path metadata

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -20,6 +20,7 @@ const express = require('express')
 const { getMetadata } = require('@signalk/path-metadata')
 const ports = require('../ports')
 const { serveStaticFiles } = require('../staticfiles')
+const { resolveUpdateContract } = require('../updateContracts')
 const {
   resolveDisplayUnits,
   getDefaultCategory
@@ -38,6 +39,14 @@ function enhanceMetadataResponse(
   includeOverride
 ) {
   if (!metadata) return metadata
+
+  // Stale data detection resolves the contract server-side from an explicit
+  // meta.updateContract, then the shipped classification, then periodic.
+  // Reporting the result lets a client show which contract is in force
+  // without reimplementing that precedence.
+  if (signalkPath) {
+    metadata.updateContract = resolveUpdateContract(signalkPath, metadata)
+  }
 
   let storedDisplayUnits = metadata.displayUnits
 

--- a/src/staleness.ts
+++ b/src/staleness.ts
@@ -5,13 +5,12 @@ import {
   Path,
   PathValue,
   SourceRef,
-  UpdateContract,
   Timestamp
 } from '@signalk/server-api'
 
 import { ServerApp, SignalKMessageHub, WithConfig } from './app'
 import { createDebug } from './debug'
-import updateContractDefaults from './defaults/updateContracts.json'
+import { resolveUpdateContract } from './updateContracts'
 
 const debug = createDebug('signalk-server:staleness')
 
@@ -76,40 +75,6 @@ const isCacheLeafEntry = (v: unknown): v is CacheLeafEntry =>
   isObject(v) &&
   typeof (v as { path?: unknown }).path === 'string' &&
   'value' in v
-
-type UpdateContractDefaults = ReadonlyArray<readonly [string, UpdateContract]>
-
-/**
- * Build a longest-prefix-match table from the shipped updateContracts.json so a
- * single defaults lookup decides whether a path is event-driven without the
- * enforcer special-casing prefixes inline.
- */
-const buildUpdateContractDefaults = (
-  raw: Record<string, string>
-): UpdateContractDefaults => {
-  const entries: Array<[string, UpdateContract]> = []
-  for (const prefix of Object.keys(raw)) {
-    const t = raw[prefix]
-    if (t === 'periodic' || t === 'event') {
-      entries.push([prefix, t])
-    }
-  }
-  entries.sort((a, b) => b[0].length - a[0].length)
-  return entries
-}
-
-const DEFAULT_UPDATE_CONTRACTS = buildUpdateContractDefaults(
-  updateContractDefaults as Record<string, string>
-)
-
-const resolveUpdateContractFromDefaults = (
-  path: string
-): UpdateContract | undefined => {
-  for (const [prefix, updateContract] of DEFAULT_UPDATE_CONTRACTS) {
-    if (path === prefix || path.startsWith(prefix + '.')) return updateContract
-  }
-  return undefined
-}
 
 /**
  * Server-side enforcer for `meta.timeout`. Walks the delta cache once per
@@ -292,7 +257,7 @@ export class StalenessEnforcer {
     }
 
     const meta = this.lookupMeta(context, path)
-    const updateContract = this.resolveUpdateContract(path, meta)
+    const updateContract = resolveUpdateContract(path, meta)
     if (updateContract !== 'periodic') return
 
     const baseTimeoutMs = this.resolveBaseTimeoutMs(context, path, meta)
@@ -346,16 +311,6 @@ export class StalenessEnforcer {
     if (meta?.timeout !== 'auto') return baseTimeoutMs
     const derived = this.deriveAutoTimeoutMs(key)
     return derived ?? baseTimeoutMs
-  }
-
-  private resolveUpdateContract(
-    path: string,
-    meta: MetaValue | undefined
-  ): UpdateContract {
-    if (meta?.updateContract) return meta.updateContract
-    const fromDefaults = resolveUpdateContractFromDefaults(path)
-    if (fromDefaults) return fromDefaults
-    return 'periodic'
   }
 
   // Resolves the base timeout (ms) ignoring `meta.timeout: 'auto'` —

--- a/src/updateContracts.ts
+++ b/src/updateContracts.ts
@@ -1,0 +1,49 @@
+import { MetaValue, UpdateContract } from '@signalk/server-api'
+import updateContractDefaults from './defaults/updateContracts.json'
+
+type UpdateContractDefaults = ReadonlyArray<readonly [string, UpdateContract]>
+
+/**
+ * Build a longest-prefix-match table from the shipped updateContracts.json so a
+ * single defaults lookup decides whether a path is event-driven without the
+ * caller special-casing prefixes inline.
+ */
+const buildUpdateContractDefaults = (
+  raw: Record<string, string>
+): UpdateContractDefaults => {
+  const entries: Array<[string, UpdateContract]> = []
+  for (const prefix of Object.keys(raw)) {
+    const t = raw[prefix]
+    if (t === 'periodic' || t === 'event') {
+      entries.push([prefix, t])
+    }
+  }
+  entries.sort((a, b) => b[0].length - a[0].length)
+  return entries
+}
+
+const DEFAULT_UPDATE_CONTRACTS = buildUpdateContractDefaults(
+  updateContractDefaults as Record<string, string>
+)
+
+/** The contract the shipped classification gives a path, if it covers it. */
+export const resolveUpdateContractFromDefaults = (
+  path: string
+): UpdateContract | undefined => {
+  for (const [prefix, updateContract] of DEFAULT_UPDATE_CONTRACTS) {
+    if (path === prefix || path.startsWith(prefix + '.')) return updateContract
+  }
+  return undefined
+}
+
+/**
+ * The contract actually in force for a path: an explicit `meta.updateContract`
+ * wins, then the shipped classification, and everything else is periodic.
+ */
+export const resolveUpdateContract = (
+  path: string,
+  meta: MetaValue | undefined
+): UpdateContract => {
+  if (meta?.updateContract) return meta.updateContract
+  return resolveUpdateContractFromDefaults(path) ?? 'periodic'
+}

--- a/test/multiple-values.js
+++ b/test/multiple-values.js
@@ -34,12 +34,20 @@ const delta = {
   ]
 }
 
-function removeDisplayUnits(tree) {
+// The server reports resolved `displayUnits` and `updateContract` in meta.
+// Neither is part of the Signal K meta schema, so strip them before the
+// full model is validated against it.
+function removeServerResolvedMeta(tree) {
   const nav = tree.vessels[uuid].navigation
-  delete nav.trip.log.meta.displayUnits
-  delete nav.log.meta.displayUnits
-  delete nav.courseOverGroundTrue.meta.displayUnits
-  delete nav.speedOverGround.meta.displayUnits
+  for (const node of [
+    nav.trip.log,
+    nav.log,
+    nav.courseOverGroundTrue,
+    nav.speedOverGround
+  ]) {
+    delete node.meta.displayUnits
+    delete node.meta.updateContract
+  }
 }
 
 describe('Server', function () {
@@ -76,7 +84,7 @@ describe('Server', function () {
           'deltaFromHttp.115'
         )
         delete treeAfterFirstDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeDisplayUnits(treeAfterFirstDelta)
+        removeServerResolvedMeta(treeAfterFirstDelta)
         treeAfterFirstDelta.should.be.validSignalK
 
         delta.updates[0].values[0].value = 1
@@ -95,7 +103,7 @@ describe('Server', function () {
           'deltaFromHttp.115'
         )
         delete treeAfterSecondDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeDisplayUnits(treeAfterSecondDelta)
+        removeServerResolvedMeta(treeAfterSecondDelta)
         treeAfterSecondDelta.should.be.validSignalK
 
         delta.updates[0].values[0].value = 2
@@ -121,7 +129,7 @@ describe('Server', function () {
           'deltaFromHttp.116'
         ].value.should.equal(2)
         delete treeAfterOtherSourceDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeDisplayUnits(treeAfterOtherSourceDelta)
+        removeServerResolvedMeta(treeAfterOtherSourceDelta)
         treeAfterOtherSourceDelta.should.be.validSignalK
       })
   }).timeout(4000)

--- a/test/multiple-values.ts
+++ b/test/multiple-values.ts
@@ -1,22 +1,30 @@
-const chai = require('chai')
-chai.Should()
-chai.use(require('chai-things'))
-chai.use(require('@signalk/signalk-schema').chaiModule)
-const { freeport } = require('./ts-servertestutilities')
-const { startServerP, sendDelta } = require('./servertestutilities')
-const uuid = 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+import chai, { expect } from 'chai'
+// @ts-expect-error no type declarations available
+import chaiThings from 'chai-things'
+// @ts-expect-error no type declarations available
+import { chaiModule } from '@signalk/signalk-schema'
+import { freeport } from './ts-servertestutilities'
+import { removeServerResolvedMeta } from './serverResolvedMeta'
+import { startServerP, sendDelta } from './servertestutilities'
 
-const delta = {
+chai.should()
+chai.use(chaiThings)
+chai.use(chaiModule)
+
+const uuid = 'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+const DELTA_ROUNDTRIP_TIMEOUT_MS = 4000
+
+const makeDelta = (tripLog: number, src: string) => ({
   context: 'vessels.' + uuid,
   updates: [
     {
       source: {
         pgn: 128275,
         label: '/dev/actisense',
-        src: '115'
+        src
       },
       values: [
-        { path: 'navigation.trip.log', value: 43374 },
+        { path: 'navigation.trip.log', value: tripLog },
         { path: 'navigation.log', value: 17404540 }
       ]
     },
@@ -32,26 +40,63 @@ const delta = {
       ]
     }
   ]
+})
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Chai {
+    interface Assertion {
+      // Added by @signalk/signalk-schema's chai plugin, which ships no types.
+      validSignalK: Assertion
+    }
+  }
 }
 
-// The server reports resolved `displayUnits` and `updateContract` in meta.
-// Neither is part of the Signal K meta schema, so strip them before the
-// full model is validated against it.
-function removeServerResolvedMeta(tree) {
+interface MetaBearingNode {
+  meta?: Record<string, unknown>
+  values?: Record<string, { value: unknown }>
+}
+
+interface FullModel {
+  vessels: Record<
+    string,
+    {
+      navigation: Record<string, MetaBearingNode & Record<string, unknown>> & {
+        trip: { log: MetaBearingNode }
+      }
+    }
+  >
+}
+
+const readFullModel = async (restUrl: string): Promise<FullModel> => {
+  const res = await fetch(restUrl)
+  const body = await res.text()
+  expect(res.ok, `GET ${restUrl} returned ${res.status}: ${body}`).to.equal(
+    true
+  )
+  const parsed: unknown = JSON.parse(body)
+  expect(parsed).to.be.an('object')
+  const model = parsed as FullModel
+  expect(
+    model.vessels?.[uuid]?.navigation,
+    `response has no vessels[${uuid}].navigation`
+  ).to.be.an('object')
+  return model
+}
+
+const stripServerResolvedMeta = (tree: FullModel): void => {
   const nav = tree.vessels[uuid].navigation
-  for (const node of [
+  removeServerResolvedMeta([
     nav.trip.log,
     nav.log,
     nav.courseOverGroundTrue,
     nav.speedOverGround
-  ]) {
-    delete node.meta.displayUnits
-    delete node.meta.updateContract
-  }
+  ])
 }
 
 describe('Server', function () {
-  let server, port
+  let server: Awaited<ReturnType<typeof startServerP>> | undefined
+  let port: number
 
   before(async function () {
     port = await freeport()
@@ -59,7 +104,7 @@ describe('Server', function () {
   })
 
   after(async function () {
-    await server.stop()
+    await server?.stop()
   })
 
   it('handles two deltas with signalk path', function () {
@@ -67,14 +112,9 @@ describe('Server', function () {
     const deltaUrl = host + '/signalk/v1/api/_test/delta'
     const restUrl = host + '/signalk/v1/api/'
 
-    console.log('send')
-    return sendDelta(delta, deltaUrl)
-      .then(function () {
-        console.log('back1')
-        return fetch(restUrl).then((r) => r.json())
-      })
-      .then(function (treeAfterFirstDelta) {
-        console.log('back2')
+    return sendDelta(makeDelta(43374, '115'), deltaUrl)
+      .then(() => readFullModel(restUrl))
+      .then((treeAfterFirstDelta) => {
         treeAfterFirstDelta.vessels[uuid].should.have.nested.property(
           'navigation.trip.log.value',
           43374
@@ -84,16 +124,13 @@ describe('Server', function () {
           'deltaFromHttp.115'
         )
         delete treeAfterFirstDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeServerResolvedMeta(treeAfterFirstDelta)
+        stripServerResolvedMeta(treeAfterFirstDelta)
         treeAfterFirstDelta.should.be.validSignalK
 
-        delta.updates[0].values[0].value = 1
-        return sendDelta(delta, deltaUrl)
+        return sendDelta(makeDelta(1, '115'), deltaUrl)
       })
-      .then(function () {
-        return fetch(restUrl).then((r) => r.json())
-      })
-      .then(function (treeAfterSecondDelta) {
+      .then(() => readFullModel(restUrl))
+      .then((treeAfterSecondDelta) => {
         treeAfterSecondDelta.vessels[uuid].should.have.nested.property(
           'navigation.trip.log.value',
           1
@@ -103,17 +140,13 @@ describe('Server', function () {
           'deltaFromHttp.115'
         )
         delete treeAfterSecondDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeServerResolvedMeta(treeAfterSecondDelta)
+        stripServerResolvedMeta(treeAfterSecondDelta)
         treeAfterSecondDelta.should.be.validSignalK
 
-        delta.updates[0].values[0].value = 2
-        delta.updates[0].source.src = '116'
-        return sendDelta(delta, deltaUrl)
+        return sendDelta(makeDelta(2, '116'), deltaUrl)
       })
-      .then(function () {
-        return fetch(restUrl).then((r) => r.json())
-      })
-      .then(function (treeAfterOtherSourceDelta) {
+      .then(() => readFullModel(restUrl))
+      .then((treeAfterOtherSourceDelta) => {
         treeAfterOtherSourceDelta.vessels[uuid].should.have.nested.property(
           'navigation.trip.log.value',
           2
@@ -122,17 +155,20 @@ describe('Server', function () {
           'navigation.trip.log.$source',
           'deltaFromHttp.116'
         )
-        treeAfterOtherSourceDelta.vessels[uuid].navigation.trip.log.values[
-          'deltaFromHttp.115'
-        ].value.should.equal(1)
-        treeAfterOtherSourceDelta.vessels[uuid].navigation.trip.log.values[
-          'deltaFromHttp.116'
-        ].value.should.equal(2)
+        // The superseded source keeps its own value alongside the new one.
+        treeAfterOtherSourceDelta.vessels[uuid].should.have.nested.property(
+          'navigation.trip.log.values.deltaFromHttp\\.115.value',
+          1
+        )
+        treeAfterOtherSourceDelta.vessels[uuid].should.have.nested.property(
+          'navigation.trip.log.values.deltaFromHttp\\.116.value',
+          2
+        )
         delete treeAfterOtherSourceDelta.vessels[uuid].navigation.course //FIXME until in schema
-        removeServerResolvedMeta(treeAfterOtherSourceDelta)
+        stripServerResolvedMeta(treeAfterOtherSourceDelta)
         treeAfterOtherSourceDelta.should.be.validSignalK
       })
-  }).timeout(4000)
+  }).timeout(DELTA_ROUNDTRIP_TIMEOUT_MS)
 
   it('preserves a schema-conformant upstream label', function () {
     const host = 'http://localhost:' + port
@@ -156,12 +192,12 @@ describe('Server', function () {
     }
 
     return sendDelta(forwarded, deltaUrl)
-      .then(() => fetch(restUrl).then((r) => r.json()))
+      .then(() => readFullModel(restUrl))
       .then((tree) => {
         tree.vessels[uuid].should.have.nested.property(
           'navigation.position.$source',
           'canhat.c0788c00e7e04312'
         )
       })
-  }).timeout(4000)
+  }).timeout(DELTA_ROUNDTRIP_TIMEOUT_MS)
 })

--- a/test/serverResolvedMeta.ts
+++ b/test/serverResolvedMeta.ts
@@ -1,0 +1,16 @@
+/**
+ * The server reports resolved `displayUnits` and `updateContract` in a path's
+ * metadata. Neither is part of the Signal K meta schema, so a full model has
+ * to be stripped of them before it is validated against the schema.
+ */
+interface MetaBearing {
+  meta?: Record<string, unknown>
+}
+
+export const removeServerResolvedMeta = (nodes: MetaBearing[]): void => {
+  for (const node of nodes) {
+    if (!node?.meta) continue
+    delete node.meta.displayUnits
+    delete node.meta.updateContract
+  }
+}

--- a/test/updateContracts.ts
+++ b/test/updateContracts.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai'
+import {
+  resolveUpdateContract,
+  resolveUpdateContractFromDefaults
+} from '../src/updateContracts'
+
+describe('updateContracts', () => {
+  describe('resolveUpdateContractFromDefaults', () => {
+    it('classifies a shipped prefix as event', () => {
+      expect(resolveUpdateContractFromDefaults('notifications')).to.equal(
+        'event'
+      )
+    })
+
+    it('classifies a descendant of a shipped prefix', () => {
+      expect(
+        resolveUpdateContractFromDefaults('navigation.anchor.position')
+      ).to.equal('event')
+    })
+
+    it('leaves an uncovered path unclassified', () => {
+      expect(resolveUpdateContractFromDefaults('navigation.state')).to.equal(
+        undefined
+      )
+    })
+
+    it('does not match a prefix that is only a string prefix', () => {
+      // `navigation.anchoring` must not inherit `navigation.anchor`.
+      expect(
+        resolveUpdateContractFromDefaults('navigation.anchoring')
+      ).to.equal(undefined)
+    })
+  })
+
+  describe('resolveUpdateContract', () => {
+    it('prefers an explicit contract over the shipped classification', () => {
+      expect(
+        resolveUpdateContract('notifications', { updateContract: 'periodic' })
+      ).to.equal('periodic')
+    })
+
+    it('falls back to the shipped classification', () => {
+      expect(resolveUpdateContract('design.airHeight', undefined)).to.equal(
+        'event'
+      )
+    })
+
+    it('treats an unclassified path as periodic', () => {
+      expect(resolveUpdateContract('navigation.state', undefined)).to.equal(
+        'periodic'
+      )
+    })
+
+    it('treats metadata without a contract as unset', () => {
+      expect(
+        resolveUpdateContract('navigation.state', { units: 'm/s' })
+      ).to.equal('periodic')
+    })
+  })
+})

--- a/test/updatecontract-meta-api-e2e.ts
+++ b/test/updatecontract-meta-api-e2e.ts
@@ -1,0 +1,75 @@
+import { expect } from 'chai'
+import { freeport } from './ts-servertestutilities'
+import { startServerP, sendDelta } from './servertestutilities'
+
+// The resolution lives server-side; a client should not have to reimplement
+// the precedence to know which contract is in force. These assertions run
+// against the real REST surface rather than the resolver in isolation.
+
+const SERVER_START_TIMEOUT_MS = 90000
+const TEST_TIMEOUT_MS = 30000
+const SETTLE_MS = 1500
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('resolved updateContract in the meta API', function () {
+  let server: Awaited<ReturnType<typeof startServerP>> | undefined
+  let port: number
+
+  const metaFor = async (path: string) => {
+    const url =
+      `http://localhost:${port}/signalk/v1/api/vessels/self/` +
+      `${path.split('.').join('/')}/meta`
+    const res = await fetch(url)
+    expect(res.ok, `GET ${path}/meta returned ${res.status}`).to.equal(true)
+    const body: unknown = await res.json()
+    expect(body).to.be.an('object')
+    return body as { updateContract?: unknown }
+  }
+
+  before(async function () {
+    this.timeout(SERVER_START_TIMEOUT_MS)
+    port = await freeport()
+    server = await startServerP(port, false, {
+      settings: { interfaces: { plugins: false } }
+    })
+    await sendDelta(
+      {
+        context: `vessels.${server.app.selfId}`,
+        updates: [
+          {
+            source: { label: 'contract-e2e' },
+            timestamp: new Date().toISOString(),
+            values: [
+              { path: 'navigation.state', value: 'moored' },
+              {
+                path: 'navigation.anchor.position',
+                value: { latitude: 1, longitude: 2 }
+              }
+            ]
+          }
+        ]
+      },
+      `http://localhost:${port}/signalk/v1/api/_test/delta`
+    )
+    await delay(SETTLE_MS)
+  })
+
+  after(async function () {
+    await server?.stop()
+  })
+
+  it('reports periodic for a path the shipped classification does not cover', async function () {
+    this.timeout(TEST_TIMEOUT_MS)
+    expect((await metaFor('navigation.state')).updateContract).to.equal(
+      'periodic'
+    )
+  })
+
+  it('reports event for a path the shipped classification covers', async function () {
+    this.timeout(TEST_TIMEOUT_MS)
+    expect(
+      (await metaFor('navigation.anchor.position')).updateContract
+    ).to.equal('event')
+  })
+})


### PR DESCRIPTION
Stale data detection resolves a path's update contract — an explicit `meta.updateContract` wins, then the shipped classification in `src/defaults/updateContracts.json`, then `periodic` — but keeps the result to itself. Nothing over HTTP reports which contract is actually in force.

That matters for any client that wants to show it. On #3027 the request was to make *Use the shipped classification* say what that classification is, and there is no way to answer without the client shipping the prefix table and reimplementing the precedence. The rule would then live in two places and drift the moment a contract is added — the same shape of bug as the string exemption in #3026, a rule encoded away from its source.

So resolve once, server-side: the precedence moves to `src/updateContracts.ts`, used by both the enforcer and the REST layer, and the result is reported alongside the other metadata a path carries. This matches how RFC #2350 described it — its HTTP/full-model example shows the contract inside `meta`, next to `units` and `timeout`.

Additive and backward compatible: a new optional key on an existing object.

`updateContract` is not in the Signal K meta schema, so the full model test strips it before validating, exactly as it already does for the server-resolved `displayUnits`. I am proposing the schema addition separately; this does not wait on it.

## Tested

- `npm run format`, `npm run build:all`, `npm test` — 1286 passing, workspaces green, ci-lint clean
- 8 unit tests for the extracted resolver: shipped prefix, descendant of a prefix, uncovered path, a prefix that is only a string prefix (`navigation.anchoring` must not inherit `navigation.anchor`), explicit contract beating the classification, and metadata with no contract
- New e2e `test/updatecontract-meta-api-e2e.ts` reads the real REST meta endpoint: `navigation.state` reports `periodic`, `navigation.anchor.position` reports `event`. Confirmed it fails without the wiring (`expected undefined to equal 'periodic'`)
- The existing 22 staleness tests pass unchanged after the extraction, so the refactor preserves enforcer behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR resolves `updateContract` server-side with the following precedence:

1. Explicit `meta.updateContract`
2. Shipped path classification
3. `periodic`

It shares the resolver between stale-data enforcement and the REST layer. The REST API reports the resolved contract in path metadata.

The PR adds resolver unit tests and an end-to-end REST test. It also migrates multiple-values test support to TypeScript, builds fresh test deltas per send, improves REST error reporting, and strips server-resolved metadata before full-model validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->