### PR TITLE
feat: allow disabling the MFD Signal K tile

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -403,6 +403,7 @@ const ServerSettings: React.FC = () => {
                                 : settings.interfaces?.[name] || false
                             }
                             disabled={disabled}
+                            aria-labelledby={`interface-label-${name}`}
                           />
                           <span
                             className="switch-label"
@@ -411,7 +412,9 @@ const ServerSettings: React.FC = () => {
                           />
                           <span className="switch-handle" />
                         </Form.Label>
-                        <span>{SettableInterfaces[name]}</span>
+                        <span id={`interface-label-${name}`}>
+                          {SettableInterfaces[name]}
+                        </span>
                       </div>
                       {disabled && (
                         <Alert

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.tsx
@@ -50,7 +50,8 @@ const SettableInterfaces: Record<string, string> = {
   logfiles: 'Data log files access',
   'nmea-tcp': 'NMEA 0183 over TCP (10110)',
   tcp: 'Signal K over TCP (8375)',
-  wasm: 'WebAssembly Runtime'
+  wasm: 'WebAssembly Runtime',
+  mfd_webapp: 'Navico MFD "Signal K" tile'
 }
 
 const OptionDescriptions: Record<string, React.ReactNode> = {

--- a/src/interfaces/mfd_webapp.ts
+++ b/src/interfaces/mfd_webapp.ts
@@ -1,3 +1,8 @@
+/**
+ * Advertises the built-in "Signal K" tile to Navico/B&G MFDs
+ * (UDP multicast 239.2.1.1:2053).
+ * Can be enabled/disabled via settings.interfaces.mfd_webapp
+ */
 import dgram from 'dgram'
 import { promisify } from 'util'
 import { exec } from 'child_process'


### PR DESCRIPTION
## Summary
- Add a Server Settings → Interfaces toggle for the built-in Navico/B&G MFD **"Signal K"** tile (`mfd_webapp`).
- The interface already honors `settings.interfaces.mfd_webapp`; this exposes that flag in the admin UI so it can be turned off without editing `settings.json`.
- Default stays enabled. Turning it off stops the UDP multicast advertisement (`239.2.1.1:2053`) on every IPv4 address, which is useful when extra addresses are used for other MFD tiles.

## Test plan
- [ ] With the toggle **on** (default), a Navico MFD still shows the Signal K tile.
- [ ] Turn the toggle **off**, Save, restart the server; the Signal K tile disappears and other MFD tiles (if any) remain.
- [ ] Equivalent `settings.json`: `"interfaces": { "mfd_webapp": false }` also disables the tile.
- [ ] Saving other Server Settings does not change the default (tile still advertised).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a Server Settings → Interfaces toggle for the Navico/B&G MFD “Signal K” tile.

The `mfd_webapp` interface advertises Signal K webapps over UDP multicast on `239.2.1.1:2053` across IPv4 interfaces. The interface is enabled by default and can be disabled through the admin UI or `settings.json`. Interface toggles use accessible names. Other MFD tiles remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->